### PR TITLE
🐛 修复可视化编辑器语句内联参数区的 placeholder 回退与宽度布局

### DIFF
--- a/src/components/editor/param-renderer/ParamRenderer.spec.ts
+++ b/src/components/editor/param-renderer/ParamRenderer.spec.ts
@@ -14,13 +14,14 @@ import ParamRenderer from './ParamRenderer.vue'
 import type { EditorField, TextField } from '~/features/editor/command-registry/schema'
 import type { StatementEditorSurface } from '~/features/editor/statement-editor/surface-context'
 
-function createStandaloneTextField(): EditorField {
+function createStandaloneTextField(overrides: Partial<TextField> = {}): EditorField {
   const field: TextField = {
     inlineLayout: 'standalone',
     key: 'text',
     label: 'Dialogue',
     type: 'text',
     variant: { inline: 'textarea-auto', panel: 'textarea-grow' },
+    ...overrides,
   }
 
   return {
@@ -72,8 +73,8 @@ const globalStubs = {
   Textarea: createTextareaStub(),
 }
 
-function renderRenderer(surface: StatementEditorSurface) {
-  const field = createStandaloneTextField()
+function renderRenderer(surface: StatementEditorSurface, fieldOverrides: Partial<TextField> = {}) {
+  const field = createStandaloneTextField(fieldOverrides)
 
   return renderInBrowser(ParamRenderer, {
     props: {
@@ -109,5 +110,12 @@ describe('ParamRenderer', () => {
 
     await expect.element(page.getByText('Dialogue')).not.toBeInTheDocument()
     await expect.element(page.getByRole('textbox')).toHaveAttribute('placeholder', 'Dialogue')
+  })
+
+  it('inline 下 standalone 文本字段保留显式空字符串 placeholder', async () => {
+    renderRenderer('inline', { placeholder: '' })
+
+    await expect.element(page.getByText('Dialogue')).not.toBeInTheDocument()
+    await expect.element(page.getByRole('textbox')).toHaveAttribute('placeholder', '')
   })
 })

--- a/src/components/editor/param-renderer/ParamRenderer.spec.ts
+++ b/src/components/editor/param-renderer/ParamRenderer.spec.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest'
+import { page } from 'vitest/browser'
+import { defineComponent, h } from 'vue'
+
+import {
+  createBrowserContainerStub,
+  createBrowserInputStub,
+  renderInBrowser,
+} from '~/__tests__/browser-render'
+import { statementEditorSurfaceKey } from '~/features/editor/statement-editor/surface-context'
+
+import ParamRenderer from './ParamRenderer.vue'
+
+import type { EditorField, TextField } from '~/features/editor/command-registry/schema'
+import type { StatementEditorSurface } from '~/features/editor/statement-editor/surface-context'
+
+function createStandaloneTextField(): EditorField {
+  const field: TextField = {
+    inlineLayout: 'standalone',
+    key: 'text',
+    label: 'Dialogue',
+    type: 'text',
+    variant: { inline: 'textarea-auto', panel: 'textarea-grow' },
+  }
+
+  return {
+    key: 'text',
+    storage: 'content',
+    field,
+  }
+}
+
+function createTextareaStub() {
+  return defineComponent({
+    name: 'TextareaStub',
+    props: {
+      id: {
+        type: String,
+        default: undefined,
+      },
+      modelValue: {
+        type: [Object, Array, Number, String, Boolean],
+        default: undefined,
+      },
+      placeholder: {
+        type: String,
+        default: undefined,
+      },
+    },
+    emits: ['update:model-value'],
+    setup(props, { emit }) {
+      return () => h('textarea', {
+        'data-testid': props.id ?? 'textarea',
+        'id': props.id,
+        'placeholder': props.placeholder,
+        'value': String(props.modelValue ?? ''),
+        'onInput': (event: Event) => emit('update:model-value', (event.target as HTMLTextAreaElement).value),
+      })
+    },
+  })
+}
+
+const globalStubs = {
+  ColorPicker: createBrowserContainerStub('ColorPickerStub'),
+  FilePicker: createBrowserContainerStub('FilePickerStub'),
+  FocusXYControl: createBrowserContainerStub('FocusXYControlStub'),
+  Input: createBrowserInputStub('InputStub'),
+  Label: createBrowserContainerStub('LabelStub', 'label'),
+  NumberControl: createBrowserContainerStub('NumberControlStub'),
+  ParamChoiceField: createBrowserContainerStub('ParamChoiceFieldStub'),
+  Switch: createBrowserContainerStub('SwitchStub'),
+  Textarea: createTextareaStub(),
+}
+
+function renderRenderer(surface: StatementEditorSurface) {
+  const field = createStandaloneTextField()
+
+  return renderInBrowser(ParamRenderer, {
+    props: {
+      canScrub: () => false,
+      fields: [field],
+      fileRootPaths: {},
+      getDynamicOptions: () => [],
+      getFieldSelectValue: () => '',
+      getFieldValue: () => '',
+      isFieldCustom: () => false,
+      isFieldFileMissing: () => false,
+      isFieldVisible: () => true,
+    },
+    global: {
+      provide: {
+        [statementEditorSurfaceKey]: surface,
+      },
+      stubs: globalStubs,
+    },
+  })
+}
+
+describe('ParamRenderer', () => {
+  it('panel 下 standalone 文本字段显示外部标签且不回退 label 为 placeholder', async () => {
+    renderRenderer('panel')
+
+    await expect.element(page.getByText('Dialogue')).toBeInTheDocument()
+    await expect.element(page.getByRole('textbox')).toHaveAttribute('placeholder', '')
+  })
+
+  it('inline 下 standalone 文本字段隐藏外部标签并回退 label 为 placeholder', async () => {
+    renderRenderer('inline')
+
+    await expect.element(page.getByText('Dialogue')).not.toBeInTheDocument()
+    await expect.element(page.getByRole('textbox')).toHaveAttribute('placeholder', 'Dialogue')
+  })
+})

--- a/src/components/editor/param-renderer/ParamRenderer.vue
+++ b/src/components/editor/param-renderer/ParamRenderer.vue
@@ -131,7 +131,7 @@ function fieldLayout(field: EditorField): 'row' | 'column' {
 
 function resolvedPlaceholder(field: EditorField): string {
   const explicitPlaceholder = fieldMeta.placeholder(field)
-  if (explicitPlaceholder) {
+  if (explicitPlaceholder !== undefined) {
     return explicitPlaceholder
   }
   if (isInlineStandalone(field)) {

--- a/src/components/editor/param-renderer/ParamRenderer.vue
+++ b/src/components/editor/param-renderer/ParamRenderer.vue
@@ -129,8 +129,15 @@ function fieldLayout(field: EditorField): 'row' | 'column' {
   return fieldMeta.fieldLayout(field, isInline)
 }
 
-function placeholder(field: EditorField): string {
-  return fieldMeta.placeholder(field)
+function resolvedPlaceholder(field: EditorField): string {
+  const explicitPlaceholder = fieldMeta.placeholder(field)
+  if (explicitPlaceholder) {
+    return explicitPlaceholder
+  }
+  if (isInlineStandalone(field)) {
+    return label(field)
+  }
+  return ''
 }
 
 function customLabel(field: EditorField): string {
@@ -327,7 +334,7 @@ function fieldInputId(field: EditorField): string {
           :custom-label="customLabel(field)"
           :custom-option-label="customOptionLabel"
           :not-selected-label="notSelectedLabel"
-          :placeholder="placeholder(field)"
+          :placeholder="resolvedPlaceholder(field)"
           :is-custom-field="customField.isCustomField(field)"
           :render-segmented="shouldRenderSegmented(field)"
           @update-select="handleSelectUpdate(field, $event)"
@@ -346,6 +353,7 @@ function fieldInputId(field: EditorField): string {
           v-else-if="isTextareaMode(field)"
           :id="fieldInputId(field)"
           :model-value="String(getFieldValue(field) || '')"
+          :placeholder="resolvedPlaceholder(field)"
           :class="cn(
             'text-xs py-1 shadow-none resize-none overflow-y-auto px-2.5 w-32 group-data-[surface=panel]:flex-1 group-data-[surface=panel]:px-3 group-data-[surface=panel]:w-full',
             fieldMode(field) === 'textareaGrow' ? 'min-h-14.5 max-h-[50vh] field-sizing-content' : 'min-h-6 max-h-14.5 field-sizing-content group-data-[surface=panel]:min-h-7',

--- a/src/components/editor/param-renderer/__tests__/useParamFieldMeta.test.ts
+++ b/src/components/editor/param-renderer/__tests__/useParamFieldMeta.test.ts
@@ -171,14 +171,21 @@ describe('useParamFieldMeta', () => {
     expect(meta.switchModelValue(argSwitch, true)).toBe(true)
   })
 
-  it('未显式配置 placeholder 时返回空字符串，由渲染层决定是否回退 label', () => {
+  it('placeholder 未配置时返回 undefined，显式空字符串保持为空字符串', () => {
     const meta = createMeta()
     const textField = createField({
       key: 'dialogue',
       label: 'Dialogue',
       type: 'text',
     })
+    const emptyPlaceholderField = createField({
+      key: 'dialogue',
+      label: 'Dialogue',
+      placeholder: '',
+      type: 'text',
+    })
 
-    expect(meta.placeholder(textField)).toBe('')
+    expect(meta.placeholder(textField)).toBeUndefined()
+    expect(meta.placeholder(emptyPlaceholderField)).toBe('')
   })
 })

--- a/src/components/editor/param-renderer/__tests__/useParamFieldMeta.test.ts
+++ b/src/components/editor/param-renderer/__tests__/useParamFieldMeta.test.ts
@@ -170,4 +170,15 @@ describe('useParamFieldMeta', () => {
     expect(meta.switchModelValue(contentSwitch, 'stop')).toBe(false)
     expect(meta.switchModelValue(argSwitch, true)).toBe(true)
   })
+
+  it('未显式配置 placeholder 时返回空字符串，由渲染层决定是否回退 label', () => {
+    const meta = createMeta()
+    const textField = createField({
+      key: 'dialogue',
+      label: 'Dialogue',
+      type: 'text',
+    })
+
+    expect(meta.placeholder(textField)).toBe('')
+  })
 })

--- a/src/components/editor/param-renderer/useParamFieldMeta.ts
+++ b/src/components/editor/param-renderer/useParamFieldMeta.ts
@@ -111,11 +111,11 @@ export function useParamFieldMeta(options: UseParamFieldMetaOptions) {
       : 'column'
   }
 
-  function placeholder(field: EditorField): string {
+  function placeholder(field: EditorField): string | undefined {
     if ('placeholder' in field.field) {
       return resolveI18n(field.field.placeholder, options.t, options.i18nContent())
     }
-    return ''
+    return undefined
   }
 
   function customLabel(field: EditorField): string {

--- a/src/components/editor/param-renderer/useParamFieldMeta.ts
+++ b/src/components/editor/param-renderer/useParamFieldMeta.ts
@@ -113,9 +113,9 @@ export function useParamFieldMeta(options: UseParamFieldMetaOptions) {
 
   function placeholder(field: EditorField): string {
     if ('placeholder' in field.field) {
-      return resolveI18n(field.field.placeholder, options.t, options.i18nContent()) || resolveI18n(field.field.label, options.t, options.i18nContent())
+      return resolveI18n(field.field.placeholder, options.t, options.i18nContent())
     }
-    return resolveI18n(field.field.label, options.t, options.i18nContent())
+    return ''
   }
 
   function customLabel(field: EditorField): string {

--- a/src/components/editor/statement-editor/StatementCommandFieldsSection.vue
+++ b/src/components/editor/statement-editor/StatementCommandFieldsSection.vue
@@ -38,18 +38,6 @@ const emit = defineEmits<{
   openEffectEditor: []
 }>()
 
-const containerClass = $computed(() => {
-  return props.surface === 'panel'
-    ? 'flex flex-wrap gap-x-4 gap-y-2.5'
-    : 'flex flex-wrap gap-x-3 gap-y-1.5 items-center'
-})
-
-const buttonClass = $computed(() => {
-  return props.surface === 'panel'
-    ? 'px-3 h-7 w-full justify-center'
-    : 'px-2 h-6'
-})
-
 const paramRendererMode = $computed(() => {
   if (props.statementType === 'say') {
     return props.surface === 'inline' ? 'all' : 'basic'
@@ -71,13 +59,15 @@ function handleOpenEffectEditor() {
 </script>
 
 <template>
-  <div :class="containerClass">
+  <div
+    class="group flex flex-wrap gap-x-3 gap-y-1.5 w-full items-center data-[surface=panel]:gap-x-4 data-[surface=panel]:gap-y-2.5 data-[surface=panel]:items-stretch"
+    :data-surface="props.surface"
+  >
     <Button
       v-if="isCommand && props.showAnimationEditorButton"
       variant="outline"
       size="sm"
-      class="btn-animation-editor"
-      :class="buttonClass"
+      class="btn-animation-editor px-2 h-6 group-data-[surface=panel]:px-3 group-data-[surface=panel]:h-7 group-data-[surface=panel]:w-full group-data-[surface=panel]:justify-center"
       @click="handleOpenAnimationEditor"
     >
       <div class="i-lucide-clapperboard size-3" />
@@ -87,8 +77,7 @@ function handleOpenEffectEditor() {
       v-if="isCommand && props.effectEditorAtTop && props.showEffectEditorButton"
       variant="outline"
       size="sm"
-      class="btn-effect-editor"
-      :class="buttonClass"
+      class="btn-effect-editor px-2 h-6 group-data-[surface=panel]:px-3 group-data-[surface=panel]:h-7 group-data-[surface=panel]:w-full group-data-[surface=panel]:justify-center"
       @click="handleOpenEffectEditor"
     >
       <div class="i-lucide-sparkles size-3" />
@@ -128,8 +117,7 @@ function handleOpenEffectEditor() {
       v-if="isCommand && props.showEffectEditorButton && !props.effectEditorAtTop"
       variant="outline"
       size="sm"
-      class="btn-effect-editor"
-      :class="buttonClass"
+      class="btn-effect-editor px-2 h-6 group-data-[surface=panel]:px-3 group-data-[surface=panel]:h-7 group-data-[surface=panel]:w-full group-data-[surface=panel]:justify-center"
       @click="handleOpenEffectEditor"
     >
       <div class="i-lucide-sparkles size-3" />

--- a/src/features/editor/command-registry/display.ts
+++ b/src/features/editor/command-registry/display.ts
@@ -25,7 +25,6 @@ export const displayEntries: CommandEntry[] = [
         variant: { inline: 'textarea-auto', panel: 'textarea-grow' },
         inlineLayout: 'standalone',
         label: t => t('edit.visualEditor.params.introText'),
-        placeholder: t => t('edit.visualEditor.params.introTextPlaceholder'),
       }),
       arg({
         key: 'fontSize',

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -701,7 +701,6 @@ edit:
       effectName: Effect
       effectCustomName: Effect Name
       introText: Text Content
-      introTextPlaceholder: "Separate lines with {'|'}"
       backgroundColor: Background Color
       backgroundImage: Background Image
       fontColor: Font Color

--- a/src/locales/ja.yml
+++ b/src/locales/ja.yml
@@ -701,7 +701,6 @@ edit:
       effectName: エフェクト
       effectCustomName: エフェクト名
       introText: テキスト内容
-      introTextPlaceholder: "{'|'} で行を区切る"
       backgroundColor: 背景色
       backgroundImage: 背景画像
       fontColor: フォント色

--- a/src/locales/zh-Hans.yml
+++ b/src/locales/zh-Hans.yml
@@ -701,7 +701,6 @@ edit:
       effectName: 特效
       effectCustomName: 特效名称
       introText: 文字内容
-      introTextPlaceholder: "用 {'|'} 分隔多行"
       backgroundColor: 背景颜色
       backgroundImage: 背景图片
       fontColor: 字体颜色

--- a/src/locales/zh-Hant.yml
+++ b/src/locales/zh-Hant.yml
@@ -701,7 +701,6 @@ edit:
       effectName: 特效
       effectCustomName: 特效名稱
       introText: 文字內容
-      introTextPlaceholder: "用 {'|'} 分隔多行"
       backgroundColor: 背景顏色
       backgroundImage: 背景圖片
       fontColor: 字體顏色


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [x] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [ ] 测试用例
- [ ] 性能优化
- [x] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

- 将 `useParamFieldMeta` 的 `placeholder` 语义收窄为仅返回显式配置值，不再默认回退到 `label`
- 在 `ParamRenderer` 中按渲染场景解析最终 placeholder，只有 `inline + standalone` 文本字段在隐藏外部标签时才回退使用 `label`
- 为 `Textarea` 同步透传 placeholder，并移除 `intro` 命令及多语言资源中不再需要的 `introTextPlaceholder`
- 修复 `StatementCommandFieldsSection` 在参数区布局中的宽度问题，为容器补齐 `w-full`，并统一改为基于 `data-surface` 的样式切换
- 补充 `ParamRenderer` 与 `useParamFieldMeta` 测试，覆盖 panel / inline 下 standalone 文本字段的标签与 placeholder 行为

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

- 之前 placeholder 的回退规则定义在元数据层，导致 panel 场景下 standalone 文本字段会同时显示外部 `label` 和同名 placeholder，信息重复且职责边界不清
- 同时，参数区容器在部分场景下没有稳定占满可用宽度，导致按钮和字段布局表现不一致
- 这次调整把“字段元信息”和“具体渲染场景”解耦，并顺手修正参数区容器宽度规则，使 inline / panel 两种 surface 的渲染行为更稳定

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
