### PR TITLE
♻️ 收敛编辑器场景预览同步规则

### DIFF
--- a/src/components/editor/TextEditor.spec.ts
+++ b/src/components/editor/TextEditor.spec.ts
@@ -448,13 +448,11 @@ describe('TextEditor', () => {
     await nextTick()
 
     const [, decorations] = monacoMockState.editorInstance.deltaDecorations.mock.calls.at(-1) ?? []
-    expect(decorations).toEqual([
-      expect.objectContaining({
-        options: expect.objectContaining({
-          glyphMarginClassName: `${PLAY_TO_LINE_GLYPH_CLASS_NAME} ${PLAY_TO_LINE_DISABLED_GLYPH_CLASS_NAME}`,
-        }),
-      }),
-    ])
+    expect(decorations).toHaveLength(1)
+    expect(decorations[0]?.options.glyphMarginClassName.split(/\s+/)).toEqual(expect.arrayContaining([
+      PLAY_TO_LINE_GLYPH_CLASS_NAME,
+      PLAY_TO_LINE_DISABLED_GLYPH_CLASS_NAME,
+    ]))
 
     const handleMouseDown = monacoMockState.editorInstance.onMouseDown.mock.calls[0]?.[0]
 

--- a/src/components/editor/TextEditor.spec.ts
+++ b/src/components/editor/TextEditor.spec.ts
@@ -447,12 +447,22 @@ describe('TextEditor', () => {
 
     await nextTick()
 
-    const [, decorations] = monacoMockState.editorInstance.deltaDecorations.mock.calls.at(-1) ?? []
+    const [, decorations = []] = monacoMockState.editorInstance.deltaDecorations.mock.calls.at(-1) ?? []
     expect(decorations).toHaveLength(1)
-    expect(decorations[0]?.options.glyphMarginClassName.split(/\s+/)).toEqual(expect.arrayContaining([
-      PLAY_TO_LINE_GLYPH_CLASS_NAME,
-      PLAY_TO_LINE_DISABLED_GLYPH_CLASS_NAME,
-    ]))
+    expect(decorations).toEqual([
+      expect.objectContaining({
+        options: expect.objectContaining({
+          glyphMarginClassName: expect.stringContaining(PLAY_TO_LINE_GLYPH_CLASS_NAME),
+        }),
+      }),
+    ])
+    expect(decorations).toEqual([
+      expect.objectContaining({
+        options: expect.objectContaining({
+          glyphMarginClassName: expect.stringContaining(PLAY_TO_LINE_DISABLED_GLYPH_CLASS_NAME),
+        }),
+      }),
+    ])
 
     const handleMouseDown = monacoMockState.editorInstance.onMouseDown.mock.calls[0]?.[0]
 

--- a/src/components/editor/TextEditor.spec.ts
+++ b/src/components/editor/TextEditor.spec.ts
@@ -5,7 +5,10 @@ import { nextTick, reactive } from 'vue'
 import { createBrowserLiteI18n } from '~/__tests__/browser'
 import { renderInBrowser } from '~/__tests__/browser-render'
 import { monacoMockState, resetMonacoMockState } from '~/__tests__/mocks/monaco'
-import { PLAY_TO_LINE_GLYPH_CLASS_NAME } from '~/features/editor/text-editor/text-editor-play-to-line'
+import {
+  PLAY_TO_LINE_DISABLED_GLYPH_CLASS_NAME,
+  PLAY_TO_LINE_GLYPH_CLASS_NAME,
+} from '~/features/editor/text-editor/text-editor-play-to-line'
 
 vi.mock('monaco-editor', async () => {
   const { createMonacoMockModule } = await import('~/__tests__/mocks/monaco')
@@ -125,18 +128,6 @@ function createMonacoModel(lines: string[]) {
       return lines.length
     },
   }
-}
-
-function getDocumentStyleRuleSelectors(): string[] {
-  return [...document.styleSheets].flatMap((sheet) => {
-    try {
-      return [...sheet.cssRules]
-        .filter((rule): rule is CSSStyleRule => 'selectorText' in rule)
-        .map(rule => rule.selectorText)
-    } catch {
-      return []
-    }
-  })
 }
 
 function createTextEditorLiteI18n() {
@@ -446,16 +437,41 @@ describe('TextEditor', () => {
     expect(editorStore.syncScenePreview).toHaveBeenCalledWith('/project/scene-8.txt', 1, 'say:hello', true)
   })
 
-  it('播放按钮样式会命中 Monaco glyph margin 装饰节点', async () => {
-    const { state } = createHarness('/project/scene-5.txt')
+  it('dirty 场景下 glyph margin 会展示禁用样式且不会触发播放', async () => {
+    const { editorStore, state } = createHarness('/project/scene-8b.txt')
+    state.isDirty = true
+    monacoMockState.editorInstance.getModel.mockReturnValue(createMonacoModel(['say:hello']))
+    monacoMockState.editorInstance.getPosition.mockReturnValue({ lineNumber: 1 })
 
     renderTextEditor(state)
 
     await nextTick()
 
-    const selectors = getDocumentStyleRuleSelectors()
+    const [, decorations] = monacoMockState.editorInstance.deltaDecorations.mock.calls.at(-1) ?? []
+    expect(decorations).toEqual([
+      expect.objectContaining({
+        options: expect.objectContaining({
+          glyphMarginClassName: `${PLAY_TO_LINE_GLYPH_CLASS_NAME} ${PLAY_TO_LINE_DISABLED_GLYPH_CLASS_NAME}`,
+        }),
+      }),
+    ])
 
-    expect(selectors).toContain(`.monaco-editor .glyph-margin-widgets .cgmr.${PLAY_TO_LINE_GLYPH_CLASS_NAME}`)
-    expect(selectors).toContain(`.monaco-editor .glyph-margin-widgets .cgmr.${PLAY_TO_LINE_GLYPH_CLASS_NAME}::before`)
+    const handleMouseDown = monacoMockState.editorInstance.onMouseDown.mock.calls[0]?.[0]
+
+    expect(handleMouseDown).toBeTypeOf('function')
+
+    handleMouseDown?.({
+      event: {
+        leftButton: true,
+      },
+      target: {
+        position: {
+          lineNumber: 1,
+        },
+        type: monaco.editor.MouseTargetType.GUTTER_GLYPH_MARGIN,
+      },
+    })
+
+    expect(editorStore.syncScenePreview).not.toHaveBeenCalled()
   })
 })

--- a/src/components/editor/TextEditor.vue
+++ b/src/components/editor/TextEditor.vue
@@ -23,6 +23,7 @@ const tabsStore = useTabsStore()
 const editSettings = useEditSettingsStore()
 const { locale, t } = useI18n()
 const showPlayToLineGlyph = $computed(() => props.state.kind === 'scene')
+const disablePlayToLineGlyph = $computed(() => props.state.kind === 'scene' && props.state.isDirty)
 
 const editorOptions = $computed<monaco.editor.IEditorConstructionOptions>(() =>
   ({
@@ -116,6 +117,7 @@ function createEditor() {
     getPath: () => props.state.path,
     glyphMarginTargetType: monaco.editor.MouseTargetType.GUTTER_GLYPH_MARGIN,
     isEnabled: () => showPlayToLineGlyph,
+    isDisabled: () => disablePlayToLineGlyph,
     syncScenePreview: (path, lineNumber, lineText, force) => {
       editorStore.syncScenePreview(path, lineNumber, lineText, force)
     },
@@ -146,6 +148,7 @@ watch(() => editorOptions, (newOptions) => {
 watch(
   [
     () => props.state.kind,
+    () => props.state.isDirty,
     () => props.state.path,
     () => locale.value,
   ],
@@ -189,5 +192,9 @@ onUnmounted(() => {
 
 .monaco-editor .glyph-margin-widgets .cgmr.play-to-line-glyph::before {
   @apply content-empty block size-4 flex-none i-lucide-play;
+}
+
+.monaco-editor .glyph-margin-widgets .cgmr.play-to-line-glyph.play-to-line-glyph-disabled {
+  @apply cursor-not-allowed text-muted-foreground/50;
 }
 </style>

--- a/src/components/editor/VisualEditorScene.spec.ts
+++ b/src/components/editor/VisualEditorScene.spec.ts
@@ -67,6 +67,7 @@ const globalStubs = {
         required: true,
       },
       index: Number,
+      playToDisabled: Boolean,
       previousSpeaker: String,
       readonly: Boolean,
       selected: Boolean,
@@ -85,6 +86,7 @@ const globalStubs = {
           onClick: () => emit('select', props.entry.id),
         }, `${props.entry.rawText}`),
         h('button', {
+          disabled: props.playToDisabled,
           type: 'button',
           onClick: () => emit('play-to', props.entry.id),
         }, `play-${props.entry.id}`),
@@ -200,6 +202,24 @@ describe('VisualEditorScene', () => {
     expect(handleSelectMock).toHaveBeenCalledWith(1)
     expect(handlePlayToMock).toHaveBeenCalledWith(2)
     expect(handleStatementDeleteMock).toHaveBeenCalledWith(2)
+  })
+
+  it('dirty 场景会禁用播放入口', async () => {
+    const state = createSceneState()
+    state.isDirty = true
+
+    renderInBrowser(VisualEditorScene, {
+      props: {
+        state,
+      },
+      global: {
+        plugins: [createPinia()],
+        stubs: globalStubs,
+      },
+    })
+
+    await expect.element(page.getByRole('button', { name: 'play-2' })).toHaveAttribute('disabled')
+    expect(handlePlayToMock).not.toHaveBeenCalled()
   })
 
   it('视觉模式请求焦点时会把焦点恢复到选中语句卡片', async () => {

--- a/src/components/editor/VisualEditorScene.vue
+++ b/src/components/editor/VisualEditorScene.vue
@@ -80,6 +80,7 @@ useVisualEditorFocusRequest({
             :collapsed="isStatementCollapsed(props.state.statements[row.index].id)"
             :entry="props.state.statements[row.index]"
             :index="row.index"
+            :play-to-disabled="props.state.isDirty"
             :selected="props.state.statements[row.index].id === selectedStatementId"
             :readonly="preferenceStore.showSidebar && editSettings.collapseStatementsOnSidebarOpen"
             :previous-speaker="previousSpeakers[row.index]"

--- a/src/components/editor/VisualEditorStatementCard.vue
+++ b/src/components/editor/VisualEditorStatementCard.vue
@@ -10,6 +10,7 @@ import { provideStatementMeta } from '~/features/editor/statement-editor/useStat
 const props = defineProps<{
   entry: StatementEntry
   index: number
+  playToDisabled?: boolean
   selected?: boolean
   readonly?: boolean
   /** 上一条 say 语句的说话人（用于 concat 占位符） */
@@ -177,7 +178,8 @@ function paramBadgeClass(param: StatementCardPreviewParam): string {
             <Button
               variant="ghost"
               size="sm"
-              class="p-0 opacity-60 h-7 w-0 transition-all overflow-hidden hover:text-green-600 group-hover:p-1 hover:opacity-100 group-hover:w-7"
+              class="p-0 opacity-60 h-7 w-0 transition-all overflow-hidden disabled:text-muted-foreground/50 hover:text-green-600 group-hover:p-1 disabled:opacity-100 hover:opacity-100 group-hover:w-7 disabled:cursor-not-allowed disabled:pointer-events-none"
+              :disabled="playToDisabled"
               :title="$t('edit.visualEditor.playToLine')"
               @click.stop="emit('playTo', entry.id)"
             >

--- a/src/features/editor/effect-editor/__tests__/useEffectEditorProvider-queue.test.ts
+++ b/src/features/editor/effect-editor/__tests__/useEffectEditorProvider-queue.test.ts
@@ -300,6 +300,51 @@ describe('useEffectEditorProvider 队列并发', () => {
     })
   })
 
+  it('重置草稿时会回滚场景预览到初始基线', async () => {
+    useEditSettingsStore().autoApplyEffectEditorChanges = false
+
+    const provider = createEffectEditorProvider()
+
+    await provider.open({
+      entryId: 1,
+      scenePath: 'scene/001.txt',
+      baseSentence: createBaseSentence('{"blur":8}'),
+      baseLineNumber: 3,
+      baseLineText: 'changeFigure: figure.png -transform={"blur":8};',
+      previewContextLineNumber: 2,
+      previewContextLineText: 'say:previous;',
+      effectTarget: 'fig-center',
+      onApply() { /* no-op */ },
+    })
+
+    provider.updateDraft({
+      duration: '300',
+      transform: { blur: 12 },
+    })
+
+    provider.resetToInitialDraft()
+
+    await vi.waitFor(() => {
+      expect(debugCommanderMock.syncScene).toHaveBeenCalledTimes(1)
+    })
+
+    expect(debugCommanderMock.syncScene).toHaveBeenCalledWith(
+      'scene/001.txt',
+      3,
+      'changeFigure: figure.png -transform={"blur":8};',
+      true,
+    )
+    expect(debugCommanderMock.executeCommand).not.toHaveBeenCalled()
+    expect(debugCommanderMock.setEffect).not.toHaveBeenCalled()
+    expect(provider.session?.draft).toEqual({
+      duration: '',
+      ease: '',
+      transform: { blur: 8 },
+    })
+    expect(provider.canApply).toBe(false)
+    expect(provider.canReset).toBe(false)
+  })
+
   it('autoApplyQueued 在提交未完成时可串行消费后续草稿', async () => {
     const applyCalls: EffectEditorDraft[] = []
     const resolvers: (() => void)[] = []

--- a/src/features/editor/text-editor/__tests__/text-editor-play-to-line.test.ts
+++ b/src/features/editor/text-editor/__tests__/text-editor-play-to-line.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import { createTextEditorPlayToLineController } from '~/features/editor/text-editor/text-editor-play-to-line'
+import {
+  createTextEditorPlayToLineController,
+  PLAY_TO_LINE_DISABLED_GLYPH_CLASS_NAME,
+} from '~/features/editor/text-editor/text-editor-play-to-line'
 
 interface EditorModelMock {
   getLineContent: (lineNumber: number) => string
@@ -33,6 +36,7 @@ describe('文本编辑器播放到此句控制器', () => {
       getPath: () => '/project/scene.txt',
       glyphMarginTargetType: 2,
       isEnabled: () => true,
+      isDisabled: () => false,
       syncScenePreview: vi.fn(),
     })
 
@@ -70,6 +74,7 @@ describe('文本编辑器播放到此句控制器', () => {
       getPath: () => '/project/scene.txt',
       glyphMarginTargetType: 2,
       isEnabled: () => true,
+      isDisabled: () => false,
       syncScenePreview,
     })
 
@@ -113,6 +118,7 @@ describe('文本编辑器播放到此句控制器', () => {
       getPath: () => '/project/scene.txt',
       glyphMarginTargetType: 2,
       isEnabled: () => true,
+      isDisabled: () => false,
       syncScenePreview,
     })
 
@@ -144,6 +150,7 @@ describe('文本编辑器播放到此句控制器', () => {
       getPath: () => '/project/scene.txt',
       glyphMarginTargetType: 2,
       isEnabled: () => true,
+      isDisabled: () => false,
       syncScenePreview,
     })
 
@@ -180,6 +187,7 @@ describe('文本编辑器播放到此句控制器', () => {
       getPath: () => '/project/scene.txt',
       glyphMarginTargetType: 2,
       isEnabled: () => enabled,
+      isDisabled: () => false,
       syncScenePreview,
     })
 
@@ -199,6 +207,46 @@ describe('文本编辑器播放到此句控制器', () => {
     })
 
     expect(deltaDecorations).toHaveBeenNthCalledWith(2, ['glyph-1'], [])
+    expect(syncScenePreview).not.toHaveBeenCalled()
+  })
+
+  it('dirty 状态会使用禁用样式并忽略点击', () => {
+    const deltaDecorations = vi.fn().mockReturnValue(['glyph-1'])
+    const syncScenePreview = vi.fn()
+    const controller = createTextEditorPlayToLineController({
+      editor: {
+        deltaDecorations,
+        getModel: () => createModel(['say:hello']),
+        getPosition: () => ({ lineNumber: 1 }),
+      },
+      getHoverMessage: () => '执行到此句',
+      getPath: () => '/project/scene.txt',
+      glyphMarginTargetType: 2,
+      isEnabled: () => true,
+      isDisabled: () => true,
+      syncScenePreview,
+    })
+
+    controller.syncFromEditorPosition()
+    controller.handleMouseDown({
+      event: {
+        leftButton: true,
+      },
+      target: {
+        position: {
+          lineNumber: 1,
+        },
+        type: 2,
+      },
+    })
+
+    expect(deltaDecorations).toHaveBeenCalledWith([], [
+      expect.objectContaining({
+        options: expect.objectContaining({
+          glyphMarginClassName: `play-to-line-glyph ${PLAY_TO_LINE_DISABLED_GLYPH_CLASS_NAME}`,
+        }),
+      }),
+    ])
     expect(syncScenePreview).not.toHaveBeenCalled()
   })
 })

--- a/src/features/editor/text-editor/__tests__/text-editor-play-to-line.test.ts
+++ b/src/features/editor/text-editor/__tests__/text-editor-play-to-line.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest'
 import {
   createTextEditorPlayToLineController,
   PLAY_TO_LINE_DISABLED_GLYPH_CLASS_NAME,
+  PLAY_TO_LINE_GLYPH_CLASS_NAME,
 } from '~/features/editor/text-editor/text-editor-play-to-line'
 
 interface EditorModelMock {
@@ -52,7 +53,7 @@ describe('文本编辑器播放到此句控制器', () => {
           startLineNumber: 1,
         },
         options: {
-          glyphMarginClassName: 'play-to-line-glyph',
+          glyphMarginClassName: PLAY_TO_LINE_GLYPH_CLASS_NAME,
           glyphMarginHoverMessage: {
             value: '执行到此句',
           },
@@ -243,7 +244,7 @@ describe('文本编辑器播放到此句控制器', () => {
     expect(deltaDecorations).toHaveBeenCalledWith([], [
       expect.objectContaining({
         options: expect.objectContaining({
-          glyphMarginClassName: `play-to-line-glyph ${PLAY_TO_LINE_DISABLED_GLYPH_CLASS_NAME}`,
+          glyphMarginClassName: `${PLAY_TO_LINE_GLYPH_CLASS_NAME} ${PLAY_TO_LINE_DISABLED_GLYPH_CLASS_NAME}`,
         }),
       }),
     ])

--- a/src/features/editor/text-editor/__tests__/useTextEditorRuntime-preview-sync.test.ts
+++ b/src/features/editor/text-editor/__tests__/useTextEditorRuntime-preview-sync.test.ts
@@ -1,0 +1,403 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { effectScope, nextTick, reactive, shallowRef } from 'vue'
+
+import { useTextEditorRuntime } from '~/features/editor/text-editor/useTextEditorRuntime'
+
+import type { TextProjectionState } from '~/stores/editor'
+
+const {
+  applySceneCursorTargetMock,
+  didResumeSingleEditTargetMock,
+  prepareSceneCursorTargetMock,
+  readEditorHasMultipleEditTargetsMock,
+  resolveSceneCursorTargetMock,
+  resolveScenePreviewLineMock,
+  useEditorStoreMock,
+  useTabsStoreMock,
+} = vi.hoisted(() => ({
+  applySceneCursorTargetMock: vi.fn(),
+  didResumeSingleEditTargetMock: vi.fn(() => false),
+  prepareSceneCursorTargetMock: vi.fn(),
+  readEditorHasMultipleEditTargetsMock: vi.fn(() => false),
+  resolveSceneCursorTargetMock: vi.fn(() => ({
+    shouldUpdatePosition: true,
+    targetPosition: {
+      column: 1,
+      lineNumber: 2,
+    },
+  })),
+  resolveScenePreviewLineMock: vi.fn(() => ({
+    lineNumber: 2,
+    lineText: 'beta',
+  })),
+  useEditorStoreMock: vi.fn(),
+  useTabsStoreMock: vi.fn(),
+}))
+
+vi.mock('monaco-editor', () => ({
+  languages: {
+    getLanguages: vi.fn(() => []),
+  },
+  editor: {
+    CursorChangeReason: {
+      ContentFlush: 1,
+      NotSet: 0,
+    },
+    ScrollType: {
+      Immediate: 0,
+    },
+  },
+}))
+
+vi.mock('~/features/editor/text-editor/text-editor-language', () => ({
+  resolveTextEditorLanguage: vi.fn(() => 'webgal'),
+}))
+
+vi.mock('~/features/editor/text-editor/text-editor-scene-restore', () => ({
+  applySceneCursorTarget: applySceneCursorTargetMock,
+  prepareSceneCursorTarget: prepareSceneCursorTargetMock,
+}))
+
+vi.mock('~/features/editor/text-editor/text-editor-scene-sync', () => ({
+  resolveSceneCursorTarget: resolveSceneCursorTargetMock,
+  resolveScenePreviewLine: resolveScenePreviewLineMock,
+}))
+
+vi.mock('~/features/editor/text-editor/text-editor-selection', () => ({
+  didResumeSingleEditTarget: didResumeSingleEditTargetMock,
+  readEditorHasMultipleEditTargets: readEditorHasMultipleEditTargetsMock,
+}))
+
+vi.mock('~/features/editor/text-editor/useTextEditorBindings', () => ({
+  useTextEditorBindings: vi.fn(() => ({
+    consumePendingTextTransactionSource: vi.fn(),
+    handleCursorSelectionChange: vi.fn(),
+  })),
+}))
+
+vi.mock('~/features/editor/text-editor/useTextEditorContentSync', () => ({
+  useTextEditorContentSync: vi.fn(() => ({
+    handleCompositionEnd: vi.fn(),
+    handleContentChange: vi.fn(),
+  })),
+}))
+
+vi.mock('~/features/editor/text-editor/useTextEditorHistory', () => ({
+  useTextEditorHistory: vi.fn(() => ({
+    captureBeforeContentChange: vi.fn(),
+    handleCompositionEnd: vi.fn(),
+    installHistoryHandling: vi.fn(),
+    rememberCurrentCursorSnapshot: vi.fn(),
+  })),
+}))
+
+vi.mock('~/features/editor/text-editor/useTextEditorPanel', () => ({
+  useTextEditorPanel: vi.fn(() => ({})),
+}))
+
+vi.mock('~/features/editor/text-editor/useTextEditorWorkspace', () => ({
+  useTextEditorWorkspace: vi.fn(() => ({
+    ensureModel: vi.fn(),
+    markEditorCreated: vi.fn(),
+    markFileInteracted: vi.fn(),
+    markFileOpened: vi.fn(),
+    restoreViewState: vi.fn(),
+    saveViewState: vi.fn(),
+    switchModel: vi.fn(),
+    syncCurrentModelLanguage: vi.fn(),
+  })),
+}))
+
+vi.mock('~/stores/editor', () => ({
+  isEditableEditor: (state: { projection?: string }) => 'projection' in state,
+  useEditorStore: useEditorStoreMock,
+}))
+
+vi.mock('~/stores/tabs', () => ({
+  useTabsStore: useTabsStoreMock,
+}))
+
+function createState(path: string): TextProjectionState {
+  return reactive({
+    isDirty: false,
+    kind: 'scene' as const,
+    path,
+    projection: 'text' as const,
+    textContent: 'alpha\nbeta',
+    textSource: 'projection' as const,
+  }) as TextProjectionState
+}
+
+function createEditor() {
+  return {
+    getModel: vi.fn(() => ({
+      getLineContent: vi.fn((lineNumber: number) => lineNumber === 2 ? 'beta' : 'alpha'),
+      getLineCount: vi.fn(() => 2),
+      getLineMaxColumn: vi.fn(() => 5),
+    })),
+    getPosition: vi.fn(() => ({
+      column: 1,
+      lineNumber: 2,
+    })),
+  }
+}
+
+function flushRuntimeWatchers() {
+  return nextTick().then(() => nextTick())
+}
+
+describe('useTextEditorRuntime 预览同步', () => {
+  beforeEach(() => {
+    applySceneCursorTargetMock.mockReset()
+    didResumeSingleEditTargetMock.mockReset()
+    prepareSceneCursorTargetMock.mockReset()
+    readEditorHasMultipleEditTargetsMock.mockReset()
+    resolveSceneCursorTargetMock.mockClear()
+    resolveScenePreviewLineMock.mockClear()
+    useEditorStoreMock.mockReset()
+    useTabsStoreMock.mockReset()
+
+    didResumeSingleEditTargetMock.mockReturnValue(false)
+    readEditorHasMultipleEditTargetsMock.mockReturnValue(false)
+
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      callback(0)
+      return 1
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('消费文本投影激活标记时会恢复光标位置且不会同步预览', async () => {
+    const path = '/project/scene.txt'
+    const state = createState(path)
+    const editor = createEditor()
+    const editorStore = reactive({
+      currentState: {
+        kind: 'scene',
+        path,
+        projection: 'visual' as const,
+      } as {
+        kind: 'scene'
+        path: string
+        projection: 'text' | 'visual'
+      },
+      getSceneSelection: vi.fn(() => ({
+        lastLineNumber: 2,
+        selectedStatementId: 1,
+      })),
+      getState: vi.fn(),
+      redoDocument: vi.fn(),
+      registerSaveHook: vi.fn(),
+      replaceTextDocumentContent: vi.fn(),
+      scheduleAutoSaveIfEnabled: vi.fn(),
+      consumePendingSceneProjectionActivation: vi.fn(() => true),
+      setTextProjectionDraft: vi.fn(),
+      syncScenePreview: vi.fn(),
+      syncSceneSelectionFromTextLine: vi.fn(),
+      undoDocument: vi.fn(),
+      unregisterSaveHook: vi.fn(),
+    })
+    const tabsStore = reactive({
+      activeTab: {
+        isPreview: false,
+        path,
+      },
+      shouldFocusEditor: false,
+      tabs: [{ path }],
+    })
+
+    useEditorStoreMock.mockReturnValue(editorStore)
+    useTabsStoreMock.mockReturnValue(tabsStore)
+
+    const scope = effectScope()
+    scope.run(() => {
+      useTextEditorRuntime({
+        editorRef: shallowRef(editor) as never,
+        getState: () => state,
+      })
+    })
+
+    await flushRuntimeWatchers()
+    prepareSceneCursorTargetMock.mockClear()
+    applySceneCursorTargetMock.mockClear()
+    editorStore.syncScenePreview.mockClear()
+
+    editorStore.currentState = {
+      kind: 'scene',
+      path,
+      projection: 'text',
+    }
+
+    await flushRuntimeWatchers()
+
+    expect(prepareSceneCursorTargetMock).toHaveBeenCalledTimes(1)
+    expect(applySceneCursorTargetMock).toHaveBeenCalledTimes(1)
+    expect(editorStore.syncScenePreview).not.toHaveBeenCalled()
+
+    scope.stop()
+  })
+
+  it('同一行内移动光标时不会重复同步预览', () => {
+    const path = '/project/scene-same-line.txt'
+    const state = createState(path)
+    const editorStore = reactive({
+      currentState: {
+        kind: 'scene',
+        path,
+        projection: 'text' as const,
+      },
+      getSceneSelection: vi.fn(() => ({
+        lastLineNumber: 2,
+        selectedStatementId: 1,
+      })),
+      getState: vi.fn(),
+      redoDocument: vi.fn(),
+      registerSaveHook: vi.fn(),
+      replaceTextDocumentContent: vi.fn(),
+      scheduleAutoSaveIfEnabled: vi.fn(),
+      consumePendingSceneProjectionActivation: vi.fn(() => false),
+      setTextProjectionDraft: vi.fn(),
+      syncScenePreview: vi.fn(),
+      syncSceneSelectionFromTextLine: vi.fn(),
+      undoDocument: vi.fn(),
+      unregisterSaveHook: vi.fn(),
+    })
+    const tabsStore = reactive({
+      activeTab: {
+        isPreview: false,
+        path,
+      },
+      shouldFocusEditor: false,
+      tabs: [{ path }],
+    })
+
+    useEditorStoreMock.mockReturnValue(editorStore)
+    useTabsStoreMock.mockReturnValue(tabsStore)
+
+    const runtime = useTextEditorRuntime({
+      editorRef: shallowRef(createEditor()) as never,
+      getState: () => state,
+    })
+
+    runtime.handleCursorPositionChange({
+      position: {
+        column: 4,
+        lineNumber: 2,
+      },
+      reason: 3,
+    } as never)
+
+    expect(editorStore.syncSceneSelectionFromTextLine).not.toHaveBeenCalled()
+    expect(editorStore.syncScenePreview).not.toHaveBeenCalled()
+  })
+
+  it('跨行移动光标时会同步预览到新的关注行', () => {
+    const path = '/project/scene-cross-line.txt'
+    const state = createState(path)
+    const editorStore = reactive({
+      currentState: {
+        kind: 'scene',
+        path,
+        projection: 'text' as const,
+      },
+      getSceneSelection: vi.fn(() => ({
+        lastLineNumber: 1,
+        selectedStatementId: 1,
+      })),
+      getState: vi.fn(),
+      redoDocument: vi.fn(),
+      registerSaveHook: vi.fn(),
+      replaceTextDocumentContent: vi.fn(),
+      scheduleAutoSaveIfEnabled: vi.fn(),
+      consumePendingSceneProjectionActivation: vi.fn(() => false),
+      setTextProjectionDraft: vi.fn(),
+      syncScenePreview: vi.fn(),
+      syncSceneSelectionFromTextLine: vi.fn(),
+      undoDocument: vi.fn(),
+      unregisterSaveHook: vi.fn(),
+    })
+    const tabsStore = reactive({
+      activeTab: {
+        isPreview: false,
+        path,
+      },
+      shouldFocusEditor: false,
+      tabs: [{ path }],
+    })
+
+    useEditorStoreMock.mockReturnValue(editorStore)
+    useTabsStoreMock.mockReturnValue(tabsStore)
+
+    const runtime = useTextEditorRuntime({
+      editorRef: shallowRef(createEditor()) as never,
+      getState: () => state,
+    })
+
+    runtime.handleCursorPositionChange({
+      position: {
+        column: 1,
+        lineNumber: 2,
+      },
+      reason: 3,
+    } as never)
+
+    expect(editorStore.syncSceneSelectionFromTextLine).toHaveBeenCalledWith(path, 2)
+    expect(editorStore.syncScenePreview).toHaveBeenCalledWith(path, 2, 'beta')
+  })
+
+  it('从多目标恢复为单目标时会同步预览到当前关注行', () => {
+    const path = '/project/scene-selection-resume.txt'
+    const state = createState(path)
+    const editorStore = reactive({
+      currentState: {
+        kind: 'scene',
+        path,
+        projection: 'text' as const,
+      },
+      getSceneSelection: vi.fn(() => ({
+        lastLineNumber: 1,
+        selectedStatementId: 1,
+      })),
+      getState: vi.fn(),
+      redoDocument: vi.fn(),
+      registerSaveHook: vi.fn(),
+      replaceTextDocumentContent: vi.fn(),
+      scheduleAutoSaveIfEnabled: vi.fn(),
+      consumePendingSceneProjectionActivation: vi.fn(() => false),
+      setTextProjectionDraft: vi.fn(),
+      syncScenePreview: vi.fn(),
+      syncSceneSelectionFromTextLine: vi.fn(),
+      undoDocument: vi.fn(),
+      unregisterSaveHook: vi.fn(),
+    })
+    const tabsStore = reactive({
+      activeTab: {
+        isPreview: false,
+        path,
+      },
+      shouldFocusEditor: false,
+      tabs: [{ path }],
+    })
+
+    useEditorStoreMock.mockReturnValue(editorStore)
+    useTabsStoreMock.mockReturnValue(tabsStore)
+    didResumeSingleEditTargetMock.mockReturnValue(true)
+
+    const runtime = useTextEditorRuntime({
+      editorRef: shallowRef(createEditor()) as never,
+      getState: () => state,
+    })
+
+    runtime.handleCursorSelectionChange({
+      selection: {
+        positionLineNumber: 2,
+      },
+    } as never)
+
+    expect(editorStore.syncSceneSelectionFromTextLine).toHaveBeenCalledWith(path, 2)
+    expect(editorStore.syncScenePreview).toHaveBeenCalledWith(path, 2, 'beta')
+  })
+})

--- a/src/features/editor/text-editor/text-editor-play-to-line.ts
+++ b/src/features/editor/text-editor/text-editor-play-to-line.ts
@@ -3,6 +3,7 @@ import { resolvePlayableScenePreviewLine } from '~/features/editor/text-editor/t
 import type { TextEditorLineReader } from '~/features/editor/text-editor/text-editor-scene-sync'
 
 export const PLAY_TO_LINE_GLYPH_CLASS_NAME = 'play-to-line-glyph'
+export const PLAY_TO_LINE_DISABLED_GLYPH_CLASS_NAME = 'play-to-line-glyph-disabled'
 
 export interface TextEditorPlayToLineEditor {
   deltaDecorations: (
@@ -46,12 +47,14 @@ interface CreateTextEditorPlayToLineControllerOptions {
   getPath: () => string
   glyphMarginTargetType: number
   isEnabled: () => boolean
+  isDisabled: () => boolean
   syncScenePreview: (path: string, lineNumber: number, lineText: string, force: boolean) => void
 }
 
 function createPlayToLineDecoration(
   lineNumber: number,
   hoverMessage: string,
+  disabled: boolean,
 ): TextEditorPlayToLineDecoration {
   return {
     range: {
@@ -61,7 +64,9 @@ function createPlayToLineDecoration(
       startLineNumber: lineNumber,
     },
     options: {
-      glyphMarginClassName: PLAY_TO_LINE_GLYPH_CLASS_NAME,
+      glyphMarginClassName: disabled
+        ? `${PLAY_TO_LINE_GLYPH_CLASS_NAME} ${PLAY_TO_LINE_DISABLED_GLYPH_CLASS_NAME}`
+        : PLAY_TO_LINE_GLYPH_CLASS_NAME,
       glyphMarginHoverMessage: {
         value: hoverMessage,
       },
@@ -102,7 +107,7 @@ export function createTextEditorPlayToLineController(options: CreateTextEditorPl
     }
 
     decorationIds = options.editor.deltaDecorations(decorationIds, [
-      createPlayToLineDecoration(previewLine.lineNumber, options.getHoverMessage()),
+      createPlayToLineDecoration(previewLine.lineNumber, options.getHoverMessage(), options.isDisabled()),
     ])
     decoratedLineNumber = previewLine.lineNumber
   }
@@ -113,6 +118,10 @@ export function createTextEditorPlayToLineController(options: CreateTextEditorPl
 
   function handleMouseDown(event: TextEditorPlayToLineMouseEvent) {
     if (!options.isEnabled()) {
+      return
+    }
+
+    if (options.isDisabled()) {
       return
     }
 

--- a/src/features/editor/text-editor/useTextEditorRuntime.ts
+++ b/src/features/editor/text-editor/useTextEditorRuntime.ts
@@ -283,7 +283,6 @@ export function useTextEditorRuntime(options: UseTextEditorRuntimeOptions) {
 
   function syncTextCursorFromSceneSelection(options: {
     persistViewState?: boolean
-    syncPreview?: boolean
   } = {}) {
     if (state.value.kind !== 'scene') {
       return
@@ -302,9 +301,6 @@ export function useTextEditorRuntime(options: UseTextEditorRuntimeOptions) {
     scheduleApplyLastLineNumber(() => {
       if (options.persistViewState) {
         textEditorWorkspace.saveViewState(state.value.path)
-      }
-      if (options.syncPreview) {
-        syncScene()
       }
     })
   }
@@ -327,10 +323,6 @@ export function useTextEditorRuntime(options: UseTextEditorRuntimeOptions) {
       value: state.value.textContent,
     })
     syncedModelPath = newPath
-
-    nextTick(() => {
-      syncScene()
-    })
   }
 
   function syncEditorModelToState() {
@@ -391,22 +383,30 @@ export function useTextEditorRuntime(options: UseTextEditorRuntimeOptions) {
       () => tabsStore.shouldFocusEditor,
       () => tabsStore.activeTab?.path,
     ],
-    ([projection, shouldFocus, activePath], [previousProjection]) => {
-      if (projection === 'text' && shouldFocus && activePath === state.value.path && readEditor()) {
+    ([projection, shouldFocus, activePath]) => {
+      let hasSyncedModel = false
+      function ensureSyncedModel() {
+        if (hasSyncedModel) {
+          return
+        }
+
+        hasSyncedModel = true
         syncEditorModelToState()
+      }
+
+      if (projection === 'text' && shouldFocus && activePath === state.value.path && readEditor()) {
+        ensureSyncedModel()
         textEditorWorkspace.restoreViewState(state.value.path)
       }
 
-      if (
-        projection === 'text'
-        && previousProjection === 'visual'
+      const shouldActivateTextProjection = projection === 'text'
         && activePath === state.value.path
         && state.value.kind === 'scene'
-      ) {
-        syncEditorModelToState()
-        syncTextCursorFromSceneSelection({
-          syncPreview: true,
-        })
+        && editorStore.consumePendingSceneProjectionActivation(state.value.path, 'text')
+
+      if (shouldActivateTextProjection) {
+        ensureSyncedModel()
+        syncTextCursorFromSceneSelection()
       }
     },
   )

--- a/src/features/editor/visual-editor/__tests__/useVisualEditorSceneRuntime.test.ts
+++ b/src/features/editor/visual-editor/__tests__/useVisualEditorSceneRuntime.test.ts
@@ -8,6 +8,7 @@ import { useVisualEditorSceneRuntime } from '../useVisualEditorSceneRuntime'
 import type { SceneVisualProjectionState } from '~/stores/editor'
 
 const {
+  restoreSelectionAndScrollMock,
   useCommandPanelBridgeBindingMock,
   useCommandPanelStoreMock,
   useEditSettingsStoreMock,
@@ -19,6 +20,7 @@ const {
   useTabsStoreMock,
   useVisualEditorSceneViewportMock,
 } = vi.hoisted(() => ({
+  restoreSelectionAndScrollMock: vi.fn(async () => undefined),
   useCommandPanelBridgeBindingMock: vi.fn(),
   useCommandPanelStoreMock: vi.fn(),
   useEditSettingsStoreMock: vi.fn(),
@@ -112,12 +114,13 @@ function createState(
   }) as SceneVisualProjectionState
 }
 
-describe('useVisualEditorSceneRuntime 的快捷键注册与预览同步', () => {
+describe('useVisualEditorSceneRuntime 的快捷键、投影同步与预览行为', () => {
   afterEach(() => {
     vi.unstubAllGlobals()
   })
 
   beforeEach(() => {
+    restoreSelectionAndScrollMock.mockReset()
     useCommandPanelBridgeBindingMock.mockReset()
     useCommandPanelStoreMock.mockReset()
     useEditSettingsStoreMock.mockReset()
@@ -140,6 +143,7 @@ describe('useVisualEditorSceneRuntime 的快捷键注册与预览同步', () => 
       applySceneStatementInsert: vi.fn(),
       applySceneStatementReorder: vi.fn(),
       applySceneStatementUpdate: vi.fn(),
+      consumePendingSceneProjectionActivation: vi.fn(() => false),
       currentState: {
         kind: 'scene',
         path: '/project/scene.txt',
@@ -172,6 +176,7 @@ describe('useVisualEditorSceneRuntime 的快捷键注册与预览同步', () => 
     useVisualEditorSceneViewportMock.mockReturnValue({
       isPositioning: computed(() => false),
       measureRowElement: vi.fn(),
+      restoreSelectionAndScroll: restoreSelectionAndScrollMock,
       scrollToSelectedStatement: vi.fn(async () => undefined),
       totalSize: computed(() => 0),
       virtualRows: computed(() => []),
@@ -215,7 +220,107 @@ describe('useVisualEditorSceneRuntime 的快捷键注册与预览同步', () => 
     scope.stop()
   })
 
-  it('键盘重排语句后会同步实时预览到新的行号', async () => {
+  it('消费可视化投影激活标记时会恢复选中项与滚动位置', async () => {
+    const scope = effectScope()
+    const state = createState()
+    const consumePendingSceneProjectionActivation = vi.fn(() => true)
+
+    useEditorStoreMock.mockReturnValue(reactive({
+      applySceneStatementDelete: vi.fn(),
+      applySceneStatementInsert: vi.fn(),
+      applySceneStatementReorder: vi.fn(),
+      applySceneStatementUpdate: vi.fn(),
+      consumePendingSceneProjectionActivation,
+      currentState: {
+        kind: 'scene',
+        path: '/project/scene.txt',
+        projection: 'visual',
+      },
+      getSceneSelection: vi.fn(() => ({
+        lastEditedStatementId: 1,
+        lastLineNumber: 1,
+        selectedStatementId: 1,
+      })),
+      isSceneStatementCollapsed: vi.fn(() => false),
+      scheduleAutoSaveIfEnabled: vi.fn(),
+      setSceneStatementCollapsed: vi.fn(),
+      syncScenePreview: vi.fn(),
+      syncSceneSelectionFromStatement: vi.fn(),
+    }))
+
+    scope.run(() => useVisualEditorSceneRuntime({
+      getScrollArea: () => undefined,
+      getState: () => state,
+    }))
+
+    await nextTick()
+
+    expect(consumePendingSceneProjectionActivation).toHaveBeenCalledWith('/project/scene.txt', 'visual')
+    expect(restoreSelectionAndScrollMock).toHaveBeenCalledTimes(1)
+
+    scope.stop()
+  })
+
+  it('脏场景切换选中语句时不会同步实时预览', () => {
+    const scope = effectScope()
+    const state = createState([
+      {
+        id: 1,
+        parseError: false,
+        parsed: undefined,
+        rawText: 'say:first',
+      },
+      {
+        id: 2,
+        parseError: false,
+        parsed: undefined,
+        rawText: 'say:second',
+      },
+    ])
+    state.isDirty = true
+    const syncScenePreview = vi.fn()
+    const syncSceneSelectionFromStatement = vi.fn()
+
+    useEditorStoreMock.mockReturnValue(reactive({
+      applySceneStatementDelete: vi.fn(),
+      applySceneStatementInsert: vi.fn(),
+      applySceneStatementReorder: vi.fn(),
+      applySceneStatementUpdate: vi.fn(),
+      consumePendingSceneProjectionActivation: vi.fn(() => false),
+      currentState: {
+        kind: 'scene',
+        path: '/project/scene.txt',
+        projection: 'visual',
+      },
+      getSceneSelection: vi.fn(() => ({
+        lastEditedStatementId: 1,
+        lastLineNumber: 1,
+        selectedStatementId: 1,
+      })),
+      isSceneStatementCollapsed: vi.fn(() => false),
+      scheduleAutoSaveIfEnabled: vi.fn(),
+      setSceneStatementCollapsed: vi.fn(),
+      syncScenePreview,
+      syncSceneSelectionFromStatement,
+    }))
+
+    const runtime = scope.run(() => useVisualEditorSceneRuntime({
+      getScrollArea: () => undefined,
+      getState: () => state,
+    }))
+
+    runtime?.handleSelect(2)
+
+    expect(syncSceneSelectionFromStatement).toHaveBeenCalledWith('/project/scene.txt', 2, {
+      lastEditedStatementId: 2,
+      lineNumber: 2,
+    })
+    expect(syncScenePreview).not.toHaveBeenCalled()
+
+    scope.stop()
+  })
+
+  it('键盘重排语句后不会自动同步实时预览', async () => {
     const scope = effectScope()
     const state = createState([
       {
@@ -256,6 +361,7 @@ describe('useVisualEditorSceneRuntime 的快捷键注册与预览同步', () => 
       applySceneStatementInsert: vi.fn(),
       applySceneStatementReorder,
       applySceneStatementUpdate: vi.fn(),
+      consumePendingSceneProjectionActivation: vi.fn(() => false),
       currentState: {
         kind: 'scene',
         path: '/project/scene.txt',
@@ -285,7 +391,7 @@ describe('useVisualEditorSceneRuntime 的快捷键注册与预览同步', () => 
     await nextTick()
 
     expect(applySceneStatementReorder).toHaveBeenCalledWith('/project/scene.txt', 0, 1)
-    expect(syncScenePreview).toHaveBeenCalledWith('/project/scene.txt', 2, 'say:first')
+    expect(syncScenePreview).not.toHaveBeenCalled()
     expect(scheduleAutoSaveIfEnabled).toHaveBeenCalledWith('/project/scene.txt')
 
     scope.stop()

--- a/src/features/editor/visual-editor/useVisualEditorSceneRuntime.ts
+++ b/src/features/editor/visual-editor/useVisualEditorSceneRuntime.ts
@@ -38,7 +38,7 @@ export function useVisualEditorSceneRuntime(options: UseVisualEditorSceneRuntime
   }
 
   function syncStatementPreview(statementId: number | undefined, force: boolean = false): void {
-    if (statementId === undefined) {
+    if (statementId === undefined || state.value.isDirty) {
       return
     }
 
@@ -261,7 +261,6 @@ export function useVisualEditorSceneRuntime(options: UseVisualEditorSceneRuntime
     }
 
     editorStore.applySceneStatementReorder(state.value.path, currentSelectedIndex, nextIndex)
-    syncStatementPreview(currentSelectedStatementId)
     void restoreSelectedStatementPresentation({
       align: 'auto',
       focus: true,
@@ -310,8 +309,6 @@ export function useVisualEditorSceneRuntime(options: UseVisualEditorSceneRuntime
 
   const previousSpeakers = computed(() => buildPreviousSpeakers(state.value.statements))
   const viewport = useVisualEditorSceneViewport({
-    getActiveProjection: () => activeProjection.value,
-    getActiveTabPath: () => tabsStore.activeTab?.path,
     getScrollArea: options.getScrollArea,
     getSelectedIndex: () => selectedIndex.value,
     getState: () => state.value,
@@ -434,6 +431,24 @@ export function useVisualEditorSceneRuntime(options: UseVisualEditorSceneRuntime
     () => {
       ensureSelectedStatementPresent()
     },
+  )
+
+  watch(
+    [
+      () => activeProjection.value,
+      () => tabsStore.activeTab?.path,
+    ],
+    ([projection, activePath]) => {
+      const shouldActivateVisualProjection = projection === 'visual'
+        && activePath === state.value.path
+        && editorStore.consumePendingSceneProjectionActivation(state.value.path, 'visual')
+      if (!shouldActivateVisualProjection) {
+        return
+      }
+
+      void viewport.restoreSelectionAndScroll()
+    },
+    { immediate: true },
   )
 
   const sceneShortcutWhen = {

--- a/src/features/editor/visual-editor/useVisualEditorSceneViewport.ts
+++ b/src/features/editor/visual-editor/useVisualEditorSceneViewport.ts
@@ -3,8 +3,6 @@ import { useVirtualizer } from '@tanstack/vue-virtual'
 import { SceneVisualProjectionState } from '~/stores/editor'
 
 interface UseVisualEditorSceneViewportOptions {
-  getActiveProjection: () => 'text' | 'visual' | undefined
-  getActiveTabPath: () => string | undefined
   getScrollArea: () => InstanceType<typeof ScrollArea> | null | undefined
   getSelectedIndex: () => number
   getState: () => SceneVisualProjectionState
@@ -13,7 +11,6 @@ interface UseVisualEditorSceneViewportOptions {
 
 export function useVisualEditorSceneViewport(options: UseVisualEditorSceneViewportOptions) {
   const state = computed(() => options.getState())
-  const activeProjection = computed(() => options.getActiveProjection())
 
   const rowVirtualizer = useVirtualizer(
     computed(() => ({
@@ -113,22 +110,11 @@ export function useVisualEditorSceneViewport(options: UseVisualEditorSceneViewpo
   watch(() => state.value.path, () => {
     void restoreSelectionAndScroll()
   })
-  watch(
-    [activeProjection, () => options.getActiveTabPath()],
-    ([projection, activePath], [previousProjection]) => {
-      if (
-        projection === 'visual'
-        && previousProjection === 'text'
-        && activePath === state.value.path
-      ) {
-        void restoreSelectionAndScroll()
-      }
-    },
-  )
 
   return {
     isPositioning,
     measureRowElement,
+    restoreSelectionAndScroll,
     scrollToSelectedStatement,
     totalSize,
     virtualRows,

--- a/src/stores/__tests__/editor.test.ts
+++ b/src/stores/__tests__/editor.test.ts
@@ -34,6 +34,23 @@ let externalDocumentModalAction: 'keep-local' | 'load-external' | 'merge' | 'can
 const asyncFixtureTimeoutMs = 10 * 1000
 let useEditorStore: typeof import('../editor').useEditorStore
 
+function isSceneVisualState(
+  state: unknown,
+): state is {
+  kind: 'scene'
+  projection: 'visual'
+  statements: { id: number }[]
+} {
+  return typeof state === 'object'
+    && state !== null
+    && 'projection' in state
+    && 'kind' in state
+    && 'statements' in state
+    && (state as { projection?: unknown }).projection === 'visual'
+    && (state as { kind?: unknown }).kind === 'scene'
+    && Array.isArray((state as { statements?: unknown }).statements)
+}
+
 const preferenceStoreMock = reactive({
   editorMode: 'text' as 'text' | 'visual',
 })
@@ -656,7 +673,7 @@ describe('编辑器状态仓库的文本与文档流程', () => {
     expect(editorStore.currentSelectedSceneStatement?.id).toBe(visualProjection.statements[0]?.id)
   })
 
-  it('切换到可视模式时也会请求重新聚焦编辑器表面', async () => {
+  it('切换到可视模式时会记录待激活投影并请求重新聚焦编辑器表面', async () => {
     const tabsStore = useTabsStore()
     const path = '/game/scene/switch-mode-focus.txt'
 
@@ -676,6 +693,63 @@ describe('编辑器状态仓库的文本与文档流程', () => {
 
     expect(preferenceStoreMock.editorMode).toBe('visual')
     expect(tabsStore.shouldFocusEditor).toBe(true)
+    expect(editorStore.consumePendingSceneProjectionActivation(path, 'text')).toBe(false)
+    expect(editorStore.consumePendingSceneProjectionActivation(path, 'visual')).toBe(true)
+    expect(editorStore.consumePendingSceneProjectionActivation(path, 'visual')).toBe(false)
+  })
+
+  it('切回文本模式时由 store 记录并消费文本投影激活标记', async () => {
+    const tabsStore = useTabsStore()
+    const path = '/game/scene/switch-mode-text-sync.txt'
+
+    preferenceStoreMock.editorMode = 'visual'
+
+    const editorStore = useEditorStore()
+
+    await openTabAndWaitFor(
+      tabsStore,
+      'switch-mode-text-sync.txt',
+      path,
+      () => editorStore.currentTextProjection !== undefined && editorStore.currentVisualProjection !== undefined,
+      'load projections for text mode activation',
+    )
+
+    if (!editorStore.currentState || !('projection' in editorStore.currentState)) {
+      throw new TypeError('expected editable editor state')
+    }
+
+    expect(editorStore.currentState.projection).toBe('visual')
+
+    tabsStore.shouldFocusEditor = false
+
+    editorStore.switchEditorMode('text', path)
+
+    expect(preferenceStoreMock.editorMode).toBe('text')
+    expect(tabsStore.shouldFocusEditor).toBe(true)
+    expect(editorStore.consumePendingSceneProjectionActivation(path, 'visual')).toBe(false)
+    expect(editorStore.consumePendingSceneProjectionActivation(path, 'text')).toBe(true)
+    expect(editorStore.consumePendingSceneProjectionActivation(path, 'text')).toBe(false)
+  })
+
+  it('重复切换到相同模式时不会清空既有投影激活标记', async () => {
+    const tabsStore = useTabsStore()
+    const path = '/game/scene/switch-mode-repeat-visual.txt'
+
+    const editorStore = useEditorStore()
+
+    await openTabAndWaitFor(
+      tabsStore,
+      'switch-mode-repeat-visual.txt',
+      path,
+      () => editorStore.currentTextProjection !== undefined && editorStore.currentVisualProjection !== undefined,
+      'load projections for repeated visual activation',
+    )
+
+    editorStore.switchEditorMode('visual', path)
+    editorStore.switchEditorMode('visual', path)
+
+    expect(editorStore.consumePendingSceneProjectionActivation(path, 'visual')).toBe(true)
+    expect(editorStore.consumePendingSceneProjectionActivation(path, 'visual')).toBe(false)
   })
 
   it('文本补丁重建语句后仍按语句 ID 保持场景侧栏选中项', async () => {
@@ -1234,6 +1308,143 @@ describe('编辑器状态仓库的文本与文档流程', () => {
     await editorStore.saveFile(path)
 
     expect(syncSceneMock).toHaveBeenCalledWith(path, 1, 'hello!', false)
+  })
+
+  it('切换场景标签页时重新同步当前预览行', async () => {
+    const tabsStore = useTabsStore()
+    const firstPath = '/game/scene/first.txt'
+    const secondPath = '/game/scene/second.txt'
+
+    readFileMock
+      .mockResolvedValueOnce(new TextEncoder().encode('alpha\nbeta'))
+      .mockResolvedValueOnce(new TextEncoder().encode('gamma\ndelta'))
+    mimeGetTypeMock.mockReturnValue('text/plain')
+
+    const editorStore = useEditorStore()
+
+    await openTabAndWaitFor(
+      tabsStore,
+      'first.txt',
+      firstPath,
+      () => editorStore.hasState(firstPath),
+      'load first scene document',
+    )
+    await openTabAndWaitFor(
+      tabsStore,
+      'second.txt',
+      secondPath,
+      () => editorStore.hasState(secondPath),
+      'load second scene document',
+    )
+
+    editorStore.syncSceneSelectionFromTextLine(firstPath, 2)
+    editorStore.syncSceneSelectionFromTextLine(secondPath, 2)
+    syncSceneMock.mockReset()
+
+    tabsStore.activateTab(0)
+    await flushEditorWatchers()
+
+    expect(syncSceneMock).toHaveBeenNthCalledWith(1, firstPath, 2, 'beta', false)
+
+    tabsStore.activateTab(1)
+    await flushEditorWatchers()
+
+    expect(syncSceneMock).toHaveBeenNthCalledWith(2, secondPath, 2, 'delta', false)
+  })
+
+  it('可视化场景切换标签页时重新同步当前预览语句', async () => {
+    const tabsStore = useTabsStore()
+    const firstPath = '/game/scene/visual-first.txt'
+    const secondPath = '/game/scene/visual-second.txt'
+
+    preferenceStoreMock.editorMode = 'visual'
+    readFileMock
+      .mockResolvedValueOnce(new TextEncoder().encode('alpha\nbeta'))
+      .mockResolvedValueOnce(new TextEncoder().encode('gamma\ndelta'))
+    mimeGetTypeMock.mockReturnValue('text/plain')
+
+    const editorStore = useEditorStore()
+
+    await openTabAndWaitFor(
+      tabsStore,
+      'visual-first.txt',
+      firstPath,
+      () => {
+        const state = editorStore.getState(firstPath)
+        return Boolean(state && 'projection' in state && state.projection === 'visual')
+      },
+      'load first visual scene document',
+    )
+    const firstProjection = editorStore.getState(firstPath)
+    if (!isSceneVisualState(firstProjection)) {
+      throw new TypeError('expected first visual scene projection')
+    }
+
+    await openTabAndWaitFor(
+      tabsStore,
+      'visual-second.txt',
+      secondPath,
+      () => {
+        const state = editorStore.getState(secondPath)
+        return Boolean(state && 'projection' in state && state.projection === 'visual')
+      },
+      'load second visual scene document',
+    )
+    const secondProjection = editorStore.getState(secondPath)
+    if (!isSceneVisualState(secondProjection)) {
+      throw new TypeError('expected second visual scene projection')
+    }
+
+    editorStore.syncSceneSelectionFromStatement(firstPath, firstProjection.statements[1]?.id, { lineNumber: 2 })
+    editorStore.syncSceneSelectionFromStatement(secondPath, secondProjection.statements[1]?.id, { lineNumber: 2 })
+    syncSceneMock.mockReset()
+
+    tabsStore.activateTab(0)
+    await flushEditorWatchers()
+
+    expect(syncSceneMock).toHaveBeenNthCalledWith(1, firstPath, 2, 'beta', false)
+
+    tabsStore.activateTab(1)
+    await flushEditorWatchers()
+
+    expect(syncSceneMock).toHaveBeenNthCalledWith(2, secondPath, 2, 'delta', false)
+  })
+
+  it('切换到脏场景标签页时不会补发预览同步', async () => {
+    const tabsStore = useTabsStore()
+    const firstPath = '/game/scene/dirty-first.txt'
+    const secondPath = '/game/scene/clean-second.txt'
+
+    readFileMock
+      .mockResolvedValueOnce(new TextEncoder().encode('alpha\nbeta'))
+      .mockResolvedValueOnce(new TextEncoder().encode('gamma\ndelta'))
+    mimeGetTypeMock.mockReturnValue('text/plain')
+
+    const editorStore = useEditorStore()
+
+    await openTabAndWaitFor(
+      tabsStore,
+      'dirty-first.txt',
+      firstPath,
+      () => editorStore.hasState(firstPath),
+      'load dirty first scene document',
+    )
+    await openTabAndWaitFor(
+      tabsStore,
+      'clean-second.txt',
+      secondPath,
+      () => editorStore.hasState(secondPath),
+      'load clean second scene document',
+    )
+
+    editorStore.applyTextDocumentContent(firstPath, 'alpha!\nbeta')
+    editorStore.syncSceneSelectionFromTextLine(firstPath, 2)
+    syncSceneMock.mockReset()
+
+    tabsStore.activateTab(0)
+    await flushEditorWatchers()
+
+    expect(syncSceneMock).not.toHaveBeenCalled()
   })
 
   it('第二个保存钩子失败时仍保留已完成的场景预览同步', async () => {

--- a/src/stores/editor.ts
+++ b/src/stores/editor.ts
@@ -42,6 +42,7 @@ import type {
   EditableEditorState,
   EditorSession,
   EditorState,
+  SceneProjectionActivation,
   TextProjectionState,
   VisualProjectionState,
 } from './internal/editor-session'
@@ -495,11 +496,55 @@ export const useEditorStore = defineStore('editor', () => {
   }
 
   function switchEditorMode(mode: 'text' | 'visual', targetPath?: string) {
-    if (!setActiveProjection(mode, targetPath)) {
+    const path = targetPath ?? tabsStore.activeTab?.path
+    if (!path) {
       return
     }
+
+    const currentState = getState(path)
+    const previousProjection = currentState && isEditableEditor(currentState)
+      ? currentState.projection
+      : undefined
+
+    if (!setActiveProjection(mode, path)) {
+      return
+    }
+
+    const session = getEditableSession(path)
+    if (session?.document.model.kind === 'scene' && previousProjection !== mode) {
+      session.pendingSceneProjectionActivation = mode
+    }
+
     usePreferenceStore().editorMode = mode
     tabsStore.shouldFocusEditor = true
+  }
+
+  function consumePendingSceneProjectionActivation(
+    path: string,
+    targetProjection: SceneProjectionActivation,
+  ): boolean {
+    const session = getEditableSession(path)
+    const pendingActivation = session?.pendingSceneProjectionActivation
+    if (!pendingActivation || pendingActivation !== targetProjection) {
+      return false
+    }
+
+    session.pendingSceneProjectionActivation = undefined
+    return true
+  }
+
+  function syncActiveScenePreview(path: string) {
+    const session = getEditableSession(path)
+    if (!session || session.document.model.kind !== 'scene') {
+      return
+    }
+
+    if (getEditableState(path)?.isDirty) {
+      return
+    }
+
+    const sceneCursor = resolveSceneCursor(session.document.savedTextContent, session.sceneSelection?.lastLineNumber)
+    syncScenePreview(path, sceneCursor.lineNumber, sceneCursor.lineText)
   }
 
   watch(() => tabsStore.activeTab?.path, async (activePath) => {
@@ -507,14 +552,15 @@ export const useEditorStore = defineStore('editor', () => {
       return
     }
 
-    if (!hasState(activePath)) {
+    if (hasState(activePath)) {
+      // 已加载的文件：同步编辑模式与全局偏好
+      const preferenceStore = usePreferenceStore()
+      setActiveProjection(preferenceStore.editorMode, activePath)
+    } else {
       await loadEditorStateAction(fileLifecycleContext, activePath)
-      return
     }
 
-    // 已加载的文件：同步编辑模式与全局偏好
-    const preferenceStore = usePreferenceStore()
-    setActiveProjection(preferenceStore.editorMode, activePath)
+    syncActiveScenePreview(activePath)
   }, { immediate: true })
 
   // 监听标签页关闭，清理编辑器状态
@@ -569,6 +615,7 @@ export const useEditorStore = defineStore('editor', () => {
     setSceneStatementCollapsed,
     setActiveProjection,
     switchEditorMode,
+    consumePendingSceneProjectionActivation,
     syncScenePreview,
     updatePreviewMediaSession,
     registerSaveHook,

--- a/src/stores/internal/editor-session.ts
+++ b/src/stores/internal/editor-session.ts
@@ -72,6 +72,7 @@ export interface EditableEditorSession {
   visualState?: VisualProjectionState
   scenePresentation?: ScenePresentationState
   sceneSelection?: SceneSelectionState
+  pendingSceneProjectionActivation?: SceneProjectionActivation
 }
 
 export interface AssetPreviewSession {
@@ -89,6 +90,8 @@ export type EditorSession =
   | EditableEditorSession
   | AssetPreviewSession
   | UnsupportedEditorSession
+
+export type SceneProjectionActivation = 'text' | 'visual'
 
 type InitialVisualProjectionState =
   Pick<SceneVisualProjectionState, 'kind' | 'statements'>


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [x] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [x] 代码重构
- [ ] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

本 PR 统一并收紧了编辑器中的场景预览同步规则，重点包括：

- 自动预览同步仅基于已保存内容，避免 dirty 场景触发无效刷新
- 打开文件、切换 tab、保存完成后，会按当前场景关注行/语句重新同步预览
- 文本/可视化模式切换不再额外补发预览，只保留“恢复关注点/滚动位置”的激活语义
- 文本编辑器与可视化编辑器的“播放到此句”入口在 dirty 场景下统一禁用，并补充禁用态样式
- 可视化编辑器语句重排后不再自动触发实时预览
- 效果编辑器重置草稿时会把预览回滚到初始基线

同时整理了相关实现命名与测试，移除了低价值和易误导的覆盖，确保当前行为与规则一致。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

根据当前预览设计，游戏端读取的是本地文件内容，因此未保存的编辑器内容无法被预览端正确获取。

这意味着：
- dirty 场景下自动刷新预览是不正确的
- 模式切换前如果已在原模式完成同步，切换后再补发一次预览没有实际意义
- 用户显式触发的手动预览入口需要在 dirty 状态下明确禁用，避免制造“看起来能点、实际上不应生效”的歧义

本 PR 的目标是把这些规则收敛到一致且可审阅的实现中，并消除模式切换链路中的重复语义和多余副作用。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->

已补充/更新的测试覆盖包括：

- 文本编辑器光标跨行移动、同一行移动、多选恢复单选时的预览同步
- 文本/可视化编辑器 dirty 状态下手动播放入口禁用
- 可视化模式切换后的选中项与滚动恢复
- tab 切换时的 clean 场景预览重同步
- dirty 场景切 tab 不补发预览
- 效果编辑器 reset 回滚预览基线

### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
