### PR TITLE
🐛 修复 statement editor 测试中的 effect scope 告警

### DIFF
--- a/src/features/editor/__tests__/statement-editor-test-utils.ts
+++ b/src/features/editor/__tests__/statement-editor-test-utils.ts
@@ -1,5 +1,5 @@
-import { vi } from 'vitest'
-import { ref, shallowReactive } from 'vue'
+import { onTestFinished, vi } from 'vitest'
+import { effectScope, ref, shallowReactive } from 'vue'
 import { commandType } from 'webgal-parser/src/interface/sceneInterface'
 
 import { useStatementEditor } from '~/features/editor/statement-editor/useStatementEditor'
@@ -103,21 +103,37 @@ export function createSentence(overrides: Partial<ISentence> = {}): ISentence {
   }
 }
 
+function createScopedEditor(factory: () => ReturnType<typeof useStatementEditor>) {
+  const scope = effectScope()
+  const editor = scope.run(factory)
+
+  if (!editor) {
+    scope.stop()
+    throw new TypeError('failed to create statement editor within effect scope')
+  }
+
+  onTestFinished(() => {
+    scope.stop()
+  })
+
+  return editor
+}
+
 export function createHarness(rawText: string) {
   const updates: StatementUpdatePayload[] = []
-  const editor = useStatementEditor({
+  const editor = createScopedEditor(() => useStatementEditor({
     entry: createEntry(rawText),
     emitUpdate(payload) {
       updates.push(payload)
     },
-  })
+  }))
   return { editor, updates }
 }
 
 export function createReactiveHarness(rawText: string) {
   const updates: StatementUpdatePayload[] = []
   const entry = ref(createEntry(rawText))
-  const editor = useStatementEditor({
+  const editor = createScopedEditor(() => useStatementEditor({
     entry,
     emitUpdate(payload) {
       updates.push(payload)
@@ -128,7 +144,7 @@ export function createReactiveHarness(rawText: string) {
         rawText: payload.rawText,
       }
     },
-  })
+  }))
   return { editor, entry, updates }
 }
 


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [x] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [ ] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

这个 PR 修复了 `statement-editor` 相关测试在运行时向 stderr 输出的 Vue 告警：

`onScopeDispose() is called when there is no active effect scope to be associated with.`

具体改动：

- 在 `src/features/editor/__tests__/statement-editor-test-utils.ts` 中为 `useStatementEditor()` 的测试 harness 增加 `effectScope()` 包裹；
- 使用 `onTestFinished()` 在每个用例结束后自动释放 scope，避免测试侧 bootstrap composable 在无激活作用域时注册清理逻辑；

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

当前多个 `statement-editor` 测试文件通过共享 harness 直接调用 `useStatementEditor()`，但该 composable 内部会触发依赖作用域清理的 bootstrap 逻辑。

在没有激活 effect scope 的测试环境中，这些清理注册不会中断逻辑执行，但会持续输出 Vue warning，污染测试 stderr，也掩盖真正需要关注的测试问题。

这次修改的目标是把测试 harness 调整为更接近真实 Composition API 生命周期的执行环境。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->


本次改动只影响测试基础设施和测试断言，不修改生产逻辑。

### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [ ] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
