### PR TITLE
✨ 支持 Combobox 与 CascadingCombobox 多关键词搜索

### DIFF
--- a/src/components/editor/param-renderer/ParamChoiceField.spec.ts
+++ b/src/components/editor/param-renderer/ParamChoiceField.spec.ts
@@ -200,7 +200,7 @@ describe('ParamChoiceField', () => {
             { id: 'group:sakiko', kind: 'group', label: 'sakiko', pathSegments: ['sakiko'], children: [] },
           ],
           searchDocuments: [
-            { rawLabel: 'sakiko/default', pathText: 'sakiko/default', value: 'sakiko/default' },
+            { label: 'sakiko/default', originalIndex: 0, pathText: 'sakiko/default', value: 'sakiko/default' },
           ],
         },
         customInputId: 'target-custom-input',

--- a/src/components/editor/param-renderer/ParamChoiceField.vue
+++ b/src/components/editor/param-renderer/ParamChoiceField.vue
@@ -4,8 +4,8 @@ import { normalizeFieldStringValue } from '~/features/editor/statement-editor/fi
 import { cn } from '~/lib/utils'
 
 import type { ParamSelectOptionItem } from './controls/types'
+import type { CascadingComboboxData } from '~/components/primitives/combobox/cascading-combobox-data'
 import type { StatementEditorSurface } from '~/features/editor/statement-editor/surface-context'
-import type { CascadingComboboxData } from '~/lib/cascading-combobox'
 
 interface Props {
   comboboxData?: CascadingComboboxData

--- a/src/components/editor/param-renderer/__tests__/useParamChoiceFieldViewModel.test.ts
+++ b/src/components/editor/param-renderer/__tests__/useParamChoiceFieldViewModel.test.ts
@@ -144,8 +144,8 @@ describe('useParamChoiceFieldViewModel', () => {
         },
       ],
       searchDocuments: [
-        { rawLabel: 'sakiko/maskon/kime01', pathText: 'sakiko/maskon/kime01', value: 'sakiko/maskon/kime01' },
-        { rawLabel: 'sakiko/default', pathText: 'sakiko/default', value: 'sakiko/default' },
+        { label: 'sakiko/maskon/kime01', originalIndex: 0, pathText: 'sakiko/maskon/kime01', value: 'sakiko/maskon/kime01' },
+        { label: 'sakiko/default', originalIndex: 1, pathText: 'sakiko/default', value: 'sakiko/default' },
       ],
     })
   })

--- a/src/components/editor/param-renderer/useParamChoiceFieldViewModel.ts
+++ b/src/components/editor/param-renderer/useParamChoiceFieldViewModel.ts
@@ -1,9 +1,9 @@
+import { buildCascadingComboboxData } from '~/components/primitives/combobox/cascading-combobox-data'
 import { isFlagChoiceField, resolveI18n } from '~/features/editor/command-registry/schema'
-import { buildCascadingComboboxData } from '~/lib/cascading-combobox'
 
 import type { ParamSelectOptionItem } from './controls/types'
+import type { CascadingComboboxData } from '~/components/primitives/combobox/cascading-combobox-data'
 import type { EditorField } from '~/features/editor/command-registry/schema'
-import type { CascadingComboboxData } from '~/lib/cascading-combobox'
 
 type ChoiceFieldMode = 'select' | 'combobox'
 type TranslateFn = (key: string, ...args: unknown[]) => string

--- a/src/components/primitives/CascadingCombobox.spec.ts
+++ b/src/components/primitives/CascadingCombobox.spec.ts
@@ -3,9 +3,9 @@ import { page, userEvent } from 'vitest/browser'
 import { defineComponent } from 'vue'
 
 import { renderInBrowser } from '~/__tests__/browser-render'
-import { buildCascadingComboboxData } from '~/lib/cascading-combobox'
 
 import CascadingCombobox from './CascadingCombobox.vue'
