### PR TITLE
⚡️ 优化可视化编辑器动态选项下拉性能

### DIFF
--- a/src/components/editor/param-renderer/ParamRenderer.vue
+++ b/src/components/editor/param-renderer/ParamRenderer.vue
@@ -1,15 +1,18 @@
 <script setup lang="ts">
 import { useControlId } from '~/composables/useControlId'
-import { EditorField, FileFieldConfig, I18nLike, resolveI18n, resolveSurfaceVariant } from '~/features/editor/command-registry/schema'
+import { EditorField, FileFieldConfig, resolveI18n, resolveSurfaceVariant } from '~/features/editor/command-registry/schema'
 import { normalizeFieldStringValue } from '~/features/editor/statement-editor/field-utils'
 import { statementEditorSurfaceKey } from '~/features/editor/statement-editor/surface-context'
 import { cn } from '~/lib/utils'
 
+import FocusXYControl from './controls/FocusXYControl.vue'
+import NumberControl from './controls/NumberControl.vue'
+import ParamChoiceField from './ParamChoiceField.vue'
+import { useParamChoiceFieldViewModel } from './useParamChoiceFieldViewModel'
 import { useParamCustomField } from './useParamCustomField'
 import { useParamFieldMeta } from './useParamFieldMeta'
 import { useParamXyPad } from './useParamXyPad'
 
-import type { ParamSelectOptionItem } from './controls/types'
 import type { StatementSchemaParamMode } from './useParamFieldMeta'
 import type { ISentence } from 'webgal-parser/src/interface/sceneInterface'
 import type { NumberField } from '~/features/editor/command-registry/schema'
@@ -172,30 +175,6 @@ function isFileFieldInvalid(field: EditorField): boolean {
   return isFileField(field) && props.isFieldFileMissing(field)
 }
 
