### PR TITLE
♻️ 收拢语句文件缺失检查并以资源索引替代热路径文件检查

### DIFF
--- a/src/components/editor/VisualEditorStatementCard.vue
+++ b/src/components/editor/VisualEditorStatementCard.vue
@@ -6,6 +6,7 @@ import { buildStatementPreviewParams, StatementCardPreviewParam } from '~/featur
 import { createStatementIdTarget, StatementUpdatePayload } from '~/features/editor/statement-editor/useStatementEditor'
 import { useStatementFileMissing } from '~/features/editor/statement-editor/useStatementFileMissing'
 import { provideStatementMeta } from '~/features/editor/statement-editor/useStatementMeta'
+import { useResourceCatalogBootstrap } from '~/services/resource-index/service'
 
 const props = defineProps<{
   entry: StatementEntry
@@ -51,6 +52,8 @@ watch(() => collapsed, (isCollapsed) => {
 const { parsed, config, contentField, argFields, theme, statementType, commandLabel } = provideStatementMeta(() => props.entry)
 
 const { t } = useI18n()
+
+useResourceCatalogBootstrap()
 
 const { fileMissingKeys } = useStatementFileMissing({
   parsed: () => parsed.value,

--- a/src/features/editor/statement-editor/__tests__/file-missing.test.ts
+++ b/src/features/editor/statement-editor/__tests__/file-missing.test.ts
@@ -1,18 +1,12 @@
-import '~/__tests__/mocks/tauri-fs'
-
-import { exists } from '@tauri-apps/plugin-fs'
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import { commandType } from 'webgal-parser/src/interface/sceneInterface'
 
 import {
   collectStatementFileChecks,
-  createStatementMissingFileLoader,
-  resolveMissingFileKeys,
+  resolveMissingFileKeysFromCatalog,
 } from '~/features/editor/statement-editor/file-missing'
 
 import type { ArgField, EditorField } from '~/features/editor/command-registry/schema'
-
-const mockExists = vi.mocked(exists)
 
 function createFileContentField(assetType = 'background'): EditorField {
   return {
@@ -45,16 +39,6 @@ function createFileArgField(storageKey: string, fieldKey = storageKey, assetType
       },
     },
   }
-}
-
-function createDeferred<T>() {
-  let resolve!: (value: T | PromiseLike<T>) => void
-  let reject!: (reason?: unknown) => void
-  const promise = new Promise<T>((res, rej) => {
-    resolve = res
-    reject = rej
-  })
-  return { promise, resolve, reject }
 }
 
 describe('语句编辑器缺失文件检查', () => {
@@ -116,103 +100,33 @@ describe('语句编辑器缺失文件检查', () => {
     expect(checks).toEqual([])
   })
 
-  it('resolveMissingFileKeys 根据 exists 结果生成缺失键集合', async () => {
-    mockExists.mockImplementation(async path => !(path as string).includes('hero.png'))
-
-    const missing = await resolveMissingFileKeys(
-      '/mock',
+  it('resolveMissingFileKeysFromCatalog 根据资源索引结果生成缺失键集合', () => {
+    const missing = resolveMissingFileKeysFromCatalog(
       [
         { key: '__content__', assetType: 'background', value: 'bg.png' },
         { key: 'sprite', assetType: 'figure', value: 'hero.png' },
         { key: 'scene', assetType: 'scene', value: 's1.txt' },
       ],
-      {
-        gameAssetDir: async (_cwd, assetType) => `/asset/${assetType}`,
-        gameSceneDir: async () => '/scene',
-        joinPath: async (left, right) => `${left}/${right}`,
-      },
+      (_assetType, relativePath) => relativePath !== 'hero.png',
     )
 
     expect(missing).toEqual(new Set(['sprite']))
   })
 
-  it('resolveMissingFileKeys 跳过不带 .txt 的场景值（可能是标签名）', async () => {
-    const paths: string[] = []
-    mockExists.mockImplementation(async (path) => {
-      paths.push(path as string)
-      return true
-    })
-
-    const missing = await resolveMissingFileKeys(
-      '/mock',
+  it('resolveMissingFileKeysFromCatalog 跳过不带 .txt 的场景值（可能是标签名）', () => {
+    const checkedPaths: string[] = []
+    const missing = resolveMissingFileKeysFromCatalog(
       [
         { key: 'a', assetType: 'scene', value: 'myLabel' },
         { key: 'b', assetType: 'scene', value: 'other.txt' },
       ],
-      {
-        gameAssetDir: async (_cwd, assetType) => `/asset/${assetType}`,
-        gameSceneDir: async () => '/scene',
-        joinPath: async (left, right) => `${left}/${right}`,
+      (_assetType, relativePath) => {
+        checkedPaths.push(relativePath)
+        return true
       },
     )
 
-    // 不带 .txt 的值可能是标签名，不检查文件存在性
-    expect(paths).not.toContain('/scene/myLabel')
-    expect(paths).not.toContain('/scene/myLabel.txt')
-    // 带 .txt 的正常检查
-    expect(paths).toContain('/scene/other.txt')
+    expect(checkedPaths).toEqual(['other.txt'])
     expect(missing).toEqual(new Set())
-  })
-
-  it('createStatementMissingFileLoader 会丢弃过期请求结果', async () => {
-    const slowExists = createDeferred<boolean>()
-
-    mockExists.mockImplementation(async (path) => {
-      if ((path as string).includes('slow.png')) {
-        return slowExists.promise
-      }
-      return true
-    })
-
-    const loader = createStatementMissingFileLoader({
-      gameAssetDir: async (_cwd, assetType) => `/asset/${assetType}`,
-      gameSceneDir: async () => '/scene',
-      joinPath: async (left, right) => `${left}/${right}`,
-    })
-
-    const slowRequest = loader({
-      cwd: '/mock',
-      parsed: {
-        command: commandType.changeBg,
-        commandRaw: 'changeBg',
-        content: 'slow.png',
-        args: [],
-        sentenceAssets: [],
-        subScene: [],
-        inlineComment: '',
-      },
-      contentField: createFileContentField('background'),
-      argFields: [],
-    })
-
-    const fastRequest = loader({
-      cwd: '/mock',
-      parsed: {
-        command: commandType.changeBg,
-        commandRaw: 'changeBg',
-        content: 'fast.png',
-        args: [],
-        sentenceAssets: [],
-        subScene: [],
-        inlineComment: '',
-      },
-      contentField: createFileContentField('background'),
-      argFields: [],
-    })
-
-    expect(await fastRequest).toEqual(new Set())
-
-    slowExists.resolve(false)
-    expect(await slowRequest).toBeUndefined()
   })
 })

--- a/src/features/editor/statement-editor/__tests__/useStatementEditor.test.ts
+++ b/src/features/editor/statement-editor/__tests__/useStatementEditor.test.ts
@@ -3,7 +3,8 @@ import '~/__tests__/mocks/router'
 import '~/__tests__/mocks/tauri-fs'
 import '~/__tests__/mocks/modal-store'
 
-import { beforeEach, describe, expect, it } from 'vitest'
+import { exists, readDir } from '@tauri-apps/plugin-fs'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { commandType } from 'webgal-parser/src/interface/sceneInterface'
 
 import { SAY_CONTINUATION_RAW } from '~/domain/script/codec'
@@ -22,9 +23,23 @@ import { registerDynamicOptions } from '~/features/editor/dynamic-options/dynami
 
 import type { ArgField } from '~/features/editor/command-registry/schema'
 
+const mockExists = vi.mocked(exists)
+const readDirMock = vi.mocked(readDir)
+
 beforeEach(() => {
   resetStatementEditorRuntime()
+  readDirMock.mockReset()
+  mockExists.mockReset()
 })
+
+function createDirEntry(name: string, isDirectory: boolean) {
+  return {
+    name,
+    isDirectory,
+    isFile: !isDirectory,
+    isSymlink: false,
+  }
+}
 
 describe('useStatementEditor 行为', () => {
   it('setTempAnimation 语句显示动画编辑器按钮并隐藏原始 content 字段', () => {
@@ -478,5 +493,39 @@ describe('useStatementEditor 行为', () => {
     await flushMicrotasks(3)
 
     expect(editor.resource.fileRootPaths.value).toEqual({})
+  })
+
+  it('file missing 应复用资源索引，而不是在编辑器热路径中直接调用 exists', async () => {
+    vi.useFakeTimers()
+
+    workspaceStoreState.CWD = '/project'
+    readDirMock.mockImplementation(async (path: string | URL) => {
+      switch (String(path)) {
+        case '/project/game': {
+          return [
+            createDirEntry('background', true),
+          ]
+        }
+        case '/project/game/background': {
+          return [
+            createDirEntry('bg.jpg', false),
+          ]
+        }
+        default: {
+          throw new TypeError(`unexpected readDir path: ${String(path)}`)
+        }
+      }
+    })
+    mockExists.mockResolvedValue(false)
+
+    const { editor } = createReactiveHarness('changeBg: bg.jpg;')
+
+    await vi.runAllTimersAsync()
+    await flushMicrotasks(6)
+
+    expect(editor.resource.fileMissingKeys.value).toEqual(new Set())
+    expect(mockExists).not.toHaveBeenCalled()
+
+    vi.useRealTimers()
   })
 })

--- a/src/features/editor/statement-editor/__tests__/useStatementEditor.test.ts
+++ b/src/features/editor/statement-editor/__tests__/useStatementEditor.test.ts
@@ -498,34 +498,36 @@ describe('useStatementEditor 行为', () => {
   it('file missing 应复用资源索引，而不是在编辑器热路径中直接调用 exists', async () => {
     vi.useFakeTimers()
 
-    workspaceStoreState.CWD = '/project'
-    readDirMock.mockImplementation(async (path: string | URL) => {
-      switch (String(path)) {
-        case '/project/game': {
-          return [
-            createDirEntry('background', true),
-          ]
+    try {
+      workspaceStoreState.CWD = '/project'
+      readDirMock.mockImplementation(async (path: string | URL) => {
+        switch (String(path)) {
+          case '/project/game': {
+            return [
+              createDirEntry('background', true),
+            ]
+          }
+          case '/project/game/background': {
+            return [
+              createDirEntry('bg.jpg', false),
+            ]
+          }
+          default: {
+            throw new TypeError(`unexpected readDir path: ${String(path)}`)
+          }
         }
-        case '/project/game/background': {
-          return [
-            createDirEntry('bg.jpg', false),
-          ]
-        }
-        default: {
-          throw new TypeError(`unexpected readDir path: ${String(path)}`)
-        }
-      }
-    })
-    mockExists.mockResolvedValue(false)
+      })
+      mockExists.mockResolvedValue(false)
 
-    const { editor } = createReactiveHarness('changeBg: bg.jpg;')
+      const { editor } = createReactiveHarness('changeBg: bg.jpg;')
 
-    await vi.runAllTimersAsync()
-    await flushMicrotasks(6)
+      await vi.runAllTimersAsync()
+      await flushMicrotasks(6)
 
-    expect(editor.resource.fileMissingKeys.value).toEqual(new Set())
-    expect(mockExists).not.toHaveBeenCalled()
-
-    vi.useRealTimers()
+      expect(editor.resource.fileMissingKeys.value).toEqual(new Set())
+      expect(mockExists).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/src/features/editor/statement-editor/file-missing.ts
+++ b/src/features/editor/statement-editor/file-missing.ts
@@ -1,5 +1,3 @@
-import { exists } from '@tauri-apps/plugin-fs'
-
 import { ArgField, EditorField, readArgFieldStorageKey } from '~/features/editor/command-registry/schema'
 
 import type { arg, ISentence } from 'webgal-parser/src/interface/sceneInterface'
@@ -10,24 +8,20 @@ export interface StatementFileCheckItem {
   value: string
 }
 
-export interface StatementFileCheckContext {
-  parsed?: ISentence
-  contentField?: EditorField
-  argFields: ArgField[]
-  cwd?: string
-}
-
-export interface StatementFileCheckDeps {
-  gameAssetDir: (cwd: string, assetType: string) => Promise<string>
-  gameSceneDir: (cwd: string) => Promise<string>
-  joinPath: (left: string, right: string) => Promise<string>
-}
-
 // WebGAL 支持 {varName} 语法引用变量作为文件路径，
 // 变量占位符无法在编辑时检查文件是否存在，跳过检查避免误报
 function isVariablePlaceholder(value: string): boolean {
   const trimmed = value.trim()
   return /^\{[^{}]+\}$/.test(trimmed)
+}
+
+function shouldCheckStatementFileValue(assetType: string, value: string): boolean {
+  // scene 中不带 .txt 的值可能是 label，而不是文件路径
+  if (assetType === 'scene' && !value.endsWith('.txt')) {
+    return false
+  }
+
+  return true
 }
 
 export function collectStatementFileChecks(
@@ -66,58 +60,25 @@ export function collectStatementFileChecks(
   return checks
 }
 
-export async function resolveMissingFileKeys(
-  cwd: string,
+export function resolveMissingFileKeysFromCatalog(
   checks: StatementFileCheckItem[],
-  deps: StatementFileCheckDeps,
-): Promise<Set<string>> {
+  hasAsset: (assetType: string, relativePath: string) => boolean,
+): Set<string> {
   if (checks.length === 0) {
     return new Set()
   }
 
-  const results = await Promise.all(
-    checks.map(async ({ key, assetType, value }) => {
-      try {
-        const assetDir = assetType === 'scene'
-          ? await deps.gameSceneDir(cwd)
-          : await deps.gameAssetDir(cwd, assetType)
-        // 不以 .txt 结尾的场景值可能是标签名（如 label），无法确定是否为文件引用，跳过检查
-        if (assetType === 'scene' && !value.endsWith('.txt')) {
-          return { key, missing: false }
-        }
-        const filePath = await deps.joinPath(assetDir, value)
-        return { key, missing: !(await exists(filePath)) }
-      } catch {
-        return { key, missing: false }
-      }
-    }),
-  )
+  const missingKeys = new Set<string>()
 
-  return new Set(results.filter(item => item.missing).map(item => item.key))
-}
-
-export function createStatementMissingFileLoader(deps: StatementFileCheckDeps) {
-  // 乐观并发控制：每次调用递增 version，异步完成后检查 version 是否仍匹配。
-  // 若不匹配说明有更新的调用已发起，当前结果已过时，丢弃以避免竞态覆盖
-  let version = 0
-
-  return async function load(context: StatementFileCheckContext): Promise<Set<string> | undefined> {
-    const currentVersion = ++version
-
-    if (!context.parsed || !context.cwd) {
-      return new Set()
+  for (const { key, assetType, value } of checks) {
+    if (!shouldCheckStatementFileValue(assetType, value)) {
+      continue
     }
 
-    const checks = collectStatementFileChecks(
-      context.parsed,
-      context.contentField,
-      context.argFields,
-    )
-
-    const missingKeys = await resolveMissingFileKeys(context.cwd, checks, deps)
-    if (currentVersion !== version) {
-      return
+    if (!hasAsset(assetType, value)) {
+      missingKeys.add(key)
     }
-    return missingKeys
   }
+
+  return missingKeys
 }

--- a/src/features/editor/statement-editor/useStatementEditor.ts
+++ b/src/features/editor/statement-editor/useStatementEditor.ts
@@ -16,6 +16,7 @@ import { useStatementEditorScrub } from '~/features/editor/statement-editor/useS
 import { useStatementFileMissing } from '~/features/editor/statement-editor/useStatementFileMissing'
 import { useStatementFileRoots } from '~/features/editor/statement-editor/useStatementFileRoots'
 import { statementMetaKey, useStatementMeta } from '~/features/editor/statement-editor/useStatementMeta'
+import { useResourceCatalogBootstrap } from '~/services/resource-index/service'
 
 import type { arg, ISentence } from 'webgal-parser/src/interface/sceneInterface'
 import type { TransactionSource } from '~/domain/document/transaction'
@@ -70,6 +71,7 @@ export function isStatementInteractiveTarget(target: EventTarget | null): boolea
 
 export function useStatementEditor(options: UseStatementEditorOptions) {
   useEditorDynamicOptionsBootstrap()
+  useResourceCatalogBootstrap()
 
   const entry = computed(() => toValue(options.entry))
   const updateTarget = computed(() => toValue(options.updateTarget) ?? createStatementIdTarget(entry.value.id))

--- a/src/features/editor/statement-editor/useStatementEditorFieldBindings.ts
+++ b/src/features/editor/statement-editor/useStatementEditorFieldBindings.ts
@@ -39,7 +39,7 @@ interface UseStatementEditorFieldBindingsOptions {
     | 'isArgVisible'
     | 'resolveFieldArgField'
   >
-  fileMissingKeys: Ref<Set<string>>
+  fileMissingKeys: Readonly<Ref<Set<string>>>
   scrub: Pick<
     ReturnType<typeof useStatementEditorScrub>,
     | 'canScrubArgField'

--- a/src/features/editor/statement-editor/useStatementEditorParams.ts
+++ b/src/features/editor/statement-editor/useStatementEditorParams.ts
@@ -16,7 +16,7 @@ export interface UseStatementEditorParamsOptions {
   parsed: ComputedRef<ISentence | undefined>
   commandNode: ComputedRef<CommandNode | undefined>
   argFields: ComputedRef<ArgField[]>
-  fileMissingKeys: Ref<Set<string>>
+  fileMissingKeys: Readonly<Ref<Set<string>>>
   readEditableArgs: () => arg[]
   emitUpdate: (patch: Partial<ISentence>) => void
 }

--- a/src/features/editor/statement-editor/useStatementFileMissing.ts
+++ b/src/features/editor/statement-editor/useStatementFileMissing.ts
@@ -1,9 +1,6 @@
-import { join } from '@tauri-apps/api/path'
-
 import { ArgField, EditorField } from '~/features/editor/command-registry/schema'
-import { createStatementMissingFileLoader } from '~/features/editor/statement-editor/file-missing'
-import { gameAssetDir, gameSceneDir } from '~/services/platform/app-paths'
-import { useWorkspaceStore } from '~/stores/workspace'
+import { collectStatementFileChecks, resolveMissingFileKeysFromCatalog } from '~/features/editor/statement-editor/file-missing'
+import { useResourceCatalog } from '~/services/resource-index/service'
 
 import type { ISentence } from 'webgal-parser/src/interface/sceneInterface'
 
@@ -14,36 +11,28 @@ export interface UseStatementFileMissingOptions {
 }
 
 export function useStatementFileMissing(options: UseStatementFileMissingOptions) {
-  const workspaceStore = useWorkspaceStore()
+  const resourceCatalog = useResourceCatalog()
 
-  const fileMissingKeys = ref(new Set<string>())
-  const loadMissingFileKeys = createStatementMissingFileLoader({
-    gameAssetDir,
-    gameSceneDir,
-    joinPath: join,
+  const fileMissingKeys = computed(() => {
+    const currentParsed = toValue(options.parsed)
+    const currentContentField = toValue(options.contentField)
+    const currentArgFields = toValue(options.argFields)
+
+    if (!currentParsed || resourceCatalog.status.value !== 'ready') {
+      return new Set<string>()
+    }
+
+    const checks = collectStatementFileChecks(
+      currentParsed,
+      currentContentField,
+      currentArgFields,
+    )
+
+    return resolveMissingFileKeysFromCatalog(
+      checks,
+      (assetType, relativePath) => resourceCatalog.hasAsset(assetType, relativePath),
+    )
   })
-
-  watchDebounced(
-    () => [toValue(options.parsed), toValue(options.contentField), toValue(options.argFields), workspaceStore.CWD] as const,
-    async ([currentParsed, currentContentField, currentArgFields, cwd], _, onCleanup) => {
-      let cancelled = false
-      onCleanup(() => {
-        cancelled = true
-      })
-
-      const nextMissingKeys = await loadMissingFileKeys({
-        parsed: currentParsed,
-        contentField: currentContentField,
-        argFields: currentArgFields,
-        cwd,
-      })
-      if (cancelled || !nextMissingKeys) {
-        return
-      }
-      fileMissingKeys.value = nextMissingKeys
-    },
-    { immediate: true, debounce: 150 },
-  )
 
   return {
     fileMissingKeys,

--- a/src/services/resource-index/__tests__/service.test.ts
+++ b/src/services/resource-index/__tests__/service.test.ts
@@ -1,0 +1,222 @@
+import '~/__tests__/mocks/tauri-fs'
+
+import { readDir } from '@tauri-apps/plugin-fs'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { effectScope, reactive } from 'vue'
+
+import { createTauriPathModuleMock } from '~/__tests__/mocks/tauri-path'
+
+const {
+  onMock,
+  useWorkspaceStoreMock,
+} = vi.hoisted(() => ({
+  onMock: vi.fn(),
+  useWorkspaceStoreMock: vi.fn(),
+}))
+
+vi.mock('@tauri-apps/api/path', () => createTauriPathModuleMock())
+
+vi.mock('~/stores/workspace', () => ({
+  useWorkspaceStore: useWorkspaceStoreMock,
+}))
+
+vi.mock('~/composables/useFileSystemEvents', () => ({
+  useFileSystemEvents: () => ({
+    on: onMock,
+  }),
+}))
+
+const readDirMock = vi.mocked(readDir)
+
+function createDirEntry(name: string, isDirectory: boolean) {
+  return {
+    name,
+    isDirectory,
+    isFile: !isDirectory,
+    isSymlink: false,
+  }
+}
+
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+async function flushMicrotasks(times = 6): Promise<void> {
+  if (times <= 0) {
+    return
+  }
+  await Promise.resolve()
+  await flushMicrotasks(times - 1)
+}
+
+async function waitFor(predicate: () => boolean, maxTries = 20): Promise<void> {
+  if (predicate()) {
+    return
+  }
+  if (maxTries <= 0) {
+    throw new TypeError('waitFor timeout')
+  }
+  await flushMicrotasks()
+  await waitFor(predicate, maxTries - 1)
+}
+
+describe('ResourceIndexService', () => {
+  let workspaceStoreState = reactive<{ CWD?: string }>({
+    CWD: '/project',
+  })
+
+  const eventHandlers = new Map<string, ((event: Record<string, unknown>) => void)[]>()
+
+  function emitFileSystemEvent(type: string, event: Record<string, unknown>) {
+    for (const handler of eventHandlers.get(type) ?? []) {
+      handler(event)
+    }
+  }
+
+  beforeEach(() => {
+    vi.resetModules()
+
+    workspaceStoreState = reactive({
+      CWD: '/project',
+    })
+
+    useWorkspaceStoreMock.mockReset()
+    useWorkspaceStoreMock.mockReturnValue(workspaceStoreState)
+
+    eventHandlers.clear()
+    onMock.mockReset()
+    onMock.mockImplementation((eventType: string, handler: (event: Record<string, unknown>) => void) => {
+      const handlers = eventHandlers.get(eventType) ?? []
+      handlers.push(handler)
+      eventHandlers.set(eventType, handlers)
+      return vi.fn(() => {
+        const nextHandlers = (eventHandlers.get(eventType) ?? []).filter(item => item !== handler)
+        eventHandlers.set(eventType, nextHandlers)
+      })
+    })
+
+    readDirMock.mockReset()
+  })
+
+  it('启动后会建立资源清单，并支持按 assetType 和相对路径查询', async () => {
+    readDirMock.mockImplementation(async (path: string | URL) => {
+      switch (String(path)) {
+        case '/project/game': {
+          return [
+            createDirEntry('background', true),
+            createDirEntry('figure', true),
+            createDirEntry('scene', true),
+          ]
+        }
+        case '/project/game/background': {
+          return [
+            createDirEntry('bg.jpg', false),
+            createDirEntry('chapter1', true),
+          ]
+        }
+        case '/project/game/background/chapter1': {
+          return [
+            createDirEntry('night.png', false),
+          ]
+        }
+        case '/project/game/figure': {
+          return [
+            createDirEntry('hero.png', false),
+          ]
+        }
+        case '/project/game/scene': {
+          return [
+            createDirEntry('intro.txt', false),
+          ]
+        }
+        default: {
+          throw new TypeError(`unexpected readDir path: ${String(path)}`)
+        }
+      }
+    })
+
+    const { useResourceCatalog, useResourceCatalogBootstrap } = await import('../service')
+
+    const scope = effectScope()
+    let catalog!: ReturnType<typeof useResourceCatalog>
+    scope.run(() => {
+      useResourceCatalogBootstrap()
+      catalog = useResourceCatalog()
+    })
+
+    await waitFor(() => catalog.status.value === 'ready')
+
+    expect(catalog.status.value).toBe('ready')
+    expect(catalog.hasAsset('background', 'bg.jpg')).toBe(true)
+    expect(catalog.hasAsset('background', 'chapter1/night.png')).toBe(true)
+    expect(catalog.hasAsset('figure', 'hero.png')).toBe(true)
+    expect(catalog.hasAsset('scene', 'intro.txt')).toBe(true)
+    expect(catalog.hasAsset('background', 'missing.png')).toBe(false)
+
+    scope.stop()
+  })
+
+  it('文件事件会增量更新资源清单，而不是强制全量重建', async () => {
+    const slowRootRead = createDeferred<ReturnType<typeof createDirEntry>[]>()
+
+    readDirMock.mockImplementation(async (path: string | URL) => {
+      switch (String(path)) {
+        case '/project/game': {
+          return slowRootRead.promise
+        }
+        case '/project/game/background': {
+          return [
+            createDirEntry('bg.jpg', false),
+          ]
+        }
+        default: {
+          throw new TypeError(`unexpected readDir path: ${String(path)}`)
+        }
+      }
+    })
+
+    const { useResourceCatalog, useResourceCatalogBootstrap } = await import('../service')
+
+    const scope = effectScope()
+    let catalog!: ReturnType<typeof useResourceCatalog>
+    scope.run(() => {
+      useResourceCatalogBootstrap()
+      catalog = useResourceCatalog()
+    })
+
+    slowRootRead.resolve([
+      createDirEntry('background', true),
+    ])
+    await waitFor(() => catalog.status.value === 'ready')
+
+    expect(catalog.status.value).toBe('ready')
+    expect(catalog.hasAsset('background', 'bg.jpg')).toBe(true)
+    expect(readDirMock).toHaveBeenCalledTimes(2)
+
+    emitFileSystemEvent('file:removed', {
+      type: 'file:removed',
+      path: '/project/game/background/bg.jpg',
+    })
+    await flushMicrotasks()
+
+    expect(catalog.hasAsset('background', 'bg.jpg')).toBe(false)
+    expect(readDirMock).toHaveBeenCalledTimes(2)
+
+    emitFileSystemEvent('file:created', {
+      type: 'file:created',
+      path: '/project/game/background/new-bg.jpg',
+    })
+    await flushMicrotasks()
+
+    expect(catalog.hasAsset('background', 'new-bg.jpg')).toBe(true)
+    expect(readDirMock).toHaveBeenCalledTimes(2)
+
+    scope.stop()
+  })
+})

--- a/src/services/resource-index/__tests__/service.test.ts
+++ b/src/services/resource-index/__tests__/service.test.ts
@@ -60,7 +60,7 @@ async function waitFor(predicate: () => boolean, maxTries = 20): Promise<void> {
     return
   }
   if (maxTries <= 0) {
-    throw new TypeError('waitFor timeout')
+    throw new Error('waitFor timeout')
   }
   await flushMicrotasks()
   await waitFor(predicate, maxTries - 1)
@@ -150,16 +150,18 @@ describe('ResourceIndexService', () => {
       catalog = useResourceCatalog()
     })
 
-    await waitFor(() => catalog.status.value === 'ready')
+    try {
+      await waitFor(() => catalog.status.value === 'ready')
 
-    expect(catalog.status.value).toBe('ready')
-    expect(catalog.hasAsset('background', 'bg.jpg')).toBe(true)
-    expect(catalog.hasAsset('background', 'chapter1/night.png')).toBe(true)
-    expect(catalog.hasAsset('figure', 'hero.png')).toBe(true)
-    expect(catalog.hasAsset('scene', 'intro.txt')).toBe(true)
-    expect(catalog.hasAsset('background', 'missing.png')).toBe(false)
-
-    scope.stop()
+      expect(catalog.status.value).toBe('ready')
+      expect(catalog.hasAsset('background', 'bg.jpg')).toBe(true)
+      expect(catalog.hasAsset('background', 'chapter1/night.png')).toBe(true)
+      expect(catalog.hasAsset('figure', 'hero.png')).toBe(true)
+      expect(catalog.hasAsset('scene', 'intro.txt')).toBe(true)
+      expect(catalog.hasAsset('background', 'missing.png')).toBe(false)
+    } finally {
+      scope.stop()
+    }
   })
 
   it('文件事件会增量更新资源清单，而不是强制全量重建', async () => {
@@ -190,34 +192,36 @@ describe('ResourceIndexService', () => {
       catalog = useResourceCatalog()
     })
 
-    slowRootRead.resolve([
-      createDirEntry('background', true),
-    ])
-    await waitFor(() => catalog.status.value === 'ready')
+    try {
+      slowRootRead.resolve([
+        createDirEntry('background', true),
+      ])
+      await waitFor(() => catalog.status.value === 'ready')
 
-    expect(catalog.status.value).toBe('ready')
-    expect(catalog.hasAsset('background', 'bg.jpg')).toBe(true)
-    expect(readDirMock).toHaveBeenCalledTimes(2)
+      expect(catalog.status.value).toBe('ready')
+      expect(catalog.hasAsset('background', 'bg.jpg')).toBe(true)
+      expect(readDirMock).toHaveBeenCalledTimes(2)
 
-    emitFileSystemEvent('file:removed', {
-      type: 'file:removed',
-      path: '/project/game/background/bg.jpg',
-    })
-    await flushMicrotasks()
+      emitFileSystemEvent('file:removed', {
+        type: 'file:removed',
+        path: '/project/game/background/bg.jpg',
+      })
+      await flushMicrotasks()
 
-    expect(catalog.hasAsset('background', 'bg.jpg')).toBe(false)
-    expect(readDirMock).toHaveBeenCalledTimes(2)
+      expect(catalog.hasAsset('background', 'bg.jpg')).toBe(false)
+      expect(readDirMock).toHaveBeenCalledTimes(2)
 
-    emitFileSystemEvent('file:created', {
-      type: 'file:created',
-      path: '/project/game/background/new-bg.jpg',
-    })
-    await flushMicrotasks()
+      emitFileSystemEvent('file:created', {
+        type: 'file:created',
+        path: '/project/game/background/new-bg.jpg',
+      })
+      await flushMicrotasks()
 
-    expect(catalog.hasAsset('background', 'new-bg.jpg')).toBe(true)
-    expect(readDirMock).toHaveBeenCalledTimes(2)
-
-    scope.stop()
+      expect(catalog.hasAsset('background', 'new-bg.jpg')).toBe(true)
+      expect(readDirMock).toHaveBeenCalledTimes(2)
+    } finally {
+      scope.stop()
+    }
   })
 
   it('构建期间收到文件事件后会在完成后补一次重建', async () => {
@@ -265,22 +269,24 @@ describe('ResourceIndexService', () => {
       catalog = useResourceCatalog()
     })
 
-    await waitFor(() => backgroundReadCount === 1)
+    try {
+      await waitFor(() => backgroundReadCount === 1)
 
-    emitFileSystemEvent('file:created', {
-      type: 'file:created',
-      path: '/project/game/background/new-bg.jpg',
-    })
-    await flushMicrotasks()
+      emitFileSystemEvent('file:created', {
+        type: 'file:created',
+        path: '/project/game/background/new-bg.jpg',
+      })
+      await flushMicrotasks()
 
-    expect(catalog.status.value).toBe('building')
+      expect(catalog.status.value).toBe('building')
 
-    slowFigureRead.resolve([])
+      slowFigureRead.resolve([])
 
-    await waitFor(() => catalog.status.value === 'ready' && catalog.hasAsset('background', 'new-bg.jpg'))
-    expect(backgroundReadCount).toBe(2)
-
-    scope.stop()
+      await waitFor(() => catalog.status.value === 'ready' && catalog.hasAsset('background', 'new-bg.jpg'))
+      expect(backgroundReadCount).toBe(2)
+    } finally {
+      scope.stop()
+    }
   })
 
   it('连续目录事件会合并为一次重建', async () => {
@@ -314,35 +320,37 @@ describe('ResourceIndexService', () => {
         catalog = useResourceCatalog()
       })
 
-      await waitFor(() => catalog.status.value === 'ready')
-      readDirMock.mockClear()
+      try {
+        await waitFor(() => catalog.status.value === 'ready')
+        readDirMock.mockClear()
 
-      emitFileSystemEvent('directory:created', {
-        type: 'directory:created',
-        path: '/project/game/background/chapter1',
-      })
-      emitFileSystemEvent('directory:removed', {
-        type: 'directory:removed',
-        path: '/project/game/background/chapter2',
-      })
-      emitFileSystemEvent('directory:renamed', {
-        type: 'directory:renamed',
-        oldPath: '/project/game/background/old-folder',
-        newPath: '/project/game/background/new-folder',
-      })
+        emitFileSystemEvent('directory:created', {
+          type: 'directory:created',
+          path: '/project/game/background/chapter1',
+        })
+        emitFileSystemEvent('directory:removed', {
+          type: 'directory:removed',
+          path: '/project/game/background/chapter2',
+        })
+        emitFileSystemEvent('directory:renamed', {
+          type: 'directory:renamed',
+          oldPath: '/project/game/background/old-folder',
+          newPath: '/project/game/background/new-folder',
+        })
 
-      expect(readDirMock).not.toHaveBeenCalled()
+        expect(readDirMock).not.toHaveBeenCalled()
 
-      await vi.advanceTimersByTimeAsync(199)
-      expect(readDirMock).not.toHaveBeenCalled()
+        await vi.advanceTimersByTimeAsync(199)
+        expect(readDirMock).not.toHaveBeenCalled()
 
-      await vi.advanceTimersByTimeAsync(1)
-      await waitFor(() => readDirMock.mock.calls.length === 2)
-      await waitFor(() => catalog.status.value === 'ready')
+        await vi.advanceTimersByTimeAsync(1)
+        await waitFor(() => readDirMock.mock.calls.length === 2)
+        await waitFor(() => catalog.status.value === 'ready')
 
-      expect(readDirMock).toHaveBeenCalledTimes(2)
-
-      scope.stop()
+        expect(readDirMock).toHaveBeenCalledTimes(2)
+      } finally {
+        scope.stop()
+      }
     } finally {
       vi.useRealTimers()
     }

--- a/src/services/resource-index/__tests__/service.test.ts
+++ b/src/services/resource-index/__tests__/service.test.ts
@@ -219,4 +219,132 @@ describe('ResourceIndexService', () => {
 
     scope.stop()
   })
+
+  it('构建期间收到文件事件后会在完成后补一次重建', async () => {
+    const slowFigureRead = createDeferred<ReturnType<typeof createDirEntry>[]>()
+    let backgroundReadCount = 0
+
+    readDirMock.mockImplementation(async (path: string | URL) => {
+      switch (String(path)) {
+        case '/project/game': {
+          return [
+            createDirEntry('background', true),
+            createDirEntry('figure', true),
+          ]
+        }
+        case '/project/game/background': {
+          backgroundReadCount += 1
+          if (backgroundReadCount === 1) {
+            return [
+              createDirEntry('bg.jpg', false),
+            ]
+          }
+          return [
+            createDirEntry('bg.jpg', false),
+            createDirEntry('new-bg.jpg', false),
+          ]
+        }
+        case '/project/game/figure': {
+          if (backgroundReadCount === 1) {
+            return slowFigureRead.promise
+          }
+          return []
+        }
+        default: {
+          throw new TypeError(`unexpected readDir path: ${String(path)}`)
+        }
+      }
+    })
+
+    const { useResourceCatalog, useResourceCatalogBootstrap } = await import('../service')
+
+    const scope = effectScope()
+    let catalog!: ReturnType<typeof useResourceCatalog>
+    scope.run(() => {
+      useResourceCatalogBootstrap()
+      catalog = useResourceCatalog()
+    })
+
+    await waitFor(() => backgroundReadCount === 1)
+
+    emitFileSystemEvent('file:created', {
+      type: 'file:created',
+      path: '/project/game/background/new-bg.jpg',
+    })
+    await flushMicrotasks()
+
+    expect(catalog.status.value).toBe('building')
+
+    slowFigureRead.resolve([])
+
+    await waitFor(() => catalog.status.value === 'ready' && catalog.hasAsset('background', 'new-bg.jpg'))
+    expect(backgroundReadCount).toBe(2)
+
+    scope.stop()
+  })
+
+  it('连续目录事件会合并为一次重建', async () => {
+    vi.useFakeTimers()
+
+    try {
+      readDirMock.mockImplementation(async (path: string | URL) => {
+        switch (String(path)) {
+          case '/project/game': {
+            return [
+              createDirEntry('background', true),
+            ]
+          }
+          case '/project/game/background': {
+            return [
+              createDirEntry('bg.jpg', false),
+            ]
+          }
+          default: {
+            throw new TypeError(`unexpected readDir path: ${String(path)}`)
+          }
+        }
+      })
+
+      const { useResourceCatalog, useResourceCatalogBootstrap } = await import('../service')
+
+      const scope = effectScope()
+      let catalog!: ReturnType<typeof useResourceCatalog>
+      scope.run(() => {
+        useResourceCatalogBootstrap()
+        catalog = useResourceCatalog()
+      })
+
+      await waitFor(() => catalog.status.value === 'ready')
+      readDirMock.mockClear()
+
+      emitFileSystemEvent('directory:created', {
+        type: 'directory:created',
+        path: '/project/game/background/chapter1',
+      })
+      emitFileSystemEvent('directory:removed', {
+        type: 'directory:removed',
+        path: '/project/game/background/chapter2',
+      })
+      emitFileSystemEvent('directory:renamed', {
+        type: 'directory:renamed',
+        oldPath: '/project/game/background/old-folder',
+        newPath: '/project/game/background/new-folder',
+      })
+
+      expect(readDirMock).not.toHaveBeenCalled()
+
+      await vi.advanceTimersByTimeAsync(199)
+      expect(readDirMock).not.toHaveBeenCalled()
+
+      await vi.advanceTimersByTimeAsync(1)
+      await waitFor(() => readDirMock.mock.calls.length === 2)
+      await waitFor(() => catalog.status.value === 'ready')
+
+      expect(readDirMock).toHaveBeenCalledTimes(2)
+
+      scope.stop()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
 })

--- a/src/services/resource-index/catalog.ts
+++ b/src/services/resource-index/catalog.ts
@@ -1,0 +1,154 @@
+import { join } from '@tauri-apps/api/path'
+import { readDir } from '@tauri-apps/plugin-fs'
+
+import { normalizeRelativePath, toComparablePath } from '~/utils/path'
+
+export interface AssetCatalogSnapshot {
+  assetFiles: Map<string, Set<string>>
+}
+
+export function createEmptyAssetCatalogSnapshot(): AssetCatalogSnapshot {
+  return {
+    assetFiles: new Map<string, Set<string>>(),
+  }
+}
+
+export function cloneAssetCatalogSnapshot(snapshot: AssetCatalogSnapshot): AssetCatalogSnapshot {
+  return {
+    assetFiles: new Map(
+      Array.from(snapshot.assetFiles.entries(), ([assetType, files]) => [assetType, new Set(files)]),
+    ),
+  }
+}
+
+export function toComparableRelativeAssetPath(path: string): string {
+  return toComparablePath(normalizeRelativePath(path))
+}
+
+export function hasAssetInCatalog(
+  snapshot: AssetCatalogSnapshot,
+  assetType: string,
+  relativePath: string,
+): boolean {
+  const files = snapshot.assetFiles.get(assetType)
+  if (!files) {
+    return false
+  }
+  return files.has(toComparableRelativeAssetPath(relativePath))
+}
+
+export async function buildAssetCatalog(gamePath: string): Promise<AssetCatalogSnapshot> {
+  const gameRootPath = await join(gamePath, 'game')
+  const rootEntries = await readDir(gameRootPath)
+  const assetDirectories = rootEntries.filter(entry => entry.isDirectory && !!entry.name)
+  const assetFiles = await Promise.all(assetDirectories.map(async (entry) => {
+    const assetType = entry.name!
+    const rootPath = await join(gameRootPath, assetType)
+    const files = await collectAssetFiles(rootPath, '')
+    return [assetType, files] as const
+  }))
+
+  return {
+    assetFiles: new Map(assetFiles),
+  }
+}
+
+export function addAssetPathToCatalog(
+  snapshot: AssetCatalogSnapshot,
+  gamePath: string,
+  absolutePath: string,
+): AssetCatalogSnapshot {
+  const resolved = resolveCatalogPath(gamePath, absolutePath)
+  if (!resolved) {
+    return snapshot
+  }
+
+  const nextSnapshot = cloneAssetCatalogSnapshot(snapshot)
+  const files = nextSnapshot.assetFiles.get(resolved.assetType) ?? new Set<string>()
+  files.add(resolved.relativePath)
+  nextSnapshot.assetFiles.set(resolved.assetType, files)
+  return nextSnapshot
+}
+
+export function removeAssetPathFromCatalog(
+  snapshot: AssetCatalogSnapshot,
+  gamePath: string,
+  absolutePath: string,
+): AssetCatalogSnapshot {
+  const resolved = resolveCatalogPath(gamePath, absolutePath)
+  if (!resolved) {
+    return snapshot
+  }
+
+  const files = snapshot.assetFiles.get(resolved.assetType)
+  if (!files?.has(resolved.relativePath)) {
+    return snapshot
+  }
+
+  const nextSnapshot = cloneAssetCatalogSnapshot(snapshot)
+  nextSnapshot.assetFiles.get(resolved.assetType)?.delete(resolved.relativePath)
+  return nextSnapshot
+}
+
+export function renameAssetPathInCatalog(
+  snapshot: AssetCatalogSnapshot,
+  gamePath: string,
+  oldPath: string,
+  newPath: string,
+): AssetCatalogSnapshot {
+  const withoutOldPath = removeAssetPathFromCatalog(snapshot, gamePath, oldPath)
+  return addAssetPathToCatalog(withoutOldPath, gamePath, newPath)
+}
+
+export function isPathWithinGameRoot(gamePath: string, path: string): boolean {
+  const normalizedGameRoot = `${toComparablePath(gamePath)}/game`
+  const normalizedPath = toComparablePath(path)
+  return normalizedPath === normalizedGameRoot || normalizedPath.startsWith(`${normalizedGameRoot}/`)
+}
+
+async function collectAssetFiles(
+  directoryPath: string,
+  relativePrefix: string,
+): Promise<Set<string>> {
+  const entries = await readDir(directoryPath)
+  const nestedFiles = await Promise.all(entries.flatMap((entry) => {
+    if (!entry.name) {
+      return []
+    }
+
+    const relativePath = normalizeRelativePath(
+      relativePrefix ? `${relativePrefix}/${entry.name}` : entry.name,
+    )
+
+    if (entry.isDirectory) {
+      return [join(directoryPath, entry.name).then(absolutePath => collectAssetFiles(absolutePath, relativePath))]
+    }
+
+    return [Promise.resolve(new Set([toComparableRelativeAssetPath(relativePath)]))]
+  }))
+
+  return new Set(nestedFiles.flatMap(files => [...files]))
+}
+
+function resolveCatalogPath(gamePath: string, absolutePath: string): {
+  assetType: string
+  relativePath: string
+} | undefined {
+  const normalizedGameRoot = `${toComparablePath(gamePath)}/game/`
+  const normalizedPath = toComparablePath(absolutePath)
+
+  if (!normalizedPath.startsWith(normalizedGameRoot)) {
+    return
+  }
+
+  const relativeToGameRoot = normalizedPath.slice(normalizedGameRoot.length)
+  const segments = relativeToGameRoot.split('/').filter(Boolean)
+  if (segments.length < 2) {
+    return
+  }
+
+  return {
+    assetType: segments[0],
+    relativePath: segments.slice(1).join('/'),
+  }
+}

--- a/src/services/resource-index/service.ts
+++ b/src/services/resource-index/service.ts
@@ -21,12 +21,14 @@ interface ResourceCatalogState {
   status: ResourceCatalogStatus
   gamePath?: string
   snapshot: ReturnType<typeof createEmptyAssetCatalogSnapshot>
+  dirty: boolean
 }
 
 const resourceCatalogState = shallowRef<ResourceCatalogState>({
   status: 'idle',
   gamePath: undefined,
   snapshot: createEmptyAssetCatalogSnapshot(),
+  dirty: false,
 })
 
 let buildVersion = 0
@@ -34,7 +36,7 @@ let bootstrapConsumerCount = 0
 let bootstrapScope: ReturnType<typeof effectScope> | undefined
 let pendingDirectoryRebuildTimer: ReturnType<typeof setTimeout> | undefined
 
-function setCatalogState(nextState: Omit<ResourceCatalogState, 'version'>): void {
+function setCatalogState(nextState: ResourceCatalogState): void {
   resourceCatalogState.value = nextState
 }
 
@@ -63,6 +65,7 @@ function clearCatalogState(): void {
     status: 'idle',
     gamePath: undefined,
     snapshot: createEmptyAssetCatalogSnapshot(),
+    dirty: false,
   })
 }
 
@@ -73,6 +76,7 @@ async function rebuildCatalog(gamePath: string): Promise<void> {
     status: 'building',
     gamePath,
     snapshot: createEmptyAssetCatalogSnapshot(),
+    dirty: false,
   })
 
   try {
@@ -81,11 +85,18 @@ async function rebuildCatalog(gamePath: string): Promise<void> {
       return
     }
 
+    const needsFollowUpRebuild = resourceCatalogState.value.gamePath === gamePath && resourceCatalogState.value.dirty
+
     setCatalogState({
       status: 'ready',
       gamePath,
       snapshot,
+      dirty: false,
     })
+
+    if (needsFollowUpRebuild) {
+      void rebuildCatalog(gamePath)
+    }
   } catch {
     if (currentBuildVersion !== buildVersion) {
       return
@@ -95,6 +106,7 @@ async function rebuildCatalog(gamePath: string): Promise<void> {
       status: 'degraded',
       gamePath,
       snapshot: createEmptyAssetCatalogSnapshot(),
+      dirty: false,
     })
   }
 }
@@ -103,7 +115,13 @@ function applyCatalogSnapshot(
   updater: (state: ResourceCatalogState) => ReturnType<typeof createEmptyAssetCatalogSnapshot>,
 ): void {
   const currentState = resourceCatalogState.value
-  if (!currentState.gamePath || currentState.status !== 'ready') {
+  if (!currentState.gamePath) {
+    return
+  }
+  if (currentState.status !== 'ready') {
+    if (currentState.status === 'building') {
+      currentState.dirty = true
+    }
     return
   }
 
@@ -111,6 +129,7 @@ function applyCatalogSnapshot(
     status: currentState.status,
     gamePath: currentState.gamePath,
     snapshot: updater(currentState),
+    dirty: currentState.dirty,
   })
 }
 

--- a/src/services/resource-index/service.ts
+++ b/src/services/resource-index/service.ts
@@ -15,6 +15,8 @@ import {
 
 type ResourceCatalogStatus = 'idle' | 'building' | 'ready' | 'degraded'
 
+const DIRECTORY_REBUILD_DEBOUNCE_MS = 200
+
 interface ResourceCatalogState {
   status: ResourceCatalogStatus
   gamePath?: string
@@ -30,13 +32,33 @@ const resourceCatalogState = shallowRef<ResourceCatalogState>({
 let buildVersion = 0
 let bootstrapConsumerCount = 0
 let bootstrapScope: ReturnType<typeof effectScope> | undefined
+let pendingDirectoryRebuildTimer: ReturnType<typeof setTimeout> | undefined
 
 function setCatalogState(nextState: Omit<ResourceCatalogState, 'version'>): void {
   resourceCatalogState.value = nextState
 }
 
+function clearPendingDirectoryRebuild(): void {
+  if (pendingDirectoryRebuildTimer) {
+    clearTimeout(pendingDirectoryRebuildTimer)
+    pendingDirectoryRebuildTimer = undefined
+  }
+}
+
+function scheduleDirectoryRebuild(gamePath: string): void {
+  clearPendingDirectoryRebuild()
+  pendingDirectoryRebuildTimer = setTimeout(() => {
+    pendingDirectoryRebuildTimer = undefined
+    if (resourceCatalogState.value.gamePath !== gamePath) {
+      return
+    }
+    void rebuildCatalog(gamePath)
+  }, DIRECTORY_REBUILD_DEBOUNCE_MS)
+}
+
 function clearCatalogState(): void {
   buildVersion += 1
+  clearPendingDirectoryRebuild()
   setCatalogState({
     status: 'idle',
     gamePath: undefined,
@@ -155,7 +177,7 @@ function bindResourceCatalogBootstrap(): void {
       if (!gamePath || !isPathWithinGameRoot(gamePath, path)) {
         return
       }
-      void rebuildCatalog(gamePath)
+      scheduleDirectoryRebuild(gamePath)
     }
 
     fileSystemEvents.on('directory:created', event => rebuildOnDirectoryChange(event.path))
@@ -168,7 +190,7 @@ function bindResourceCatalogBootstrap(): void {
       if (!isPathWithinGameRoot(gamePath, event.oldPath) && !isPathWithinGameRoot(gamePath, event.newPath)) {
         return
       }
-      void rebuildCatalog(gamePath)
+      scheduleDirectoryRebuild(gamePath)
     })
   })
 }
@@ -179,6 +201,7 @@ function releaseResourceCatalogBootstrap(): void {
     return
   }
 
+  clearPendingDirectoryRebuild()
   bootstrapScope?.stop()
   bootstrapScope = undefined
 }

--- a/src/services/resource-index/service.ts
+++ b/src/services/resource-index/service.ts
@@ -81,7 +81,7 @@ function applyCatalogSnapshot(
   updater: (state: ResourceCatalogState) => ReturnType<typeof createEmptyAssetCatalogSnapshot>,
 ): void {
   const currentState = resourceCatalogState.value
-  if (!currentState.gamePath || currentState.status === 'building') {
+  if (!currentState.gamePath || currentState.status !== 'ready') {
     return
   }
 
@@ -161,8 +161,14 @@ function bindResourceCatalogBootstrap(): void {
     fileSystemEvents.on('directory:created', event => rebuildOnDirectoryChange(event.path))
     fileSystemEvents.on('directory:removed', event => rebuildOnDirectoryChange(event.path))
     fileSystemEvents.on('directory:renamed', (event) => {
-      rebuildOnDirectoryChange(event.oldPath)
-      rebuildOnDirectoryChange(event.newPath)
+      const { gamePath } = resourceCatalogState.value
+      if (!gamePath) {
+        return
+      }
+      if (!isPathWithinGameRoot(gamePath, event.oldPath) && !isPathWithinGameRoot(gamePath, event.newPath)) {
+        return
+      }
+      void rebuildCatalog(gamePath)
     })
   })
 }

--- a/src/services/resource-index/service.ts
+++ b/src/services/resource-index/service.ts
@@ -1,0 +1,195 @@
+import { effectScope } from 'vue'
+
+import { useFileSystemEvents } from '~/composables/useFileSystemEvents'
+import { useWorkspaceStore } from '~/stores/workspace'
+
+import {
+  addAssetPathToCatalog,
+  buildAssetCatalog,
+  createEmptyAssetCatalogSnapshot,
+  hasAssetInCatalog,
+  isPathWithinGameRoot,
+  removeAssetPathFromCatalog,
+  renameAssetPathInCatalog,
+} from './catalog'
+
+type ResourceCatalogStatus = 'idle' | 'building' | 'ready' | 'degraded'
+
+interface ResourceCatalogState {
+  status: ResourceCatalogStatus
+  gamePath?: string
+  snapshot: ReturnType<typeof createEmptyAssetCatalogSnapshot>
+}
+
+const resourceCatalogState = shallowRef<ResourceCatalogState>({
+  status: 'idle',
+  gamePath: undefined,
+  snapshot: createEmptyAssetCatalogSnapshot(),
+})
+
+let buildVersion = 0
+let bootstrapConsumerCount = 0
+let bootstrapScope: ReturnType<typeof effectScope> | undefined
+
+function setCatalogState(nextState: Omit<ResourceCatalogState, 'version'>): void {
+  resourceCatalogState.value = nextState
+}
+
+function clearCatalogState(): void {
+  buildVersion += 1
+  setCatalogState({
+    status: 'idle',
+    gamePath: undefined,
+    snapshot: createEmptyAssetCatalogSnapshot(),
+  })
+}
+
+async function rebuildCatalog(gamePath: string): Promise<void> {
+  const currentBuildVersion = ++buildVersion
+
+  setCatalogState({
+    status: 'building',
+    gamePath,
+    snapshot: createEmptyAssetCatalogSnapshot(),
+  })
+
+  try {
+    const snapshot = await buildAssetCatalog(gamePath)
+    if (currentBuildVersion !== buildVersion) {
+      return
+    }
+
+    setCatalogState({
+      status: 'ready',
+      gamePath,
+      snapshot,
+    })
+  } catch {
+    if (currentBuildVersion !== buildVersion) {
+      return
+    }
+
+    setCatalogState({
+      status: 'degraded',
+      gamePath,
+      snapshot: createEmptyAssetCatalogSnapshot(),
+    })
+  }
+}
+
+function applyCatalogSnapshot(
+  updater: (state: ResourceCatalogState) => ReturnType<typeof createEmptyAssetCatalogSnapshot>,
+): void {
+  const currentState = resourceCatalogState.value
+  if (!currentState.gamePath || currentState.status === 'building') {
+    return
+  }
+
+  setCatalogState({
+    status: currentState.status,
+    gamePath: currentState.gamePath,
+    snapshot: updater(currentState),
+  })
+}
+
+function bindResourceCatalogBootstrap(): void {
+  bootstrapConsumerCount += 1
+  if (bootstrapScope) {
+    return
+  }
+
+  bootstrapScope = effectScope()
+  bootstrapScope.run(() => {
+    const workspaceStore = useWorkspaceStore()
+    const fileSystemEvents = useFileSystemEvents()
+
+    watch(
+      () => workspaceStore.CWD,
+      (gamePath) => {
+        if (!gamePath) {
+          clearCatalogState()
+          return
+        }
+        void rebuildCatalog(gamePath)
+      },
+      { immediate: true },
+    )
+
+    fileSystemEvents.on('file:created', (event) => {
+      const gamePath = resourceCatalogState.value.gamePath
+      if (!gamePath || !isPathWithinGameRoot(gamePath, event.path)) {
+        return
+      }
+
+      applyCatalogSnapshot(state => addAssetPathToCatalog(state.snapshot, gamePath, event.path))
+    })
+
+    fileSystemEvents.on('file:removed', (event) => {
+      const gamePath = resourceCatalogState.value.gamePath
+      if (!gamePath || !isPathWithinGameRoot(gamePath, event.path)) {
+        return
+      }
+
+      applyCatalogSnapshot(state => removeAssetPathFromCatalog(state.snapshot, gamePath, event.path))
+    })
+
+    fileSystemEvents.on('file:renamed', (event) => {
+      const gamePath = resourceCatalogState.value.gamePath
+      if (!gamePath) {
+        return
+      }
+      if (!isPathWithinGameRoot(gamePath, event.oldPath) && !isPathWithinGameRoot(gamePath, event.newPath)) {
+        return
+      }
+
+      applyCatalogSnapshot(state => renameAssetPathInCatalog(
+        state.snapshot,
+        gamePath,
+        event.oldPath,
+        event.newPath,
+      ))
+    })
+
+    const rebuildOnDirectoryChange = (path: string) => {
+      const gamePath = resourceCatalogState.value.gamePath
+      if (!gamePath || !isPathWithinGameRoot(gamePath, path)) {
+        return
+      }
+      void rebuildCatalog(gamePath)
+    }
+
+    fileSystemEvents.on('directory:created', event => rebuildOnDirectoryChange(event.path))
+    fileSystemEvents.on('directory:removed', event => rebuildOnDirectoryChange(event.path))
+    fileSystemEvents.on('directory:renamed', (event) => {
+      rebuildOnDirectoryChange(event.oldPath)
+      rebuildOnDirectoryChange(event.newPath)
+    })
+  })
+}
+
+function releaseResourceCatalogBootstrap(): void {
+  bootstrapConsumerCount = Math.max(0, bootstrapConsumerCount - 1)
+  if (bootstrapConsumerCount > 0) {
+    return
+  }
+
+  bootstrapScope?.stop()
+  bootstrapScope = undefined
+}
+
+export function useResourceCatalogBootstrap() {
+  bindResourceCatalogBootstrap()
+
+  onScopeDispose(() => {
+    releaseResourceCatalogBootstrap()
+  })
+}
+
+export function useResourceCatalog() {
+  return {
+    status: computed(() => resourceCatalogState.value.status),
+    hasAsset(assetType: string, relativePath: string): boolean {
+      return hasAssetInCatalog(resourceCatalogState.value.snapshot, assetType, relativePath)
+    },
+  }
+}


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [ ] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [x] 代码重构
- [ ] 测试用例
- [x] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

本次改动围绕语句卡片中的 `file missing` 检查做了收敛与性能治理，核心变化如下：

- 新增工作区级资源索引基础设施，在 `game` 目录上构建资源快照，并在文件事件后做增量更新
- 将 `file missing` 判定从编辑器/语句卡片热路径中的异步文件存在检查，改为同步查询资源索引
- 删除旧的异步 loader、竞态控制和相关残留接口，收敛 `scene` 的 `.txt` 特判逻辑到纯函数
- 将资源索引 bootstrap 上移到明确的调用入口，避免 `useStatementFileMissing` 隐式触发副作用
- 同步收紧相关类型边界，并补充/整理测试覆盖

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

当前语句卡片中的 `file missing` 功能会在滚动和渲染热路径触发文件系统访问，用户已经可以明显感知到卡顿。

继续在原实现上叠加补丁，会让检查逻辑长期停留在组件级副作用和局部特判上，技术债会越来越重。本次改动的目标是在保留 `file missing` 功能的前提下，把判定迁移到可复用的资源索引层，先解决性能问题，同时为后续资源引用能力扩展打基础。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
