### PR TITLE
♻️ 清理 gameCmds 中失效的预览服务器封装

### DIFF
--- a/src/__tests__/mocks/tauri-commands.ts
+++ b/src/__tests__/mocks/tauri-commands.ts
@@ -17,9 +17,7 @@ export interface TauriCommandMockBundle {
   }
   gameCmds: {
     getGameConfig: ReturnType<typeof vi.fn>
-    runGameServer: ReturnType<typeof vi.fn>
     setGameConfig: ReturnType<typeof vi.fn>
-    stopGameServer: ReturnType<typeof vi.fn>
   }
   serverCmds: {
     addStaticSite: ReturnType<typeof vi.fn>
@@ -51,9 +49,7 @@ export function createTauriCommandMockBundle(): TauriCommandMockBundle {
     },
     gameCmds: {
       getGameConfig: vi.fn(),
-      runGameServer: vi.fn(),
       setGameConfig: vi.fn(),
-      stopGameServer: vi.fn(),
     },
     serverCmds: {
       addStaticSite: vi.fn(),

--- a/src/commands/game.ts
+++ b/src/commands/game.ts
@@ -48,17 +48,7 @@ async function setGameConfig(gamePath: string, config: GameConfigPatch) {
   return safeInvoke<void>('set_game_config', { gamePath, config })
 }
 
-async function runGameServer(gamePath: string) {
-  return safeInvoke<string>('run_game_server', { gamePath })
-}
-
-async function stopGameServer(gamePath: string) {
-  return safeInvoke<void>('stop_game_server', { gamePath })
-}
-
 export const gameCmds = {
   getGameConfig,
   setGameConfig,
-  runGameServer,
-  stopGameServer,
 }


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [ ] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [x] 代码重构
- [ ] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

- 移除 `src/commands/game.ts` 中已经失效的 `runGameServer` / `stopGameServer` wrapper，收紧 `gameCmds` 的职责边界，只保留游戏配置读写能力。
- 同步更新前端测试 mock，避免继续把这两个陈旧接口当成有效契约。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

当前预览服务链路已经统一迁移到 `serverCmds.startServer` 与 `serverCmds.addStaticSite`。`gameCmds` 中遗留的两个 wrapper 对应的 Tauri invoke 命令已不存在，也没有任何生产调用点。

继续保留它们会制造错误的 API 暗示，后续一旦被误用会直接触发运行时调用失败。本次调整用于清理死代码，并让前端命令边界和后端实际注册状态保持一致。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->

本次变更不涉及用户可见行为调整，也不涉及数据结构、持久化格式或 Tauri 命令协议变更。

### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [ ] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
