### PR TITLE
✨ 支持编辑自定义游戏配置项

### DIFF
--- a/integration/support/editor-flow.ts
+++ b/integration/support/editor-flow.ts
@@ -51,8 +51,13 @@ export async function createGameFromHome(page: Page, gameName: string = 'Demo Ga
 
 export async function enterEditorFromCreatedGame(page: Page, gameName: string = 'Demo Game') {
   await createGameFromHome(page, gameName)
-  await page.getByRole('heading', { name: gameName }).click()
-  await expect(page).toHaveURL(/\/edit\//)
+  const gameCard = page.getByRole('heading', { name: gameName }).locator('xpath=..')
+
+  await Promise.all([
+    page.waitForURL(/\/edit\//),
+    gameCard.click(),
+  ])
+
   await expect(page.getByRole('button', { name: EDITOR_TEST_GAME_BUTTON_NAME })).toBeVisible()
 }
 

--- a/integration/support/editor-flow.ts
+++ b/integration/support/editor-flow.ts
@@ -14,7 +14,7 @@ interface LaunchCraftAppOptions {
   persistedStores?: Record<string, unknown>
 }
 
-const HOME_CREATE_GAME_BUTTON_NAME = /Create Game|创建游戏|ゲームを作成/
+export const HOME_CREATE_GAME_BUTTON_NAME = /Create Game|创建游戏|建立遊戲|ゲームを作成/
 const EDITOR_TEST_GAME_BUTTON_NAME = /Test Game|测试游戏|測試遊戲|ゲームをテスト/
 
 export async function launchCraftApp(page: Page, options: LaunchCraftAppOptions = {}) {

--- a/integration/support/mock-tauri.ts
+++ b/integration/support/mock-tauri.ts
@@ -65,11 +65,6 @@ const defaultSeedEngine: SeedEngine = {
   },
 }
 
-function normalizeDefaultPackageNameSegment(gameName: string): string {
-  const normalized = gameName.toLowerCase().replaceAll(/[^a-z0-9]+/g, '')
-  return normalized || 'demo'
-}
-
 export async function installMockTauri(page: Page, options: InstallMockTauriOptions = {}) {
   await page.addInitScript(
     async ({ documentDir, seedEngines }) => {
@@ -98,6 +93,11 @@ export async function installMockTauri(page: Page, options: InstallMockTauriOpti
 
       function now() {
         return Date.now()
+      }
+
+      function normalizeDefaultPackageNameSegment(gameName: string): string {
+        const normalized = gameName.toLowerCase().replaceAll(/[^a-z0-9]+/g, '')
+        return normalized || 'demo'
       }
 
       function ensureDirectory(path: string) {
@@ -318,7 +318,7 @@ export async function installMockTauri(page: Page, options: InstallMockTauriOpti
 
       async function seedDatabase(engines: SeedEngine[]) {
         await new Promise<void>((resolve, reject) => {
-          const request = globalThis.indexedDB.open('WebGALCraft', 1)
+          const request = globalThis.indexedDB.open('WebGALCraft')
 
           request.onupgradeneeded = () => {
             const db = request.result
@@ -345,6 +345,13 @@ export async function installMockTauri(page: Page, options: InstallMockTauriOpti
 
           request.onsuccess = () => {
             const db = request.result
+
+            if (!db.objectStoreNames.contains('games') || !db.objectStoreNames.contains('engines')) {
+              db.close()
+              reject(new Error('IndexedDB 缺少 games 或 engines store'))
+              return
+            }
+
             const tx = db.transaction(['games', 'engines'], 'readwrite')
             const gamesStore = tx.objectStore('games')
             const enginesStore = tx.objectStore('engines')

--- a/integration/support/mock-tauri.ts
+++ b/integration/support/mock-tauri.ts
@@ -210,6 +210,14 @@ export async function installMockTauri(page: Page, options: InstallMockTauriOpti
         return entries
       }
 
+      function requireGamePath(gamePath: unknown): string {
+        if (typeof gamePath !== 'string' || gamePath === '') {
+          throw new Error('缺少 gamePath')
+        }
+
+        return gamePath
+      }
+
       function createDefaultGameConfig(gameName: string): GameConfigReadResult {
         const resolvedGameName = gameName.trim() || 'Demo Game'
         const slug = resolvedGameName.toLowerCase().replaceAll(/\s+/g, '-')
@@ -603,7 +611,7 @@ export async function installMockTauri(page: Page, options: InstallMockTauriOpti
               return
             }
             case 'set_game_config': {
-              const gamePath = String(invokeArgs.gamePath ?? '')
+              const gamePath = requireGamePath(invokeArgs.gamePath)
               const current = getGameConfig(gamePath)
               const nextEntries = requireGameConfigEntries(invokeArgs.config)
               writeGameConfig(gamePath, {
@@ -613,7 +621,7 @@ export async function installMockTauri(page: Page, options: InstallMockTauriOpti
               return
             }
             case 'get_game_config': {
-              const gamePath = String(invokeArgs.gamePath ?? '')
+              const gamePath = requireGamePath(invokeArgs.gamePath)
               return getGameConfig(gamePath)
             }
             case 'get_thumbnail': {

--- a/integration/support/mock-tauri.ts
+++ b/integration/support/mock-tauri.ts
@@ -203,19 +203,30 @@ export async function installMockTauri(page: Page, options: InstallMockTauriOpti
         }
 
         const { entries } = config as { entries?: unknown }
-        if (!Array.isArray(entries) || entries.some(entry => !isGameConfigEntry(entry))) {
+        if (!Array.isArray(entries)) {
           throw new TypeError('set_game_config mock 要求 config.entries 为 GameConfigEntry[]')
+        }
+
+        for (let index = 0; index < entries.length; index++) {
+          if (!Object.prototype.hasOwnProperty.call(entries, index) || !isGameConfigEntry(entries[index])) {
+            throw new TypeError('set_game_config mock 要求 config.entries 为 GameConfigEntry[]')
+          }
         }
 
         return entries
       }
 
       function requireGamePath(gamePath: unknown): string {
-        if (typeof gamePath !== 'string' || gamePath === '') {
+        if (typeof gamePath !== 'string') {
+          throw new TypeError('缺少 gamePath')
+        }
+
+        const trimmedGamePath = gamePath.trim()
+        if (trimmedGamePath === '') {
           throw new Error('缺少 gamePath')
         }
 
-        return gamePath
+        return trimmedGamePath
       }
 
       function createDefaultGameConfig(gameName: string): GameConfigReadResult {

--- a/integration/support/mock-tauri.ts
+++ b/integration/support/mock-tauri.ts
@@ -17,6 +17,16 @@ export interface InstallMockTauriOptions {
   seedEngines?: SeedEngine[]
 }
 
+interface GameConfigEntry {
+  key: string
+  value: string
+}
+
+interface GameConfigReadResult {
+  entries: GameConfigEntry[]
+  unmanagedLineCount: number
+}
+
 interface VirtualEntry {
   isDirectory: boolean
   size?: number
@@ -65,7 +75,7 @@ export async function installMockTauri(page: Page, options: InstallMockTauriOpti
         targetLabel?: string
         targetKind?: string
       }>()
-      const gameConfigStore = new Map<string, Record<string, string>>()
+      const gameConfigStore = new Map<string, GameConfigReadResult>()
       const fileSystem = new Map<string, VirtualEntry>()
       const fileContents = new Map<string, Uint8Array>()
       const openWindows = new Set<string>(['main'])
@@ -169,6 +179,63 @@ export async function installMockTauri(page: Page, options: InstallMockTauriOpti
         return [...children.values()]
       }
 
+      function cloneGameConfigEntries(entries: readonly GameConfigEntry[]) {
+        return entries.map(entry => ({ ...entry }))
+      }
+
+      function createDefaultGameConfig(gameName: string): GameConfigReadResult {
+        const resolvedGameName = gameName.trim() || 'Demo Game'
+        const slug = resolvedGameName.toLowerCase().replaceAll(/\s+/g, '-')
+
+        return {
+          entries: [
+            {
+              key: 'Game_name',
+              value: resolvedGameName,
+            },
+            {
+              key: 'Game_key',
+              value: slug,
+            },
+            {
+              key: 'Title_img',
+              value: 'cover.png',
+            },
+            {
+              key: 'Description',
+              value: `${resolvedGameName} description`,
+            },
+            {
+              key: 'Package_name',
+              value: `craft.${slug}`,
+            },
+          ],
+          unmanagedLineCount: 0,
+        }
+      }
+
+      function writeGameConfig(gamePath: string, config: GameConfigReadResult) {
+        gameConfigStore.set(normalizePath(gamePath), {
+          entries: cloneGameConfigEntries(config.entries),
+          unmanagedLineCount: config.unmanagedLineCount,
+        })
+      }
+
+      function getGameConfig(gamePath: string): GameConfigReadResult {
+        const normalized = normalizePath(gamePath)
+        const current = gameConfigStore.get(normalized)
+        if (current) {
+          return {
+            entries: cloneGameConfigEntries(current.entries),
+            unmanagedLineCount: current.unmanagedLineCount,
+          }
+        }
+
+        const fallback = createDefaultGameConfig(basename(normalized))
+        writeGameConfig(normalized, fallback)
+        return fallback
+      }
+
       function createGameSkeleton(gamePath: string) {
         ensureDirectory(gamePath)
         ensureDirectory(joinPaths([gamePath, 'assets']))
@@ -182,6 +249,7 @@ export async function installMockTauri(page: Page, options: InstallMockTauriOpti
         ensureFile(joinPaths([gamePath, 'icons', 'favicon.ico']))
         ensureFile(joinPaths([gamePath, 'game', 'background', 'cover.png']))
         ensureFile(joinPaths([gamePath, 'game', 'scene', 'start.txt']), '; WebGAL scene\nintro:欢迎来到集成测试。')
+        writeGameConfig(gamePath, createDefaultGameConfig(basename(gamePath)))
       }
 
       function emitWindowEvent(label: string, event: string) {
@@ -216,6 +284,7 @@ export async function installMockTauri(page: Page, options: InstallMockTauriOpti
         ensureFile(joinPaths([engine.path, 'icons', 'favicon.ico']))
         ensureFile(joinPaths([engine.path, 'game', 'background', 'cover.png']))
         ensureFile(joinPaths([engine.path, 'game', 'scene', 'start.txt']), '; Engine default scene')
+        writeGameConfig(engine.path, createDefaultGameConfig(engine.metadata.name))
       }
 
       function dirname(path: string) {
@@ -340,6 +409,12 @@ export async function installMockTauri(page: Page, options: InstallMockTauriOpti
             label: 'main',
           },
         },
+        plugins: {
+          path: {
+            delimiter: ';',
+            sep: '/',
+          },
+        },
         transformCallback(callback?: (payload: unknown) => void, once = false) {
           const id = nextCallbackId++
           callbackRegistry.set(id, { callback, once })
@@ -457,8 +532,15 @@ export async function installMockTauri(page: Page, options: InstallMockTauriOpti
             case 'add_static_site': {
               return basename(String(invokeArgs.path ?? '')) || 'game'
             }
+            case 'broadcast_message':
             case 'remove_static_site': {
               return
+            }
+            case 'unicast_message': {
+              return
+            }
+            case 'get_connected_clients': {
+              return []
             }
             case 'copy_directory_with_progress': {
               createGameSkeleton(String(invokeArgs.destination ?? ''))
@@ -487,25 +569,17 @@ export async function installMockTauri(page: Page, options: InstallMockTauriOpti
             }
             case 'set_game_config': {
               const gamePath = String(invokeArgs.gamePath ?? '')
-              const current = gameConfigStore.get(gamePath) ?? {}
-              gameConfigStore.set(gamePath, {
-                ...current,
-                ...(invokeArgs.config as Record<string, string> | undefined),
+              const current = getGameConfig(gamePath)
+              const nextConfig = invokeArgs.config as Partial<GameConfigReadResult> | undefined
+              writeGameConfig(gamePath, {
+                entries: cloneGameConfigEntries(nextConfig?.entries ?? current.entries),
+                unmanagedLineCount: current.unmanagedLineCount,
               })
               return
             }
             case 'get_game_config': {
               const gamePath = String(invokeArgs.gamePath ?? '')
-              const config = gameConfigStore.get(gamePath) ?? {}
-              const gameName = config.gameName ?? 'Demo Game'
-
-              return {
-                gameName,
-                description: `${gameName} description`,
-                gameKey: gameName.toLowerCase().replaceAll(/\s+/g, '-'),
-                packageName: `craft.${gameName.toLowerCase().replaceAll(/\s+/g, '-')}`,
-                titleImg: 'cover.png',
-              }
+              return getGameConfig(gamePath)
             }
             case 'get_thumbnail': {
               return new Uint8Array([])

--- a/integration/support/mock-tauri.ts
+++ b/integration/support/mock-tauri.ts
@@ -65,6 +65,11 @@ const defaultSeedEngine: SeedEngine = {
   },
 }
 
+function normalizeDefaultPackageNameSegment(gameName: string): string {
+  const normalized = gameName.toLowerCase().replaceAll(/[^a-z0-9]+/g, '')
+  return normalized || 'demo'
+}
+
 export async function installMockTauri(page: Page, options: InstallMockTauriOptions = {}) {
   await page.addInitScript(
     async ({ documentDir, seedEngines }) => {
@@ -186,6 +191,7 @@ export async function installMockTauri(page: Page, options: InstallMockTauriOpti
       function createDefaultGameConfig(gameName: string): GameConfigReadResult {
         const resolvedGameName = gameName.trim() || 'Demo Game'
         const slug = resolvedGameName.toLowerCase().replaceAll(/\s+/g, '-')
+        const packageNameSegment = normalizeDefaultPackageNameSegment(resolvedGameName)
 
         return {
           entries: [
@@ -207,7 +213,7 @@ export async function installMockTauri(page: Page, options: InstallMockTauriOpti
             },
             {
               key: 'Package_name',
-              value: `craft.${slug}`,
+              value: `craft.${packageNameSegment}`,
             },
           ],
           unmanagedLineCount: 0,

--- a/integration/support/mock-tauri.ts
+++ b/integration/support/mock-tauri.ts
@@ -188,6 +188,28 @@ export async function installMockTauri(page: Page, options: InstallMockTauriOpti
         return entries.map(entry => ({ ...entry }))
       }
 
+      function isGameConfigEntry(value: unknown): value is GameConfigEntry {
+        if (!value || typeof value !== 'object') {
+          return false
+        }
+
+        const entry = value as Partial<GameConfigEntry>
+        return typeof entry.key === 'string' && typeof entry.value === 'string'
+      }
+
+      function requireGameConfigEntries(config: unknown): GameConfigEntry[] {
+        if (!config || typeof config !== 'object') {
+          throw new TypeError('set_game_config mock 要求 config.entries 为 GameConfigEntry[]')
+        }
+
+        const { entries } = config as { entries?: unknown }
+        if (!Array.isArray(entries) || entries.some(entry => !isGameConfigEntry(entry))) {
+          throw new TypeError('set_game_config mock 要求 config.entries 为 GameConfigEntry[]')
+        }
+
+        return entries
+      }
+
       function createDefaultGameConfig(gameName: string): GameConfigReadResult {
         const resolvedGameName = gameName.trim() || 'Demo Game'
         const slug = resolvedGameName.toLowerCase().replaceAll(/\s+/g, '-')
@@ -583,9 +605,9 @@ export async function installMockTauri(page: Page, options: InstallMockTauriOpti
             case 'set_game_config': {
               const gamePath = String(invokeArgs.gamePath ?? '')
               const current = getGameConfig(gamePath)
-              const nextConfig = invokeArgs.config as Partial<GameConfigReadResult> | undefined
+              const nextEntries = requireGameConfigEntries(invokeArgs.config)
               writeGameConfig(gamePath, {
-                entries: cloneGameConfigEntries(nextConfig?.entries ?? current.entries),
+                entries: nextEntries,
                 unmanagedLineCount: current.unmanagedLineCount,
               })
               return

--- a/integration/tests/smoke.spec.ts
+++ b/integration/tests/smoke.spec.ts
@@ -1,14 +1,12 @@
 import { expect, test } from '@playwright/test'
 
-import { launchCraftApp } from '../support/editor-flow'
+import { HOME_CREATE_GAME_BUTTON_NAME, launchCraftApp } from '../support/editor-flow'
 
 test.describe('应用冒烟测试', () => {
   test('首页可正常加载', async ({ page }) => {
     await launchCraftApp(page)
 
-    await expect(page.getByRole('button', {
-      name: /Create Game|创建游戏|ゲームを作成/,
-    })).toBeVisible()
+    await expect(page.getByRole('button', { name: HOME_CREATE_GAME_BUTTON_NAME })).toBeVisible()
 
     // 页面标题应包含应用名称
     await expect(page).toHaveTitle(/WebGAL/)

--- a/src-tauri/src/commands/game.rs
+++ b/src-tauri/src/commands/game.rs
@@ -5,212 +5,271 @@ use std::{
 };
 
 use super::{AppError, AppResult};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Copy)]
-struct GameConfigKeyMapping {
-    raw_key: &'static str,
-    frontend_key: &'static str,
-}
-
-const GAME_CONFIG_KEY_MAPPINGS: [GameConfigKeyMapping; 16] = [
-    GameConfigKeyMapping {
-        raw_key: "Game_name",
-        frontend_key: "gameName",
-    },
-    GameConfigKeyMapping {
-        raw_key: "Game_key",
-        frontend_key: "gameKey",
-    },
-    GameConfigKeyMapping {
-        raw_key: "Title_img",
-        frontend_key: "titleImg",
-    },
-    GameConfigKeyMapping {
-        raw_key: "Title_bgm",
-        frontend_key: "titleBgm",
-    },
-    GameConfigKeyMapping {
-        raw_key: "Game_Logo",
-        frontend_key: "gameLogo",
-    },
-    GameConfigKeyMapping {
-        raw_key: "Enable_Appreciation",
-        frontend_key: "enableAppreciation",
-    },
-    GameConfigKeyMapping {
-        raw_key: "Legacy_Expression_Blend_Mode",
-        frontend_key: "legacyExpressionBlendMode",
-    },
-    GameConfigKeyMapping {
-        raw_key: "Steam_AppID",
-        frontend_key: "steamAppId",
-    },
-    GameConfigKeyMapping {
-        raw_key: "Default_Language",
-        frontend_key: "defaultLanguage",
-    },
-    GameConfigKeyMapping {
-        raw_key: "Show_panic",
-        frontend_key: "showPanic",
-    },
-    GameConfigKeyMapping {
-        raw_key: "Max_line",
-        frontend_key: "maxLine",
-    },
-    GameConfigKeyMapping {
-        raw_key: "Line_height",
-        frontend_key: "lineHeight",
-    },
-    GameConfigKeyMapping {
-        raw_key: "Stage_Width",
-        frontend_key: "stageWidth",
-    },
-    GameConfigKeyMapping {
-        raw_key: "Stage_Height",
-        frontend_key: "stageHeight",
-    },
-    GameConfigKeyMapping {
-        raw_key: "Description",
-        frontend_key: "description",
-    },
-    GameConfigKeyMapping {
-        raw_key: "Package_name",
-        frontend_key: "packageName",
-    },
-];
-
-fn map_raw_key_to_frontend_key(raw_key: &str) -> Option<&'static str> {
-    GAME_CONFIG_KEY_MAPPINGS
-        .iter()
-        .find(|mapping| mapping.raw_key == raw_key)
-        .map(|mapping| mapping.frontend_key)
-}
-
-fn map_frontend_key_to_raw_key(frontend_key: &str) -> Option<&'static str> {
-    GAME_CONFIG_KEY_MAPPINGS
-        .iter()
-        .find(|mapping| mapping.frontend_key == frontend_key)
-        .map(|mapping| mapping.raw_key)
-}
-
-fn require_raw_key(frontend_key: &str) -> AppResult<&'static str> {
-    map_frontend_key_to_raw_key(frontend_key)
-        .ok_or_else(|| AppError::Config(format!("不支持的游戏配置字段: {frontend_key}")))
-}
-
-fn ensure_single_line_value(frontend_key: &str, value: &str) -> AppResult<()> {
+fn ensure_field_has_no_line_breaks(field_name: &str, value: &str) -> AppResult<()> {
     if value.contains('\n') || value.contains('\r') {
         return Err(AppError::Config(format!(
-            "游戏配置字段不能包含换行: {frontend_key}"
+            "游戏配置字段不能包含换行: {field_name}"
         )));
     }
 
     Ok(())
 }
 
-/// 解析配置行中的键名
-fn parse_config_line_key(line: &str) -> Option<String> {
+fn ensure_field_has_no_semicolons(field_name: &str, value: &str) -> AppResult<()> {
+    if value.contains(';') {
+        return Err(AppError::Config(format!(
+            "游戏配置字段不能包含分号: {field_name}"
+        )));
+    }
+
+    Ok(())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ParsedConfigLine {
+    key: String,
+    value: String,
+    trailing_suffix: String,
+}
+
+fn parse_config_line(line: &str) -> Option<ParsedConfigLine> {
     let line = line.trim();
-    let line = line.strip_suffix(";")?;
-    let (key, _) = line.split_once(":")?;
-    Some(key.trim().to_string())
+    if is_comment_line(line) {
+        return None;
+    }
+
+    let (content_prefix, trailing_suffix) = split_content_prefix_and_trailing_suffix(line);
+    let (key, value) = content_prefix.split_once(":")?;
+    let key = key.trim();
+    if key.is_empty() {
+        return None;
+    }
+
+    Some(ParsedConfigLine {
+        key: key.to_string(),
+        value: value.trim().to_string(),
+        trailing_suffix: trailing_suffix.to_string(),
+    })
+}
+
+fn is_comment_line(line: &str) -> bool {
+    let line = line.trim();
+    line.starts_with(';')
+}
+
+fn split_content_prefix_and_trailing_suffix(line: &str) -> (&str, &str) {
+    match line.find(';') {
+        Some(index) => (&line[..index], &line[index..]),
+        None => (line, ""),
+    }
+}
+
+fn looks_like_config_line(line: &str) -> bool {
+    let line = line.trim();
+    !line.is_empty() && !is_comment_line(line) && (line.contains(':') || line.ends_with(';'))
+}
+
+fn format_config_line(key: &str, value: &str, trailing_suffix: &str) -> String {
+    if trailing_suffix.is_empty() {
+        return format!("{key}: {value};");
+    }
+
+    format!("{key}: {value}{trailing_suffix}")
+}
+
+fn collect_last_line_indices_by(content: &str) -> HashMap<String, usize> {
+    let mut last_indices = HashMap::new();
+
+    for (line_index, line) in content.lines().enumerate() {
+        let Some(parsed_line) = parse_config_line(line) else {
+            continue;
+        };
+
+        last_indices.insert(parsed_line.key, line_index);
+    }
+
+    last_indices
+}
+
+fn normalize_entry_key(key: &str) -> AppResult<String> {
+    ensure_field_has_no_line_breaks("configKey", key)?;
+
+    let normalized_key = key.trim();
+    if normalized_key.is_empty() {
+        return Err(AppError::Config("配置键不能为空".to_string()));
+    }
+
+    if normalized_key.contains(':') {
+        return Err(AppError::Config(format!(
+            "配置键不能包含冒号: {normalized_key}"
+        )));
+    }
+
+    if normalized_key.contains(';') {
+        return Err(AppError::Config(format!(
+            "配置键不能包含分号: {normalized_key}"
+        )));
+    }
+
+    Ok(normalized_key.to_string())
+}
+
+fn normalize_entries(entries: Vec<GameConfigEntry>) -> AppResult<Vec<GameConfigEntry>> {
+    let mut normalized_entries = Vec::with_capacity(entries.len());
+    let mut seen_keys = HashSet::new();
+
+    for entry in entries {
+        let key = normalize_entry_key(&entry.key)?;
+        ensure_field_has_no_line_breaks(&key, &entry.value)?;
+        ensure_field_has_no_semicolons(&key, &entry.value)?;
+
+        if !seen_keys.insert(key.clone()) {
+            return Err(AppError::Config(format!("配置键重复: {key}")));
+        }
+
+        normalized_entries.push(GameConfigEntry {
+            key,
+            value: entry.value,
+        });
+    }
+
+    Ok(normalized_entries)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GameConfigEntry {
+    pub key: String,
+    pub value: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GameConfigReadResult {
+    #[serde(default)]
+    pub entries: Vec<GameConfigEntry>,
+    pub unmanaged_line_count: usize,
 }
 
 #[derive(Debug, Deserialize)]
-pub struct GameConfigPatch {
+#[serde(rename_all = "camelCase")]
+pub struct GameConfigWritePayload {
     #[serde(default)]
-    pub set: HashMap<String, String>,
-    #[serde(default)]
-    pub unset: Vec<String>,
+    pub entries: Vec<GameConfigEntry>,
 }
 
 #[tauri::command]
-pub fn get_game_config(game_path: String) -> AppResult<HashMap<String, String>> {
+pub fn get_game_config(game_path: String) -> AppResult<GameConfigReadResult> {
     // 构建配置文件路径
     let config_path = Path::new(&game_path).join("game").join("config.txt");
 
     // 读取配置文件内容
     let content = fs::read_to_string(&config_path)?;
 
-    // 解析配置项
-    let mut config_map = HashMap::new();
-    for line in content.lines() {
-        let line = line.trim();
-        if line.is_empty() || !line.ends_with(";") {
+    let mut entry_values = HashMap::new();
+    let mut entry_positions = HashMap::new();
+    let mut unmanaged_line_count = 0;
+
+    for (line_index, line) in content.lines().enumerate() {
+        let trimmed_line = line.trim();
+        if trimmed_line.is_empty() || is_comment_line(trimmed_line) {
             continue;
         }
 
-        if let Some(line) = line.strip_suffix(";") {
-            if let Some((key, value)) = line.split_once(":") {
-                let key = key.trim();
-                let value = value.trim().to_string();
-                let Some(frontend_key) = map_raw_key_to_frontend_key(key) else {
-                    continue;
-                };
-
-                config_map.insert(frontend_key.to_string(), value);
+        let Some(parsed_line) = parse_config_line(line) else {
+            if looks_like_config_line(trimmed_line) {
+                unmanaged_line_count += 1;
             }
-        }
+            continue;
+        };
+
+        entry_positions.insert(parsed_line.key.clone(), line_index);
+        entry_values.insert(parsed_line.key, parsed_line.value);
     }
 
-    Ok(config_map)
+    let mut entries = entry_positions
+        .into_iter()
+        .map(|(key, line_index)| {
+            (
+                line_index,
+                GameConfigEntry {
+                    value: entry_values
+                        .remove(&key)
+                        .expect("config value should exist for collected key"),
+                    key,
+                },
+            )
+        })
+        .collect::<Vec<_>>();
+    entries.sort_by_key(|(line_index, _)| *line_index);
+
+    Ok(GameConfigReadResult {
+        entries: entries.into_iter().map(|(_, entry)| entry).collect(),
+        unmanaged_line_count,
+    })
 }
 
 #[tauri::command]
-pub fn set_game_config(game_path: String, config: GameConfigPatch) -> AppResult<()> {
+pub fn set_game_config(game_path: String, config: GameConfigWritePayload) -> AppResult<()> {
     // 构建配置文件路径
     let config_path = Path::new(&game_path).join("game").join("config.txt");
 
     // 读取配置文件内容
     let content = fs::read_to_string(&config_path)?;
 
-    // 同键同时出现在 unset 和 set 时，非空 set 视为最终值；空字符串 set 仍视为显式 unset
-    let mut pending_removals = HashSet::new();
-    for key in config.unset {
-        pending_removals.insert(require_raw_key(&key)?.to_string());
-    }
-    let mut pending_updates = HashMap::new();
-
-    for (key, value) in config.set {
-        // config.txt 只接受已知原始键名，且每个值都必须保持单行
-        ensure_single_line_value(&key, &value)?;
-        let raw_key = require_raw_key(&key)?.to_string();
-
-        if value.is_empty() {
-            pending_removals.insert(raw_key);
-            continue;
-        }
-
-        pending_updates.insert(raw_key, value);
-    }
+    let normalized_entries = normalize_entries(config.entries)?;
+    let existing_line_indices = collect_last_line_indices_by(&content);
+    let next_entry_value_map = normalized_entries
+        .iter()
+        .map(|entry| (entry.key.clone(), entry.value.clone()))
+        .collect::<HashMap<_, _>>();
+    let entry_order = normalized_entries
+        .iter()
+        .map(|entry| entry.key.clone())
+        .collect::<Vec<_>>();
+    let mut written_keys = HashSet::new();
 
     let mut updated_lines = Vec::new();
 
-    for line in content.lines() {
-        let Some(existing_key) = parse_config_line_key(line) else {
+    for (line_index, line) in content.lines().enumerate() {
+        let Some(parsed_line) = parse_config_line(line) else {
             updated_lines.push(line.to_string());
             continue;
         };
 
-        if let Some(next_value) = pending_updates.remove(&existing_key) {
-            updated_lines.push(format!("{}: {};", existing_key, next_value));
+        let Some(last_line_index) = existing_line_indices.get(&parsed_line.key) else {
+            updated_lines.push(line.to_string());
+            continue;
+        };
+
+        let Some(next_value) = next_entry_value_map.get(&parsed_line.key) else {
+            continue;
+        };
+
+        if *last_line_index != line_index {
             continue;
         }
 
-        if pending_removals.contains(&existing_key) {
-            continue;
-        }
-
-        updated_lines.push(line.to_string());
+        updated_lines.push(format_config_line(
+            &parsed_line.key,
+            next_value,
+            &parsed_line.trailing_suffix,
+        ));
+        written_keys.insert(parsed_line.key);
     }
 
-    let mut appended_lines = pending_updates
-        .into_iter()
-        .map(|(key, value)| format!("{}: {};", key, value))
-        .collect::<Vec<_>>();
-    appended_lines.sort_unstable();
-    updated_lines.extend(appended_lines);
+    for key in entry_order {
+        if written_keys.contains(&key) {
+            continue;
+        }
+
+        let value = next_entry_value_map
+            .get(&key)
+            .expect("config value should exist for ordered key");
+        updated_lines.push(format!("{}: {};", key, value));
+    }
 
     let mut updated_content = updated_lines.join("\n");
     if content.ends_with('\n') && !updated_content.is_empty() {
@@ -225,135 +284,300 @@ pub fn set_game_config(game_path: String, config: GameConfigPatch) -> AppResult<
 
 #[cfg(test)]
 mod tests {
-    use super::{get_game_config, set_game_config, AppError, GameConfigPatch};
+    use super::{
+        get_game_config, set_game_config, AppError, GameConfigEntry, GameConfigWritePayload,
+    };
     use std::{
-        collections::HashMap,
         fs,
         path::PathBuf,
+        sync::atomic::{AtomicU64, Ordering},
         time::{SystemTime, UNIX_EPOCH},
     };
+
+    static TEMP_GAME_DIR_COUNTER: AtomicU64 = AtomicU64::new(0);
 
     fn create_temp_game_dir() -> PathBuf {
         let unique_suffix = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("system clock should be after unix epoch")
             .as_nanos();
-        let game_dir =
-            std::env::temp_dir().join(format!("webgal-craft-game-config-{unique_suffix}"));
+        let counter = TEMP_GAME_DIR_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let game_dir = std::env::temp_dir().join(format!(
+            "webgal-craft-game-config-{unique_suffix}-{counter}"
+        ));
         fs::create_dir_all(game_dir.join("game")).expect("temp game directory should be created");
         game_dir
     }
 
+    fn entry(key: &str, value: &str) -> GameConfigEntry {
+        GameConfigEntry {
+            key: key.to_string(),
+            value: value.to_string(),
+        }
+    }
+
     #[test]
-    fn get_game_config_maps_known_raw_keys_to_frontend_keys() {
+    fn get_game_config_returns_raw_entries_and_counts_unmanaged_lines() {
         let game_dir = create_temp_game_dir();
         let config_path = game_dir.join("game").join("config.txt");
         fs::write(
             &config_path,
-            "Game_name: Demo;\nDefault_Language: zh_CN;\nSteam_AppID: 123456;\nGame_Logo: logo1|logo2;\nStage_Width: 1280;\nStage_Height: 720;\nUnexpected_key: keep-hidden;\n",
+            "Game_name: Demo;\nCustom_flag: old;\nBroken_line missing;semicolon;\nCustom_flag: new;\n; comment\nStage_Width: 1280;\n",
         )
         .expect("config should be written");
 
         let config =
             get_game_config(game_dir.to_string_lossy().into_owned()).expect("config should parse");
 
-        assert_eq!(config.get("gameName"), Some(&"Demo".to_string()));
-        assert_eq!(config.get("defaultLanguage"), Some(&"zh_CN".to_string()));
-        assert_eq!(config.get("steamAppId"), Some(&"123456".to_string()));
-        assert_eq!(config.get("gameLogo"), Some(&"logo1|logo2".to_string()));
-        assert_eq!(config.get("stageWidth"), Some(&"1280".to_string()));
-        assert_eq!(config.get("stageHeight"), Some(&"720".to_string()));
-        assert!(!config.contains_key("Unexpected_key"));
+        assert_eq!(
+            config.entries,
+            vec![
+                GameConfigEntry {
+                    key: "Game_name".to_string(),
+                    value: "Demo".to_string(),
+                },
+                GameConfigEntry {
+                    key: "Custom_flag".to_string(),
+                    value: "new".to_string(),
+                },
+                GameConfigEntry {
+                    key: "Stage_Width".to_string(),
+                    value: "1280".to_string(),
+                }
+            ]
+        );
+        assert_eq!(config.unmanaged_line_count, 1);
 
         fs::remove_dir_all(game_dir).expect("temp game directory should be removed");
     }
 
     #[test]
-    fn set_game_config_updates_existing_values_with_explicit_raw_keys() {
+    fn get_game_config_parses_lines_without_trailing_semicolons_and_discards_inline_tail() {
         let game_dir = create_temp_game_dir();
         let config_path = game_dir.join("game").join("config.txt");
         fs::write(
             &config_path,
-            "Game_name: Demo;\nMax_line: 3;\nLine_height: 2.2;\nShow_panic: true;\n",
+            "Game_name: Demo\nDescription: Intro story; official sample\nCustom_flag: enabled;tail;comment\n",
         )
         .expect("config should be written");
 
-        let mut set = HashMap::new();
-        set.insert("gameName".to_string(), "Renamed Demo".to_string());
-        set.insert("defaultLanguage".to_string(), "ja".to_string());
-        set.insert("steamAppId".to_string(), "999".to_string());
-        let patch = GameConfigPatch {
-            set,
-            unset: vec!["maxLine".to_string()],
+        let config =
+            get_game_config(game_dir.to_string_lossy().into_owned()).expect("config should parse");
+
+        assert_eq!(
+            config.entries,
+            vec![
+                GameConfigEntry {
+                    key: "Game_name".to_string(),
+                    value: "Demo".to_string(),
+                },
+                GameConfigEntry {
+                    key: "Description".to_string(),
+                    value: "Intro story".to_string(),
+                },
+                GameConfigEntry {
+                    key: "Custom_flag".to_string(),
+                    value: "enabled".to_string(),
+                }
+            ]
+        );
+        assert_eq!(config.unmanaged_line_count, 0);
+
+        fs::remove_dir_all(game_dir).expect("temp game directory should be removed");
+    }
+
+    #[test]
+    fn get_game_config_ignores_semicolon_comments_even_if_they_look_like_entries() {
+        let game_dir = create_temp_game_dir();
+        let config_path = game_dir.join("game").join("config.txt");
+        fs::write(
+            &config_path,
+            "; note: keep this;\nGame_name: Demo;\nCustom_flag: enabled;\n",
+        )
+        .expect("config should be written");
+
+        let config =
+            get_game_config(game_dir.to_string_lossy().into_owned()).expect("config should parse");
+
+        assert_eq!(
+            config.entries,
+            vec![
+                GameConfigEntry {
+                    key: "Game_name".to_string(),
+                    value: "Demo".to_string(),
+                },
+                GameConfigEntry {
+                    key: "Custom_flag".to_string(),
+                    value: "enabled".to_string(),
+                }
+            ]
+        );
+        assert_eq!(config.unmanaged_line_count, 0);
+
+        fs::remove_dir_all(game_dir).expect("temp game directory should be removed");
+    }
+
+    #[test]
+    fn set_game_config_rewrites_entries_in_raw_key_space_and_preserves_unmanaged_lines() {
+        let game_dir = create_temp_game_dir();
+        let config_path = game_dir.join("game").join("config.txt");
+        fs::write(
+            &config_path,
+            "; heading\nGame_name: Demo;\nCustom_keep: old;\nCustom_remove: stale;\nCustom_remove: stale-2;\nBroken_line missing;semicolon;\n",
+        )
+        .expect("config should be written");
+
+        let payload = GameConfigWritePayload {
+            entries: vec![
+                entry("Game_name", "Renamed"),
+                entry("Custom_keep", "updated"),
+                entry("Stage_Width", "1280"),
+                entry("New_key", "fresh"),
+            ],
         };
 
-        set_game_config(game_dir.to_string_lossy().into_owned(), patch)
+        set_game_config(game_dir.to_string_lossy().into_owned(), payload)
             .expect("config should update");
 
         let content = fs::read_to_string(&config_path).expect("updated config should be readable");
-        assert!(content.contains("Game_name: Renamed Demo;"));
-        assert!(content.contains("Default_Language: ja;"));
-        assert!(content.contains("Line_height: 2.2;"));
-        assert!(content.contains("Show_panic: true;"));
-        assert!(content.contains("Steam_AppID: 999;"));
-        assert!(!content.contains("Max_line:"));
+        assert_eq!(
+            content,
+            "; heading\nGame_name: Renamed;\nCustom_keep: updated;\nBroken_line missing;semicolon;\nStage_Width: 1280;\nNew_key: fresh;\n"
+        );
 
         fs::remove_dir_all(game_dir).expect("temp game directory should be removed");
     }
 
     #[test]
-    fn set_game_config_removes_empty_non_toggle_values_and_keeps_toggle_values() {
+    fn set_game_config_preserves_inline_tail_and_normalizes_missing_trailing_semicolons() {
         let game_dir = create_temp_game_dir();
         let config_path = game_dir.join("game").join("config.txt");
         fs::write(
             &config_path,
-            "Game_name: Demo;\nDescription: Story;\nGame_Logo: opening.webp|enter.webp|;\nDefault_Language: zh_CN;\nSteam_AppID: 123456;\nEnable_Appreciation: true;\nLegacy_Expression_Blend_Mode: false;\nShow_panic: true;\n",
+            "Game_name: Demo\nDescription: Intro story; official sample\nCustom_flag: enabled\n",
         )
         .expect("config should be written");
 
-        let mut set = HashMap::new();
-        set.insert("gameName".to_string(), "".to_string());
-        set.insert("description".to_string(), "".to_string());
-        set.insert("gameLogo".to_string(), "".to_string());
-        set.insert("defaultLanguage".to_string(), "".to_string());
-        set.insert("steamAppId".to_string(), "".to_string());
-        set.insert("enableAppreciation".to_string(), "false".to_string());
-        set.insert("legacyExpressionBlendMode".to_string(), "true".to_string());
-        set.insert("showPanic".to_string(), "false".to_string());
-        let patch = GameConfigPatch { set, unset: vec![] };
+        let payload = GameConfigWritePayload {
+            entries: vec![
+                entry("Game_name", "Renamed"),
+                entry("Description", "Updated story"),
+                entry("Custom_flag", "disabled"),
+            ],
+        };
 
-        set_game_config(game_dir.to_string_lossy().into_owned(), patch)
+        set_game_config(game_dir.to_string_lossy().into_owned(), payload)
             .expect("config should update");
 
         let content = fs::read_to_string(&config_path).expect("updated config should be readable");
-        assert!(!content.contains("Game_name:"));
-        assert!(!content.contains("Description:"));
-        assert!(!content.contains("Game_Logo:"));
-        assert!(!content.contains("Default_Language:"));
-        assert!(!content.contains("Steam_AppID:"));
-        assert!(content.contains("Enable_Appreciation: false;"));
-        assert!(content.contains("Legacy_Expression_Blend_Mode: true;"));
-        assert!(content.contains("Show_panic: false;"));
+        assert_eq!(
+            content,
+            "Game_name: Renamed;\nDescription: Updated story; official sample\nCustom_flag: disabled;\n"
+        );
 
         fs::remove_dir_all(game_dir).expect("temp game directory should be removed");
     }
 
     #[test]
-    fn set_game_config_rejects_unknown_frontend_keys() {
+    fn set_game_config_preserves_semicolon_comments_that_contain_colons() {
+        let game_dir = create_temp_game_dir();
+        let config_path = game_dir.join("game").join("config.txt");
+        fs::write(
+            &config_path,
+            "; note: keep this;\nGame_name: Demo;\nCustom_keep: old;\n",
+        )
+        .expect("config should be written");
+
+        let payload = GameConfigWritePayload {
+            entries: vec![
+                entry("Game_name", "Renamed"),
+                entry("Custom_keep", "updated"),
+            ],
+        };
+
+        set_game_config(game_dir.to_string_lossy().into_owned(), payload)
+            .expect("config should update");
+
+        let content = fs::read_to_string(&config_path).expect("updated config should be readable");
+        assert_eq!(
+            content,
+            "; note: keep this;\nGame_name: Renamed;\nCustom_keep: updated;\n"
+        );
+
+        fs::remove_dir_all(game_dir).expect("temp game directory should be removed");
+    }
+
+    #[test]
+    fn set_game_config_rejects_keys_and_values_with_semicolons() {
         let game_dir = create_temp_game_dir();
         let config_path = game_dir.join("game").join("config.txt");
         fs::write(&config_path, "Game_name: Demo;\n").expect("config should be written");
 
-        let mut set = HashMap::new();
-        set.insert("unsupportedKey".to_string(), "value".to_string());
-        let patch = GameConfigPatch { set, unset: vec![] };
+        let key_error = set_game_config(
+            game_dir.to_string_lossy().into_owned(),
+            GameConfigWritePayload {
+                entries: vec![entry("Bad;Key", "value")],
+            },
+        )
+        .expect_err("semicolon keys should be rejected");
 
-        let error = set_game_config(game_dir.to_string_lossy().into_owned(), patch)
-            .expect_err("unknown frontend key should be rejected");
+        assert!(matches!(
+            key_error,
+            AppError::Config(message) if message.contains("Bad;Key")
+        ));
+
+        let value_error = set_game_config(
+            game_dir.to_string_lossy().into_owned(),
+            GameConfigWritePayload {
+                entries: vec![entry("Game_name", "Demo;Broken")],
+            },
+        )
+        .expect_err("semicolon values should be rejected");
+
+        assert!(matches!(
+            value_error,
+            AppError::Config(message) if message.contains("Game_name")
+        ));
+
+        fs::remove_dir_all(game_dir).expect("temp game directory should be removed");
+    }
+
+    #[test]
+    fn set_game_config_rejects_duplicate_keys() {
+        let game_dir = create_temp_game_dir();
+        let config_path = game_dir.join("game").join("config.txt");
+        fs::write(&config_path, "Game_name: Demo;\n").expect("config should be written");
+        let payload = GameConfigWritePayload {
+            entries: vec![entry("Game_name", "Demo"), entry("Game_name", "Renamed")],
+        };
+
+        let error = set_game_config(game_dir.to_string_lossy().into_owned(), payload)
+            .expect_err("duplicate keys should be rejected");
 
         assert!(matches!(
             error,
-            AppError::Config(message) if message.contains("unsupportedKey")
+            AppError::Config(message) if message.contains("Game_name")
+        ));
+
+        fs::remove_dir_all(game_dir).expect("temp game directory should be removed");
+    }
+
+    #[test]
+    fn set_game_config_rejects_blank_and_invalid_keys() {
+        let game_dir = create_temp_game_dir();
+        let config_path = game_dir.join("game").join("config.txt");
+        fs::write(&config_path, "Game_name: Demo;\n").expect("config should be written");
+
+        let payload = GameConfigWritePayload {
+            entries: vec![entry("Invalid:key", "value")],
+        };
+
+        let error = set_game_config(game_dir.to_string_lossy().into_owned(), payload)
+            .expect_err("invalid keys should be rejected");
+
+        assert!(matches!(
+            error,
+            AppError::Config(message) if message.contains("Invalid:key")
         ));
 
         fs::remove_dir_all(game_dir).expect("temp game directory should be removed");
@@ -366,16 +590,16 @@ mod tests {
         fs::write(&config_path, "Game_name: Demo;\nDescription: Story;\n")
             .expect("config should be written");
 
-        let mut set = HashMap::new();
-        set.insert("description".to_string(), "Line 1\nLine 2".to_string());
-        let patch = GameConfigPatch { set, unset: vec![] };
+        let payload = GameConfigWritePayload {
+            entries: vec![entry("Description", "Line 1\nLine 2")],
+        };
 
-        let error = set_game_config(game_dir.to_string_lossy().into_owned(), patch)
+        let error = set_game_config(game_dir.to_string_lossy().into_owned(), payload)
             .expect_err("multiline values should be rejected");
 
         assert!(matches!(
             error,
-            AppError::Config(message) if message.contains("description")
+            AppError::Config(message) if message.contains("Description")
         ));
 
         fs::remove_dir_all(game_dir).expect("temp game directory should be removed");

--- a/src/commands/__tests__/game.test.ts
+++ b/src/commands/__tests__/game.test.ts
@@ -1,0 +1,132 @@
+import '~/__tests__/setup'
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const { safeInvokeMock } = vi.hoisted(() => ({
+  safeInvokeMock: vi.fn(),
+}))
+
+vi.mock('~/utils/invoke', () => ({
+  safeInvoke: safeInvokeMock,
+}))
+
+import { findGameConfigEntryValue, gameCmds } from '../game'
+
+describe('gameCmds', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('findGameConfigEntryValue 会返回最后一个匹配的 raw entry', () => {
+    expect(findGameConfigEntryValue([
+      {
+        key: 'Game_name',
+        value: 'Old Name',
+      },
+      {
+        key: 'Custom_flag',
+        value: 'on',
+      },
+      {
+        key: 'Game_name',
+        value: 'New Name',
+      },
+    ], 'Game_name')).toBe('New Name')
+  })
+
+  it('getGameConfig 会返回统一的 raw entries 结果', async () => {
+    safeInvokeMock.mockResolvedValue({
+      entries: [
+        {
+          key: 'Game_name',
+          value: 'Demo Game',
+        },
+        {
+          key: 'Stage_Width',
+          value: '1280',
+        },
+        {
+          key: 'Custom_flag',
+          value: 'on',
+        },
+      ],
+      unmanagedLineCount: 1,
+    })
+
+    await expect(gameCmds.getGameConfig('/games/demo')).resolves.toEqual({
+      entries: [
+        {
+          key: 'Game_name',
+          value: 'Demo Game',
+        },
+        {
+          key: 'Stage_Width',
+          value: '1280',
+        },
+        {
+          key: 'Custom_flag',
+          value: 'on',
+        },
+      ],
+      unmanagedLineCount: 1,
+    })
+    expect(safeInvokeMock).toHaveBeenCalledWith('get_game_config', { gamePath: '/games/demo' })
+  })
+
+  it('setGameConfig 会直接透传统一 entries payload', async () => {
+    safeInvokeMock.mockResolvedValue(undefined)
+
+    await gameCmds.setGameConfig('/games/demo', {
+      entries: [
+        {
+          key: 'Game_name',
+          value: 'Renamed Game',
+        },
+        {
+          key: 'Custom_flag',
+          value: 'on',
+        },
+      ],
+    })
+
+    expect(safeInvokeMock).toHaveBeenCalledTimes(1)
+    expect(safeInvokeMock).toHaveBeenCalledWith('set_game_config', {
+      gamePath: '/games/demo',
+      config: {
+        entries: [
+          {
+            key: 'Game_name',
+            value: 'Renamed Game',
+          },
+          {
+            key: 'Custom_flag',
+            value: 'on',
+          },
+        ],
+      },
+    })
+  })
+
+  it('getGameConfig 在返回旧版扁平结构时会拒绝解析', async () => {
+    safeInvokeMock.mockResolvedValue({
+      entries: Object.fromEntries([
+        ['Game_name', 'Demo Game'],
+      ]),
+    })
+
+    await expect(gameCmds.getGameConfig('/games/demo')).rejects.toThrow()
+  })
+
+  it('getGameConfig 在返回值缺失必需字段时会拒绝解析', async () => {
+    safeInvokeMock.mockResolvedValue({
+      entries: [
+        {
+          key: 'Game_name',
+          value: 'Demo Game',
+        },
+      ],
+    })
+
+    await expect(gameCmds.getGameConfig('/games/demo')).rejects.toThrow()
+  })
+})

--- a/src/commands/game.ts
+++ b/src/commands/game.ts
@@ -1,50 +1,64 @@
+import * as z from 'zod'
+
 import { safeInvoke } from '~/utils/invoke'
 
-export interface GameConfig {
-  defaultLanguage?: string
-  description?: string
-  enableAppreciation?: string
-  gameKey?: string
-  gameName?: string
-  gameLogo?: string
-  legacyExpressionBlendMode?: string
-  lineHeight?: string
-  maxLine?: string
-  packageName?: string
-  showPanic?: string
-  stageHeight?: string
-  stageWidth?: string
-  steamAppId?: string
-  titleBgm?: string
-  titleImg?: string
+export const BUILT_IN_GAME_CONFIG_RAW_KEYS = [
+  'Game_name',
+  'Game_key',
+  'Title_img',
+  'Title_bgm',
+  'Game_Logo',
+  'Enable_Appreciation',
+  'Legacy_Expression_Blend_Mode',
+  'Steam_AppID',
+  'Default_Language',
+  'Show_panic',
+  'Max_line',
+  'Line_height',
+  'Description',
+  'Package_name',
+] as const
+
+export interface GameConfigEntry {
+  key: string
+  value: string
 }
 
-export type GameConfigPatchKey =
-  | 'defaultLanguage'
-  | 'description'
-  | 'enableAppreciation'
-  | 'gameKey'
-  | 'gameName'
-  | 'gameLogo'
-  | 'legacyExpressionBlendMode'
-  | 'lineHeight'
-  | 'maxLine'
-  | 'packageName'
-  | 'showPanic'
-  | 'steamAppId'
-  | 'titleBgm'
-  | 'titleImg'
-
-export interface GameConfigPatch {
-  set: Partial<Record<GameConfigPatchKey, string>>
-  unset: GameConfigPatchKey[]
+export interface GameConfigReadResult {
+  entries: GameConfigEntry[]
+  unmanagedLineCount: number
 }
+
+export interface GameConfigWritePayload {
+  entries: GameConfigEntry[]
+}
+
+export function findGameConfigEntryValue(entries: readonly GameConfigEntry[], rawKey: string): string | undefined {
+  for (let index = entries.length - 1; index >= 0; index -= 1) {
+    const entry = entries[index]
+    if (entry?.key === rawKey) {
+      return entry.value
+    }
+  }
+}
+
+const gameConfigEntryShapeSchema = z.object({
+  key: z.string(),
+  value: z.string(),
+}) satisfies z.ZodType<GameConfigEntry>
+
+const gameConfigEntriesShapeSchema = z.array(gameConfigEntryShapeSchema) satisfies z.ZodType<GameConfigEntry[]>
+
+const gameConfigReadPayloadShapeSchema = z.looseObject({
+  entries: gameConfigEntriesShapeSchema,
+  unmanagedLineCount: z.number().int().nonnegative(),
+}) satisfies z.ZodType<GameConfigReadResult>
 
 async function getGameConfig(gamePath: string) {
-  return safeInvoke<GameConfig>('get_game_config', { gamePath })
+  return gameConfigReadPayloadShapeSchema.parse(await safeInvoke<unknown>('get_game_config', { gamePath }))
 }
 
-async function setGameConfig(gamePath: string, config: GameConfigPatch) {
+async function setGameConfig(gamePath: string, config: GameConfigWritePayload) {
   return safeInvoke<void>('set_game_config', { gamePath, config })
 }
 

--- a/src/components/editor/EditHeader.spec.ts
+++ b/src/components/editor/EditHeader.spec.ts
@@ -166,20 +166,28 @@ describe('EditHeader', () => {
       currentGameServeUrl: 'http://127.0.0.1:8899/game/test/',
     }))
     getConfigMock.mockResolvedValue({
-      defaultLanguage: 'zh_CN',
-      description: 'Intro',
-      enableAppreciation: 'false',
-      gameKey: 'demo-key',
-      gameName: '测试游戏',
-      titleImg: 'cover.webp',
-      legacyExpressionBlendMode: 'false',
-      lineHeight: '2.2',
-      maxLine: '3',
-      packageName: 'org.demo.game',
-      gameLogo: 'opening.webp|enter.webp|',
-      showPanic: 'true',
-      steamAppId: '480',
-      titleBgm: 'title.ogg',
+      entries: [
+        { key: 'Default_Language', value: 'zh_CN' },
+        { key: 'Description', value: 'Intro' },
+        { key: 'Enable_Appreciation', value: 'false' },
+        { key: 'Game_key', value: 'demo-key' },
+        { key: 'Game_name', value: '测试游戏' },
+        { key: 'Title_img', value: 'cover.webp' },
+        { key: 'Legacy_Expression_Blend_Mode', value: 'false' },
+        { key: 'Line_height', value: '2.2' },
+        { key: 'Max_line', value: '3' },
+        { key: 'Package_name', value: 'org.demo.game' },
+        { key: 'Game_Logo', value: 'opening.webp|enter.webp|' },
+        { key: 'Show_panic', value: 'true' },
+        { key: 'Steam_AppID', value: '480' },
+        { key: 'Title_bgm', value: 'title.ogg' },
+        { key: 'Stage_Width', value: '1920' },
+        {
+          key: 'Custom_flag',
+          value: 'enabled',
+        },
+      ],
+      unmanagedLineCount: 1,
     })
   })
 
@@ -245,6 +253,16 @@ describe('EditHeader', () => {
         initialValues: {
           defaultLanguage: 'zh_CN',
           description: 'Intro',
+          customConfig: [
+            {
+              key: 'Stage_Width',
+              value: '1920',
+            },
+            {
+              key: 'Custom_flag',
+              value: 'enabled',
+            },
+          ],
           enableAppreciation: false,
           gameKey: 'demo-key',
           gameLogo: ['opening.webp', 'enter.webp'],
@@ -258,6 +276,7 @@ describe('EditHeader', () => {
           titleBgm: 'title.ogg',
           titleImg: 'cover.webp',
         },
+        unmanagedLineCount: 1,
         serveUrl: 'http://127.0.0.1:8899/game/test/',
       })
     })

--- a/src/components/editor/EditHeader.vue
+++ b/src/components/editor/EditHeader.vue
@@ -68,6 +68,7 @@ async function handleOpenGameConfig() {
       gamePath,
       initialValues: parseGameConfigFormValues(config),
       serveUrl: currentGameServeUrl,
+      unmanagedLineCount: config.unmanagedLineCount,
     })
   } catch (error) {
     logger.error(`加载游戏配置失败: ${error}`)

--- a/src/components/editor/PreviewPanel.spec.ts
+++ b/src/components/editor/PreviewPanel.spec.ts
@@ -47,6 +47,14 @@ vi.mock('~/stores/workspace', () => ({
 }))
 
 vi.mock('~/commands/game', () => ({
+  findGameConfigEntryValue(entries: { key: string, value: string }[], rawKey: string) {
+    for (let index = entries.length - 1; index >= 0; index -= 1) {
+      const entry = entries[index]
+      if (entry?.key === rawKey) {
+        return entry.value
+      }
+    }
+  },
   gameCmds: {
     getGameConfig: getGameConfigMock,
   },
@@ -66,6 +74,17 @@ const globalStubs = {
   TooltipContent: createBrowserContainerStub('StubTooltipContent'),
   TooltipProvider: createBrowserContainerStub('StubTooltipProvider'),
   TooltipTrigger: createBrowserContainerStub('StubTooltipTrigger'),
+}
+
+let workspaceStoreState: {
+  currentGame: {
+    lastModified: number
+    metadata: {
+      name: string
+    }
+    path: string
+  }
+  currentGameServeUrl: string
 }
 
 function createPreviewPanelLiteI18n() {
@@ -95,22 +114,27 @@ describe('PreviewPanel', () => {
     useClipboardMock.mockReset()
     useWorkspaceStoreMock.mockReset()
 
-    useWorkspaceStoreMock.mockReturnValue(reactive({
+    workspaceStoreState = reactive({
       currentGame: {
+        lastModified: 100,
         metadata: {
           name: 'Demo Game',
         },
         path: '/games/demo',
       },
       currentGameServeUrl: 'http://127.0.0.1:8899',
-    }))
+    })
+    useWorkspaceStoreMock.mockReturnValue(workspaceStoreState)
     useClipboardMock.mockReturnValue({
       copied: ref(true),
       copy: copyMock,
     })
     getGameConfigMock.mockResolvedValue({
-      stageHeight: 720,
-      stageWidth: 1280,
+      entries: [
+        { key: 'Stage_Height', value: '720' },
+        { key: 'Stage_Width', value: '1280' },
+      ],
+      unmanagedLineCount: 0,
     })
   })
 
@@ -154,5 +178,24 @@ describe('PreviewPanel', () => {
     await page.getByRole('button', { name: 'edit.previewPanel.refreshPreview' }).click()
 
     expect(getGameConfigMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('当前游戏快照更新时间变化时会自动重新读取游戏配置', async () => {
+    renderInBrowser(PreviewPanel, {
+      global: {
+        plugins: [createPreviewPanelLiteI18n()],
+        stubs: globalStubs,
+      },
+    })
+
+    await vi.waitFor(() => {
+      expect(getGameConfigMock).toHaveBeenCalledTimes(1)
+    })
+
+    workspaceStoreState.currentGame.lastModified += 1
+
+    await vi.waitFor(() => {
+      expect(getGameConfigMock).toHaveBeenCalledTimes(2)
+    })
   })
 })

--- a/src/components/editor/PreviewPanel.spec.ts
+++ b/src/components/editor/PreviewPanel.spec.ts
@@ -46,19 +46,17 @@ vi.mock('~/stores/workspace', () => ({
   useWorkspaceStore: useWorkspaceStoreMock,
 }))
 
-vi.mock('~/commands/game', () => ({
-  findGameConfigEntryValue(entries: { key: string, value: string }[], rawKey: string) {
-    for (let index = entries.length - 1; index >= 0; index -= 1) {
-      const entry = entries[index]
-      if (entry?.key === rawKey) {
-        return entry.value
-      }
-    }
-  },
-  gameCmds: {
-    getGameConfig: getGameConfigMock,
-  },
-}))
+vi.mock('~/commands/game', async () => {
+  const actual = await vi.importActual<typeof import('~/commands/game')>('~/commands/game')
+
+  return {
+    ...actual,
+    gameCmds: {
+      ...actual.gameCmds,
+      getGameConfig: getGameConfigMock,
+    },
+  }
+})
 
 vi.mock('notivue', () => ({
   push: {

--- a/src/components/editor/PreviewPanel.vue
+++ b/src/components/editor/PreviewPanel.vue
@@ -2,7 +2,7 @@
 import { Copy, ExternalLink, Link, RotateCw } from '@lucide/vue'
 import { openUrl } from '@tauri-apps/plugin-opener'
 
-import { gameCmds } from '~/commands/game'
+import { findGameConfigEntryValue, gameCmds } from '~/commands/game'
 import {
   DEFAULT_PREVIEW_PANEL_ASPECT_RATIO,
   resolvePreviewPanelStageSize,
@@ -32,7 +32,10 @@ async function updateAspectRatio(): Promise<void> {
     const gameConfig = await gameCmds.getGameConfig(requestedPath)
     const nextStageSize = resolvePreviewPanelStageSize({
       currentGamePath: workspaceStore.currentGame?.path,
-      gameConfig,
+      gameConfig: {
+        stageHeight: findGameConfigEntryValue(gameConfig.entries, 'Stage_Height'),
+        stageWidth: findGameConfigEntryValue(gameConfig.entries, 'Stage_Width'),
+      },
       requestedPath,
     })
     if (!nextStageSize) {
@@ -86,11 +89,22 @@ async function openPreviewInBrowser(): Promise<void> {
 }
 
 watch(
-  () => workspaceStore.currentGame,
+  () => workspaceStore.currentGame?.path,
   () => {
     void updateAspectRatio()
   },
   { immediate: true },
+)
+
+watch(
+  () => workspaceStore.currentGame?.lastModified,
+  (lastModified, previousLastModified) => {
+    if (lastModified === undefined || previousLastModified === undefined) {
+      return
+    }
+
+    refreshIframe()
+  },
 )
 </script>
 

--- a/src/components/modals/GameConfigModal.spec.ts
+++ b/src/components/modals/GameConfigModal.spec.ts
@@ -49,6 +49,7 @@ const preparedModalProps = {
   initialValues: {
     defaultLanguage: 'zh_CN',
     description: 'An introductory story',
+    customConfig: [],
     enableAppreciation: false,
     gameKey: 'demo-key',
     gameLogo: ['opening.webp', 'enter.webp'],
@@ -62,6 +63,7 @@ const preparedModalProps = {
     titleBgm: 'title.ogg',
     titleImg: 'cover.webp',
   },
+  unmanagedLineCount: 0,
   serveUrl: 'http://127.0.0.1:8899/game/demo/',
 } as const
 
@@ -296,6 +298,15 @@ describe('GameConfigModal', () => {
         'open': true,
         'onUpdate:open': updateOpen,
         ...preparedModalProps,
+        'initialValues': {
+          ...preparedModalProps.initialValues,
+          customConfig: [
+            {
+              key: 'Stage_Width',
+              value: '1920',
+            },
+          ],
+        },
       },
       global: {
         stubs: globalStubs,
@@ -307,9 +318,12 @@ describe('GameConfigModal', () => {
 
     await vi.waitFor(() => {
       expect(setConfigMock).toHaveBeenCalledWith('/games/demo', expect.objectContaining({
-        set: expect.objectContaining({
-          description: 'Line 1 Line 2',
-        }),
+        entries: expect.arrayContaining([
+          expect.objectContaining({
+            key: 'Description',
+            value: 'Line 1 Line 2',
+          }),
+        ]),
       }))
     })
     expect(updateOpen).toHaveBeenCalledWith(false)
@@ -342,9 +356,12 @@ describe('GameConfigModal', () => {
 
     await vi.waitFor(() => {
       expect(setConfigMock).toHaveBeenCalledWith('/games/demo', expect.objectContaining({
-        set: expect.objectContaining({
-          gameKey: '22222222-2222-2222-2222-222222222222',
-        }),
+        entries: expect.arrayContaining([
+          expect.objectContaining({
+            key: 'Game_key',
+            value: '22222222-2222-2222-2222-222222222222',
+          }),
+        ]),
       }))
     })
 
@@ -387,6 +404,15 @@ describe('GameConfigModal', () => {
         'open': true,
         'onUpdate:open': updateOpen,
         ...preparedModalProps,
+        'initialValues': {
+          ...preparedModalProps.initialValues,
+          customConfig: [
+            {
+              key: 'Stage_Width',
+              value: '1920',
+            },
+          ],
+        },
       },
       global: {
         stubs: globalStubs,
@@ -414,8 +440,118 @@ describe('GameConfigModal', () => {
     })
   })
 
-  it('保存时会提交序列化后的配置补丁并关闭弹窗', async () => {
+  it('打开时会渲染自定义配置项并显示未托管配置提示', async () => {
+    renderInBrowser(GameConfigModal, {
+      browser: {
+        i18nMode: 'lite',
+      },
+      props: {
+        'open': true,
+        'onUpdate:open': vi.fn(),
+        ...preparedModalProps,
+        'initialValues': {
+          ...preparedModalProps.initialValues,
+          customConfig: [
+            {
+              key: 'Custom_flag',
+              value: 'enabled',
+            },
+          ],
+        },
+        'unmanagedLineCount': 2,
+      },
+      global: {
+        stubs: globalStubs,
+      },
+    })
+
+    await expect.element(page.getByTestId('game-config-custom-key-0')).toHaveValue('Custom_flag')
+    await expect.element(page.getByTestId('game-config-custom-value-0')).toHaveValue('enabled')
+    await expect.element(page.getByTestId('game-config-unmanaged-notice')).toBeVisible()
+    await expect.element(page.getByTestId('game-config-custom-section')).toBeVisible()
+  })
+
+  it('底部添加的自定义配置项会随保存一起提交', async () => {
+    renderInBrowser(GameConfigModal, {
+      browser: {
+        i18nMode: 'lite',
+      },
+      props: {
+        'open': true,
+        'onUpdate:open': vi.fn(),
+        ...preparedModalProps,
+      },
+      global: {
+        stubs: globalStubs,
+      },
+    })
+
+    await page.getByTestId('game-config-custom-add').click()
+    await page.getByTestId('game-config-custom-key-0').fill('Custom_flag')
+    await page.getByTestId('game-config-custom-value-0').fill('enabled')
+    await page.getByRole('button', { name: 'common.save' }).click()
+
+    await vi.waitFor(() => {
+      expect(setConfigMock).toHaveBeenCalledWith('/games/demo', expect.objectContaining({
+        entries: expect.arrayContaining([
+          {
+            key: 'Custom_flag',
+            value: 'enabled',
+          },
+        ]),
+      }))
+    })
+  })
+
+  it('清空自定义配置列表后仍可直接保存', async () => {
+    renderInBrowser(GameConfigModal, {
+      browser: {
+        i18nMode: 'lite',
+      },
+      props: {
+        'open': true,
+        'onUpdate:open': vi.fn(),
+        ...preparedModalProps,
+        'initialValues': {
+          ...preparedModalProps.initialValues,
+          customConfig: [
+            {
+              key: 'Custom_flag',
+              value: 'enabled',
+            },
+          ],
+        },
+      },
+      global: {
+        stubs: globalStubs,
+      },
+    })
+
+    await page.getByTestId('game-config-custom-remove-0').click()
+    await page.getByRole('button', { name: 'common.save' }).click()
+
+    await vi.waitFor(() => {
+      expect(setConfigMock).toHaveBeenCalledWith('/games/demo', expect.objectContaining({
+        entries: expect.not.arrayContaining([
+          expect.objectContaining({
+            key: 'Custom_flag',
+          }),
+        ]),
+      }))
+    })
+  })
+
+  it('保存时会提交编辑结果并关闭弹窗', async () => {
     const updateOpen = vi.fn()
+    const initialValues = {
+      ...preparedModalProps.initialValues,
+      customConfig: [
+        {
+          key: 'Stage_Width',
+          value: '1920',
+        },
+      ],
+    } as const
 
     renderInBrowser(GameConfigModal, {
       browser: {
@@ -425,6 +561,7 @@ describe('GameConfigModal', () => {
         'open': true,
         'onUpdate:open': updateOpen,
         ...preparedModalProps,
+        initialValues,
       },
       global: {
         stubs: globalStubs,
@@ -439,25 +576,35 @@ describe('GameConfigModal', () => {
     await page.getByRole('button', { name: 'common.save' }).click()
 
     await vi.waitFor(() => {
-      expect(setConfigMock).toHaveBeenCalledWith('/games/demo', {
-        set: {
-          defaultLanguage: 'zh_CN',
-          description: 'Updated description',
-          enableAppreciation: 'false',
-          gameKey: 'demo-key',
-          gameName: 'Renamed Game',
-          titleImg: 'cover-next.webp',
-          legacyExpressionBlendMode: 'false',
-          lineHeight: '2.2',
-          maxLine: '3',
-          packageName: 'org.demo.game',
-          gameLogo: 'enter-next.webp|logo-next.webp|',
-          showPanic: 'true',
-          steamAppId: '480',
-          titleBgm: 'title-next.ogg',
-        },
-        unset: [],
-      })
+      expect(setConfigMock).toHaveBeenCalledTimes(1)
+      expect(setConfigMock).toHaveBeenCalledWith('/games/demo', expect.objectContaining({
+        entries: expect.arrayContaining([
+          expect.objectContaining({
+            key: 'Game_name',
+            value: 'Renamed Game',
+          }),
+          expect.objectContaining({
+            key: 'Description',
+            value: 'Updated description',
+          }),
+          expect.objectContaining({
+            key: 'Title_img',
+            value: 'cover-next.webp',
+          }),
+          expect.objectContaining({
+            key: 'Title_bgm',
+            value: 'title-next.ogg',
+          }),
+          expect.objectContaining({
+            key: 'Game_Logo',
+            value: 'enter-next.webp|logo-next.webp|',
+          }),
+          expect.objectContaining({
+            key: 'Stage_Width',
+            value: '1920',
+          }),
+        ]),
+      }))
     })
 
     await vi.waitFor(() => {

--- a/src/components/modals/GameConfigModal.vue
+++ b/src/components/modals/GameConfigModal.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { Info } from '@lucide/vue'
 import { useForm } from 'vee-validate'
 
 import {
@@ -6,7 +7,7 @@ import {
   createEmptyGameConfigFormValues,
   createGameConfigKey,
   createGameConfigSchema,
-  serializeGameConfigPatch,
+  serializeGameConfigEntries,
 } from '~/features/modals/game-config/game-config-form'
 import { configManager } from '~/services/config-manager'
 import { useModalStore } from '~/stores/modal'
@@ -20,6 +21,7 @@ interface Props {
   gamePath: string
   initialValues: GameConfigFormValues
   serveUrl?: string
+  unmanagedLineCount: number
 }
 
 const props = defineProps<Props>()
@@ -106,7 +108,7 @@ const submitConfig = handleSubmit(async (formValues) => {
 
   isSaving = true
   try {
-    await configManager.setConfig(props.gamePath, serializeGameConfigPatch(formValues))
+    await configManager.setConfig(props.gamePath, serializeGameConfigEntries(formValues))
     notify.success(t('common.saved'))
     resetForm({
       values: cloneGameConfigFormValues(formValues),
@@ -139,6 +141,14 @@ async function handleSave() {
         <DialogDescription>
           {{ $t('modals.gameConfig.description') }}
         </DialogDescription>
+        <div
+          v-if="props.unmanagedLineCount > 0"
+          data-testid="game-config-unmanaged-notice"
+          class="text-xs text-muted-foreground px-3 py-2 rounded-md bg-muted/60 flex gap-2 items-start"
+        >
+          <Info class="mt-0.5 shrink-0 size-3.5" aria-hidden="true" />
+          <span>{{ $t('modals.gameConfig.custom.unmanagedNotice') }}</span>
+        </div>
       </DialogHeader>
 
       <ScrollArea data-testid="game-config-modal-scroll-area" class="min-h-0">

--- a/src/components/modals/game-config/GameConfigFieldsSection.spec.ts
+++ b/src/components/modals/game-config/GameConfigFieldsSection.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import { page } from 'vitest/browser'
-import { defineComponent, h } from 'vue'
+import { defineComponent, h, ref } from 'vue'
 
 import {
   createBrowserCheckboxStub,
@@ -9,6 +9,19 @@ import {
   createBrowserInputStub,
   renderInBrowser,
 } from '~/__tests__/browser-render'
+
+const { useFieldArrayMock } = vi.hoisted(() => ({
+  useFieldArrayMock: vi.fn(),
+}))
+
+vi.mock('vee-validate', async () => {
+  const actual = await vi.importActual<typeof import('vee-validate')>('vee-validate')
+
+  return {
+    ...actual,
+    useFieldArray: useFieldArrayMock,
+  }
+})
 
 vi.mock('~/components/ui/form', async () => {
   const actual = await vi.importActual<typeof import('~/components/ui/form')>('~/components/ui/form')
@@ -21,6 +34,10 @@ vi.mock('~/components/ui/form', async () => {
         name: {
           type: String,
           required: true,
+        },
+        validateOnModelUpdate: {
+          type: Boolean,
+          default: undefined,
         },
       },
       setup(_props, { slots }) {
@@ -40,6 +57,7 @@ vi.mock('~/components/ui/form', async () => {
 import GameConfigFieldsSection from './GameConfigFieldsSection.vue'
 
 const globalStubs = {
+  Button: createBrowserClickStub('StubButton'),
   TitleImgPicker: createBrowserContainerStub('StubTitleImgPicker'),
   FilePicker: defineComponent({
     name: 'StubFilePicker',
@@ -101,6 +119,17 @@ const globalStubs = {
   TooltipTrigger: createBrowserContainerStub('StubTooltipTrigger'),
 }
 
+function setCustomConfigFields(entries: { key: string, value: string }[]) {
+  useFieldArrayMock.mockReturnValue({
+    fields: ref(entries.map((entry, index) => ({
+      key: `custom-row-${index}`,
+      value: entry,
+    }))),
+    push: vi.fn(),
+    remove: vi.fn(),
+  })
+}
+
 function renderSection(i18nMode: 'lite' | 'localized' = 'lite', messages?: Record<string, unknown>) {
   return renderInBrowser(GameConfigFieldsSection, {
     browser: {
@@ -130,6 +159,7 @@ const localizedDefaultLanguageOptions = Object.fromEntries([
 
 describe('GameConfigFieldsSection', () => {
   it('titleBgm 使用限定在 bgm 目录的文件选择器', async () => {
+    setCustomConfigFields([])
     const result = renderSection()
 
     await expect.element(page.getByLabelText('modals.gameConfig.fields.titleBgm.label')).toHaveAttribute('data-root-path', '/games/demo/game/bgm')
@@ -140,6 +170,7 @@ describe('GameConfigFieldsSection', () => {
   })
 
   it('默认游戏语言选项使用固定语言名，不跟随界面 i18n 文案改变', async () => {
+    setCustomConfigFields([])
     const result = renderSection('localized', {
       'zh-Hans': {
         modals: {
@@ -167,6 +198,44 @@ describe('GameConfigFieldsSection', () => {
     await expect.element(page.getByText(/^Test Japanese$/)).not.toBeInTheDocument()
     await expect.element(page.getByText(/^Test French$/)).not.toBeInTheDocument()
     await expect.element(page.getByText(/^Test German$/)).not.toBeInTheDocument()
+
+    await result.unmount()
+  })
+
+  it('空列表时仍会渲染底部添加自定义配置项按钮', async () => {
+    setCustomConfigFields([])
+    const result = renderSection()
+
+    await expect.element(page.getByTestId('game-config-custom-add')).toBeVisible()
+
+    await result.unmount()
+  })
+
+  it('自定义行删除按钮保留可访问名称', async () => {
+    setCustomConfigFields([
+      {
+        key: 'Custom_flag',
+        value: 'enabled',
+      },
+    ])
+    const result = renderInBrowser(GameConfigFieldsSection, {
+      browser: {
+        i18nMode: 'lite',
+      },
+      props: {
+        backgroundRootPath: '/games/demo/game/background',
+        bgmRootPath: '/games/demo/game/bgm',
+        gamePath: '/games/demo',
+        serveUrl: 'http://127.0.0.1:8899/game/demo/',
+      },
+      global: {
+        stubs: globalStubs,
+      },
+    })
+
+    const removeButton = page.getByRole('button', { name: 'modals.gameConfig.custom.remove' })
+
+    await expect.element(removeButton).toBeVisible()
 
     await result.unmount()
   })

--- a/src/components/modals/game-config/GameConfigFieldsSection.vue
+++ b/src/components/modals/game-config/GameConfigFieldsSection.vue
@@ -1,7 +1,12 @@
 <script setup lang="ts">
+import { X } from '@lucide/vue'
+import { useFieldArray } from 'vee-validate'
+
 import { FormField } from '~/components/ui/form'
 import { AUDIO_EXTENSIONS } from '~/features/editor/command-registry/common-params'
 import { createGameConfigKey } from '~/features/modals/game-config/game-config-form'
+
+import type { GameConfigFormValues } from '~/features/modals/game-config/game-config-form'
 
 interface Props {
   backgroundRootPath: string
@@ -13,6 +18,11 @@ interface Props {
 defineProps<Props>()
 
 const DEFAULT_LANGUAGE_EMPTY_VALUE = '__runtime_fallback__'
+const {
+  fields: customConfigFields,
+  push: pushCustomConfig,
+  remove: removeCustomConfig,
+} = useFieldArray<GameConfigFormValues['customConfig'][number]>('customConfig')
 
 const defaultLanguageOptions = [
   {
@@ -76,6 +86,47 @@ function normalizeSingleLineText(value: string): string {
 
 function handleDescriptionChange(handleChange: (value: string) => void, nextValue: string | number) {
   handleChange(normalizeSingleLineText(String(nextValue)))
+}
+
+function handleTextInputChange(handleChange: (value: string) => void, nextValue: string | number) {
+  handleChange(String(nextValue))
+}
+
+const customAddButtonContainerRef = $(useTemplateRef<HTMLDivElement>('customAddButtonContainerRef'))
+
+async function handleAddCustomConfig() {
+  pushCustomConfig({
+    key: '',
+    value: '',
+  })
+
+  await nextTick()
+  focusCustomConfigKey(customConfigFields.value.length - 1)
+  scrollCustomAddButtonIntoView()
+}
+
+function handleRemoveCustomConfig(index: number) {
+  removeCustomConfig(index)
+}
+
+function focusCustomConfigKey(index: number) {
+  const customKeyInput = document.querySelector<HTMLInputElement>(`#game-config-custom-key-${index}`)
+
+  if (!customKeyInput) {
+    return
+  }
+
+  customKeyInput.focus()
+}
+
+function scrollCustomAddButtonIntoView() {
+  const addButton = customAddButtonContainerRef?.querySelector('[data-testid="game-config-custom-add"]')
+
+  if (!(addButton instanceof HTMLElement)) {
+    return
+  }
+
+  addButton.scrollIntoView({ block: 'nearest' })
 }
 </script>
 
@@ -497,5 +548,98 @@ function handleDescriptionChange(handleChange: (value: string) => void, nextValu
         </FormItem>
       </FormField>
     </div>
+
+    <section class="flex flex-col gap-3" data-testid="game-config-custom-section">
+      <div>
+        <h3 class="text-sm font-medium">
+          {{ $t('modals.gameConfig.custom.title') }}
+        </h3>
+      </div>
+
+      <div class="flex flex-col gap-3" data-testid="game-config-custom-list">
+        <div
+          v-for="(field, index) in customConfigFields"
+          :key="field.key"
+          class="gap-2 grid grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto] items-start"
+        >
+          <FormField
+            v-slot="{ handleChange, value }"
+            :name="`customConfig[${index}].key`"
+          >
+            <FormItem class="flex flex-col gap-2">
+              <FormLabel class="sr-only" :for="`game-config-custom-key-${index}`">
+                {{ $t('modals.gameConfig.custom.keyLabel') }}
+              </FormLabel>
+              <FormControl>
+                <Input
+                  :id="`game-config-custom-key-${index}`"
+                  :data-testid="`game-config-custom-key-${index}`"
+                  :model-value="typeof value === 'string' ? value : field.value.key"
+                  class="text-xs h-8 shadow-none"
+                  :placeholder="$t('modals.gameConfig.custom.keyPlaceholder')"
+                  @update:model-value="handleTextInputChange(handleChange, $event)"
+                />
+              </FormControl>
+              <FormMessage class="text-xs" />
+            </FormItem>
+          </FormField>
+
+          <FormField
+            v-slot="{ handleChange, value }"
+            :name="`customConfig[${index}].value`"
+          >
+            <FormItem class="flex flex-col gap-2">
+              <FormLabel class="sr-only" :for="`game-config-custom-value-${index}`">
+                {{ $t('modals.gameConfig.custom.valueLabel') }}
+              </FormLabel>
+              <FormControl>
+                <Input
+                  :id="`game-config-custom-value-${index}`"
+                  :data-testid="`game-config-custom-value-${index}`"
+                  :model-value="typeof value === 'string' ? value : field.value.value"
+                  class="text-xs h-8 shadow-none"
+                  :placeholder="$t('modals.gameConfig.custom.valuePlaceholder')"
+                  @update:model-value="handleTextInputChange(handleChange, $event)"
+                />
+              </FormControl>
+              <FormMessage class="text-xs" />
+            </FormItem>
+          </FormField>
+
+          <TooltipProvider :delay-duration="0">
+            <Tooltip>
+              <TooltipTrigger as-child>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  class="text-muted-foreground size-8 shadow-none self-start hover:text-destructive"
+                  :aria-label="$t('modals.gameConfig.custom.remove')"
+                  :data-testid="`game-config-custom-remove-${index}`"
+                  @click="handleRemoveCustomConfig(index)"
+                >
+                  <X class="size-3.5" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="top" class="px-2 py-1">
+                {{ $t('modals.gameConfig.custom.remove') }}
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        </div>
+
+        <div ref="customAddButtonContainerRef">
+          <Button
+            type="button"
+            variant="outline"
+            class="text-xs h-8 w-full"
+            data-testid="game-config-custom-add"
+            @click="handleAddCustomConfig"
+          >
+            {{ $t('modals.gameConfig.custom.add') }}
+          </Button>
+        </div>
+      </div>
+    </section>
   </div>
 </template>

--- a/src/features/modals/game-config/__tests__/game-config-form.test.ts
+++ b/src/features/modals/game-config/__tests__/game-config-form.test.ts
@@ -1,36 +1,138 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  cloneGameConfigFormValues,
   createGameConfigSchema,
   parseGameConfigFormValues,
-  serializeGameConfigPatch,
+  serializeGameConfigEntries,
 } from '../game-config-form'
 
+import type { GameConfigFormValues } from '../game-config-form'
+import type { GameConfigReadResult } from '~/commands/game'
 import type { I18nT } from '~/utils/i18n-like'
 
 const t = ((key: string) => key) as unknown as I18nT
 
+function createFormValues(overrides: Partial<GameConfigFormValues> = {}): GameConfigFormValues {
+  return {
+    defaultLanguage: '',
+    description: '',
+    enableAppreciation: false,
+    gameKey: '',
+    gameName: 'Demo',
+    legacyExpressionBlendMode: false,
+    lineHeight: '',
+    maxLine: '',
+    packageName: '',
+    showPanic: true,
+    steamAppId: '',
+    titleBgm: '',
+    titleImg: '',
+    ...overrides,
+    customConfig: overrides.customConfig?.map(entry => ({ ...entry })) ?? [],
+    gameLogo: overrides.gameLogo ? [...overrides.gameLogo] : [],
+  }
+}
+
+function createReadResult(overrides: Partial<GameConfigReadResult> = {}): GameConfigReadResult {
+  return {
+    entries: [],
+    unmanagedLineCount: 0,
+    ...overrides,
+  }
+}
+
 describe('game-config form helpers', () => {
-  it('parseGameConfigFormValues 会把原始配置解析成表单可编辑值', () => {
-    expect(parseGameConfigFormValues({
+  it('parseGameConfigFormValues 会把 raw entries 解析成表单可编辑值，并保留自定义项', () => {
+    expect(parseGameConfigFormValues(createReadResult({
+      entries: [
+        {
+          key: 'Default_Language',
+          value: 'ja',
+        },
+        {
+          key: 'Description',
+          value: 'A visual novel',
+        },
+        {
+          key: 'Enable_Appreciation',
+          value: 'TRUE',
+        },
+        {
+          key: 'Game_key',
+          value: 'demo-key',
+        },
+        {
+          key: 'Game_Logo',
+          value: 'opening.webp|enter.webp|',
+        },
+        {
+          key: 'Game_name',
+          value: 'Demo',
+        },
+        {
+          key: 'Legacy_Expression_Blend_Mode',
+          value: 'false',
+        },
+        {
+          key: 'Line_height',
+          value: '2.5',
+        },
+        {
+          key: 'Max_line',
+          value: '4',
+        },
+        {
+          key: 'Package_name',
+          value: 'com.demo.game',
+        },
+        {
+          key: 'Show_panic',
+          value: 'false',
+        },
+        {
+          key: 'Steam_AppID',
+          value: '480',
+        },
+        {
+          key: 'Title_bgm',
+          value: 'title.ogg',
+        },
+        {
+          key: 'Title_img',
+          value: 'cover.webp',
+        },
+        {
+          key: 'Stage_Width',
+          value: '1920',
+        },
+        {
+          key: 'Stage_Height',
+          value: '1080',
+        },
+        {
+          key: 'Custom_flag',
+          value: 'enabled',
+        },
+      ],
+    }))).toEqual(createFormValues({
+      titleImg: 'cover.webp',
       defaultLanguage: 'ja',
       description: 'A visual novel',
-      enableAppreciation: 'TRUE',
-      gameKey: 'demo-key',
-      gameLogo: 'opening.webp|enter.webp|',
-      gameName: 'Demo',
-      legacyExpressionBlendMode: 'false',
-      lineHeight: '2.5',
-      maxLine: '4',
-      packageName: 'com.demo.game',
-      showPanic: 'false',
-      steamAppId: '480',
-      titleBgm: 'title.ogg',
-      titleImg: 'cover.webp',
-    })).toEqual({
-      titleImg: 'cover.webp',
-      defaultLanguage: 'ja',
-      description: 'A visual novel',
+      customConfig: [
+        {
+          key: 'Stage_Width',
+          value: '1920',
+        },
+        {
+          key: 'Stage_Height',
+          value: '1080',
+        },
+        {
+          key: 'Custom_flag',
+          value: 'enabled',
+        },
+      ],
       enableAppreciation: true,
       gameKey: 'demo-key',
       gameName: 'Demo',
@@ -42,300 +144,346 @@ describe('game-config form helpers', () => {
       gameLogo: ['opening.webp', 'enter.webp'],
       steamAppId: '480',
       titleBgm: 'title.ogg',
-    })
+    }))
   })
 
   it('parseGameConfigFormValues 会为无效值回退到编辑器默认值', () => {
-    expect(parseGameConfigFormValues({
-      defaultLanguage: 'ko',
-      enableAppreciation: 'unexpected',
-      legacyExpressionBlendMode: undefined,
-      lineHeight: '',
-      maxLine: 'not-a-number',
-      showPanic: undefined,
-    })).toEqual({
-      titleImg: '',
-      defaultLanguage: '',
-      description: '',
-      enableAppreciation: false,
-      gameKey: '',
+    expect(parseGameConfigFormValues(createReadResult({
+      entries: [
+        {
+          key: 'Default_Language',
+          value: 'ko',
+        },
+        {
+          key: 'Enable_Appreciation',
+          value: 'unexpected',
+        },
+        {
+          key: 'Line_height',
+          value: '',
+        },
+        {
+          key: 'Max_line',
+          value: 'not-a-number',
+        },
+      ],
+      unmanagedLineCount: 2,
+    }))).toEqual(createFormValues({
       gameName: '',
-      legacyExpressionBlendMode: false,
-      lineHeight: '',
-      maxLine: '',
-      packageName: '',
-      showPanic: true,
-      gameLogo: [],
-      steamAppId: '',
-      titleBgm: '',
+    }))
+  })
+
+  it('cloneGameConfigFormValues 会深拷贝数组字段', () => {
+    const original = createFormValues({
+      customConfig: [
+        {
+          key: 'Custom_flag',
+          value: 'enabled',
+        },
+      ],
+      gameLogo: ['opening.webp'],
     })
+
+    const cloned = cloneGameConfigFormValues(original)
+    cloned.customConfig[0]!.key = 'Changed_flag'
+    cloned.gameLogo.push('ending.webp')
+
+    expect(original).toEqual(createFormValues({
+      customConfig: [
+        {
+          key: 'Custom_flag',
+          value: 'enabled',
+        },
+      ],
+      gameLogo: ['opening.webp'],
+    }))
   })
 
   it('createGameConfigSchema 会拒绝不支持的默认语言', () => {
     const schema = createGameConfigSchema(t)
 
     expect(schema.safeParse({
-      titleImg: '',
+      ...createFormValues(),
       defaultLanguage: 'ko',
-      description: '',
-      enableAppreciation: false,
-      gameKey: '',
-      gameName: '',
-      legacyExpressionBlendMode: false,
-      lineHeight: '',
-      maxLine: '',
-      packageName: '',
-      showPanic: true,
-      gameLogo: [],
-      steamAppId: '',
-      titleBgm: '',
     }).success).toBe(false)
   })
 
   it('createGameConfigSchema 会拒绝空白游戏名称', () => {
     const schema = createGameConfigSchema(t)
 
-    expect(schema.safeParse({
-      titleImg: '',
-      defaultLanguage: '',
-      description: '',
-      enableAppreciation: false,
-      gameKey: '',
+    expect(schema.safeParse(createFormValues({
       gameName: '',
-      legacyExpressionBlendMode: false,
-      lineHeight: '',
-      maxLine: '',
-      packageName: '',
-      showPanic: true,
-      gameLogo: [],
-      steamAppId: '',
-      titleBgm: '',
-    }).success).toBe(false)
+    })).success).toBe(false)
 
-    expect(schema.safeParse({
-      titleImg: '',
-      defaultLanguage: '',
-      description: '',
-      enableAppreciation: false,
-      gameKey: '',
+    expect(schema.safeParse(createFormValues({
       gameName: '   ',
-      legacyExpressionBlendMode: false,
-      lineHeight: '',
-      maxLine: '',
-      packageName: '',
-      showPanic: true,
-      gameLogo: [],
-      steamAppId: '',
-      titleBgm: '',
-    }).success).toBe(false)
+    })).success).toBe(false)
   })
 
-  it('createGameConfigSchema 会拒绝明显无效的跨平台包名', () => {
+  it('createGameConfigSchema 会校验并裁剪包名', () => {
     const schema = createGameConfigSchema(t)
 
-    expect(schema.safeParse({
-      titleImg: '',
-      defaultLanguage: '',
-      description: '',
-      enableAppreciation: false,
-      gameKey: '',
-      gameName: '',
-      legacyExpressionBlendMode: false,
-      lineHeight: '',
-      maxLine: '',
+    expect(schema.safeParse(createFormValues({
       packageName: 'org.example_demo',
-      showPanic: true,
-      gameLogo: [],
-      steamAppId: '',
-      titleBgm: '',
-    }).success).toBe(false)
-
-    expect(schema.safeParse({
-      titleImg: '',
-      defaultLanguage: '',
-      description: '',
-      enableAppreciation: false,
-      gameKey: '',
-      gameName: '',
-      legacyExpressionBlendMode: false,
-      lineHeight: '',
-      maxLine: '',
+    })).success).toBe(false)
+    expect(schema.safeParse(createFormValues({
       packageName: 'Demo.App',
-      showPanic: true,
-      gameLogo: [],
-      steamAppId: '',
-      titleBgm: '',
-    }).success).toBe(false)
-  })
+    })).success).toBe(false)
 
-  it('createGameConfigSchema 会把包名前后空白裁剪后再校验', () => {
-    const schema = createGameConfigSchema(t)
-
-    const result = schema.parse({
-      titleImg: '',
-      defaultLanguage: '',
-      description: '',
-      enableAppreciation: false,
-      gameKey: '',
-      gameName: 'Demo',
-      legacyExpressionBlendMode: false,
-      lineHeight: '',
-      maxLine: '',
+    const result = schema.parse(createFormValues({
       packageName: '  org.example.demo  ',
-      showPanic: true,
-      gameLogo: [],
-      steamAppId: '',
-      titleBgm: '',
-    })
+    }))
 
     expect(result.packageName).toBe('org.example.demo')
   })
 
-  it('createGameConfigSchema 会拒绝无效的 Steam AppID', () => {
+  it('createGameConfigSchema 会校验并裁剪 Steam AppID', () => {
     const schema = createGameConfigSchema(t)
 
-    expect(schema.safeParse({
-      titleImg: '',
-      defaultLanguage: '',
-      description: '',
-      enableAppreciation: false,
-      gameKey: '',
-      gameName: '',
-      legacyExpressionBlendMode: false,
-      lineHeight: '',
-      maxLine: '',
-      packageName: '',
-      showPanic: true,
-      gameLogo: [],
+    expect(schema.safeParse(createFormValues({
       steamAppId: 'abc',
-      titleBgm: '',
-    }).success).toBe(false)
-
-    expect(schema.safeParse({
-      titleImg: '',
-      defaultLanguage: '',
-      description: '',
-      enableAppreciation: false,
-      gameKey: '',
-      gameName: '',
-      legacyExpressionBlendMode: false,
-      lineHeight: '',
-      maxLine: '',
-      packageName: '',
-      showPanic: true,
-      gameLogo: [],
+    })).success).toBe(false)
+    expect(schema.safeParse(createFormValues({
       steamAppId: '0',
-      titleBgm: '',
-    }).success).toBe(false)
-
-    expect(schema.safeParse({
-      titleImg: '',
-      defaultLanguage: '',
-      description: '',
-      enableAppreciation: false,
-      gameKey: '',
-      gameName: '',
-      legacyExpressionBlendMode: false,
-      lineHeight: '',
-      maxLine: '',
-      packageName: '',
-      showPanic: true,
-      gameLogo: [],
+    })).success).toBe(false)
+    expect(schema.safeParse(createFormValues({
       steamAppId: '4294967296',
-      titleBgm: '',
-    }).success).toBe(false)
-  })
+    })).success).toBe(false)
 
-  it('createGameConfigSchema 会把 Steam AppID 前后空白裁剪后再校验', () => {
-    const schema = createGameConfigSchema(t)
-
-    const result = schema.parse({
-      titleImg: '',
-      defaultLanguage: '',
-      description: '',
-      enableAppreciation: false,
-      gameKey: '',
-      gameName: 'Demo',
-      legacyExpressionBlendMode: false,
-      lineHeight: '',
-      maxLine: '',
-      packageName: '',
-      showPanic: true,
-      gameLogo: [],
+    const result = schema.parse(createFormValues({
       steamAppId: '  480  ',
-      titleBgm: '',
-    })
+    }))
 
     expect(result.steamAppId).toBe('480')
   })
 
-  it('serializeGameConfigPatch 会把可选回退字段序列化为删除补丁', () => {
-    expect(serializeGameConfigPatch({
+  it('createGameConfigSchema 会拒绝和内置 raw key 重名的自定义项', () => {
+    const schema = createGameConfigSchema(t)
+
+    expect(schema.safeParse(createFormValues({
+      customConfig: [
+        {
+          key: 'Game_name',
+          value: 'Demo',
+        },
+      ],
+    })).success).toBe(false)
+  })
+
+  it('createGameConfigSchema 允许 Stage_Width 和 Stage_Height 作为自定义项', () => {
+    const schema = createGameConfigSchema(t)
+
+    expect(schema.safeParse(createFormValues({
+      customConfig: [
+        {
+          key: 'Stage_Width',
+          value: '1920',
+        },
+        {
+          key: 'Stage_Height',
+          value: '1080',
+        },
+      ],
+    })).success).toBe(true)
+  })
+
+  it('createGameConfigSchema 会拒绝重复的自定义键', () => {
+    const schema = createGameConfigSchema(t)
+
+    expect(schema.safeParse(createFormValues({
+      customConfig: [
+        {
+          key: 'Custom_flag',
+          value: 'a',
+        },
+        {
+          key: 'Custom_flag',
+          value: 'b',
+        },
+      ],
+    })).success).toBe(false)
+  })
+
+  it('createGameConfigSchema 会拒绝包含分号的内置字符串字段', () => {
+    const schema = createGameConfigSchema(t)
+
+    expect(schema.safeParse(createFormValues({
+      gameName: 'Demo;Broken',
+    })).success).toBe(false)
+
+    expect(schema.safeParse(createFormValues({
+      description: 'Intro;Comment',
+    })).success).toBe(false)
+  })
+
+  it('createGameConfigSchema 会拒绝包含分号的自定义键和值', () => {
+    const schema = createGameConfigSchema(t)
+
+    expect(schema.safeParse(createFormValues({
+      customConfig: [
+        {
+          key: 'Custom;Flag',
+          value: 'enabled',
+        },
+      ],
+    })).success).toBe(false)
+
+    expect(schema.safeParse(createFormValues({
+      customConfig: [
+        {
+          key: 'Custom_flag',
+          value: 'enabled;comment',
+        },
+      ],
+    })).success).toBe(false)
+  })
+
+  it('createGameConfigSchema 会忽略键和值都为空的自定义行', () => {
+    const schema = createGameConfigSchema(t)
+
+    expect(schema.safeParse(createFormValues({
+      customConfig: [
+        {
+          key: '',
+          value: '',
+        },
+        {
+          key: '   ',
+          value: '',
+        },
+        {
+          key: 'Custom_flag',
+          value: '',
+        },
+      ],
+    })).success).toBe(true)
+  })
+
+  it('serializeGameConfigEntries 会输出统一 raw entries，并保留自定义配置项', () => {
+    expect(serializeGameConfigEntries(createFormValues({
       titleImg: 'cover.webp',
-      defaultLanguage: '',
       description: 'A visual novel',
+      customConfig: [
+        {
+          key: 'Stage_Width',
+          value: '1920',
+        },
+        {
+          key: 'Stage_Height',
+          value: '1080',
+        },
+        {
+          key: 'Custom_flag',
+          value: 'enabled',
+        },
+      ],
       enableAppreciation: true,
       gameKey: 'demo-key',
-      gameName: 'Demo',
-      legacyExpressionBlendMode: false,
-      lineHeight: '',
-      maxLine: '',
       packageName: 'com.demo.game',
-      showPanic: true,
       gameLogo: ['opening.webp', 'enter.webp'],
       steamAppId: '',
       titleBgm: 'title.ogg',
-    })).toEqual({
-      set: {
-        description: 'A visual novel',
-        enableAppreciation: 'true',
-        gameKey: 'demo-key',
-        gameLogo: 'opening.webp|enter.webp|',
-        gameName: 'Demo',
-        legacyExpressionBlendMode: 'false',
-        packageName: 'com.demo.game',
-        showPanic: 'true',
-        titleBgm: 'title.ogg',
-        titleImg: 'cover.webp',
-      },
-      unset: ['defaultLanguage', 'lineHeight', 'maxLine', 'steamAppId'],
+    }))).toEqual({
+      entries: [
+        {
+          key: 'Game_name',
+          value: 'Demo',
+        },
+        {
+          key: 'Description',
+          value: 'A visual novel',
+        },
+        {
+          key: 'Title_img',
+          value: 'cover.webp',
+        },
+        {
+          key: 'Title_bgm',
+          value: 'title.ogg',
+        },
+        {
+          key: 'Game_Logo',
+          value: 'opening.webp|enter.webp|',
+        },
+        {
+          key: 'Enable_Appreciation',
+          value: 'true',
+        },
+        {
+          key: 'Legacy_Expression_Blend_Mode',
+          value: 'false',
+        },
+        {
+          key: 'Show_panic',
+          value: 'true',
+        },
+        {
+          key: 'Package_name',
+          value: 'com.demo.game',
+        },
+        {
+          key: 'Game_key',
+          value: 'demo-key',
+        },
+        {
+          key: 'Stage_Width',
+          value: '1920',
+        },
+        {
+          key: 'Stage_Height',
+          value: '1080',
+        },
+        {
+          key: 'Custom_flag',
+          value: 'enabled',
+        },
+      ],
     })
   })
 
-  it('serializeGameConfigPatch 会把非开关空字段序列化为删除补丁', () => {
-    expect(serializeGameConfigPatch({
-      titleImg: '',
+  it('serializeGameConfigEntries 会省略为空的可选 built-in 字段，但保留空字符串自定义值', () => {
+    expect(serializeGameConfigEntries(createFormValues({
       defaultLanguage: '',
       description: '',
-      enableAppreciation: false,
       gameKey: '',
       gameName: '',
-      legacyExpressionBlendMode: true,
+      gameLogo: [],
       lineHeight: '',
       maxLine: '',
       packageName: '',
-      showPanic: false,
-      gameLogo: [],
       steamAppId: '',
       titleBgm: '',
-    })).toEqual({
-      set: {
-        enableAppreciation: 'false',
-        legacyExpressionBlendMode: 'true',
-        showPanic: 'false',
-      },
-      unset: [
-        'defaultLanguage',
-        'description',
-        'gameKey',
-        'gameName',
-        'gameLogo',
-        'lineHeight',
-        'maxLine',
-        'packageName',
-        'steamAppId',
-        'titleBgm',
-        'titleImg',
+      titleImg: '',
+      legacyExpressionBlendMode: true,
+      showPanic: false,
+      customConfig: [
+        {
+          key: '',
+          value: '',
+        },
+        {
+          key: 'Custom_flag',
+          value: '',
+        },
+      ],
+    }))).toEqual({
+      entries: [
+        {
+          key: 'Enable_Appreciation',
+          value: 'false',
+        },
+        {
+          key: 'Legacy_Expression_Blend_Mode',
+          value: 'true',
+        },
+        {
+          key: 'Show_panic',
+          value: 'false',
+        },
+        {
+          key: 'Custom_flag',
+          value: '',
+        },
       ],
     })
   })

--- a/src/features/modals/game-config/__tests__/game-config-form.test.ts
+++ b/src/features/modals/game-config/__tests__/game-config-form.test.ts
@@ -160,11 +160,19 @@ describe('game-config form helpers', () => {
         },
         {
           key: 'Line_height',
-          value: '',
+          value: '0',
         },
         {
           key: 'Max_line',
+          value: '2.5',
+        },
+        {
+          key: 'Line_height',
           value: 'not-a-number',
+        },
+        {
+          key: 'Max_line',
+          value: '-1',
         },
       ],
       unmanagedLineCount: 2,

--- a/src/features/modals/game-config/__tests__/game-config-form.test.ts
+++ b/src/features/modals/game-config/__tests__/game-config-form.test.ts
@@ -270,6 +270,26 @@ describe('game-config form helpers', () => {
     })).success).toBe(false)
   })
 
+  it('createGameConfigSchema 会拒绝带首尾空格的自定义键，并按去空格后的结果识别内置键', () => {
+    const schema = createGameConfigSchema(t)
+    const result = schema.safeParse(createFormValues({
+      customConfig: [
+        {
+          key: ' Game_name ',
+          value: 'Demo',
+        },
+      ],
+    }))
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues.map(issue => issue.message)).toEqual(expect.arrayContaining([
+        'modals.gameConfig.validation.customConfigKeyNoSurroundingWhitespace',
+        'modals.gameConfig.validation.customConfigKeyReserved',
+      ]))
+    }
+  })
+
   it('createGameConfigSchema 允许 Stage_Width 和 Stage_Height 作为自定义项', () => {
     const schema = createGameConfigSchema(t)
 
@@ -302,6 +322,30 @@ describe('game-config form helpers', () => {
         },
       ],
     })).success).toBe(false)
+  })
+
+  it('createGameConfigSchema 会按去空格后的结果拒绝重复的自定义键', () => {
+    const schema = createGameConfigSchema(t)
+    const result = schema.safeParse(createFormValues({
+      customConfig: [
+        {
+          key: 'Custom_flag',
+          value: 'a',
+        },
+        {
+          key: ' Custom_flag ',
+          value: 'b',
+        },
+      ],
+    }))
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues.map(issue => issue.message)).toEqual(expect.arrayContaining([
+        'modals.gameConfig.validation.customConfigKeyNoSurroundingWhitespace',
+        'modals.gameConfig.validation.customConfigKeyDuplicate',
+      ]))
+    }
   })
 
   it('createGameConfigSchema 会拒绝包含分号的内置字符串字段', () => {
@@ -459,6 +503,10 @@ describe('game-config form helpers', () => {
       customConfig: [
         {
           key: '',
+          value: '',
+        },
+        {
+          key: '   ',
           value: '',
         },
         {

--- a/src/features/modals/game-config/game-config-form.ts
+++ b/src/features/modals/game-config/game-config-form.ts
@@ -64,9 +64,17 @@ function cloneGameConfigEntries(entries: readonly GameConfigEntry[]): GameConfig
   return entries.map(entry => ({ ...entry }))
 }
 
+function isPositiveFiniteNumber(value: number): boolean {
+  return Number.isFinite(value) && value > 0
+}
+
+function isPositiveInteger(value: number): boolean {
+  return Number.isInteger(value) && value > 0
+}
+
 function createOptionalPositiveIntegerSchema(t: I18nT) {
   return z.literal('').or(z.number()).refine(
-    value => value === '' || (Number.isInteger(value) && value > 0),
+    value => value === '' || isPositiveInteger(value),
     { error: t('modals.gameConfig.validation.maxLineInvalid') },
   ) satisfies z.ZodType<'' | number>
 }
@@ -79,7 +87,7 @@ function createRequiredGameNameSchema(t: I18nT) {
 
 function createOptionalPositiveNumberSchema(t: I18nT) {
   return z.literal('').or(z.number()).refine(
-    value => value === '' || value > 0,
+    value => value === '' || isPositiveFiniteNumber(value),
     { error: t('modals.gameConfig.validation.lineHeightInvalid') },
   ) satisfies z.ZodType<'' | number>
 }
@@ -239,13 +247,16 @@ function parseBooleanValue(value: string | undefined, fallback: boolean): boolea
   }
 }
 
-function parseOptionalNumberValue(value: string | undefined): '' | number {
+function parseOptionalNumberValue(
+  value: string | undefined,
+  isValid: (value: number) => boolean,
+): '' | number {
   if (!value?.trim()) {
     return ''
   }
 
   const parsedValue = Number(value)
-  return Number.isFinite(parsedValue) ? parsedValue : ''
+  return isValid(parsedValue) ? parsedValue : ''
 }
 
 function parseDefaultLanguage(value: string | undefined): '' | GameConfigDefaultLanguage {
@@ -317,8 +328,8 @@ export function parseGameConfigFormValues(config: GameConfigReadResult): GameCon
     gameName: readEntryValue(entryValueMap, 'Game_name') ?? '',
     gameLogo: parseGameLogoImages(readEntryValue(entryValueMap, 'Game_Logo') ?? ''),
     legacyExpressionBlendMode: parseBooleanValue(readEntryValue(entryValueMap, 'Legacy_Expression_Blend_Mode'), false),
-    lineHeight: parseOptionalNumberValue(readEntryValue(entryValueMap, 'Line_height')),
-    maxLine: parseOptionalNumberValue(readEntryValue(entryValueMap, 'Max_line')),
+    lineHeight: parseOptionalNumberValue(readEntryValue(entryValueMap, 'Line_height'), isPositiveFiniteNumber),
+    maxLine: parseOptionalNumberValue(readEntryValue(entryValueMap, 'Max_line'), isPositiveInteger),
     packageName: readEntryValue(entryValueMap, 'Package_name') ?? '',
     showPanic: parseBooleanValue(readEntryValue(entryValueMap, 'Show_panic'), true),
     steamAppId: readEntryValue(entryValueMap, 'Steam_AppID') ?? '',

--- a/src/features/modals/game-config/game-config-form.ts
+++ b/src/features/modals/game-config/game-config-form.ts
@@ -117,6 +117,10 @@ function hasSemicolon(value: string): boolean {
   return value.includes(';')
 }
 
+function normalizeCustomConfigKey(key: string): string {
+  return key.trim()
+}
+
 function createConfigValueSchema(t: I18nT) {
   return z.string().refine(
     value => !hasSemicolon(value),
@@ -125,29 +129,39 @@ function createConfigValueSchema(t: I18nT) {
 }
 
 function isBlankCustomConfigEntry(entry: Pick<GameConfigEntry, 'key' | 'value'>): boolean {
-  return entry.key.trim() === '' && entry.value === ''
+  return normalizeCustomConfigKey(entry.key) === '' && entry.value === ''
 }
 
 function createCustomConfigEntrySchema(t: I18nT) {
   return z.object({
-    key: z.string().trim(),
+    key: z.string(),
     value: createConfigValueSchema(t)
       .refine(
         value => !hasLineBreak(value),
         { error: t('modals.gameConfig.validation.customConfigValueSingleLine') },
       ),
   }).superRefine((entry, ctx) => {
+    const normalizedKey = normalizeCustomConfigKey(entry.key)
+
     if (isBlankCustomConfigEntry(entry)) {
       return
     }
 
-    if (entry.key.length === 0) {
+    if (normalizedKey.length === 0) {
       ctx.addIssue({
         code: 'custom',
         message: t('modals.gameConfig.validation.customConfigKeyRequired'),
         path: ['key'],
       })
       return
+    }
+
+    if (entry.key !== normalizedKey) {
+      ctx.addIssue({
+        code: 'custom',
+        message: t('modals.gameConfig.validation.customConfigKeyNoSurroundingWhitespace'),
+        path: ['key'],
+      })
     }
 
     if (hasLineBreak(entry.key)) {
@@ -174,7 +188,7 @@ function createCustomConfigEntrySchema(t: I18nT) {
       })
     }
 
-    if (BUILT_IN_GAME_CONFIG_RAW_KEY_SET.has(entry.key)) {
+    if (BUILT_IN_GAME_CONFIG_RAW_KEY_SET.has(normalizedKey)) {
       ctx.addIssue({
         code: 'custom',
         message: t('modals.gameConfig.validation.customConfigKeyReserved'),
@@ -193,9 +207,10 @@ function createCustomConfigSchema(t: I18nT) {
         continue
       }
 
-      const previousIndex = seenKeys.get(entry.key)
+      const normalizedKey = normalizeCustomConfigKey(entry.key)
+      const previousIndex = seenKeys.get(normalizedKey)
       if (previousIndex === undefined) {
-        seenKeys.set(entry.key, index)
+        seenKeys.set(normalizedKey, index)
         continue
       }
 
@@ -366,7 +381,7 @@ export function serializeGameConfigEntries(values: GameConfigFormValues): GameCo
     ...values.customConfig
       .filter(entry => !isBlankCustomConfigEntry(entry))
       .map(entry => ({
-        key: entry.key.trim(),
+        key: entry.key,
         value: entry.value,
       })),
   )

--- a/src/features/modals/game-config/game-config-form.ts
+++ b/src/features/modals/game-config/game-config-form.ts
@@ -110,7 +110,7 @@ function createOptionalSteamAppIdSchema(t: I18nT) {
 }
 
 function hasLineBreak(value: string): boolean {
-  return /\r\n?|\n/g.test(value)
+  return /\r\n?|\n/.test(value)
 }
 
 function hasSemicolon(value: string): boolean {

--- a/src/features/modals/game-config/game-config-form.ts
+++ b/src/features/modals/game-config/game-config-form.ts
@@ -1,11 +1,14 @@
 import * as z from 'zod'
 
-import {
-  parseGameLogoImages,
-  serializeGameLogoImages,
-} from './game-config-images'
+import { BUILT_IN_GAME_CONFIG_RAW_KEYS } from '~/commands/game'
 
-import type { GameConfig, GameConfigPatch, GameConfigPatchKey } from '~/commands/game'
+import { parseGameLogoImages, serializeGameLogoImages } from './game-config-images'
+
+import type {
+  GameConfigEntry,
+  GameConfigReadResult,
+  GameConfigWritePayload,
+} from '~/commands/game'
 import type { I18nT } from '~/utils/i18n-like'
 
 export const GAME_CONFIG_DEFAULT_LANGUAGES = [
@@ -19,7 +22,10 @@ export const GAME_CONFIG_DEFAULT_LANGUAGES = [
 
 export type GameConfigDefaultLanguage = (typeof GAME_CONFIG_DEFAULT_LANGUAGES)[number]
 
+const BUILT_IN_GAME_CONFIG_RAW_KEY_SET: ReadonlySet<string> = new Set(BUILT_IN_GAME_CONFIG_RAW_KEYS)
+
 export interface GameConfigFormValues {
+  customConfig: GameConfigEntry[]
   defaultLanguage: '' | GameConfigDefaultLanguage
   description: string
   enableAppreciation: boolean
@@ -36,44 +42,170 @@ export interface GameConfigFormValues {
   titleImg: string
 }
 
+const EMPTY_GAME_CONFIG_FORM_VALUES = {
+  customConfig: [],
+  defaultLanguage: '',
+  description: '',
+  enableAppreciation: false,
+  gameKey: '',
+  gameName: '',
+  gameLogo: [],
+  legacyExpressionBlendMode: false,
+  lineHeight: '',
+  maxLine: '',
+  packageName: '',
+  showPanic: true,
+  steamAppId: '',
+  titleBgm: '',
+  titleImg: '',
+} satisfies GameConfigFormValues
+
+function cloneGameConfigEntries(entries: readonly GameConfigEntry[]): GameConfigEntry[] {
+  return entries.map(entry => ({ ...entry }))
+}
+
 function createOptionalPositiveIntegerSchema(t: I18nT) {
-  return z.union([z.literal(''), z.number()]).refine(
+  return z.literal('').or(z.number()).refine(
     value => value === '' || (Number.isInteger(value) && value > 0),
-    t('modals.gameConfig.validation.maxLineInvalid'),
-  ) as z.ZodType<'' | number>
+    { error: t('modals.gameConfig.validation.maxLineInvalid') },
+  ) satisfies z.ZodType<'' | number>
 }
 
 function createRequiredGameNameSchema(t: I18nT) {
-  return z.string().trim().min(1, t('modals.gameConfig.validation.gameNameRequired'))
+  return createConfigValueSchema(t)
+    .trim()
+    .min(1, { error: t('modals.gameConfig.validation.gameNameRequired') })
 }
 
 function createOptionalPositiveNumberSchema(t: I18nT) {
-  return z.union([z.literal(''), z.number()]).refine(
+  return z.literal('').or(z.number()).refine(
     value => value === '' || value > 0,
-    t('modals.gameConfig.validation.lineHeightInvalid'),
-  ) as z.ZodType<'' | number>
+    { error: t('modals.gameConfig.validation.lineHeightInvalid') },
+  ) satisfies z.ZodType<'' | number>
 }
 
 function createOptionalPackageNameSchema(t: I18nT) {
   return z.string().trim().refine(
     value => value === '' || /^[a-z][a-z0-9]*(\.[a-z][a-z0-9]*)+$/.test(value),
-    t('modals.gameConfig.validation.packageNameInvalid'),
+    { error: t('modals.gameConfig.validation.packageNameInvalid') },
   )
 }
 
 function createOptionalSteamAppIdSchema(t: I18nT) {
-  return z.string().trim().refine((value) => {
-    if (value === '') {
-      return true
+  return z.string().trim().refine(
+    (value) => {
+      if (value === '') {
+        return true
+      }
+
+      if (!/^\d+$/.test(value)) {
+        return false
+      }
+
+      const numericValue = BigInt(value)
+      return numericValue >= 1n && numericValue <= 42_9496_7295n
+    },
+    { error: t('modals.gameConfig.validation.steamAppIdInvalid') },
+  )
+}
+
+function hasLineBreak(value: string): boolean {
+  return /\r\n?|\n/g.test(value)
+}
+
+function hasSemicolon(value: string): boolean {
+  return value.includes(';')
+}
+
+function createConfigValueSchema(t: I18nT) {
+  return z.string().refine(
+    value => !hasSemicolon(value),
+    { error: t('modals.gameConfig.validation.configValueNoSemicolon') },
+  )
+}
+
+function isBlankCustomConfigEntry(entry: Pick<GameConfigEntry, 'key' | 'value'>): boolean {
+  return entry.key.trim() === '' && entry.value === ''
+}
+
+function createCustomConfigEntrySchema(t: I18nT) {
+  return z.object({
+    key: z.string().trim(),
+    value: createConfigValueSchema(t)
+      .refine(
+        value => !hasLineBreak(value),
+        { error: t('modals.gameConfig.validation.customConfigValueSingleLine') },
+      ),
+  }).superRefine((entry, ctx) => {
+    if (isBlankCustomConfigEntry(entry)) {
+      return
     }
 
-    if (!/^\d+$/.test(value)) {
-      return false
+    if (entry.key.length === 0) {
+      ctx.addIssue({
+        code: 'custom',
+        message: t('modals.gameConfig.validation.customConfigKeyRequired'),
+        path: ['key'],
+      })
+      return
     }
 
-    const numericValue = BigInt(value)
-    return numericValue >= 1n && numericValue <= 42_9496_7295n
-  }, t('modals.gameConfig.validation.steamAppIdInvalid'))
+    if (hasLineBreak(entry.key)) {
+      ctx.addIssue({
+        code: 'custom',
+        message: t('modals.gameConfig.validation.customConfigKeySingleLine'),
+        path: ['key'],
+      })
+    }
+
+    if (entry.key.includes(':')) {
+      ctx.addIssue({
+        code: 'custom',
+        message: t('modals.gameConfig.validation.customConfigKeyNoColon'),
+        path: ['key'],
+      })
+    }
+
+    if (hasSemicolon(entry.key)) {
+      ctx.addIssue({
+        code: 'custom',
+        message: t('modals.gameConfig.validation.customConfigKeyNoSemicolon'),
+        path: ['key'],
+      })
+    }
+
+    if (BUILT_IN_GAME_CONFIG_RAW_KEY_SET.has(entry.key)) {
+      ctx.addIssue({
+        code: 'custom',
+        message: t('modals.gameConfig.validation.customConfigKeyReserved'),
+        path: ['key'],
+      })
+    }
+  })
+}
+
+function createCustomConfigSchema(t: I18nT) {
+  return z.array(createCustomConfigEntrySchema(t)).superRefine((entries, ctx) => {
+    const seenKeys = new Map<string, number>()
+
+    for (const [index, entry] of entries.entries()) {
+      if (isBlankCustomConfigEntry(entry)) {
+        continue
+      }
+
+      const previousIndex = seenKeys.get(entry.key)
+      if (previousIndex === undefined) {
+        seenKeys.set(entry.key, index)
+        continue
+      }
+
+      ctx.addIssue({
+        code: 'custom',
+        message: t('modals.gameConfig.validation.customConfigKeyDuplicate'),
+        path: [index, 'key'],
+      })
+    }
+  })
 }
 
 function parseBooleanValue(value: string | undefined, fallback: boolean): boolean {
@@ -107,28 +239,22 @@ function parseDefaultLanguage(value: string | undefined): '' | GameConfigDefault
     : ''
 }
 
+function createEntryValueMap(entries: readonly GameConfigEntry[]): ReadonlyMap<string, string> {
+  return new Map(entries.map(entry => [entry.key, entry.value]))
+}
+
+function readEntryValue(entryValueMap: ReadonlyMap<string, string>, rawKey: string): string | undefined {
+  return entryValueMap.get(rawKey)
+}
+
 export function createEmptyGameConfigFormValues(): GameConfigFormValues {
-  return {
-    defaultLanguage: '',
-    description: '',
-    enableAppreciation: false,
-    gameKey: '',
-    gameName: '',
-    gameLogo: [],
-    legacyExpressionBlendMode: false,
-    lineHeight: '',
-    maxLine: '',
-    packageName: '',
-    showPanic: true,
-    steamAppId: '',
-    titleBgm: '',
-    titleImg: '',
-  }
+  return cloneGameConfigFormValues(EMPTY_GAME_CONFIG_FORM_VALUES)
 }
 
 export function cloneGameConfigFormValues(values: GameConfigFormValues): GameConfigFormValues {
   return {
     ...values,
+    customConfig: cloneGameConfigEntries(values.customConfig),
     gameLogo: [...values.gameLogo],
   }
 }
@@ -139,85 +265,111 @@ export function createGameConfigKey(): string {
 
 export function createGameConfigSchema(t: I18nT) {
   return z.object({
+    customConfig: createCustomConfigSchema(t),
     defaultLanguage: z.union([
       z.literal(''),
       z.enum(GAME_CONFIG_DEFAULT_LANGUAGES),
     ]),
-    description: z.string(),
+    description: createConfigValueSchema(t),
     enableAppreciation: z.boolean(),
-    gameKey: z.string(),
+    gameKey: createConfigValueSchema(t),
     gameName: createRequiredGameNameSchema(t),
-    gameLogo: z.array(z.string()),
+    gameLogo: z.array(createConfigValueSchema(t)),
     legacyExpressionBlendMode: z.boolean(),
     lineHeight: createOptionalPositiveNumberSchema(t),
     maxLine: createOptionalPositiveIntegerSchema(t),
     packageName: createOptionalPackageNameSchema(t),
     showPanic: z.boolean(),
     steamAppId: createOptionalSteamAppIdSchema(t),
-    titleBgm: z.string(),
-    titleImg: z.string(),
+    titleBgm: createConfigValueSchema(t),
+    titleImg: createConfigValueSchema(t),
+  }) satisfies z.ZodType<GameConfigFormValues>
+}
+
+export function parseGameConfigFormValues(config: GameConfigReadResult): GameConfigFormValues {
+  const entryValueMap = createEntryValueMap(config.entries)
+  const customConfig = config.entries
+    .filter(entry => !BUILT_IN_GAME_CONFIG_RAW_KEY_SET.has(entry.key))
+    .map(entry => ({ ...entry }))
+
+  return {
+    ...createEmptyGameConfigFormValues(),
+    customConfig,
+    defaultLanguage: parseDefaultLanguage(readEntryValue(entryValueMap, 'Default_Language')),
+    description: readEntryValue(entryValueMap, 'Description') ?? '',
+    enableAppreciation: parseBooleanValue(readEntryValue(entryValueMap, 'Enable_Appreciation'), false),
+    gameKey: readEntryValue(entryValueMap, 'Game_key') ?? '',
+    gameName: readEntryValue(entryValueMap, 'Game_name') ?? '',
+    gameLogo: parseGameLogoImages(readEntryValue(entryValueMap, 'Game_Logo') ?? ''),
+    legacyExpressionBlendMode: parseBooleanValue(readEntryValue(entryValueMap, 'Legacy_Expression_Blend_Mode'), false),
+    lineHeight: parseOptionalNumberValue(readEntryValue(entryValueMap, 'Line_height')),
+    maxLine: parseOptionalNumberValue(readEntryValue(entryValueMap, 'Max_line')),
+    packageName: readEntryValue(entryValueMap, 'Package_name') ?? '',
+    showPanic: parseBooleanValue(readEntryValue(entryValueMap, 'Show_panic'), true),
+    steamAppId: readEntryValue(entryValueMap, 'Steam_AppID') ?? '',
+    titleBgm: readEntryValue(entryValueMap, 'Title_bgm') ?? '',
+    titleImg: readEntryValue(entryValueMap, 'Title_img') ?? '',
+  }
+}
+
+function appendOptionalStringEntry(entries: GameConfigEntry[], rawKey: string, value: string) {
+  if (value === '') {
+    return
+  }
+
+  entries.push({
+    key: rawKey,
+    value,
   })
 }
 
-export function parseGameConfigFormValues(config: GameConfig): GameConfigFormValues {
-  return {
-    ...createEmptyGameConfigFormValues(),
-    defaultLanguage: parseDefaultLanguage(config.defaultLanguage),
-    description: config.description ?? '',
-    enableAppreciation: parseBooleanValue(config.enableAppreciation, false),
-    gameKey: config.gameKey ?? '',
-    gameName: config.gameName ?? '',
-    gameLogo: parseGameLogoImages(config.gameLogo ?? ''),
-    legacyExpressionBlendMode: parseBooleanValue(config.legacyExpressionBlendMode, false),
-    lineHeight: parseOptionalNumberValue(config.lineHeight),
-    maxLine: parseOptionalNumberValue(config.maxLine),
-    packageName: config.packageName ?? '',
-    showPanic: parseBooleanValue(config.showPanic, true),
-    steamAppId: config.steamAppId ?? '',
-    titleBgm: config.titleBgm ?? '',
-    titleImg: config.titleImg ?? '',
-  }
-}
-
-function assignOptionalStringPatch(patch: GameConfigPatch, key: GameConfigPatchKey, value: string) {
+function appendOptionalNumberEntry(entries: GameConfigEntry[], rawKey: string, value: '' | number) {
   if (value === '') {
-    patch.unset.push(key)
     return
   }
 
-  patch.set[key] = value
+  entries.push({
+    key: rawKey,
+    value: String(value),
+  })
 }
 
-function assignOptionalNumberPatch(patch: GameConfigPatch, key: GameConfigPatchKey, value: '' | number) {
-  if (value === '') {
-    patch.unset.push(key)
-    return
-  }
+export function serializeGameConfigEntries(values: GameConfigFormValues): GameConfigWritePayload {
+  const entries: GameConfigEntry[] = []
 
-  patch.set[key] = String(value)
-}
-
-export function serializeGameConfigPatch(values: GameConfigFormValues): GameConfigPatch {
-  const patch: GameConfigPatch = {
-    set: {
-      enableAppreciation: String(values.enableAppreciation),
-      legacyExpressionBlendMode: String(values.legacyExpressionBlendMode),
-      showPanic: String(values.showPanic),
+  appendOptionalStringEntry(entries, 'Game_name', values.gameName)
+  appendOptionalStringEntry(entries, 'Description', values.description)
+  appendOptionalStringEntry(entries, 'Title_img', values.titleImg)
+  appendOptionalStringEntry(entries, 'Title_bgm', values.titleBgm)
+  appendOptionalStringEntry(entries, 'Game_Logo', serializeGameLogoImages(values.gameLogo))
+  appendOptionalStringEntry(entries, 'Default_Language', values.defaultLanguage)
+  entries.push(
+    {
+      key: 'Enable_Appreciation',
+      value: String(values.enableAppreciation),
     },
-    unset: [],
-  }
+    {
+      key: 'Legacy_Expression_Blend_Mode',
+      value: String(values.legacyExpressionBlendMode),
+    },
+    {
+      key: 'Show_panic',
+      value: String(values.showPanic),
+    },
+  )
+  appendOptionalNumberEntry(entries, 'Max_line', values.maxLine)
+  appendOptionalNumberEntry(entries, 'Line_height', values.lineHeight)
+  appendOptionalStringEntry(entries, 'Steam_AppID', values.steamAppId)
+  appendOptionalStringEntry(entries, 'Package_name', values.packageName)
+  appendOptionalStringEntry(entries, 'Game_key', values.gameKey)
+  entries.push(
+    ...values.customConfig
+      .filter(entry => !isBlankCustomConfigEntry(entry))
+      .map(entry => ({
+        key: entry.key.trim(),
+        value: entry.value,
+      })),
+  )
 
-  assignOptionalStringPatch(patch, 'defaultLanguage', values.defaultLanguage)
-  assignOptionalStringPatch(patch, 'description', values.description)
-  assignOptionalStringPatch(patch, 'gameKey', values.gameKey)
-  assignOptionalStringPatch(patch, 'gameName', values.gameName)
-  assignOptionalStringPatch(patch, 'gameLogo', serializeGameLogoImages(values.gameLogo))
-  assignOptionalNumberPatch(patch, 'lineHeight', values.lineHeight)
-  assignOptionalNumberPatch(patch, 'maxLine', values.maxLine)
-  assignOptionalStringPatch(patch, 'packageName', values.packageName)
-  assignOptionalStringPatch(patch, 'steamAppId', values.steamAppId)
-  assignOptionalStringPatch(patch, 'titleBgm', values.titleBgm)
-  assignOptionalStringPatch(patch, 'titleImg', values.titleImg)
-
-  return patch
+  return { entries }
 }

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -222,6 +222,23 @@ modals:
       lineHeightInvalid: Text line height must be a positive number or left empty
       packageNameInvalid: Package name must use lowercase dot-separated identifiers like org.example.demo, or be left empty
       steamAppIdInvalid: Steam AppID must be a valid integer, or be left empty
+      configValueNoSemicolon: "Configuration values cannot contain ;"
+      customConfigKeyRequired: Custom key cannot be empty
+      customConfigKeySingleLine: Custom key must be a single line
+      customConfigKeyNoColon: "Custom key cannot contain :"
+      customConfigKeyNoSemicolon: "Custom key cannot contain ;"
+      customConfigKeyReserved: This key conflicts with a built-in configuration item
+      customConfigKeyDuplicate: Custom keys cannot repeat
+      customConfigValueSingleLine: Custom value must be a single line
+    custom:
+      title: Custom Configuration Items
+      keyLabel: Key
+      valueLabel: Value
+      keyPlaceholder: e.g. customFlag
+      valuePlaceholder: e.g. enabled, 1920
+      add: Add Configuration Item
+      remove: Remove
+      unmanagedNotice: Some content in the configuration file cannot be recognized or edited here and will be preserved on save
     titleImg:
       empty: Click to choose a title background image
       replace: Replace

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -224,6 +224,7 @@ modals:
       steamAppIdInvalid: Steam AppID must be a valid integer, or be left empty
       configValueNoSemicolon: "Configuration values cannot contain ;"
       customConfigKeyRequired: Custom key cannot be empty
+      customConfigKeyNoSurroundingWhitespace: Custom key cannot have leading or trailing whitespace
       customConfigKeySingleLine: Custom key must be a single line
       customConfigKeyNoColon: "Custom key cannot contain :"
       customConfigKeyNoSemicolon: "Custom key cannot contain ;"

--- a/src/locales/ja.yml
+++ b/src/locales/ja.yml
@@ -222,6 +222,23 @@ modals:
       lineHeightInvalid: テキスト行の高さは正の数値にするか、空欄にしてください
       packageNameInvalid: パッケージ名は org.example.demo のような小文字のドット区切り識別子にするか、空欄にしてください
       steamAppIdInvalid: Steam AppID は有効な整数にするか、空欄にしてください
+      configValueNoSemicolon: "設定値に ; は使えません"
+      customConfigKeyRequired: カスタム設定キーは空にできません
+      customConfigKeySingleLine: カスタム設定キーは1行で入力してください
+      customConfigKeyNoColon: "カスタム設定キーに : は使えません"
+      customConfigKeyNoSemicolon: "カスタム設定キーに ; は使えません"
+      customConfigKeyReserved: このキーは組み込み設定と重複しています
+      customConfigKeyDuplicate: カスタム設定キーは重複できません
+      customConfigValueSingleLine: カスタム設定値は1行で入力してください
+    custom:
+      title: カスタム設定項目
+      keyLabel: キー
+      valueLabel: 値
+      keyPlaceholder: "例: customFlag"
+      valuePlaceholder: "例: enabled、1920"
+      add: 設定項目を追加
+      remove: 削除
+      unmanagedNotice: 設定ファイル内の一部の内容はここでは認識・編集できませんが、保存時には元の内容が保持されます
     titleImg:
       empty: クリックしてタイトル背景画像を選択
       replace: 変更

--- a/src/locales/ja.yml
+++ b/src/locales/ja.yml
@@ -224,6 +224,7 @@ modals:
       steamAppIdInvalid: Steam AppID は有効な整数にするか、空欄にしてください
       configValueNoSemicolon: "設定値に ; は使えません"
       customConfigKeyRequired: カスタム設定キーは空にできません
+      customConfigKeyNoSurroundingWhitespace: カスタム設定キーの先頭と末尾に空白は使えません
       customConfigKeySingleLine: カスタム設定キーは1行で入力してください
       customConfigKeyNoColon: "カスタム設定キーに : は使えません"
       customConfigKeyNoSemicolon: "カスタム設定キーに ; は使えません"

--- a/src/locales/zh-Hans.yml
+++ b/src/locales/zh-Hans.yml
@@ -222,6 +222,23 @@ modals:
       lineHeightInvalid: 文本框行高必须是正数，或留空
       packageNameInvalid: 包名必须使用小写点分标识，例如 org.example.demo，或留空
       steamAppIdInvalid: Steam AppID 必须是有效的整数，或留空
+      configValueNoSemicolon: "配置值不能包含 ;"
+      customConfigKeyRequired: 自定义配置键不能为空
+      customConfigKeySingleLine: 自定义配置键必须是单行文本
+      customConfigKeyNoColon: "自定义配置键不能包含 :"
+      customConfigKeyNoSemicolon: "自定义配置键不能包含 ;"
+      customConfigKeyReserved: 自定义配置键不能与内置配置重名
+      customConfigKeyDuplicate: 自定义配置键不能重复
+      customConfigValueSingleLine: 自定义配置值必须是单行文本
+    custom:
+      title: 自定义配置项
+      keyLabel: 键
+      valueLabel: 值
+      keyPlaceholder: 例如 customFlag
+      valuePlaceholder: 例如 enabled、1920
+      add: 添加配置项
+      remove: 移除
+      unmanagedNotice: 配置文件中有部分内容无法在此识别和编辑，保存时会保留原内容
     titleImg:
       empty: 点击选择标题背景图片
       replace: 更换

--- a/src/locales/zh-Hans.yml
+++ b/src/locales/zh-Hans.yml
@@ -224,6 +224,7 @@ modals:
       steamAppIdInvalid: Steam AppID 必须是有效的整数，或留空
       configValueNoSemicolon: "配置值不能包含 ;"
       customConfigKeyRequired: 自定义配置键不能为空
+      customConfigKeyNoSurroundingWhitespace: 自定义配置键不能包含首尾空格
       customConfigKeySingleLine: 自定义配置键必须是单行文本
       customConfigKeyNoColon: "自定义配置键不能包含 :"
       customConfigKeyNoSemicolon: "自定义配置键不能包含 ;"

--- a/src/locales/zh-Hant.yml
+++ b/src/locales/zh-Hant.yml
@@ -222,6 +222,23 @@ modals:
       lineHeightInvalid: 文字框行高必須是正數，或留空
       packageNameInvalid: 包名必須使用像 org.example.demo 這樣的小寫點分識別，或留空
       steamAppIdInvalid: Steam AppID 必須是有效的整數，或留空
+      configValueNoSemicolon: "設定值不能包含 ;"
+      customConfigKeyRequired: 自訂設定鍵不能為空
+      customConfigKeySingleLine: 自訂設定鍵必須是單行文字
+      customConfigKeyNoColon: "自訂設定鍵不能包含 :"
+      customConfigKeyNoSemicolon: "自訂設定鍵不能包含 ;"
+      customConfigKeyReserved: 自訂設定鍵不能與內建設定重名
+      customConfigKeyDuplicate: 自訂設定鍵不能重複
+      customConfigValueSingleLine: 自訂設定值必須是單行文字
+    custom:
+      title: 自訂設定項
+      keyLabel: 鍵
+      valueLabel: 值
+      keyPlaceholder: 例如 customFlag
+      valuePlaceholder: 例如 enabled、1920
+      add: 新增設定項
+      remove: 移除
+      unmanagedNotice: 設定檔中有部分內容無法在此識別和編輯，儲存時會保留原內容
     titleImg:
       empty: 點擊選擇標題背景圖片
       replace: 更換

--- a/src/locales/zh-Hant.yml
+++ b/src/locales/zh-Hant.yml
@@ -224,6 +224,7 @@ modals:
       steamAppIdInvalid: Steam AppID 必須是有效的整數，或留空
       configValueNoSemicolon: "設定值不能包含 ;"
       customConfigKeyRequired: 自訂設定鍵不能為空
+      customConfigKeyNoSurroundingWhitespace: 自訂設定鍵不能包含首尾空白
       customConfigKeySingleLine: 自訂設定鍵必須是單行文字
       customConfigKeyNoColon: "自訂設定鍵不能包含 :"
       customConfigKeyNoSemicolon: "自訂設定鍵不能包含 ;"

--- a/src/services/__tests__/config-manager.test.ts
+++ b/src/services/__tests__/config-manager.test.ts
@@ -30,13 +30,21 @@ describe('configManager 配置管理', () => {
 
   it('setConfig 会写入配置并刷新已注册游戏快照', async () => {
     await configManager.setConfig('/game', {
-      set: { gameName: 'Renamed' },
-      unset: [],
+      entries: [
+        {
+          key: 'Game_name',
+          value: 'Renamed',
+        },
+      ],
     })
 
     expect(setGameConfigMock).toHaveBeenCalledWith('/game', {
-      set: { gameName: 'Renamed' },
-      unset: [],
+      entries: [
+        {
+          key: 'Game_name',
+          value: 'Renamed',
+        },
+      ],
     })
     expect(refreshRegisteredGameSnapshotMock).toHaveBeenCalledWith('/game')
   })

--- a/src/services/__tests__/game-manager.test.ts
+++ b/src/services/__tests__/game-manager.test.ts
@@ -110,6 +110,14 @@ vi.mock('~/commands/fs', () => ({
 }))
 
 vi.mock('~/commands/game', () => ({
+  findGameConfigEntryValue(entries: { key: string, value: string }[], rawKey: string) {
+    for (let index = entries.length - 1; index >= 0; index -= 1) {
+      const entry = entries[index]
+      if (entry?.key === rawKey) {
+        return entry.value
+      }
+    }
+  },
   gameCmds: {
     getGameConfig: gameCmdsGetGameConfigMock,
     setGameConfig: gameCmdsSetGameConfigMock,
@@ -180,7 +188,13 @@ describe('gameManager 游戏管理', () => {
   })
 
   it('getGameMetadata 只返回语义元数据', async () => {
-    gameCmdsGetGameConfigMock.mockResolvedValue({ gameName: 'Demo Game', titleImg: 'cover.png' })
+    gameCmdsGetGameConfigMock.mockResolvedValue({
+      entries: [
+        { key: 'Game_name', value: 'Demo Game' },
+        { key: 'Title_img', value: 'cover.png' },
+      ],
+      unmanagedLineCount: 0,
+    })
 
     await expect(gameManager.getGameMetadata('/games/demo')).resolves.toEqual({
       name: 'Demo Game',
@@ -188,7 +202,13 @@ describe('gameManager 游戏管理', () => {
   })
 
   it('getGamePreviewAssets 只返回封面和图标路径', async () => {
-    gameCmdsGetGameConfigMock.mockResolvedValue({ gameName: 'Demo Game', titleImg: 'cover.png' })
+    gameCmdsGetGameConfigMock.mockResolvedValue({
+      entries: [
+        { key: 'Game_name', value: 'Demo Game' },
+        { key: 'Title_img', value: 'cover.png' },
+      ],
+      unmanagedLineCount: 0,
+    })
     gameIconPathMock.mockResolvedValue('/games/demo/icons/icon.png')
     gameCoverPathMock.mockResolvedValue('/games/demo/assets/cover.png')
 
@@ -206,7 +226,13 @@ describe('gameManager 游戏管理', () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-03-28T10:00:00.000Z'))
     dbGamesAddMock.mockResolvedValue('game-1')
-    gameCmdsGetGameConfigMock.mockResolvedValue({ gameName: 'Resolved Name', titleImg: 'cover.png' })
+    gameCmdsGetGameConfigMock.mockResolvedValue({
+      entries: [
+        { key: 'Game_name', value: 'Resolved Name' },
+        { key: 'Title_img', value: 'cover.png' },
+      ],
+      unmanagedLineCount: 0,
+    })
     gameIconPathMock.mockResolvedValue('/games/demo/icons/icon.png')
     gameCoverPathMock.mockResolvedValue('/games/demo/assets/cover.png')
 
@@ -248,7 +274,13 @@ describe('gameManager 游戏管理', () => {
       onProgress(25)
       onProgress(100)
     })
-    gameCmdsGetGameConfigMock.mockResolvedValue({ gameName: 'Demo Game', titleImg: 'cover.png' })
+    gameCmdsGetGameConfigMock.mockResolvedValue({
+      entries: [
+        { key: 'Game_name', value: 'Demo Game' },
+        { key: 'Title_img', value: 'cover.png' },
+      ],
+      unmanagedLineCount: 0,
+    })
     gameIconPathMock.mockResolvedValue('/games/demo/icons/icon.png')
     gameCoverPathMock.mockResolvedValue('/games/demo/assets/cover.png')
 
@@ -271,11 +303,20 @@ describe('gameManager 游戏管理', () => {
       },
     }))
     expect(gameCmdsSetGameConfigMock).toHaveBeenCalledWith('/games/demo', {
-      set: {
-        gameKey: '22222222-2222-2222-2222-222222222222',
-        gameName: 'Demo Game',
-      },
-      unset: [],
+      entries: [
+        {
+          key: 'Game_name',
+          value: 'Demo Game',
+        },
+        {
+          key: 'Title_img',
+          value: 'cover.png',
+        },
+        {
+          key: 'Game_key',
+          value: '22222222-2222-2222-2222-222222222222',
+        },
+      ],
     })
     expect(resourceStoreMock.updateProgress).toHaveBeenNthCalledWith(1, 'game-1', 25)
     expect(resourceStoreMock.updateProgress).toHaveBeenNthCalledWith(2, 'game-1', 100)
@@ -304,6 +345,12 @@ describe('gameManager 游戏管理', () => {
     dbGamesAddMock.mockResolvedValue('game-1')
     existsMock.mockResolvedValueOnce(false).mockResolvedValueOnce(true)
     copyDirectoryWithProgressMock.mockResolvedValue(undefined)
+    gameCmdsGetGameConfigMock.mockResolvedValue({
+      entries: [
+        { key: 'Game_name', value: 'Demo Game' },
+      ],
+      unmanagedLineCount: 0,
+    })
     gameCmdsSetGameConfigMock.mockRejectedValue(new Error('config failed'))
 
     await expect(gameManager.createGame('Demo Game', '/games/demo', '/engines/base')).rejects.toThrow('config failed')
@@ -353,8 +400,11 @@ describe('gameManager 游戏管理', () => {
       },
     }))
     gameCmdsGetGameConfigMock.mockResolvedValue({
-      gameName: 'Renamed Game',
-      titleImg: 'cover-next.png',
+      entries: [
+        { key: 'Game_name', value: 'Renamed Game' },
+        { key: 'Title_img', value: 'cover-next.png' },
+      ],
+      unmanagedLineCount: 0,
     })
     gameIconPathMock.mockResolvedValue('/games/demo/icons/favicon.ico')
     gameCoverPathMock.mockResolvedValue('/games/demo/assets/cover-next.png')
@@ -461,7 +511,13 @@ describe('gameManager 游戏管理', () => {
       id: 'game-1',
       path: '/games/demo',
     })
-    gameCmdsGetGameConfigMock.mockResolvedValue({ gameName: 'Changed Name', titleImg: 'cover-next.png' })
+    gameCmdsGetGameConfigMock.mockResolvedValue({
+      entries: [
+        { key: 'Game_name', value: 'Changed Name' },
+        { key: 'Title_img', value: 'cover-next.png' },
+      ],
+      unmanagedLineCount: 0,
+    })
     gameIconPathMock.mockResolvedValue('/games/demo/icons/next.ico')
     gameCoverPathMock.mockResolvedValue('/games/demo/assets/cover-next.png')
 
@@ -543,7 +599,13 @@ describe('gameManager 游戏管理', () => {
         },
       },
     })
-    gameCmdsGetGameConfigMock.mockResolvedValue({ gameName: 'Demo Game', titleImg: 'cover.png' })
+    gameCmdsGetGameConfigMock.mockResolvedValue({
+      entries: [
+        { key: 'Game_name', value: 'Demo Game' },
+        { key: 'Title_img', value: 'cover.png' },
+      ],
+      unmanagedLineCount: 0,
+    })
     gameIconPathMock.mockRejectedValue(new Error('icon missing'))
 
     await gameManager.updateGameLastModified('game-1')

--- a/src/services/config-manager.ts
+++ b/src/services/config-manager.ts
@@ -1,14 +1,14 @@
 import { gameCmds } from '~/commands/game'
 import { gameManager } from '~/services/game-manager'
 
-import type { GameConfig, GameConfigPatch } from '~/commands/game'
+import type { GameConfigReadResult, GameConfigWritePayload } from '~/commands/game'
 
 /**
  * 获取游戏配置
  * @param gamePath 游戏路径
  * @returns 游戏配置对象
  */
-async function getConfig(gamePath: string): Promise<GameConfig> {
+async function getConfig(gamePath: string): Promise<GameConfigReadResult> {
   return await gameCmds.getGameConfig(gamePath)
 }
 
@@ -17,7 +17,7 @@ async function getConfig(gamePath: string): Promise<GameConfig> {
  * @param gamePath 游戏路径
  * @param config 配置对象
  */
-async function setConfig(gamePath: string, config: GameConfigPatch) {
+async function setConfig(gamePath: string, config: GameConfigWritePayload) {
   await gameCmds.setGameConfig(gamePath, config)
   await gameManager.refreshRegisteredGameSnapshot(gamePath)
 }

--- a/src/services/game-manager.ts
+++ b/src/services/game-manager.ts
@@ -1,7 +1,7 @@
 import { exists } from '@tauri-apps/plugin-fs'
 
 import { fsCmds } from '~/commands/fs'
-import { gameCmds } from '~/commands/game'
+import { findGameConfigEntryValue, gameCmds } from '~/commands/game'
 import { db } from '~/database/db'
 import { Game } from '~/database/model'
 import { gameCoverPath, gameIconPath } from '~/services/platform/app-paths'
@@ -10,10 +10,46 @@ import { useResourceStore } from '~/stores/resource'
 import { useWorkspaceStore } from '~/stores/workspace'
 import { AppError } from '~/types/errors'
 
+import type { GameConfigEntry } from '~/commands/game'
+
 interface RegisterGameOptions {
   metadata?: GameMetadata
   previewAssets?: GamePreviewAssets
   status?: Game['status']
+}
+
+const GAME_NAME_RAW_KEY = 'Game_name'
+const GAME_KEY_RAW_KEY = 'Game_key'
+const TITLE_IMAGE_RAW_KEY = 'Title_img'
+
+function mergeGameConfigEntries(
+  entries: readonly GameConfigEntry[],
+  nextEntries: readonly GameConfigEntry[],
+): GameConfigEntry[] {
+  const nextEntryValueMap = new Map(nextEntries.map(entry => [entry.key, entry.value]))
+  const writtenKeys = new Set<string>()
+  const mergedEntries = entries.map((entry) => {
+    const nextValue = nextEntryValueMap.get(entry.key)
+    if (nextValue === undefined) {
+      return { ...entry }
+    }
+
+    writtenKeys.add(entry.key)
+    return {
+      key: entry.key,
+      value: nextValue,
+    }
+  })
+
+  for (const entry of nextEntries) {
+    if (writtenKeys.has(entry.key)) {
+      continue
+    }
+
+    mergedEntries.push({ ...entry })
+  }
+
+  return mergedEntries
 }
 
 /**
@@ -38,7 +74,7 @@ async function getGameMetadata(gamePath: string): Promise<GameMetadata> {
   const gameConfig = await gameCmds.getGameConfig(gamePath)
 
   return {
-    name: gameConfig.gameName ?? '',
+    name: findGameConfigEntryValue(gameConfig.entries, GAME_NAME_RAW_KEY) ?? '',
   }
 }
 
@@ -81,17 +117,17 @@ function withGamePreviewCacheVersion(
 
 async function getGamePreviewAssets(gamePath: string): Promise<GamePreviewAssets> {
   const gameConfig = await gameCmds.getGameConfig(gamePath)
-  return await resolveGamePreviewAssets(gamePath, gameConfig.titleImg ?? '')
+  return await resolveGamePreviewAssets(gamePath, findGameConfigEntryValue(gameConfig.entries, TITLE_IMAGE_RAW_KEY) ?? '')
 }
 
 async function getGameSnapshot(gamePath: string): Promise<Pick<Game, 'metadata' | 'previewAssets'>> {
   const gameConfig = await gameCmds.getGameConfig(gamePath)
   const cacheVersion = Date.now()
   const metadata = {
-    name: gameConfig.gameName ?? '',
+    name: findGameConfigEntryValue(gameConfig.entries, GAME_NAME_RAW_KEY) ?? '',
   }
   const previewAssets = withGamePreviewCacheVersion(
-    await resolveGamePreviewAssets(gamePath, gameConfig.titleImg ?? ''),
+    await resolveGamePreviewAssets(gamePath, findGameConfigEntryValue(gameConfig.entries, TITLE_IMAGE_RAW_KEY) ?? ''),
     cacheVersion,
   )
 
@@ -218,12 +254,18 @@ async function createGame(gameName: string, gamePath: string, enginePath: string
 
     // 3. 设置游戏配置
     const gameKey = crypto.randomUUID()
+    const gameConfig = await gameCmds.getGameConfig(gamePath)
     await gameCmds.setGameConfig(gamePath, {
-      set: {
-        gameKey,
-        gameName,
-      },
-      unset: [],
+      entries: mergeGameConfigEntries(gameConfig.entries, [
+        {
+          key: GAME_NAME_RAW_KEY,
+          value: gameName,
+        },
+        {
+          key: GAME_KEY_RAW_KEY,
+          value: gameKey,
+        },
+      ]),
     })
     logger.info(`[游戏 ${gameName}] 设置游戏配置`)
 


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [ ] 错误修复
- [x] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [x] 代码重构
- [ ] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

本 PR 将游戏配置读写从“固定字段补丁”重构为“原始配置条目列表”模型，并在游戏配置弹窗中补充了自定义配置项编辑能力。

主要改动包括：

- 将前后端 `game config` 读写接口统一为 `entries` 模型，直接传递原始 `key/value` 配置项
- 读取 `config.txt` 时保留原始键空间、最后一次生效的配置值和原始顺序，并统计无法托管的配置行数量
- 保存 `config.txt` 时保留无法托管的原始内容，同时覆盖已识别配置项并追加新配置项
- 游戏配置弹窗新增“自定义配置项”区域，支持添加、删除、编辑额外配置键值
- 为自定义配置项补充校验，限制空键、重复键、保留键、冒号、分号和多行内容
- 当配置文件中存在无法在弹窗中托管的内容时，显示提示但继续保留原内容
- 编辑器预览、游戏快照和配置服务改为基于 raw entries 读取所需字段
- 更新并补充前端与 Rust 测试，覆盖新配置模型和自定义配置编辑流程

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

现有游戏配置编辑流程只能处理一组固定内置字段，无法安全读写额外的自定义配置项，也容易在保存时丢失或覆盖 `config.txt` 中无法识别的内容。

这导致两个问题：

- 高级配置和引擎扩展字段无法通过编辑器维护
- 配置文件里存在非标准或暂未托管的内容时，弹窗保存可能破坏原始配置结构

本次调整的目标是把配置系统升级为更贴近 `config.txt` 原始语义的模型，让编辑器既能支持内置配置表单，也能安全承载自定义配置和未托管内容。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->

本次改动同时调整了以下相关行为：

- 预览面板改为从 raw entries 读取 `Stage_Width` 和 `Stage_Height`
- 新建游戏时改为合并写回原始配置条目，而不是写固定补丁结构
- 配置弹窗打开时会将非内置条目映射到自定义配置列表中展示

### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
