### PR TITLE
🐛 修复首页 tab 内容区域无法滚动

### DIFF
--- a/src/components/home/SearchView.vue
+++ b/src/components/home/SearchView.vue
@@ -21,7 +21,7 @@ const updateSearch = useDebounceFn((value: string | number) => {
 </script>
 
 <template>
-  <div class="mt-4 flex items-center justify-between">
+  <div class="flex items-center justify-between">
     <div class="max-w-sm w-full relative">
       <Search class="text-muted-foreground h-4 w-4 left-2.5 top-2.5 absolute" />
       <Input

--- a/src/components/home/engines-tab/EnginesTabCollectionSection.vue
+++ b/src/components/home/engines-tab/EnginesTabCollectionSection.vue
@@ -48,168 +48,170 @@ const LIST_ICON_THUMBNAIL: AssetThumbnailOptions = {
 </script>
 
 <template>
-  <div v-if="viewMode === 'grid'" class="gap-4 grid grid-cols-1 lg:grid-cols-4 md:grid-cols-3 sm:grid-cols-2">
-    <ContextMenu v-for="item in items" :key="item.engine.id">
-      <ContextMenuTrigger as-child>
-        <Card
-          class="group rounded-lg shadow-sm transition-all duration-300 relative overflow-hidden hover:shadow"
-          :class="{ 'cursor-wait': hasEngineProgress(item.engine) }"
-        >
-          <CardContent class="p-0">
-            <div class="p-4 flex gap-4 items-start">
-              <div class="rounded shrink-0 h-15 w-15 overflow-hidden">
-                <AssetImage
-                  :path="item.engine.previewAssets.icon.path"
-                  :root-path="item.engine.path"
-                  :serve-url="item.serveUrl"
-                  :alt="$t('home.engines.engineIcon', { name: item.engine.metadata.name })"
-                  :cache-version="item.engine.previewAssets.icon.cacheVersion"
-                  object-fit="cover"
-                  fallback-image="/placeholder.svg"
-                  :thumbnail="GRID_ICON_THUMBNAIL"
-                  class="h-full w-full"
-                />
-              </div>
-              <div class="flex-1">
-                <div class="flex items-center justify-between">
-                  <h4 class="font-medium">
-                    {{ item.engine.metadata.name }}
-                  </h4>
+  <ScrollArea class="h-full min-h-0">
+    <div v-if="viewMode === 'grid'" class="gap-4 grid grid-cols-1 lg:grid-cols-4 md:grid-cols-3 sm:grid-cols-2">
+      <ContextMenu v-for="item in items" :key="item.engine.id">
+        <ContextMenuTrigger as-child>
+          <Card
+            class="group rounded-lg shadow-sm transition-all duration-300 relative overflow-hidden hover:shadow"
+            :class="{ 'cursor-wait': hasEngineProgress(item.engine) }"
+          >
+            <CardContent class="p-0">
+              <div class="p-4 flex gap-4 items-start">
+                <div class="rounded shrink-0 h-15 w-15 overflow-hidden">
+                  <AssetImage
+                    :path="item.engine.previewAssets.icon.path"
+                    :root-path="item.engine.path"
+                    :serve-url="item.serveUrl"
+                    :alt="$t('home.engines.engineIcon', { name: item.engine.metadata.name })"
+                    :cache-version="item.engine.previewAssets.icon.cacheVersion"
+                    object-fit="cover"
+                    fallback-image="/placeholder.svg"
+                    :thumbnail="GRID_ICON_THUMBNAIL"
+                    class="h-full w-full"
+                  />
                 </div>
-                <p class="text-sm text-muted-foreground mt-1">
-                  {{ item.engine.metadata.description }}
-                </p>
+                <div class="flex-1">
+                  <div class="flex items-center justify-between">
+                    <h4 class="font-medium">
+                      {{ item.engine.metadata.name }}
+                    </h4>
+                  </div>
+                  <p class="text-sm text-muted-foreground mt-1">
+                    {{ item.engine.metadata.description }}
+                  </p>
+                </div>
               </div>
-            </div>
-          </CardContent>
-          <Progress v-if="hasEngineProgress(item.engine)" :model-value="getEngineProgress(item.engine)" class="rounded-none h-1 inset-x-0 bottom-0 absolute" />
-        </Card>
-      </ContextMenuTrigger>
-      <ContextMenuContent class="w-42">
-        <ContextMenuItem v-if="!hasEngineProgress(item.engine)" @click="emit('openFolder', item.engine)">
-          <Folder class="mr-2 size-3.5" />
-          {{ $t('common.openFolder') }}
-        </ContextMenuItem>
-        <ContextMenuItem
-          v-if="!hasEngineProgress(item.engine)"
-          class="text-destructive text-13px! focus:text-destructive-foreground focus:bg-destructive"
-          @click="emit('deleteEngine', item.engine)"
-        >
-          <Trash2 class="mr-2 size-3.5" />
-          {{ $t('home.engines.uninstallEngine') }}
-        </ContextMenuItem>
-      </ContextMenuContent>
-    </ContextMenu>
-    <button
-      ref="dropZoneGridRef"
-      type="button"
-      :aria-label="$t('home.engines.installEngine')"
-      class="p-4 border-1 border-gray-300 rounded-lg border-dashed bg-gray-50 flex flex-row gap-4 cursor-pointer shadow-none transition-colors items-center justify-center overflow-hidden dark:border-gray-700 hover:border-purple-300 dark:bg-gray-900 dark:hover:border-purple-700"
-      :class="{'border-purple-300 bg-purple-50': isOverDropZoneGrid}"
-      @click="emit('importClick')"
-    >
-      <div class="p-3 rounded-full bg-purple-100 dark:bg-purple-900/20">
-        <Box class="text-purple-600 h-6 w-6 dark:text-purple-400" />
-      </div>
-      <div class="text-left">
-        <p class="text-sm font-medium">
-          {{ $t('home.engines.installEngine') }}
-        </p>
-        <p class="text-xs text-muted-foreground mt-1">
-          {{ $t('home.engines.installEngineHint') }}
-        </p>
-      </div>
-    </button>
-  </div>
-  <div v-else class="border rounded-lg overflow-hidden divide-y">
-    <div
-      v-for="item in items"
-      :key="item.engine.id"
-      class="p-3 flex transition-colors duration-200 items-center justify-between relative hover:bg-primary/5 dark:hover:bg-primary/10"
-      :class="{ 'cursor-wait': hasEngineProgress(item.engine) }"
-    >
-      <div class="flex gap-3 items-center">
-        <div class="rounded h-10 w-10 overflow-hidden">
-          <AssetImage
-            :path="item.engine.previewAssets.icon.path"
-            :root-path="item.engine.path"
-            :serve-url="item.serveUrl"
-            :alt="$t('home.engines.engineIcon', { name: item.engine.metadata.name })"
-            :cache-version="item.engine.previewAssets.icon.cacheVersion"
-            object-fit="cover"
-            fallback-image="/placeholder.svg"
-            :thumbnail="LIST_ICON_THUMBNAIL"
-            class="h-full w-full"
-          />
-        </div>
-        <div>
-          <h3 class="font-medium">
-            {{ item.engine.metadata.name }}
-          </h3>
-          <p class="text-xs text-muted-foreground">
-            {{ item.engine.metadata.description }}
-          </p>
-        </div>
-      </div>
-      <div v-if="!hasEngineProgress(item.engine)" class="flex gap-2 items-center">
-        <TooltipProvider>
-          <Tooltip>
-            <TooltipTrigger as-child>
-              <Button
-                :aria-label="$t('common.openFolder')"
-                variant="ghost"
-                size="icon"
-                class="h-8 w-8"
-                @click="emit('openFolder', item.engine)"
-              >
-                <Folder class="h-4 w-4" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>
-              <p>{{ $t('common.openFolder') }}</p>
-            </TooltipContent>
-          </Tooltip>
-          <Tooltip>
-            <TooltipTrigger as-child>
-              <Button
-                :aria-label="$t('home.engines.uninstallEngine')"
-                variant="ghost"
-                size="icon"
-                class="text-destructive h-8 w-8 hover:text-destructive-foreground hover:bg-destructive"
-                @click="emit('deleteEngine', item.engine)"
-              >
-                <Trash2 class="h-4 w-4" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>
-              <p>{{ $t('home.engines.uninstallEngine') }}</p>
-            </TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
-      </div>
-      <Progress v-if="hasEngineProgress(item.engine)" :model-value="getEngineProgress(item.engine)" class="rounded-none h-0.75 inset-x-0 bottom-0 absolute" />
-    </div>
-    <button
-      ref="dropZoneListRef"
-      type="button"
-      :aria-label="$t('home.engines.installEngine')"
-      class="p-3 bg-gray-50/50 flex w-full cursor-pointer transition-colors items-center justify-between dark:bg-gray-800/10 hover:bg-gray-100 dark:hover:bg-gray-800/20"
-      :class="{'bg-purple-50': isOverDropZoneList}"
-      @click="emit('importClick')"
-    >
-      <div class="flex gap-3 items-center">
-        <div class="rounded-md bg-purple-100 flex h-10 w-10 items-center justify-center dark:bg-purple-900/20">
-          <Box class="text-purple-600 h-5 w-5 dark:text-purple-400" />
+            </CardContent>
+            <Progress v-if="hasEngineProgress(item.engine)" :model-value="getEngineProgress(item.engine)" class="rounded-none h-1 inset-x-0 bottom-0 absolute" />
+          </Card>
+        </ContextMenuTrigger>
+        <ContextMenuContent class="w-42">
+          <ContextMenuItem v-if="!hasEngineProgress(item.engine)" @click="emit('openFolder', item.engine)">
+            <Folder class="mr-2 size-3.5" />
+            {{ $t('common.openFolder') }}
+          </ContextMenuItem>
+          <ContextMenuItem
+            v-if="!hasEngineProgress(item.engine)"
+            class="text-destructive text-13px! focus:text-destructive-foreground focus:bg-destructive"
+            @click="emit('deleteEngine', item.engine)"
+          >
+            <Trash2 class="mr-2 size-3.5" />
+            {{ $t('home.engines.uninstallEngine') }}
+          </ContextMenuItem>
+        </ContextMenuContent>
+      </ContextMenu>
+      <button
+        ref="dropZoneGridRef"
+        type="button"
+        :aria-label="$t('home.engines.installEngine')"
+        class="p-4 border-1 border-gray-300 rounded-lg border-dashed bg-gray-50 flex flex-row gap-4 cursor-pointer shadow-none transition-colors items-center justify-center overflow-hidden dark:border-gray-700 hover:border-purple-300 dark:bg-gray-900 dark:hover:border-purple-700"
+        :class="{'border-purple-300 bg-purple-50': isOverDropZoneGrid}"
+        @click="emit('importClick')"
+      >
+        <div class="p-3 rounded-full bg-purple-100 dark:bg-purple-900/20">
+          <Box class="text-purple-600 h-6 w-6 dark:text-purple-400" />
         </div>
         <div class="text-left">
-          <h3 class="font-medium">
+          <p class="text-sm font-medium">
             {{ $t('home.engines.installEngine') }}
-          </h3>
-          <p class="text-xs text-muted-foreground">
+          </p>
+          <p class="text-xs text-muted-foreground mt-1">
             {{ $t('home.engines.installEngineHint') }}
           </p>
         </div>
+      </button>
+    </div>
+    <div v-else class="border rounded-lg overflow-hidden divide-y">
+      <div
+        v-for="item in items"
+        :key="item.engine.id"
+        class="p-3 flex transition-colors duration-200 items-center justify-between relative hover:bg-primary/5 dark:hover:bg-primary/10"
+        :class="{ 'cursor-wait': hasEngineProgress(item.engine) }"
+      >
+        <div class="flex gap-3 items-center">
+          <div class="rounded h-10 w-10 overflow-hidden">
+            <AssetImage
+              :path="item.engine.previewAssets.icon.path"
+              :root-path="item.engine.path"
+              :serve-url="item.serveUrl"
+              :alt="$t('home.engines.engineIcon', { name: item.engine.metadata.name })"
+              :cache-version="item.engine.previewAssets.icon.cacheVersion"
+              object-fit="cover"
+              fallback-image="/placeholder.svg"
+              :thumbnail="LIST_ICON_THUMBNAIL"
+              class="h-full w-full"
+            />
+          </div>
+          <div>
+            <h3 class="font-medium">
+              {{ item.engine.metadata.name }}
+            </h3>
+            <p class="text-xs text-muted-foreground">
+              {{ item.engine.metadata.description }}
+            </p>
+          </div>
+        </div>
+        <div v-if="!hasEngineProgress(item.engine)" class="flex gap-2 items-center">
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger as-child>
+                <Button
+                  :aria-label="$t('common.openFolder')"
+                  variant="ghost"
+                  size="icon"
+                  class="h-8 w-8"
+                  @click="emit('openFolder', item.engine)"
+                >
+                  <Folder class="h-4 w-4" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p>{{ $t('common.openFolder') }}</p>
+              </TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger as-child>
+                <Button
+                  :aria-label="$t('home.engines.uninstallEngine')"
+                  variant="ghost"
+                  size="icon"
+                  class="text-destructive h-8 w-8 hover:text-destructive-foreground hover:bg-destructive"
+                  @click="emit('deleteEngine', item.engine)"
+                >
+                  <Trash2 class="h-4 w-4" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p>{{ $t('home.engines.uninstallEngine') }}</p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        </div>
+        <Progress v-if="hasEngineProgress(item.engine)" :model-value="getEngineProgress(item.engine)" class="rounded-none h-0.75 inset-x-0 bottom-0 absolute" />
       </div>
-    </button>
-  </div>
+      <button
+        ref="dropZoneListRef"
+        type="button"
+        :aria-label="$t('home.engines.installEngine')"
+        class="p-3 bg-gray-50/50 flex w-full cursor-pointer transition-colors items-center justify-between dark:bg-gray-800/10 hover:bg-gray-100 dark:hover:bg-gray-800/20"
+        :class="{'bg-purple-50': isOverDropZoneList}"
+        @click="emit('importClick')"
+      >
+        <div class="flex gap-3 items-center">
+          <div class="rounded-md bg-purple-100 flex h-10 w-10 items-center justify-center dark:bg-purple-900/20">
+            <Box class="text-purple-600 h-5 w-5 dark:text-purple-400" />
+          </div>
+          <div class="text-left">
+            <h3 class="font-medium">
+              {{ $t('home.engines.installEngine') }}
+            </h3>
+            <p class="text-xs text-muted-foreground">
+              {{ $t('home.engines.installEngineHint') }}
+            </p>
+          </div>
+        </div>
+      </button>
+    </div>
+  </ScrollArea>
 </template>

--- a/src/components/home/games-tab/GamesTabCollectionSection.vue
+++ b/src/components/home/games-tab/GamesTabCollectionSection.vue
@@ -56,15 +56,96 @@ const LIST_COVER_THUMBNAIL: AssetThumbnailOptions = {
 </script>
 
 <template>
-  <div v-if="viewMode === 'grid'" class="gap-4 grid grid-cols-1 lg:grid-cols-4 md:grid-cols-3 sm:grid-cols-2">
-    <ContextMenu v-for="item in items" :key="item.game.id">
-      <ContextMenuTrigger as-child>
-        <Card
-          class="group rounded-lg cursor-pointer shadow-sm transition-all duration-300 relative overflow-hidden hover:shadow"
-          :class="{ 'cursor-wait': hasGameProgress(item.game) }"
-          @click="emit('gameClick', item.game)"
-        >
-          <div class="bg-gray-100 w-full aspect-16/9 overflow-hidden">
+  <ScrollArea class="h-full min-h-0">
+    <div v-if="viewMode === 'grid'" class="gap-4 grid grid-cols-1 lg:grid-cols-4 md:grid-cols-3 sm:grid-cols-2">
+      <ContextMenu v-for="item in items" :key="item.game.id">
+        <ContextMenuTrigger as-child>
+          <Card
+            class="group rounded-lg cursor-pointer shadow-sm transition-all duration-300 relative overflow-hidden hover:shadow"
+            :class="{ 'cursor-wait': hasGameProgress(item.game) }"
+            @click="emit('gameClick', item.game)"
+          >
+            <div class="bg-gray-100 w-full aspect-16/9 overflow-hidden">
+              <AssetImage
+                :path="item.game.previewAssets.cover.path"
+                :root-path="item.game.path"
+                :serve-url="item.serveUrl"
+                :alt="$t('home.games.gameCover', { name: item.game.metadata.name })"
+                :cache-version="item.game.previewAssets.cover.cacheVersion"
+                object-fit="cover"
+                fallback-image="/placeholder.svg"
+                :thumbnail="GRID_COVER_THUMBNAIL"
+                class="h-full w-full transition-transform duration-300 group-hover:scale-105"
+              />
+            </div>
+            <CardContent class="p-3">
+              <div class="flex gap-4 items-center">
+                <AssetImage
+                  :path="item.game.previewAssets.icon.path"
+                  :root-path="item.game.path"
+                  :serve-url="item.serveUrl"
+                  :alt="$t('home.games.gameIcon', { name: item.game.metadata.name })"
+                  :cache-version="item.game.previewAssets.icon.cacheVersion"
+                  :thumbnail="GRID_ICON_THUMBNAIL"
+                  class="rounded-md size-8"
+                />
+                <div>
+                  <h3 class="font-medium">
+                    {{ item.game.metadata.name }}
+                  </h3>
+                  <p class="text-xs text-muted-foreground/80">
+                    {{ hasGameProgress(item.game) ? $t('home.games.creating') : $t('home.games.modifiedAt', { time: dayjs(item.game.lastModified).fromNow() }) }}
+                  </p>
+                </div>
+              </div>
+            </CardContent>
+            <Progress v-if="hasGameProgress(item.game)" :model-value="getGameProgress(item.game)" class="rounded-none h-1 inset-x-0 bottom-0 absolute" />
+          </Card>
+        </ContextMenuTrigger>
+        <ContextMenuContent class="w-42">
+          <ContextMenuItem @click="emit('openFolder', item.game)">
+            <Folder class="mr-2 size-3.5" />
+            {{ $t('common.openFolder') }}
+          </ContextMenuItem>
+          <ContextMenuItem
+            v-if="!hasGameProgress(item.game)"
+            class="text-destructive text-13px! focus:text-destructive-foreground focus:bg-destructive"
+            @click="emit('deleteGame', item.game)"
+          >
+            <Trash2 class="mr-2 size-3.5" />
+            {{ $t('home.games.deleteGame') }}
+          </ContextMenuItem>
+        </ContextMenuContent>
+      </ContextMenu>
+      <button
+        ref="dropZoneGridRef"
+        type="button"
+        :aria-label="$t('home.games.importGame')"
+        class="p-4 border-1 border-gray-300 rounded-lg border-dashed bg-gray-50 flex flex-col w-full cursor-pointer shadow-none transition-colors items-center justify-center overflow-hidden dark:border-gray-700 hover:border-purple-300 dark:bg-gray-900 dark:hover:border-purple-700"
+        :class="{'border-purple-300 bg-purple-50': isOverDropZoneGrid}"
+        @click="emit('importClick')"
+      >
+        <div class="mb-3 p-3 rounded-full bg-purple-100 dark:bg-purple-900/20">
+          <Scroll class="text-purple-600 h-6 w-6 dark:text-purple-400" />
+        </div>
+        <p class="text-sm font-medium">
+          {{ $t('home.games.importGame') }}
+        </p>
+        <p class="text-xs text-muted-foreground mt-1">
+          {{ $t('home.games.importGameHint') }}
+        </p>
+      </button>
+    </div>
+    <div v-else class="border rounded-lg overflow-hidden divide-y">
+      <div
+        v-for="item in items"
+        :key="item.game.id"
+        class="p-3 flex cursor-pointer transition-colors duration-200 items-center justify-between relative hover:bg-primary/5 dark:hover:bg-primary/10"
+        :class="{ 'cursor-wait': hasGameProgress(item.game) }"
+        @click="emit('gameClick', item.game)"
+      >
+        <div class="flex gap-3 items-center">
+          <div class="rounded-md h-10 w-10 overflow-hidden">
             <AssetImage
               :path="item.game.previewAssets.cover.path"
               :root-path="item.game.path"
@@ -73,158 +154,79 @@ const LIST_COVER_THUMBNAIL: AssetThumbnailOptions = {
               :cache-version="item.game.previewAssets.cover.cacheVersion"
               object-fit="cover"
               fallback-image="/placeholder.svg"
-              :thumbnail="GRID_COVER_THUMBNAIL"
-              class="h-full w-full transition-transform duration-300 group-hover:scale-105"
+              :thumbnail="LIST_COVER_THUMBNAIL"
+              class="h-full w-full"
             />
           </div>
-          <CardContent class="p-3">
-            <div class="flex gap-4 items-center">
-              <AssetImage
-                :path="item.game.previewAssets.icon.path"
-                :root-path="item.game.path"
-                :serve-url="item.serveUrl"
-                :alt="$t('home.games.gameIcon', { name: item.game.metadata.name })"
-                :cache-version="item.game.previewAssets.icon.cacheVersion"
-                :thumbnail="GRID_ICON_THUMBNAIL"
-                class="rounded-md size-8"
-              />
-              <div>
-                <h3 class="font-medium">
-                  {{ item.game.metadata.name }}
-                </h3>
-                <p class="text-xs text-muted-foreground/80">
-                  {{ hasGameProgress(item.game) ? $t('home.games.creating') : $t('home.games.modifiedAt', { time: dayjs(item.game.lastModified).fromNow() }) }}
-                </p>
-              </div>
-            </div>
-          </CardContent>
-          <Progress v-if="hasGameProgress(item.game)" :model-value="getGameProgress(item.game)" class="rounded-none h-1 inset-x-0 bottom-0 absolute" />
-        </Card>
-      </ContextMenuTrigger>
-      <ContextMenuContent class="w-42">
-        <ContextMenuItem @click="emit('openFolder', item.game)">
-          <Folder class="mr-2 size-3.5" />
-          {{ $t('common.openFolder') }}
-        </ContextMenuItem>
-        <ContextMenuItem
-          v-if="!hasGameProgress(item.game)"
-          class="text-destructive text-13px! focus:text-destructive-foreground focus:bg-destructive"
-          @click="emit('deleteGame', item.game)"
-        >
-          <Trash2 class="mr-2 size-3.5" />
-          {{ $t('home.games.deleteGame') }}
-        </ContextMenuItem>
-      </ContextMenuContent>
-    </ContextMenu>
-    <button
-      ref="dropZoneGridRef"
-      type="button"
-      :aria-label="$t('home.games.importGame')"
-      class="p-4 border-1 border-gray-300 rounded-lg border-dashed bg-gray-50 flex flex-col w-full cursor-pointer shadow-none transition-colors items-center justify-center overflow-hidden dark:border-gray-700 hover:border-purple-300 dark:bg-gray-900 dark:hover:border-purple-700"
-      :class="{'border-purple-300 bg-purple-50': isOverDropZoneGrid}"
-      @click="emit('importClick')"
-    >
-      <div class="mb-3 p-3 rounded-full bg-purple-100 dark:bg-purple-900/20">
-        <Scroll class="text-purple-600 h-6 w-6 dark:text-purple-400" />
-      </div>
-      <p class="text-sm font-medium">
-        {{ $t('home.games.importGame') }}
-      </p>
-      <p class="text-xs text-muted-foreground mt-1">
-        {{ $t('home.games.importGameHint') }}
-      </p>
-    </button>
-  </div>
-  <div v-else class="border rounded-lg overflow-hidden divide-y">
-    <div
-      v-for="item in items"
-      :key="item.game.id"
-      class="p-3 flex cursor-pointer transition-colors duration-200 items-center justify-between relative hover:bg-primary/5 dark:hover:bg-primary/10"
-      :class="{ 'cursor-wait': hasGameProgress(item.game) }"
-      @click="emit('gameClick', item.game)"
-    >
-      <div class="flex gap-3 items-center">
-        <div class="rounded-md h-10 w-10 overflow-hidden">
-          <AssetImage
-            :path="item.game.previewAssets.cover.path"
-            :root-path="item.game.path"
-            :serve-url="item.serveUrl"
-            :alt="$t('home.games.gameCover', { name: item.game.metadata.name })"
-            :cache-version="item.game.previewAssets.cover.cacheVersion"
-            object-fit="cover"
-            fallback-image="/placeholder.svg"
-            :thumbnail="LIST_COVER_THUMBNAIL"
-            class="h-full w-full"
-          />
+          <div>
+            <h3 class="font-medium">
+              {{ item.game.metadata.name }}
+            </h3>
+            <p class="text-xs text-muted-foreground">
+              {{ hasGameProgress(item.game) ? $t('home.games.creating') : $t('home.games.modifiedAt', { time: dayjs(item.game.lastModified).fromNow() }) }}
+            </p>
+          </div>
         </div>
-        <div>
-          <h3 class="font-medium">
-            {{ item.game.metadata.name }}
-          </h3>
-          <p class="text-xs text-muted-foreground">
-            {{ hasGameProgress(item.game) ? $t('home.games.creating') : $t('home.games.modifiedAt', { time: dayjs(item.game.lastModified).fromNow() }) }}
-          </p>
+        <div v-if="!hasGameProgress(item.game)" class="flex gap-2 items-center">
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger as-child>
+                <Button
+                  :aria-label="$t('common.openFolder')"
+                  variant="ghost"
+                  size="icon"
+                  class="h-8 w-8"
+                  @click.stop="emit('openFolder', item.game)"
+                >
+                  <Folder class="h-4 w-4" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p>{{ $t('common.openFolder') }}</p>
+              </TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger as-child>
+                <Button
+                  :aria-label="$t('home.games.deleteGame')"
+                  variant="ghost"
+                  size="icon"
+                  class="text-destructive h-8 w-8 hover:text-destructive-foreground hover:bg-destructive"
+                  @click.stop="emit('deleteGame', item.game)"
+                >
+                  <Trash2 class="h-4 w-4" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p>{{ $t('home.games.deleteGame') }}</p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
         </div>
+        <Progress v-if="hasGameProgress(item.game)" :model-value="getGameProgress(item.game)" class="rounded-none h-0.75 inset-x-0 bottom-0 absolute" />
       </div>
-      <div v-if="!hasGameProgress(item.game)" class="flex gap-2 items-center">
-        <TooltipProvider>
-          <Tooltip>
-            <TooltipTrigger as-child>
-              <Button
-                :aria-label="$t('common.openFolder')"
-                variant="ghost"
-                size="icon"
-                class="h-8 w-8"
-                @click.stop="emit('openFolder', item.game)"
-              >
-                <Folder class="h-4 w-4" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>
-              <p>{{ $t('common.openFolder') }}</p>
-            </TooltipContent>
-          </Tooltip>
-          <Tooltip>
-            <TooltipTrigger as-child>
-              <Button
-                :aria-label="$t('home.games.deleteGame')"
-                variant="ghost"
-                size="icon"
-                class="text-destructive h-8 w-8 hover:text-destructive-foreground hover:bg-destructive"
-                @click.stop="emit('deleteGame', item.game)"
-              >
-                <Trash2 class="h-4 w-4" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>
-              <p>{{ $t('home.games.deleteGame') }}</p>
-            </TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
-      </div>
-      <Progress v-if="hasGameProgress(item.game)" :model-value="getGameProgress(item.game)" class="rounded-none h-0.75 inset-x-0 bottom-0 absolute" />
+      <button
+        ref="dropZoneListRef"
+        type="button"
+        :aria-label="$t('home.games.importGame')"
+        class="p-3 bg-gray-50/50 flex w-full cursor-pointer transition-colors items-center justify-between dark:bg-gray-800/10 hover:bg-gray-100 dark:hover:bg-gray-800/20"
+        :class="{'bg-purple-50': isOverDropZoneList}"
+        @click="emit('importClick')"
+      >
+        <div class="flex gap-3 items-center">
+          <div class="rounded-md bg-purple-100 flex h-10 w-10 items-center justify-center dark:bg-purple-900/20">
+            <Scroll class="text-purple-600 h-5 w-5 dark:text-purple-400" />
+          </div>
+          <div class="text-left">
+            <h3 class="font-medium">
+              {{ $t('home.games.importGame') }}
+            </h3>
+            <p class="text-xs text-muted-foreground">
+              {{ $t('home.games.importGameHint') }}
+            </p>
+          </div>
+        </div>
+      </button>
     </div>
-    <button
-      ref="dropZoneListRef"
-      type="button"
-      :aria-label="$t('home.games.importGame')"
-      class="p-3 bg-gray-50/50 flex w-full cursor-pointer transition-colors items-center justify-between dark:bg-gray-800/10 hover:bg-gray-100 dark:hover:bg-gray-800/20"
-      :class="{'bg-purple-50': isOverDropZoneList}"
-      @click="emit('importClick')"
-    >
-      <div class="flex gap-3 items-center">
-        <div class="rounded-md bg-purple-100 flex h-10 w-10 items-center justify-center dark:bg-purple-900/20">
-          <Scroll class="text-purple-600 h-5 w-5 dark:text-purple-400" />
-        </div>
-        <div class="text-left">
-          <h3 class="font-medium">
-            {{ $t('home.games.importGame') }}
-          </h3>
-          <p class="text-xs text-muted-foreground">
-            {{ $t('home.games.importGameHint') }}
-          </p>
-        </div>
-      </div>
-    </button>
-  </div>
+  </ScrollArea>
 </template>

--- a/src/views/index.vue
+++ b/src/views/index.vue
@@ -18,7 +18,7 @@ watch(() => workspaceStore.activeTab, checkResourcesForActiveTab, { immediate: t
     <AppHeader />
     <main class="mx-auto px-4 py-8 container flex flex-1 flex-col min-h-0 overflow-hidden lg:px-8 sm:px-6">
       <WelcomeSection />
-      <Tabs ::="workspaceStore.activeTab" class="mb-6 gap-4 grid grid-rows-[auto_minmax(0,1fr)] min-h-0">
+      <Tabs ::="workspaceStore.activeTab" class="mb-6 flex-1 gap-4 grid grid-rows-[auto_minmax(0,1fr)] min-h-0">
         <div data-testid="home-tabs-header" class="space-y-4">
           <TabsList>
             <TabsTrigger

--- a/src/views/index.vue
+++ b/src/views/index.vue
@@ -14,12 +14,12 @@ watch(() => workspaceStore.activeTab, checkResourcesForActiveTab, { immediate: t
 </script>
 
 <template>
-  <div class="bg-gray-50 dark:bg-gray-900">
+  <div class="bg-gray-50 flex flex-col h-full min-h-0 overflow-hidden dark:bg-gray-900">
     <AppHeader />
-    <main class="mx-auto px-4 py-8 container lg:px-8 sm:px-6">
+    <main class="mx-auto px-4 py-8 container flex flex-1 flex-col min-h-0 overflow-hidden lg:px-8 sm:px-6">
       <WelcomeSection />
-      <div class="mb-6">
-        <Tabs ::="workspaceStore.activeTab">
+      <Tabs ::="workspaceStore.activeTab" class="mb-6 gap-4 grid grid-rows-[auto_minmax(0,1fr)] min-h-0">
+        <div data-testid="home-tabs-header" class="space-y-4">
           <TabsList>
             <TabsTrigger
               v-for="tab in HOME_TABS"
@@ -31,14 +31,16 @@ watch(() => workspaceStore.activeTab, checkResourcesForActiveTab, { immediate: t
             </TabsTrigger>
           </TabsList>
           <SearchView />
-          <TabsContent value="recent" class="mt-4">
+        </div>
+        <div data-testid="home-tabs-body" class="min-h-0 overflow-hidden">
+          <TabsContent value="recent" class="mt-0 h-full min-h-0 overflow-hidden">
             <GamesTab v-if="resourceStore.games" />
           </TabsContent>
-          <TabsContent value="engines" class="mt-4">
+          <TabsContent value="engines" class="mt-0 h-full min-h-0 overflow-hidden">
             <EnginesTab v-if="resourceStore.engines" />
           </TabsContent>
-        </Tabs>
-      </div>
+        </div>
+      </Tabs>
     </main>
   </div>
 </template>


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [x] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [ ] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

调整首页资源 tab 的布局高度传递链路，确保 tab 内容区能够形成正确的滚动容器。

具体包括：

- 为首页 `Tabs` 容器补齐 `flex`、`min-h-0` 和 `overflow-hidden` 约束，拆分 tab header 与 tab body，避免内容区域被整体撑开
- 为游戏列表和引擎列表集合区引入 `ScrollArea`，让超出可视区域的内容在 tab 内部滚动
- 移除 `SearchView` 顶部的额外外边距，改由首页 tab 头部统一控制间距

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

当前首页在资源数量较多时，`recent` 和 `engines` tab 的内容区域不会形成独立滚动，列表会直接撑开页面，导致主页 tab 内部无法正常滚动浏览资源。

这次修改把滚动职责明确下沉到资源集合区，同时补齐父级容器的高度约束，修复首页资源浏览体验。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [ ] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
