### PR TITLE
♻️ 清理依赖自动导入的冗余组件导入

### DIFF
--- a/src/components/editor/AssetPanel.vue
+++ b/src/components/editor/AssetPanel.vue
@@ -2,11 +2,8 @@
 import { ArrowDown, ArrowUp, ArrowUpDown, Blend, Check, Image, LayoutGrid, LayoutList, LayoutTemplate, MicVocal, Minus, Music, Plus, UserRound, Video } from '@lucide/vue'
 
 import { canCreateAssetFile } from '~/components/editor/asset-file-defaults'
-import ExpandableSearchInput from '~/components/shared/ExpandableSearchInput.vue'
 import { usePreferenceStore } from '~/stores/preference'
 import { FileViewerSortBy, FileViewerSortOrder } from '~/types/file-viewer'
-
-import AssetView from './AssetView.vue'
 
 const preferenceStore = usePreferenceStore()
 

--- a/src/components/editor/AssetView.vue
+++ b/src/components/editor/AssetView.vue
@@ -3,7 +3,6 @@ import { File, FileImage, FileJson2, FileMusic, FileVideo, FileVolume, Folder } 
 import { basename, join } from '@tauri-apps/api/path'
 
 import { canCreateAssetFile, resolveAssetFileNameParts } from '~/components/editor/asset-file-defaults'
-import FileTreeContextMenuContent from '~/components/editor/FileTreeContextMenuContent.vue'
 import { useAssetViewItemsLoader } from '~/components/editor/useAssetViewItemsLoader'
 import { PopoverAnchor } from '~/components/ui/popover'
 import { useFileSystemEvents } from '~/composables/useFileSystemEvents'

--- a/src/components/editor/EffectEditorPanel.vue
+++ b/src/components/editor/EffectEditorPanel.vue
@@ -3,8 +3,6 @@ import { Transform } from '~/domain/stage/types'
 import { EffectEditorPreviewPayload, EffectEditorTransformUpdatePayload } from '~/features/editor/effect-editor/useEffectEditorProvider'
 import { useShortcutContext } from '~/features/editor/shortcut/useShortcutContext'
 