+import { buildCascadingComboboxData } from './combobox/cascading-combobox-data'
 
 interface FloatingRect {
   height: number
@@ -473,6 +473,21 @@ describe('CascadingCombobox', () => {
     expect(searchInput).toBeDefined()
     expect(activeOption).toBeDefined()
     expect(searchInput!.getAttribute('aria-activedescendant')).toBe(activeOption!.id)
+  })
+
+  it('会把搜索词按空格拆分并要求所有关键词都命中完整路径文本', async () => {
+    renderInBrowser(GroupedHarness, {
+      props: {
+        initialValue: 'sakiko/default',
+      },
+    })
+
+    await page.getByTestId('grouped-trigger').click()
+    await page.getByPlaceholder('Search motion').fill('sakiko kime01')
+
+    await expect.element(page.getByRole('option', { name: 'sakiko/maskon/kime01' })).toBeInTheDocument()
+    await expect.element(page.getByRole('option', { name: 'sakiko/default' })).not.toBeInTheDocument()
+    await expect.element(page.getByRole('option', { name: 'anon/cry01' })).not.toBeInTheDocument()
   })
 
   it('鼠标离开搜索结果列表时，不会回退到已有的键盘高亮项', async () => {

--- a/src/components/primitives/CascadingCombobox.vue
+++ b/src/components/primitives/CascadingCombobox.vue
@@ -4,10 +4,12 @@ import { ScrollAreaCorner, ScrollAreaRoot, ScrollAreaViewport } from 'reka-ui'
 
 import { cn } from '~/lib/utils'
 
+import { filterSearchOptionDocuments } from './combobox/search'
 import { useCascadingComboboxState } from './combobox/useCascadingComboboxState'
 
+import type { CascadingComboboxNode } from './combobox/cascading-combobox-data'
+import type { SearchOptionDocument } from './combobox/search'
 import type { HTMLAttributes } from 'vue'
-import type { CascadingComboboxNode, CascadingComboboxSearchDocument } from '~/lib/cascading-combobox'
 
 defineOptions({
   inheritAttrs: false,
@@ -18,7 +20,7 @@ const props = defineProps<{
   class?: HTMLAttributes['class']
   modelValue?: string
   placeholder?: string
-  searchDocuments: CascadingComboboxSearchDocument[]
+  searchDocuments: SearchOptionDocument[]
   searchPlaceholder?: string
 }>()
 
@@ -59,12 +61,7 @@ const activeSearchOptionId = $computed(() => (
 ))
 
 const searchResults = $computed(() => {
-  const keyword = searchQuery.trim().toLowerCase()
-  if (!keyword) {
-    return props.searchDocuments
-  }
-
-  return props.searchDocuments.filter(document => matchesSearchDocument(document, keyword))
+  return filterSearchOptionDocuments(props.searchDocuments, searchQuery)
 })
 
 const selectedLabel = $computed(() => {
@@ -73,13 +70,8 @@ const selectedLabel = $computed(() => {
   }
 
   const selectedDocument = props.searchDocuments.find(document => document.value === props.modelValue)
-  return selectedDocument?.rawLabel ?? props.modelValue
+  return selectedDocument?.label ?? props.modelValue
 })
-
-function matchesSearchDocument(document: CascadingComboboxSearchDocument, keyword: string): boolean {
-  return document.pathText.toLowerCase().includes(keyword)
-    || document.value.toLowerCase().includes(keyword)
-}
 
 function getSearchOptionId(index: number): string {
   return `${searchListboxId}-option-${index}`
@@ -431,7 +423,7 @@ watch(() => searchQuery, (nextQuery, previousQuery) => {
                 @click="selectOption(result.value)"
               >
                 <div class="i-lucide-check shrink-0 size-3.5" :class="props.modelValue === result.value ? 'opacity-100' : 'opacity-0'" />
-                <span class="truncate">{{ result.rawLabel }}</span>
+                <span class="truncate">{{ result.label }}</span>
               </li>
               <li
                 v-if="searchResults.length === 0"

--- a/src/components/primitives/Combobox.spec.ts
+++ b/src/components/primitives/Combobox.spec.ts
@@ -19,6 +19,12 @@ const baseOptions = [
   { label: 'Sad', value: 'sad' },
 ]
 
+const multiKeywordOptions = [
+  { label: 'Dark Joy', value: 'dark-joy' },
+  { label: 'Dark Sad', value: 'dark-sad' },
+  { label: 'Bright Joy', value: 'bright-joy' },
+]
+
 const scrollOptions = Array.from({ length: 20 }, (_, index) => ({
   label: `Option ${index + 1}`,
   value: `option-${index + 1}`,
@@ -134,6 +140,27 @@ const CenteredComboboxHarness = defineComponent({
   `,
 })
 
+const MultiKeywordComboboxHarness = defineComponent({
+  components: { Combobox },
+  setup() {
+    const modelValue = ref('')
+
+    return {
+      modelValue,
+      multiKeywordOptions,
+    }
+  },
+  template: `
+    <Combobox
+      v-model="modelValue"
+      data-testid="multi-keyword-trigger"
+      :options="multiKeywordOptions"
+      placeholder="Select option"
+      search-placeholder="Search option"
+    />
+  `,
+})
+
 describe('Combobox', () => {
   it('打开后会把焦点交给搜索框', async () => {
     renderInBrowser(ComboboxHarness, {
@@ -214,5 +241,20 @@ describe('Combobox', () => {
     await page.getByPlaceholder('Search motion').fill('zzz')
 
     await expect.element(page.getByText('edit.visualEditor.noResults')).toBeInTheDocument()
+  })
+
+  it('会把搜索词按空格拆分并要求所有关键词都命中', async () => {
+    renderInBrowser(MultiKeywordComboboxHarness, {
+      global: {
+        stubs: globalStubs,
+      },
+    })
+
+    await page.getByTestId('multi-keyword-trigger').click()
+    await page.getByPlaceholder('Search option').fill('joy dark')
+
+    await expect.element(page.getByRole('option', { name: 'Dark Joy' })).toBeInTheDocument()
+    await expect.element(page.getByRole('option', { name: 'Dark Sad' })).not.toBeInTheDocument()
+    await expect.element(page.getByRole('option', { name: 'Bright Joy' })).not.toBeInTheDocument()
   })
 })

--- a/src/components/primitives/Combobox.vue
+++ b/src/components/primitives/Combobox.vue
@@ -3,6 +3,8 @@ import { Search } from '@lucide/vue'
 
 import { cn } from '~/lib/utils'
 
+import { createSearchOptionDocuments, filterSearchOptionDocuments } from './combobox/search'
+
 import type { HTMLAttributes } from 'vue'
 
 defineOptions({
@@ -36,14 +38,10 @@ const attrs = useAttrs()
 const inputRef = $(useTemplateRef<HTMLInputElement>('inputRef'))
 const listRef = $(useTemplateRef<HTMLElement>('listRef'))
 const scrollAreaRef = $(useTemplateRef<ScrollAreaViewportHandle>('scrollAreaRef'))
+const searchDocuments = $computed(() => createSearchOptionDocuments(props.options))
 
-const filteredOptions = $computed(() => {
-  const keyword = searchQuery.trim().toLowerCase()
-  if (!keyword) {
-    return props.options
-  }
-
-  return props.options.filter(option => option.label.toLowerCase().includes(keyword))
+const filteredDocuments = $computed(() => {
+  return filterSearchOptionDocuments(searchDocuments, searchQuery)
 })
 
 const selectedLabel = $computed(() => {
@@ -51,7 +49,7 @@ const selectedLabel = $computed(() => {
     return ''
   }
 
-  const selected = props.options.find(option => option.value === props.modelValue)
+  const selected = searchDocuments.find(option => option.value === props.modelValue)
   return selected?.label ?? props.modelValue
 })
 
@@ -63,7 +61,7 @@ function focusSearchInput() {
 }
 
 function syncHighlightFromSelectedValue() {
-  highlightedIndex = filteredOptions.findIndex(option => option.value === props.modelValue)
+  highlightedIndex = filteredDocuments.findIndex(option => option.value === props.modelValue)
 }
 
 function clearHoveredHighlight() {
@@ -106,25 +104,25 @@ async function handleInputKeydown(event: KeyboardEvent) {
 
   if (event.key === 'ArrowDown') {
     event.preventDefault()
-    if (filteredOptions.length === 0) {
+    if (filteredDocuments.length === 0) {
       return
     }
     hoveredIndex = undefined
     highlightedIndex = currentIndex < 0
       ? 0
-      : Math.min(currentIndex + 1, filteredOptions.length - 1)
+      : Math.min(currentIndex + 1, filteredDocuments.length - 1)
     await scrollHighlightedOptionAfterNextTick('nearest')
     return
   }
 
   if (event.key === 'ArrowUp') {
     event.preventDefault()
-    if (filteredOptions.length === 0) {
+    if (filteredDocuments.length === 0) {
       return
     }
     hoveredIndex = undefined
     highlightedIndex = currentIndex < 0
-      ? filteredOptions.length - 1
+      ? filteredDocuments.length - 1
       : Math.max(currentIndex - 1, 0)
     await scrollHighlightedOptionAfterNextTick('nearest')
     return
@@ -132,7 +130,7 @@ async function handleInputKeydown(event: KeyboardEvent) {
 
   if (event.key === 'Enter' && currentIndex >= 0) {
     event.preventDefault()
-    selectOption(filteredOptions[currentIndex]!.value)
+    selectOption(filteredDocuments[currentIndex]!.value)
     return
   }
 
@@ -142,7 +140,7 @@ async function handleInputKeydown(event: KeyboardEvent) {
   }
 }
 
-watch(() => filteredOptions, (nextOptions) => {
+watch(() => filteredDocuments, (nextOptions) => {
   if (!open) {
     return
   }
@@ -233,7 +231,7 @@ watch(() => searchQuery, async (nextQuery) => {
             @mouseleave="clearHoveredHighlight"
           >
             <li
-              v-for="(option, index) in filteredOptions"
+              v-for="(option, index) in filteredDocuments"
               :key="option.value"
               role="option"
               :aria-selected="props.modelValue === option.value"
@@ -250,7 +248,7 @@ watch(() => searchQuery, async (nextQuery) => {
               <span class="truncate">{{ option.label }}</span>
             </li>
             <li
-              v-if="filteredOptions.length === 0"
+              v-if="filteredDocuments.length === 0"
               class="text-sm text-muted-foreground px-2 py-6 text-center"
             >
               {{ $t('edit.visualEditor.noResults') }}

--- a/src/components/primitives/combobox/CascadingBrowseLayer.vue
+++ b/src/components/primitives/combobox/CascadingBrowseLayer.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import { cn } from '~/lib/utils'
 
+import type { CascadingComboboxNode } from './cascading-combobox-data'
 import type { ComponentPublicInstance } from 'vue'
-import type { CascadingComboboxNode } from '~/lib/cascading-combobox'
 
 defineOptions({
   name: 'CascadingBrowseLayer',

--- a/src/components/primitives/combobox/__tests__/cascading-combobox-data.test.ts
+++ b/src/components/primitives/combobox/__tests__/cascading-combobox-data.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { buildCascadingComboboxData } from '../cascading-combobox'
+import { buildCascadingComboboxData } from '../cascading-combobox-data'
 
 describe('buildCascadingComboboxData', () => {
   it('会把同一路径前缀的候选项聚合成级联树，并保留搜索文档', () => {
@@ -31,9 +31,9 @@ describe('buildCascadingComboboxData', () => {
       },
     ])
     expect(result.searchDocuments).toEqual([
-      { rawLabel: 'anon/cry01', pathText: 'anon/cry01', value: 'anon/cry01' },
-      { rawLabel: 'anon/cry02', pathText: 'anon/cry02', value: 'anon/cry02' },
-      { rawLabel: 'saki/cry01', pathText: 'saki/cry01', value: 'saki/cry01' },
+      { label: 'anon/cry01', originalIndex: 0, pathText: 'anon/cry01', value: 'anon/cry01' },
+      { label: 'anon/cry02', originalIndex: 1, pathText: 'anon/cry02', value: 'anon/cry02' },
+      { label: 'saki/cry01', originalIndex: 2, pathText: 'saki/cry01', value: 'saki/cry01' },
     ])
   })
 
@@ -119,8 +119,8 @@ describe('buildCascadingComboboxData', () => {
       { kind: 'item', label: 'plain', rawLabel: 'plain', value: 'plain' },
     ])
     expect(result.searchDocuments).toEqual([
-      { rawLabel: 'sakiko/maskon/kime01', pathText: 'sakiko/maskon/kime01', value: 'sakiko/maskon/kime01' },
-      { rawLabel: 'plain', pathText: 'plain', value: 'plain' },
+      { label: 'sakiko/maskon/kime01', originalIndex: 0, pathText: 'sakiko/maskon/kime01', value: 'sakiko/maskon/kime01' },
+      { label: 'plain', originalIndex: 1, pathText: 'plain', value: 'plain' },
     ])
   })
 })

--- a/src/components/primitives/combobox/__tests__/search.test.ts
+++ b/src/components/primitives/combobox/__tests__/search.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+
+import { createSearchOptionDocuments, filterSearchOptionDocuments } from '../search'
+
+describe('createSearchOptionDocuments', () => {
+  it('会保留原始顺序并为每个选项附加 originalIndex', () => {
+    const documents = createSearchOptionDocuments([
+      { label: 'Joy', value: 'joy' },
+      { label: 'Sad', value: 'sad' },
+    ])
+
+    expect(documents).toEqual([
+      { label: 'Joy', originalIndex: 0, pathText: 'Joy', value: 'joy' },
+      { label: 'Sad', originalIndex: 1, pathText: 'Sad', value: 'sad' },
+    ])
+  })
+
+  it('会在 label 为空时回退到 value', () => {
+    const documents = createSearchOptionDocuments([
+      { label: '', value: 'joy' },
+    ])
+
+    expect(documents).toEqual([
+      { label: 'joy', originalIndex: 0, pathText: 'joy', value: 'joy' },
+    ])
+  })
+})
+
+describe('filterSearchOptionDocuments', () => {
+  const documents = createSearchOptionDocuments([
+    { label: 'sakiko/default', value: 'sakiko/default' },
+    { label: 'sakiko/maskon/kime01', value: 'sakiko/maskon/kime01' },
+    { label: 'anon/cry01', value: 'anon/cry01' },
+  ])
+
+  it('空查询时返回全部结果', () => {
+    expect(filterSearchOptionDocuments(documents, '')).toEqual(documents)
+  })
+
+  it('会按空格拆分关键词并要求全部命中', () => {
+    expect(filterSearchOptionDocuments(documents, 'sakiko kime01')).toEqual([
+      documents[1],
+    ])
+  })
+
+  it('会忽略多余空格并做大小写无关匹配', () => {
+    expect(filterSearchOptionDocuments(documents, '  SAKIKO   DEFAULT  ')).toEqual([
+      documents[0],
+    ])
+  })
+})

--- a/src/components/primitives/combobox/__tests__/useCascadingComboboxState.test.ts
+++ b/src/components/primitives/combobox/__tests__/useCascadingComboboxState.test.ts
@@ -1,10 +1,9 @@
 import { describe, expect, it } from 'vitest'
 
-import { buildCascadingComboboxData } from '~/lib/cascading-combobox'
-
+import { buildCascadingComboboxData } from '../cascading-combobox-data'
 import { useCascadingComboboxState } from '../useCascadingComboboxState'
 
-import type { CascadingComboboxNode } from '~/lib/cascading-combobox'
+import type { CascadingComboboxNode } from '../cascading-combobox-data'
 
 const groupedData = buildCascadingComboboxData([
   { label: 'anon/cry01', value: 'anon/cry01' },

--- a/src/components/primitives/combobox/cascading-combobox-data.ts
+++ b/src/components/primitives/combobox/cascading-combobox-data.ts
@@ -1,13 +1,6 @@
-interface ComboboxOptionItem {
-  label: string
-  value: string
-}
+import { createSearchOptionDocuments } from './search'
 
-export interface CascadingComboboxSearchDocument {
-  rawLabel: string
-  pathText: string
-  value: string
-}
+import type { SearchOptionDocument, SearchOptionItem } from './search'
 
 interface CascadingComboboxBaseNode {
   id: string
@@ -37,7 +30,7 @@ export interface BuildCascadingComboboxDataOptions {
 
 export interface CascadingComboboxData {
   browseNodes: CascadingComboboxNode[]
-  searchDocuments: CascadingComboboxSearchDocument[]
+  searchDocuments: SearchOptionDocument[]
 }
 
 function createGroupId(pathSegments: string[]): string {
@@ -48,8 +41,12 @@ function createItemId(value: string): string {
   return `item:${value}`
 }
 
+function normalizeOptionLabel(option: SearchOptionItem): string {
+  return option.label || option.value
+}
+
 function createLeafNode(
-  option: ComboboxOptionItem,
+  option: SearchOptionItem,
   label: string,
   pathSegments: string[],
 ): CascadingComboboxLeafNode {
@@ -65,16 +62,12 @@ function createLeafNode(
   }
 }
 
-function normalizeOptionLabel(option: ComboboxOptionItem): string {
-  return option.label || option.value
-}
-
 function shouldUsePathGrouping(options: BuildCascadingComboboxDataOptions): boolean {
   return options.grouping?.mode === 'path'
     && Boolean(options.resolvedDelimiter)
 }
 
-function buildFlatNodes(options: ComboboxOptionItem[]): CascadingComboboxLeafNode[] {
+function buildFlatNodes(options: SearchOptionItem[]): CascadingComboboxLeafNode[] {
   return options.map((option) => {
     const rawLabel = normalizeOptionLabel(option)
     return createLeafNode(option, rawLabel, [rawLabel])
@@ -89,7 +82,7 @@ function splitPathSegments(label: string, delimiter: string): string[] {
 }
 
 function buildGroupedNodes(
-  options: ComboboxOptionItem[],
+  options: SearchOptionItem[],
   delimiter: string,
 ): CascadingComboboxNode[] {
   const rootNodes: CascadingComboboxNode[] = []
@@ -134,16 +127,8 @@ function buildGroupedNodes(
   return rootNodes
 }
 
-function buildSearchDocuments(options: ComboboxOptionItem[]): CascadingComboboxSearchDocument[] {
-  return options.map(option => ({
-    rawLabel: normalizeOptionLabel(option),
-    pathText: normalizeOptionLabel(option),
-    value: option.value,
-  }))
-}
-
 export function buildCascadingComboboxData(
-  options: ComboboxOptionItem[],
+  options: SearchOptionItem[],
   config: BuildCascadingComboboxDataOptions = {},
 ): CascadingComboboxData {
   const browseNodes = shouldUsePathGrouping(config)
@@ -152,6 +137,6 @@ export function buildCascadingComboboxData(
 
   return {
     browseNodes,
-    searchDocuments: buildSearchDocuments(options),
+    searchDocuments: createSearchOptionDocuments(options),
   }
 }

--- a/src/components/primitives/combobox/search.ts
+++ b/src/components/primitives/combobox/search.ts
@@ -1,0 +1,53 @@
+export interface SearchOptionItem {
+  label: string
+  value: string
+}
+
+export interface SearchOptionDocument {
+  label: string
+  originalIndex: number
+  pathText: string
+  value: string
+}
+
+function normalizeSearchOptionLabel(option: SearchOptionItem): string {
+  return option.label || option.value
+}
+
+function tokenizeSearchQuery(query: string): string[] {
+  return query
+    .trim()
+    .toLowerCase()
+    .split(/\s+/)
+    .filter(Boolean)
+}
+
+export function createSearchOptionDocuments(
+  options: SearchOptionItem[],
+): SearchOptionDocument[] {
+  return options.map((option, index) => {
+    const label = normalizeSearchOptionLabel(option)
+
+    return {
+      label,
+      originalIndex: index,
+      pathText: label,
+      value: option.value,
+    }
+  })
+}
+
+export function filterSearchOptionDocuments(
+  documents: SearchOptionDocument[],
+  query: string,
+): SearchOptionDocument[] {
+  const tokens = tokenizeSearchQuery(query)
+  if (tokens.length === 0) {
+    return documents
+  }
+
+  return documents.filter((document) => {
+    const normalizedPathText = document.pathText.toLowerCase()
+    return tokens.every(token => normalizedPathText.includes(token))
+  })
+}

--- a/src/components/primitives/combobox/useCascadingComboboxState.ts
+++ b/src/components/primitives/combobox/useCascadingComboboxState.ts
@@ -1,5 +1,5 @@
+import type { CascadingComboboxNode } from './cascading-combobox-data'
 import type { ShallowRef } from 'vue'
-import type { CascadingComboboxNode } from '~/lib/cascading-combobox'
 
 interface IndexedNodeRecord {
   ancestorGroupIds: string[]


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [ ] 错误修复
- [x] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [ ] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

本 PR 为 `Combobox` 和 `CascadingCombobox` 增加了多关键词搜索能力。

搜索行为调整为：

- 按空格拆分搜索词
- 忽略空 token
- 大小写不敏感
- 所有关键词都必须命中候选项文本

例如：

- `joy dark` 可以命中 `Dark Joy`
- `ano smile` 可以命中 `anon/smile01`

同时，本 PR 将两类组件的搜索实现统一到同一套共享逻辑上，保证搜索语义一致，并补充了对应测试。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

当前 `Combobox` 和 `CascadingCombobox` 的搜索只支持单段字符串的大小写无关 `includes` 匹配。

这会导致一个问题：

- 用户输入多个关键词时，只有在关键词以连续子串形式出现时才能命中
- 像 `joy dark`、`ano smile` 这类更自然的组合搜索无法工作

本次更改的目标是让 combobox 搜索更符合用户输入习惯，同时保持交互简单、可预测，不引入模糊匹配、排序或第三方搜索库。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->

实现上顺带做了以下整理：

- 统一了 `Combobox` 和 `CascadingCombobox` 的搜索文档结构
- 将 combobox 专属搜索与级联数据构建收敛到同一 primitive 子目录
- 删除了不再需要的旧实现路径，避免留下兼容层和重复逻辑

本次没有引入：

- 搜索排序
- 搜索防抖
- fuzzy / typo tolerance
- 第三方搜索库

### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