-function getStaticOptions(field: EditorField): ParamSelectOptionItem[] {
-  if (field.field.type !== 'choice') {
-    return []
-  }
-  const options = field.field.options as { value: string, label: I18nLike }[]
-  return options.map(option => ({
-    value: option.value,
-    label: resolveI18n(option.label, t, i18nContent),
-  }))
-}
-
-function getMergedOptions(field: EditorField): ParamSelectOptionItem[] {
-  const merged: ParamSelectOptionItem[] = []
-  const seen = new Set<string>()
-  for (const option of [...(props.getDynamicOptions(field) ?? []), ...getStaticOptions(field)]) {
-    if (seen.has(option.value)) {
-      continue
-    }
-    seen.add(option.value)
-    merged.push(option)
-  }
-  return merged
-}
-
 function shouldRenderSegmented(field: EditorField): boolean {
   return field.field.type === 'choice'
     && resolveSurfaceVariant(field.field.variant, surface, 'select') === 'segmented'
@@ -256,6 +235,19 @@ function customFieldInputId(field: EditorField): string {
 function fieldInputId(field: EditorField): string {
   return buildControlId(`field-${field.key}`)
 }
+
+const choiceFieldViewModels = $(useParamChoiceFieldViewModel({
+  visibleFields: () => visibleFields,
+  getChoiceFieldMode: choiceFieldMode,
+  getCustomLabel: customLabel,
+  getDynamicOptions: field => props.getDynamicOptions(field),
+  getPlaceholder: resolvedPlaceholder,
+  getSelectValue: field => customField.selectModelValue(field),
+  isCustomField: field => customField.isCustomField(field),
+  i18nContent: () => i18nContent,
+  shouldRenderSegmented,
+  t,
+}).viewModels)
 </script>
 
 <template>
@@ -321,22 +313,22 @@ function fieldInputId(field: EditorField): string {
         />
 
         <ParamChoiceField
-          v-else-if="choiceFieldMode(field)"
+          v-else-if="choiceFieldViewModels.get(field.key)"
           :field="field"
-          :mode="choiceFieldMode(field) ?? 'select'"
+          :mode="choiceFieldViewModels.get(field.key)?.mode ?? 'select'"
           :input-id="fieldInputId(field)"
           :custom-input-id="customFieldInputId(field)"
           :surface="surface"
           :control-class="controlClass(field)"
-          :options="getMergedOptions(field)"
-          :select-value="customField.selectModelValue(field)"
+          :options="choiceFieldViewModels.get(field.key)?.options ?? []"
+          :select-value="choiceFieldViewModels.get(field.key)?.selectValue ?? ''"
           :value="getFieldValue(field)"
-          :custom-label="customLabel(field)"
+          :custom-label="choiceFieldViewModels.get(field.key)?.customLabel"
           :custom-option-label="customOptionLabel"
           :not-selected-label="notSelectedLabel"
-          :placeholder="resolvedPlaceholder(field)"
-          :is-custom-field="customField.isCustomField(field)"
-          :render-segmented="shouldRenderSegmented(field)"
+          :placeholder="choiceFieldViewModels.get(field.key)?.placeholder ?? ''"
+          :is-custom-field="choiceFieldViewModels.get(field.key)?.isCustomField ?? false"
+          :render-segmented="choiceFieldViewModels.get(field.key)?.renderSegmented ?? false"
           @update-select="handleSelectUpdate(field, $event)"
           @update-value="emit('updateValue', { field, value: $event })"
         />

--- a/src/components/editor/param-renderer/__tests__/useParamChoiceFieldViewModel.test.ts
+++ b/src/components/editor/param-renderer/__tests__/useParamChoiceFieldViewModel.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest'
+
+import { useParamChoiceFieldViewModel } from '../useParamChoiceFieldViewModel'
+
+import type { ParamSelectOptionItem } from '../controls/types'
+import type { EditorField, ValueChoiceField } from '~/features/editor/command-registry/schema'
+
+function createChoiceField(key: string = 'motion'): EditorField {
+  const field: ValueChoiceField = {
+    key,
+    label: 'Motion',
+    options: [
+      { label: 'Static Joy', value: 'joy' },
+      { label: 'Static Sad', value: 'sad' },
+    ],
+    placeholder: 'Select motion',
+    type: 'choice',
+    variant: 'combobox',
+    customizable: true,
+    customLabel: 'Custom motion',
+  }
+
+  return {
+    key,
+    field,
+    storage: 'arg',
+  } as EditorField
+}
+
+describe('useParamChoiceFieldViewModel', () => {
+  it('会合并动态和静态选项，并在依赖变化后保持动态选项优先级', async () => {
+    const field = createChoiceField()
+    const visibleFields = ref([field])
+    const dynamicOptions = ref<ParamSelectOptionItem[]>([
+      { label: 'Dynamic Joy', value: 'joy' },
+      { label: 'Idle', value: 'idle' },
+    ])
+    const customLabel = ref('Custom motion')
+    const placeholder = ref('Search motion')
+    const selectValue = ref('joy')
+
+    const viewModel = useParamChoiceFieldViewModel({
+      getChoiceFieldMode: () => 'combobox',
+      getCustomLabel: () => customLabel.value,
+      getDynamicOptions: () => dynamicOptions.value,
+      getPlaceholder: () => placeholder.value,
+      getSelectValue: () => selectValue.value,
+      isCustomField: () => false,
+      i18nContent: () => '',
+      shouldRenderSegmented: () => false,
+      t: key => key,
+      visibleFields: () => visibleFields.value,
+    })
+
+    expect(viewModel.viewModels.value.get(field.key)).toEqual({
+      customLabel: 'Custom motion',
+      isCustomField: false,
+      mode: 'combobox',
+      options: [
+        { label: 'Dynamic Joy', value: 'joy' },
+        { label: 'Idle', value: 'idle' },
+        { label: 'Static Sad', value: 'sad' },
+      ],
+      placeholder: 'Search motion',
+      renderSegmented: false,
+      selectValue: 'joy',
+    })
+
+    dynamicOptions.value = [{ label: 'Joy', value: 'joy' }]
+    placeholder.value = 'Filter motion'
+    customLabel.value = 'Custom expression'
+    selectValue.value = 'idle'
+
+    await nextTick()
+
+    expect(viewModel.viewModels.value.get(field.key)).toMatchObject({
+      customLabel: 'Custom expression',
+      isCustomField: false,
+      placeholder: 'Filter motion',
+      renderSegmented: false,
+      selectValue: 'idle',
+    })
+    expect(viewModel.viewModels.value.get(field.key)?.options).toEqual([
+      { label: 'Joy', value: 'joy' },
+      { label: 'Static Sad', value: 'sad' },
+    ])
+  })
+})

--- a/src/components/editor/param-renderer/useParamChoiceFieldViewModel.ts
+++ b/src/components/editor/param-renderer/useParamChoiceFieldViewModel.ts
@@ -1,0 +1,108 @@
+import { resolveI18n } from '~/features/editor/command-registry/schema'
+
+import type { ParamSelectOptionItem } from './controls/types'
+import type { EditorField } from '~/features/editor/command-registry/schema'
+
+type ChoiceFieldMode = 'select' | 'combobox'
+type TranslateFn = (key: string, ...args: unknown[]) => string
+
+interface UseParamChoiceFieldViewModelOptions {
+  getChoiceFieldMode: (field: EditorField) => ChoiceFieldMode | undefined
+  getCustomLabel: (field: EditorField) => string
+  getDynamicOptions: (field: EditorField) => ParamSelectOptionItem[]
+  getPlaceholder: (field: EditorField) => string
+  getSelectValue: (field: EditorField) => string
+  isCustomField: (field: EditorField) => boolean
+  i18nContent: () => string
+  shouldRenderSegmented: (field: EditorField) => boolean
+  t: TranslateFn
+  visibleFields: () => EditorField[]
+}
+
+export interface ParamChoiceFieldViewModel {
+  customLabel: string
+  isCustomField: boolean
+  mode: ChoiceFieldMode
+  options: ParamSelectOptionItem[]
+  placeholder: string
+  renderSegmented: boolean
+  selectValue: string
+}
+
+function resolveStaticOptions(
+  field: EditorField,
+  t: TranslateFn,
+  i18nContent: string,
+): ParamSelectOptionItem[] {
+  if (field.field.type !== 'choice') {
+    return []
+  }
+
+  return field.field.options.map(option => ({
+    value: option.value,
+    label: resolveI18n(option.label, t, i18nContent),
+  }))
+}
+
+function mergeOptions(
+  dynamicOptions: ParamSelectOptionItem[],
+  staticOptions: ParamSelectOptionItem[],
+): ParamSelectOptionItem[] {
+  const merged: ParamSelectOptionItem[] = []
+  const seen = new Set<string>()
+
+  for (const option of [...dynamicOptions, ...staticOptions]) {
+    if (seen.has(option.value)) {
+      continue
+    }
+
+    seen.add(option.value)
+    merged.push(option)
+  }
+
+  return merged
+}
+
+function createViewModel(
+  field: EditorField,
+  options: UseParamChoiceFieldViewModelOptions,
+): ParamChoiceFieldViewModel | undefined {
+  const mode = options.getChoiceFieldMode(field)
+  if (field.field.type !== 'choice' || !mode) {
+    return
+  }
+
+  return {
+    customLabel: options.getCustomLabel(field),
+    isCustomField: options.isCustomField(field),
+    mode,
+    options: mergeOptions(
+      options.getDynamicOptions(field),
+      resolveStaticOptions(field, options.t, options.i18nContent()),
+    ),
+    placeholder: options.getPlaceholder(field),
+    renderSegmented: options.shouldRenderSegmented(field),
+    selectValue: options.getSelectValue(field),
+  }
+}
+
+export function useParamChoiceFieldViewModel(
+  options: UseParamChoiceFieldViewModelOptions,
+) {
+  const viewModels = computed(() => {
+    const result = new Map<string, ParamChoiceFieldViewModel>()
+
+    for (const field of options.visibleFields()) {
+      const viewModel = createViewModel(field, options)
+      if (viewModel) {
+        result.set(field.key, viewModel)
+      }
+    }
+
+    return result
+  })
+
+  return {
+    viewModels,
+  }
+}

--- a/src/components/primitives/Combobox.spec.ts
+++ b/src/components/primitives/Combobox.spec.ts
@@ -84,8 +84,8 @@ const globalStubs = {
 
       return () => h('div', {
         ...attrs,
-        'style': 'max-height: 64px; overflow: auto;',
-        'ref': viewportElement,
+        style: 'max-height: 64px; overflow: auto;',
+        ref: viewportElement,
       }, slots.default?.())
     },
   }),

--- a/src/components/primitives/Combobox.spec.ts
+++ b/src/components/primitives/Combobox.spec.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it } from 'vitest'
+import { page, userEvent } from 'vitest/browser'
+import { defineComponent } from 'vue'
+
+import { createBrowserContainerStub, renderInBrowser } from '~/__tests__/browser-render'
+
+import Combobox from './Combobox.vue'
+
+import type { InjectionKey, Ref } from 'vue'
+
+const popoverContextKey: InjectionKey<{
+  open: Readonly<Ref<boolean>>
+  setOpen: (value: boolean) => void
+}> = Symbol('ComboboxPopoverContext')
+
+const baseOptions = [
+  { label: 'Idle', value: 'idle' },
+  { label: 'Joy', value: 'joy' },
+  { label: 'Sad', value: 'sad' },
+]
+
+const scrollOptions = Array.from({ length: 20 }, (_, index) => ({
+  label: `Option ${index + 1}`,
+  value: `option-${index + 1}`,
+}))
+
+const globalStubs = {
+  Button: createBrowserContainerStub('StubButton', 'button'),
+  Popover: defineComponent({
+    name: 'StubPopover',
+    props: {
+      open: {
+        type: Boolean,
+        default: false,
+      },
+    },
+    emits: ['update:open'],
+    setup(props, { emit, slots }) {
+      const open = computed(() => props.open)
+
+      provide(popoverContextKey, {
+        open: readonly(open),
+        setOpen(value: boolean) {
+          emit('update:open', value)
+        },
+      })
+
+      return () => slots.default?.()
+    },
+  }),
+  PopoverContent: defineComponent({
+    name: 'StubPopoverContent',
+    inheritAttrs: false,
+    setup(_, { attrs, slots }) {
+      const context = inject(popoverContextKey)
+
+      return () => context?.open.value
+        ? h('div', attrs, slots.default?.())
+        : undefined
+    },
+  }),
+  PopoverTrigger: defineComponent({
+    name: 'StubPopoverTrigger',
+    setup(_, { slots }) {
+      const context = inject(popoverContextKey)
+
+      return () => h('div', {
+        onClick: () => context?.setOpen(!context.open.value),
+      }, slots.default?.())
+    },
+  }),
+  ScrollArea: defineComponent({
+    name: 'StubScrollArea',
+    setup(_, { attrs, slots, expose }) {
+      const viewportElement = ref<HTMLElement>()
+
+      expose({
+        viewport: {
+          get viewportElement() {
+            return viewportElement.value
+          },
+        },
+      })
+
+      return () => h('div', {
+        ...attrs,
+        'style': 'max-height: 64px; overflow: auto;',
+        'ref': viewportElement,
+      }, slots.default?.())
+    },
+  }),
+}
+
+const ComboboxHarness = defineComponent({
+  components: { Combobox },
+  setup() {
+    const modelValue = ref('')
+
+    return {
+      baseOptions,
+      modelValue,
+    }
+  },
+  template: `
+    <Combobox
+      v-model="modelValue"
+      id="motion"
+      data-testid="motion-trigger"
+      :options="baseOptions"
+      placeholder="Select motion"
+      search-placeholder="Search motion"
+    />
+  `,
+})
+
+const CenteredComboboxHarness = defineComponent({
+  components: { Combobox },
+  setup() {
+    const modelValue = ref('option-12')
+
+    return {
+      modelValue,
+      scrollOptions,
+    }
+  },
+  template: `
+    <Combobox
+      v-model="modelValue"
+      data-testid="centered-trigger"
+      :options="scrollOptions"
+      placeholder="Select option"
+      search-placeholder="Search option"
+    />
+  `,
+})
+
+describe('Combobox', () => {
+  it('打开后会把焦点交给搜索框', async () => {
+    renderInBrowser(ComboboxHarness, {
+      global: {
+        stubs: globalStubs,
+      },
+    })
+
+    await page.getByTestId('motion-trigger').click()
+    await userEvent.keyboard('j')
+
+    await expect.element(page.getByPlaceholder('Search motion')).toHaveValue('j')
+  })
+
+  it('会根据搜索词过滤候选项', async () => {
+    renderInBrowser(ComboboxHarness, {
+      global: {
+        stubs: globalStubs,
+      },
+    })
+
+    await page.getByTestId('motion-trigger').click()
+    await page.getByPlaceholder('Search motion').fill('jo')
+
+    await expect.element(page.getByRole('option', { name: 'Joy' })).toBeInTheDocument()
+    await expect.element(page.getByRole('option', { name: 'Idle' })).not.toBeInTheDocument()
+  })
+
+  it('搜索后方向键导航会从第一个匹配项开始', async () => {
+    renderInBrowser(CenteredComboboxHarness, {
+      global: {
+        stubs: globalStubs,
+      },
+    })
+
+    await page.getByTestId('centered-trigger').click()
+    await page.getByPlaceholder('Search option').fill('1')
+    await userEvent.keyboard('{ArrowDown}{Enter}')
+
+    await expect.element(page.getByTestId('centered-trigger')).toHaveTextContent('Option 1')
+  })
+
+  it('搜索后直接按 Enter 不会误选最后一个匹配项', async () => {
+    renderInBrowser(CenteredComboboxHarness, {
+      global: {
+        stubs: globalStubs,
+      },
+    })
+
+    await page.getByTestId('centered-trigger').click()
+    await page.getByPlaceholder('Search option').fill('1')
+    await userEvent.keyboard('{Enter}')
+
+    await expect.element(page.getByTestId('centered-trigger')).toHaveTextContent('Option 12')
+  })
+
+  it('支持方向键高亮并用 Enter 提交', async () => {
+    renderInBrowser(ComboboxHarness, {
+      global: {
+        stubs: globalStubs,
+      },
+    })
+
+    await page.getByTestId('motion-trigger').click()
+    await userEvent.keyboard('{ArrowDown}{ArrowDown}{Enter}')
+
+    await expect.element(page.getByTestId('motion-trigger')).toHaveTextContent('Joy')
+  })
+
+  it('无匹配项时显示空状态', async () => {
+    renderInBrowser(ComboboxHarness, {
+      global: {
+        stubs: globalStubs,
+      },
+    })
+
+    await page.getByTestId('motion-trigger').click()
+    await page.getByPlaceholder('Search motion').fill('zzz')
+
+    await expect.element(page.getByText('edit.visualEditor.noResults')).toBeInTheDocument()
+  })
+})