-import EffectDraftForm from './effect-editor/EffectDraftForm.vue'
-
 interface EffectEditorPanelProps {
   transform: Transform
   duration: string

--- a/src/components/editor/FileTree.vue
+++ b/src/components/editor/FileTree.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts" generic="T extends object">
 import { LucideFile, LucideFolder, LucideFolderOpen } from '@lucide/vue'
 
-import FileTreeContextMenu from '~/components/editor/FileTreeContextMenu.vue'
 import { useFileTreeController } from '~/features/editor/file-tree/useFileTreeController'
 import { useShortcut } from '~/features/editor/shortcut/useShortcut'
 import { useShortcutContext } from '~/features/editor/shortcut/useShortcutContext'

--- a/src/components/editor/FileTreeContextMenu.vue
+++ b/src/components/editor/FileTreeContextMenu.vue
@@ -1,6 +1,4 @@
 <script setup lang="ts">
-import FileTreeContextMenuContent from '~/components/editor/FileTreeContextMenuContent.vue'
-
 interface FileItem {
   path: string
   name: string

--- a/src/components/editor/StatementAnimationEditorPanel.vue
+++ b/src/components/editor/StatementAnimationEditorPanel.vue
@@ -1,8 +1,6 @@
 <script setup lang="ts">
 import { useStatementAnimationEditorPanel } from '~/features/editor/animation/useStatementAnimationEditorPanel'
 
-import AnimationEditorPane from './animation/AnimationEditorPane.vue'
-
 import type { AnimationFrame } from '~/domain/stage/types'
 
 interface Props {

--- a/src/components/editor/StatementAssetPreview.vue
+++ b/src/components/editor/StatementAssetPreview.vue
@@ -1,6 +1,4 @@
 <script setup lang="ts">
-import StatementAudioPreview from './StatementAudioPreview.vue'
-
 interface Props {
   /** 资源的完整 URL */
   src: string

--- a/src/components/editor/VisualEditorAnimation.vue
+++ b/src/components/editor/VisualEditorAnimation.vue
@@ -6,8 +6,6 @@ import { useVisualEditorFocusRequest } from '~/features/editor/visual-editor/use
 import { findSelectedVisualEditorAnimationFrame } from '~/features/editor/visual-editor/visual-editor-focus'
 import { useEditorStore } from '~/stores/editor'
 
-import AnimationEditorPane from './animation/AnimationEditorPane.vue'
-
 import type { AnimationVisualProjectionState } from '~/stores/editor'
 
 interface Props {

--- a/src/components/editor/animation/AnimationEditorPane.vue
+++ b/src/components/editor/animation/AnimationEditorPane.vue
@@ -1,6 +1,4 @@
 <script setup lang="ts">
-import EffectDraftForm from '../effect-editor/EffectDraftForm.vue'
-
 import type { AnimationEditorSelectedFrameState, AnimationTimelineResizeDurationPayload } from '~/features/editor/animation/animation-editor-contract'
 import type { AnimationEditorKeyframe } from '~/features/editor/animation/animation-inspector'
 import type { EffectEditorTransformUpdatePayload } from '~/features/editor/effect-editor/useEffectEditorProvider'

--- a/src/components/editor/param-renderer/ParamChoiceField.vue
+++ b/src/components/editor/param-renderer/ParamChoiceField.vue
@@ -3,8 +3,6 @@ import { CUSTOM_CONTENT, EditorField } from '~/features/editor/command-registry/
 import { normalizeFieldStringValue } from '~/features/editor/statement-editor/field-utils'
 import { cn } from '~/lib/utils'
 
-import SegmentedControl from './controls/SegmentedControl.vue'
-
 import type { ParamSelectOptionItem } from './controls/types'
 import type { StatementEditorSurface } from '~/features/editor/statement-editor/surface-context'
 

--- a/src/components/editor/param-renderer/ParamRenderer.vue
+++ b/src/components/editor/param-renderer/ParamRenderer.vue
@@ -5,9 +5,6 @@ import { normalizeFieldStringValue } from '~/features/editor/statement-editor/fi
 import { statementEditorSurfaceKey } from '~/features/editor/statement-editor/surface-context'
 import { cn } from '~/lib/utils'
 
-import FocusXYControl from './controls/FocusXYControl.vue'
-import NumberControl from './controls/NumberControl.vue'
-import ParamChoiceField from './ParamChoiceField.vue'
 import { useParamCustomField } from './useParamCustomField'
 import { useParamFieldMeta } from './useParamFieldMeta'
 import { useParamXyPad } from './useParamXyPad'

--- a/src/components/file-picker/FilePicker.vue
+++ b/src/components/file-picker/FilePicker.vue
@@ -9,9 +9,6 @@ import { usePreferenceStore } from '~/stores/preference'
 import { useWorkspaceStore } from '~/stores/workspace'
 import { FileViewerSortBy, FileViewerSortOrder } from '~/types/file-viewer'
 
-import FilePickerRecentHistory from './FilePickerRecentHistory.vue'
-import FilePickerToolbar from './FilePickerToolbar.vue'
-
 import type { HTMLAttributes } from 'vue'
 
 interface FilePickerProps {

--- a/src/components/file-picker/FilePickerToolbar.vue
+++ b/src/components/file-picker/FilePickerToolbar.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { ArrowDown, ArrowUp, EllipsisVertical, LayoutGrid, LayoutList } from '@lucide/vue'
 
-import ExpandableSearchInput from '~/components/shared/ExpandableSearchInput.vue'
 import { FileViewerSortBy, FileViewerSortOrder } from '~/types/file-viewer'
 
 import type { AcceptableValue } from 'reka-ui'

--- a/src/components/file-viewer/FileViewerBody.vue
+++ b/src/components/file-viewer/FileViewerBody.vue
@@ -2,8 +2,6 @@
 import { File, FileImage, FileJson2, FileMusic, FileVideo, Folder } from '@lucide/vue'
 
 import { loadFileViewerImageDimensions } from '~/components/file-viewer/fileViewerImageDimensions'
-import FileViewerImageHoverCard from '~/components/file-viewer/FileViewerImageHoverCard.vue'
-import FileViewerItemContextMenu from '~/components/file-viewer/FileViewerItemContextMenu.vue'
 import { formatFileSize } from '~/utils/format'
 import { isValidPositiveNumber } from '~/utils/sort'
 

--- a/src/components/home/engines-tab/EnginesTab.vue
+++ b/src/components/home/engines-tab/EnginesTab.vue
@@ -8,8 +8,6 @@ import { usePreferenceStore } from '~/stores/preference'
 import { usePreviewRuntimeStore } from '~/stores/preview-runtime'
 import { useResourceStore } from '~/stores/resource'
 
-import EnginesTabCollectionSection from './EnginesTabCollectionSection.vue'
-
 import type { EngineCollectionItem } from '~/features/home/home-collection-items'
 
 const modalStore = useModalStore()

--- a/src/components/home/engines-tab/EnginesTabCollectionSection.vue
+++ b/src/components/home/engines-tab/EnginesTabCollectionSection.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { Box, Folder, Trash2 } from '@lucide/vue'
 
-import AssetImage from '~/components/shared/AssetImage.vue'
 import { useTauriDropZone } from '~/composables/useTauriDropZone'
 
 import type { Engine } from '~/database/model'

--- a/src/components/home/games-tab/GamesTab.vue
+++ b/src/components/home/games-tab/GamesTab.vue
@@ -9,8 +9,6 @@ import { usePreviewRuntimeStore } from '~/stores/preview-runtime'
 import { useResourceStore } from '~/stores/resource'
 import { useWorkspaceStore } from '~/stores/workspace'
 
-import GamesTabCollectionSection from './GamesTabCollectionSection.vue'
-
 import type { GameCollectionItem } from '~/features/home/home-collection-items'
 
 const modalStore = useModalStore()

--- a/src/components/home/games-tab/GamesTabCollectionSection.vue
+++ b/src/components/home/games-tab/GamesTabCollectionSection.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { Folder, Scroll, Trash2 } from '@lucide/vue'
 
-import AssetImage from '~/components/shared/AssetImage.vue'
 import { useTauriDropZone } from '~/composables/useTauriDropZone'
 import dayjs from '~/plugins/dayjs'
 

--- a/src/components/modals/GameConfigModal.vue
+++ b/src/components/modals/GameConfigModal.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { useForm } from 'vee-validate'
 
-import GameConfigFieldsSection from '~/components/modals/game-config/GameConfigFieldsSection.vue'
 import {
   cloneGameConfigFormValues,
   createEmptyGameConfigFormValues,

--- a/src/components/settings/EditSettings.vue
+++ b/src/components/settings/EditSettings.vue
@@ -2,8 +2,6 @@
 import { editSettingsDefinition } from '~/features/settings/edit-settings'
 import { useEditSettingsStore } from '~/stores/edit-settings'
 
-import SettingsForm from './form/SettingsForm.vue'
-
 const editSettingsStore = useEditSettingsStore()
 </script>
 

--- a/src/components/settings/GeneralSettings.vue
+++ b/src/components/settings/GeneralSettings.vue
@@ -2,8 +2,6 @@
 import { generalSettingsDefinition } from '~/features/settings/general-settings'
 import { useGeneralSettingsStore } from '~/stores/general-settings'
 
-import SettingsForm from './form/SettingsForm.vue'
-
 const { t } = useI18n()
 const generalSettingsStore = useGeneralSettingsStore()
 const themeFieldName = 'general-theme'

--- a/src/components/settings/PreviewSettings.vue
+++ b/src/components/settings/PreviewSettings.vue
@@ -2,8 +2,6 @@
 import { previewSettingsDefinition } from '~/features/settings/preview-settings'
 import { usePreviewSettingsStore } from '~/stores/preview-settings'
 
-import SettingsForm from './form/SettingsForm.vue'
-
 const previewSettingsStore = usePreviewSettingsStore()
 </script>
 

--- a/src/components/settings/StorageSettings.vue
+++ b/src/components/settings/StorageSettings.vue
@@ -2,8 +2,6 @@
 import { storageSettingsDefinition } from '~/features/settings/storage-settings'
 import { useStorageSettingsStore } from '~/stores/storage-settings'
 
-import SettingsForm from './form/SettingsForm.vue'
-
 const storageSettingsStore = useStorageSettingsStore()
 </script>
 


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [ ] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [x] 代码重构
- [ ] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

- 移除了多个 Vue 组件中已经由现有自动导入机制覆盖的手动组件导入
- 收敛了 `<script setup>` 顶部的依赖声明，减少重复声明和阅读噪音
- 本次改动不涉及运行时逻辑、接口定义或持久化数据结构调整

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

当前部分组件同时保留了自动导入和手动导入两套组件依赖来源，增加了维护时的认知负担，也让脚本区的真实依赖边界不够清晰。

这次清理将组件依赖来源统一到现有的自动导入机制上，使组件脚本只保留真正需要手动声明的依赖，降低后续维护成本，并让导入列表更聚焦。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [ ] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
