### PR TITLE
♻️ 统一表单 Zod 4 错误参数写法

### DIFF
--- a/src/components/modals/CreateFileModal.vue
+++ b/src/components/modals/CreateFileModal.vue
@@ -44,14 +44,14 @@ async function isFileAvailable(fileName: string): Promise<boolean> {
 const schema = z.object({
   fileName: z.preprocess(
     val => val || '',
-    z.string().min(1, t('modals.createFile.fileNameRequired')),
+    z.string().min(1, { error: t('modals.createFile.fileNameRequired') }),
   ),
 }).refine(
   async (data) => {
     return await isFileAvailable(data.fileName)
   },
   {
-    message: t('modals.createFile.fileExists'),
+    error: t('modals.createFile.fileExists'),
     path: ['fileName'],
   },
 )

--- a/src/components/settings/form/SettingsForm.spec.ts
+++ b/src/components/settings/form/SettingsForm.spec.ts
@@ -140,7 +140,7 @@ function renderSwitchFieldValidationHarness() {
         },
         validationSchema: z.object({
           advancedMode: z.boolean().refine(value => value, {
-            message: '必须开启',
+            error: '必须开启',
           }),
         }),
       })

--- a/src/features/modals/create-game/useCreateGameForm.ts
+++ b/src/features/modals/create-game/useCreateGameForm.ts
@@ -46,11 +46,11 @@ export function useCreateGameForm(options: UseCreateGameFormOptions) {
   const schema = z.object({
     gameName: z.preprocess(
       value => value ?? '',
-      z.string().min(1, t('modals.createGame.gameNameRequired')),
+      z.string().min(1, { error: t('modals.createGame.gameNameRequired') }),
     ),
     gamePath: z.string().refine(
       async path => await checkPath(path),
-      t('modals.createGame.pathNotEmpty'),
+      { error: t('modals.createGame.pathNotEmpty') },
     ),
     gameEngine: z.string(),
   })


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [ ] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [x] 代码重构
- [ ] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

将当前表单相关代码中的 Zod 错误自定义写法收敛到 Zod 4 推荐形式：

- 在创建游戏表单中，将 `min` / `refine` 的旧式错误参数改为统一的 `error` 参数
- 在创建文件弹窗中，将字段校验和表单级 `refine` 的错误配置改为统一的 `error` 参数
- 同步更新 settings form 浏览器测试中的 Zod 校验写法，避免测试代码继续示范旧式 `message` 选项

这次提交只收敛 API 写法，不调整现有校验规则，也不改变用户可见行为。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

当前暂存更改集中在 Zod 4 的错误自定义 API 收敛。

Zod 4 已推荐使用统一的 `error` 参数。继续在表单 schema 中混用旧式写法，会让校验层风格不一致，也会增加后续继续清理 Zod 4 兼容性问题的成本。

这次先只覆盖当前已暂存的 create-game、create-file 和 settings form test 三处，保持改动面最小，便于审阅和回溯。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