--- a/src/components/primitives/Combobox.vue
+++ b/src/components/primitives/Combobox.vue
@@ -1,7 +1,19 @@
 <script setup lang="ts">
+import { Search } from '@lucide/vue'
+
 import { cn } from '~/lib/utils'
 
 import type { HTMLAttributes } from 'vue'
+
+defineOptions({
+  inheritAttrs: false,
+})
+
+interface ScrollAreaViewportHandle {
+  viewport?: {
+    viewportElement?: HTMLElement | null
+  } | null
+}
 
 const props = defineProps<{
   class?: HTMLAttributes['class']
@@ -16,38 +28,165 @@ const emit = defineEmits<{
 }>()
 
 let open = $ref(false)
-const scrollAreaRef = $(useTemplateRef('scrollAreaRef'))
+let searchQuery = $ref('')
+let highlightedIndex = $ref(-1)
+let hoveredIndex = $ref<number | undefined>(undefined)
 
-function scrollToSelectedOption() {
-  const viewport = scrollAreaRef?.viewport?.viewportElement
-  if (!viewport) {
-    return
-  }
-  const selected = viewport.querySelector('[role="option"][data-selected]') as HTMLElement | null
-  if (!selected) {
-    return
-  }
-  const viewportRect = viewport.getBoundingClientRect()
-  const selectedRect = selected.getBoundingClientRect()
-  if (selectedRect.top < viewportRect.top || selectedRect.bottom > viewportRect.bottom) {
-    selected.scrollIntoView({ block: 'center', behavior: 'auto' })
-  }
-}
+const attrs = useAttrs()
+const inputRef = $(useTemplateRef<HTMLInputElement>('inputRef'))
+const listRef = $(useTemplateRef<HTMLElement>('listRef'))
+const scrollAreaRef = $(useTemplateRef<ScrollAreaViewportHandle>('scrollAreaRef'))
 
-watch(() => open, async (val) => {
-  if (!val) {
-    return
+const filteredOptions = $computed(() => {
+  const keyword = searchQuery.trim().toLowerCase()
+  if (!keyword) {
+    return props.options
   }
-  await nextTick()
-  requestAnimationFrame(scrollToSelectedOption)
+
+  return props.options.filter(option => option.label.toLowerCase().includes(keyword))
 })
 
-const displayLabel = $computed(() => {
+const selectedLabel = $computed(() => {
   if (!props.modelValue) {
     return ''
   }
-  const opt = props.options.find(o => o.value === props.modelValue)
-  return opt ? opt.label : props.modelValue
+
+  const selected = props.options.find(option => option.value === props.modelValue)
+  return selected?.label ?? props.modelValue
+})
+
+const activeHighlightedIndex = $computed(() => hoveredIndex ?? highlightedIndex)
+
+function focusSearchInput() {
+  inputRef?.focus()
+  inputRef?.select()
+}
+
+function syncHighlightFromSelectedValue() {
+  highlightedIndex = filteredOptions.findIndex(option => option.value === props.modelValue)
+}
+
+function clearHoveredHighlight() {
+  hoveredIndex = -1
+}
+
+function scrollHighlightedOptionIntoView(block: ScrollLogicalPosition = 'nearest') {
+  const listElement = listRef
+  if (!listElement) {
+    return
+  }
+
+  const highlightedElement = listElement.querySelector('[role="option"][data-active-highlighted="true"]') as HTMLElement | null
+  highlightedElement?.scrollIntoView({ block, behavior: 'auto' })
+}
+
+function scrollOptionsToTop() {
+  const viewportElement = scrollAreaRef?.viewport?.viewportElement
+  if (!viewportElement) {
+    return
+  }
+
+  viewportElement.scrollTo({ top: 0, behavior: 'auto' })
+}
+
+async function scrollHighlightedOptionAfterNextTick(block: ScrollLogicalPosition) {
+  await nextTick()
+  requestAnimationFrame(() => {
+    scrollHighlightedOptionIntoView(block)
+  })
+}
+
+function selectOption(value: string) {
+  emit('update:modelValue', value)
+  open = false
+}
+
+async function handleInputKeydown(event: KeyboardEvent) {
+  const currentIndex = activeHighlightedIndex
+
+  if (event.key === 'ArrowDown') {
+    event.preventDefault()
+    if (filteredOptions.length === 0) {
+      return
+    }
+    hoveredIndex = undefined
+    highlightedIndex = currentIndex < 0
+      ? 0
+      : Math.min(currentIndex + 1, filteredOptions.length - 1)
+    await scrollHighlightedOptionAfterNextTick('nearest')
+    return
+  }
+
+  if (event.key === 'ArrowUp') {
+    event.preventDefault()
+    if (filteredOptions.length === 0) {
+      return
+    }
+    hoveredIndex = undefined
+    highlightedIndex = currentIndex < 0
+      ? filteredOptions.length - 1
+      : Math.max(currentIndex - 1, 0)
+    await scrollHighlightedOptionAfterNextTick('nearest')
+    return
+  }
+
+  if (event.key === 'Enter' && currentIndex >= 0) {
+    event.preventDefault()
+    selectOption(filteredOptions[currentIndex]!.value)
+    return
+  }
+
+  if (event.key === 'Escape') {
+    event.preventDefault()
+    open = false
+  }
+}
+
+watch(() => filteredOptions, (nextOptions) => {
+  if (!open) {
+    return
+  }
+
+  if (nextOptions.length === 0) {
+    highlightedIndex = -1
+    return
+  }
+
+  if (searchQuery.trim()) {
+    highlightedIndex = -1
+    return
+  }
+
+  syncHighlightFromSelectedValue()
+})
+
+watch(() => open, async (isOpen) => {
+  if (!isOpen) {
+    searchQuery = ''
+    highlightedIndex = -1
+    hoveredIndex = undefined
+    return
+  }
+
+  searchQuery = ''
+  hoveredIndex = undefined
+  syncHighlightFromSelectedValue()
+  await nextTick()
+  focusSearchInput()
+  requestAnimationFrame(() => {
+    scrollHighlightedOptionIntoView('center')
+  })
+})
+
+watch(() => searchQuery, async (nextQuery) => {
+  if (!open || !nextQuery.trim()) {
+    return
+  }
+
+  await nextTick()
+  requestAnimationFrame(() => {
+    scrollOptionsToTop()
+  })
 })
 </script>
 
@@ -55,41 +194,70 @@ const displayLabel = $computed(() => {
   <Popover ::open="open">
     <PopoverTrigger as-child>
       <Button
+        v-bind="attrs"
         variant="outline"
         role="combobox"
+        :aria-expanded="open"
+        aria-haspopup="listbox"
         :class="cn('text-xs shadow-none justify-between font-normal px-2 py-1.5', props.class)"
       >
-        <span class="truncate" :class="!displayLabel && 'text-muted-foreground'">{{ displayLabel || placeholder }}</span>
+        <span class="truncate" :class="!selectedLabel && 'text-muted-foreground'">
+          {{ selectedLabel || placeholder }}
+        </span>
         <div class="i-lucide-chevrons-up-down ml-1 opacity-50 shrink-0 size-3" />
       </Button>
     </PopoverTrigger>
-    <PopoverContent class="p-0 min-w-[--reka-popover-trigger-width] w-auto">
-      <Command class="grid grid-rows-[auto_1fr]">
-        <CommandInput
-          :placeholder="searchPlaceholder"
-          class="text-xs h-8"
-        />
+    <PopoverContent
+      class="p-0 min-w-[--reka-popover-trigger-width] w-auto"
+      @open-auto-focus.prevent
+      @close-auto-focus.prevent
+    >
+      <div class="grid grid-rows-[auto_1fr]">
+        <div class="px-2 border-b flex items-center">
+          <Search aria-hidden="true" class="mr-2 opacity-50 shrink-0 h-4 w-4" />
+          <input
+            ref="inputRef"
+            v-model="searchQuery"
+            type="text"
+            role="searchbox"
+            :placeholder="searchPlaceholder"
+            class="text-xs outline-none border-0 bg-transparent h-8 w-full"
+            @keydown="handleInputKeydown"
+          >
+        </div>
         <ScrollArea ref="scrollAreaRef" class="max-h-40vh" type="auto">
-          <CommandList class="max-h-initial">
-            <CommandEmpty class="text-sm text-muted-foreground py-6 text-center">
+          <ul
+            ref="listRef"
+            role="listbox"
+            class="text-xs m-0 p-1 list-none"
+            @mouseleave="clearHoveredHighlight"
+          >
+            <li
+              v-for="(option, index) in filteredOptions"
+              :key="option.value"
+              role="option"
+              :aria-selected="props.modelValue === option.value"
+              :data-active-highlighted="index === highlightedIndex ? 'true' : undefined"
+              :class="cn(
+                'flex cursor-pointer list-none items-center gap-2 rounded-sm px-2 py-1.5',
+                index === activeHighlightedIndex && 'bg-muted',
+                props.modelValue === option.value && 'font-medium',
+              )"
+              @mouseenter="hoveredIndex = index"
+              @click="selectOption(option.value)"
+            >
+              <div class="i-lucide-check shrink-0 size-3.5" :class="props.modelValue === option.value ? 'opacity-100' : 'opacity-0'" />
+              <span class="truncate">{{ option.label }}</span>
+            </li>
+            <li
+              v-if="filteredOptions.length === 0"
+              class="text-sm text-muted-foreground px-2 py-6 text-center"
+            >
               {{ $t('edit.visualEditor.noResults') }}
-            </CommandEmpty>
-            <CommandGroup>
-              <CommandItem
-                v-for="opt in options"
-                :key="opt.value"
-                :value="opt.label"
-                class="text-xs gap-2"
-                :data-selected="modelValue === opt.value || undefined"
-                @select="emit('update:modelValue', opt.value); open = false"
-              >
-                <div class="i-lucide-check size-3.5" :class="modelValue === opt.value ? 'opacity-100' : 'opacity-0'" />
-                {{ opt.label }}
-              </CommandItem>
-            </CommandGroup>
-          </CommandList>
+            </li>
+          </ul>
         </ScrollArea>
-      </Command>
+      </div>
     </PopoverContent>
   </Popover>
 </template>


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [ ] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [x] 代码重构
- [ ] 测试用例
- [x] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

- 重写可视化编辑器动态选项下拉的 `Combobox` 内部实现，移除原有较重的 `Command` 结果列表路径，改为轻量搜索输入框和原生结果列表。
- 在打开下拉时阻止默认 autofocus，改为手动聚焦搜索输入框，并补齐搜索过滤、键盘高亮、Enter 提交、滚动定位和空状态展示等交互。
- 提取 `useParamChoiceFieldViewModel`，将选项合并、placeholder、custom label 和 select value 等派生逻辑从 `ParamRenderer` 的渲染期收敛到稳定视图模型中。
- 新增 `Combobox` 浏览器测试和 `useParamChoiceFieldViewModel` 单元测试，覆盖焦点、过滤、键盘导航、提交和动态/静态选项合并行为。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

- `changeFigure` 等动态选项场景在打开下拉时存在明显卡顿，主因是下拉打开瞬间的同步主线程工作过重。
- 旧实现依赖较重的结果列表组件树和默认焦点流程，打开时会引入额外的挂载、过滤和焦点扫描成本。
- 同时，`ParamRenderer` 中与选择字段相关的派生逻辑分散在渲染期执行，局部交互容易牵动不必要的重复计算。
- 这次改动的目标是收缩下拉打开路径上的同步开销，并稳定选择字段的派生数据边界。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
