### PR TITLE
🐛 修复编辑器预览异常整页刷新并收敛预览会话状态

### DIFF
--- a/src/components/editor/AssetView.spec.ts
+++ b/src/components/editor/AssetView.spec.ts
@@ -443,6 +443,10 @@ let previewSessionStoreState: {
   currentGameServeUrl: string | undefined
 }
 
+function setPreviewUnavailable() {
+  previewSessionStoreState.currentGameServeUrl = undefined
+}
+
 describe('AssetView', () => {
   beforeEach(() => {
     fileSystemEventHandlers.clear()
@@ -542,7 +546,7 @@ describe('AssetView', () => {
         path: '/project',
       },
     }))
-    previewSessionStoreState.currentGameServeUrl = undefined
+    setPreviewUnavailable()
 
     renderInBrowser(createHarness('background'), {
       global: {
@@ -594,7 +598,7 @@ describe('AssetView', () => {
         path: '/project',
       },
     }))
-    previewSessionStoreState.currentGameServeUrl = undefined
+    setPreviewUnavailable()
 
     renderInBrowser(createHarness('background'), {
       global: {
@@ -640,7 +644,7 @@ describe('AssetView', () => {
         path: '/project',
       },
     }))
-    previewSessionStoreState.currentGameServeUrl = undefined
+    setPreviewUnavailable()
 
     renderInBrowser(createHarness('background'), {
       global: {
@@ -675,7 +679,7 @@ describe('AssetView', () => {
         path: '/project',
       },
     }))
-    previewSessionStoreState.currentGameServeUrl = undefined
+    setPreviewUnavailable()
     usePreferenceStoreMock.mockReturnValue(reactive({
       assetViewMode: 'list',
       assetZoom: [100],
@@ -714,7 +718,7 @@ describe('AssetView', () => {
         path: '/project',
       },
     }))
-    previewSessionStoreState.currentGameServeUrl = undefined
+    setPreviewUnavailable()
 
     renderInBrowser(createHarness('background'), {
       global: {
@@ -1063,7 +1067,7 @@ describe('AssetView', () => {
         path: '/project',
       },
     }))
-    previewSessionStoreState.currentGameServeUrl = undefined
+    setPreviewUnavailable()
 
     renderInBrowser(createHarness('animation'), {
       global: {
@@ -1130,7 +1134,7 @@ describe('AssetView', () => {
         path: '/project',
       },
     }))
-    previewSessionStoreState.currentGameServeUrl = undefined
+    setPreviewUnavailable()
 
     renderInBrowser(createHarness('background'), {
       global: {
@@ -1170,7 +1174,7 @@ describe('AssetView', () => {
         path: '/project',
       },
     }))
-    previewSessionStoreState.currentGameServeUrl = undefined
+    setPreviewUnavailable()
 
     renderInBrowser(createCreateFolderAndChangePathHarness('background'), {
       global: {
@@ -1237,7 +1241,7 @@ describe('AssetView', () => {
         path: '/project',
       },
     }))
-    previewSessionStoreState.currentGameServeUrl = undefined
+    setPreviewUnavailable()
 
     renderInBrowser(createHarness('background', { searchQuery: 'hero' }), {
       global: {
@@ -1355,7 +1359,7 @@ describe('AssetView', () => {
         path: '/project',
       },
     }))
-    previewSessionStoreState.currentGameServeUrl = undefined
+    setPreviewUnavailable()
 
     renderInBrowser(createHarness('background'), {
       global: {

--- a/src/components/editor/AssetView.spec.ts
+++ b/src/components/editor/AssetView.spec.ts
@@ -27,6 +27,7 @@ const {
   renameFileMock,
   useFileStoreMock,
   usePreferenceStoreMock,
+  usePreviewSessionStoreMock,
   useTabsStoreMock,
   useWorkspaceStoreMock,
 } = vi.hoisted(() => ({
@@ -42,6 +43,7 @@ const {
   renameFileMock: vi.fn(),
   useFileStoreMock: vi.fn(),
   usePreferenceStoreMock: vi.fn(),
+  usePreviewSessionStoreMock: vi.fn(),
   useTabsStoreMock: vi.fn(),
   useWorkspaceStoreMock: vi.fn(),
 }))
@@ -176,6 +178,10 @@ vi.mock('~/stores/file', () => ({
 
 vi.mock('~/stores/preference', () => ({
   usePreferenceStore: usePreferenceStoreMock,
+}))
+
+vi.mock('~/stores/preview-session', () => ({
+  usePreviewSessionStore: usePreviewSessionStoreMock,
 }))
 
 vi.mock('~/stores/tabs', () => ({
@@ -433,6 +439,10 @@ const commonGlobalStubs = {
   PopoverContent: createBrowserContainerStub('StubPopoverContent'),
 }
 
+let previewSessionStoreState: {
+  currentGameServeUrl: string | undefined
+}
+
 describe('AssetView', () => {
   beforeEach(() => {
     fileSystemEventHandlers.clear()
@@ -447,6 +457,7 @@ describe('AssetView', () => {
     renameFileMock.mockReset()
     useFileStoreMock.mockReset()
     usePreferenceStoreMock.mockReset()
+    usePreviewSessionStoreMock.mockReset()
     useTabsStoreMock.mockReset()
     useWorkspaceStoreMock.mockReset()
 
@@ -470,11 +481,14 @@ describe('AssetView', () => {
       openTab: vi.fn(),
       tabs: [],
     })
+    previewSessionStoreState = reactive({
+      currentGameServeUrl: 'http://127.0.0.1:8899/game/demo/',
+    })
+    usePreviewSessionStoreMock.mockReturnValue(previewSessionStoreState)
     useWorkspaceStoreMock.mockReturnValue(reactive({
       currentGame: {
         path: '/games/demo',
       },
-      currentGameServeUrl: 'http://127.0.0.1:8899/game/demo/',
     }))
     fileSystemEventsOnMock.mockImplementation((eventType: string, handler: (event: Record<string, unknown>) => void) => {
       const handlers = fileSystemEventHandlers.get(eventType) ?? []
@@ -527,8 +541,8 @@ describe('AssetView', () => {
       currentGame: {
         path: '/project',
       },
-      currentGameServeUrl: undefined,
     }))
+    previewSessionStoreState.currentGameServeUrl = undefined
 
     renderInBrowser(createHarness('background'), {
       global: {
@@ -579,8 +593,8 @@ describe('AssetView', () => {
       currentGame: {
         path: '/project',
       },
-      currentGameServeUrl: undefined,
     }))
+    previewSessionStoreState.currentGameServeUrl = undefined
 
     renderInBrowser(createHarness('background'), {
       global: {
@@ -625,8 +639,8 @@ describe('AssetView', () => {
       currentGame: {
         path: '/project',
       },
-      currentGameServeUrl: undefined,
     }))
+    previewSessionStoreState.currentGameServeUrl = undefined
 
     renderInBrowser(createHarness('background'), {
       global: {
@@ -660,8 +674,8 @@ describe('AssetView', () => {
       currentGame: {
         path: '/project',
       },
-      currentGameServeUrl: undefined,
     }))
+    previewSessionStoreState.currentGameServeUrl = undefined
     usePreferenceStoreMock.mockReturnValue(reactive({
       assetViewMode: 'list',
       assetZoom: [100],
@@ -699,8 +713,8 @@ describe('AssetView', () => {
       currentGame: {
         path: '/project',
       },
-      currentGameServeUrl: undefined,
     }))
+    previewSessionStoreState.currentGameServeUrl = undefined
 
     renderInBrowser(createHarness('background'), {
       global: {
@@ -1048,8 +1062,8 @@ describe('AssetView', () => {
       currentGame: {
         path: '/project',
       },
-      currentGameServeUrl: undefined,
     }))
+    previewSessionStoreState.currentGameServeUrl = undefined
 
     renderInBrowser(createHarness('animation'), {
       global: {
@@ -1115,8 +1129,8 @@ describe('AssetView', () => {
       currentGame: {
         path: '/project',
       },
-      currentGameServeUrl: undefined,
     }))
+    previewSessionStoreState.currentGameServeUrl = undefined
 
     renderInBrowser(createHarness('background'), {
       global: {
@@ -1155,8 +1169,8 @@ describe('AssetView', () => {
       currentGame: {
         path: '/project',
       },
-      currentGameServeUrl: undefined,
     }))
+    previewSessionStoreState.currentGameServeUrl = undefined
 
     renderInBrowser(createCreateFolderAndChangePathHarness('background'), {
       global: {
@@ -1222,8 +1236,8 @@ describe('AssetView', () => {
       currentGame: {
         path: '/project',
       },
-      currentGameServeUrl: undefined,
     }))
+    previewSessionStoreState.currentGameServeUrl = undefined
 
     renderInBrowser(createHarness('background', { searchQuery: 'hero' }), {
       global: {
@@ -1340,8 +1354,8 @@ describe('AssetView', () => {
       currentGame: {
         path: '/project',
       },
-      currentGameServeUrl: undefined,
     }))
+    previewSessionStoreState.currentGameServeUrl = undefined
 
     renderInBrowser(createHarness('background'), {
       global: {

--- a/src/components/editor/AssetView.vue
+++ b/src/components/editor/AssetView.vue
@@ -11,6 +11,7 @@ import { gameFs } from '~/services/game-fs'
 import { gameAssetDir } from '~/services/platform/app-paths'
 import { FileSystemItem, useFileStore } from '~/stores/file'
 import { usePreferenceStore } from '~/stores/preference'
+import { usePreviewSessionStore } from '~/stores/preview-session'
 import { useTabsStore } from '~/stores/tabs'
 import { useWorkspaceStore } from '~/stores/workspace'
 import { FileViewerItem, FileViewerSortBy, FileViewerSortOrder } from '~/types/file-viewer'
@@ -49,6 +50,7 @@ const preferenceStore = usePreferenceStore()
 const tabsStore = useTabsStore()
 const fileStore = useFileStore()
 const fileSystemEvents = useFileSystemEvents()
+const previewSessionStore = usePreviewSessionStore()
 const workspaceStore = useWorkspaceStore()
 const { t } = useI18n()
 
@@ -175,7 +177,7 @@ const renamePopoverAlign = $computed(() =>
   preferenceStore.assetViewMode === 'grid' ? 'center' : 'start',
 )
 const previewCwd = $computed(() => workspaceStore.currentGame?.path)
-const previewBaseUrl = $computed(() => workspaceStore.currentGameServeUrl)
+const previewBaseUrl = $computed(() => previewSessionStore.currentGameServeUrl)
 
 const isRenameDuplicate = $computed(() => {
   const currentItem = renameTargetItem

--- a/src/components/editor/EditHeader.spec.ts
+++ b/src/components/editor/EditHeader.spec.ts
@@ -22,6 +22,7 @@ const {
   routerPushMock,
   toastErrorMock,
   useModalStoreMock,
+  usePreviewSessionStoreMock,
   useWorkspaceStoreMock,
 } = vi.hoisted(() => ({
   getConfigMock: vi.fn(),
@@ -31,6 +32,7 @@ const {
   routerPushMock: vi.fn(),
   toastErrorMock: vi.fn(),
   useModalStoreMock: vi.fn(),
+  usePreviewSessionStoreMock: vi.fn(),
   useWorkspaceStoreMock: vi.fn(),
 }))
 
@@ -69,6 +71,10 @@ vi.mock('~/services/platform/app-paths', () => ({
 
 vi.mock('~/stores/modal', () => ({
   useModalStore: useModalStoreMock,
+}))
+
+vi.mock('~/stores/preview-session', () => ({
+  usePreviewSessionStore: usePreviewSessionStoreMock,
 }))
 
 vi.mock('~/stores/workspace', () => ({
@@ -142,6 +148,7 @@ describe('EditHeader', () => {
     routerPushMock.mockReset()
     toastErrorMock.mockReset()
     useModalStoreMock.mockReset()
+    usePreviewSessionStoreMock.mockReset()
     useWorkspaceStoreMock.mockReset()
 
     useModalStoreMock.mockReturnValue({
@@ -163,6 +170,8 @@ describe('EditHeader', () => {
           },
         },
       },
+    }))
+    usePreviewSessionStoreMock.mockReturnValue(reactive({
       currentGameServeUrl: 'http://127.0.0.1:8899/game/test/',
     }))
     getConfigMock.mockResolvedValue({
@@ -217,6 +226,8 @@ describe('EditHeader', () => {
     useWorkspaceStoreMock.mockReturnValue(reactive({
       CWD: String.raw`C:\Users\Akirami\Documents\WebGALCraft\games\test`,
       currentGame: undefined,
+    }))
+    usePreviewSessionStoreMock.mockReturnValue(reactive({
       currentGameServeUrl: undefined,
     }))
 

--- a/src/components/editor/EditHeader.vue
+++ b/src/components/editor/EditHeader.vue
@@ -7,6 +7,7 @@ import { parseGameConfigFormValues } from '~/features/modals/game-config/game-co
 import { configManager } from '~/services/config-manager'
 import { gameAssetDir } from '~/services/platform/app-paths'
 import { useModalStore } from '~/stores/modal'
+import { usePreviewSessionStore } from '~/stores/preview-session'
 import { useWorkspaceStore } from '~/stores/workspace'
 import { handleError } from '~/utils/error-handler'
 
@@ -22,6 +23,7 @@ function handleBack() {
 }
 
 const workspaceStore = useWorkspaceStore()
+const previewSessionStore = usePreviewSessionStore()
 const modalStore = useModalStore()
 
 const HEADER_ICON_THUMBNAIL = {
@@ -30,7 +32,8 @@ const HEADER_ICON_THUMBNAIL = {
   resizeMode: 'contain',
 } as const
 
-const canTestGame = $computed(() => !!workspaceStore.currentGameServeUrl && !!workspaceStore.currentGame)
+const currentGameServeUrl = $computed(() => previewSessionStore.currentGameServeUrl)
+const canTestGame = $computed(() => !!currentGameServeUrl && !!workspaceStore.currentGame)
 const canOpenGameConfig = $computed(() => !!workspaceStore.currentGame?.path)
 const testWindowLabel = $computed(() => (workspaceStore.currentGame ? `test-${workspaceStore.currentGame.id}` : ''))
 
@@ -42,7 +45,6 @@ let isGameConfigOpening = false
 
 async function handleOpenGameConfig() {
   const currentGame = workspaceStore.currentGame
-  const currentGameServeUrl = workspaceStore.currentGameServeUrl
 
   if (!currentGame?.path || isGameConfigOpening) {
     return
@@ -79,7 +81,7 @@ async function handleOpenGameConfig() {
 }
 
 async function handleTestGame() {
-  const gameUrl = workspaceStore.currentGameServeUrl
+  const gameUrl = currentGameServeUrl
   const currentGame = workspaceStore.currentGame
 
   if (!canTestGame) {
@@ -133,7 +135,7 @@ async function handleTestGame() {
 }
 
 watch(
-  [() => workspaceStore.currentGame?.id, () => workspaceStore.currentGameServeUrl],
+  [() => workspaceStore.currentGame?.id, () => currentGameServeUrl],
   ([gameId]) => {
     if (gameId) {
       lastTestWindowLabel = `test-${gameId}`
@@ -180,7 +182,7 @@ onBeforeUnmount(() => {
         <AssetImage
           :path="workspaceStore.currentGame?.previewAssets.icon.path"
           :root-path="workspaceStore.CWD"
-          :serve-url="workspaceStore.currentGameServeUrl"
+          :serve-url="currentGameServeUrl"
           :alt="`${workspaceStore.currentGame?.metadata.name} 游戏图标`"
           :cache-version="workspaceStore.currentGame?.previewAssets.icon.cacheVersion"
           :thumbnail="HEADER_ICON_THUMBNAIL"

--- a/src/components/editor/PreviewPanel.spec.ts
+++ b/src/components/editor/PreviewPanel.spec.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { page } from 'vitest/browser'
-import { reactive, ref } from 'vue'
+import { nextTick, reactive, ref } from 'vue'
 
 import { createBrowserLiteI18n } from '~/__tests__/browser'
 import { createBrowserClickStub, createBrowserContainerStub, renderInBrowser } from '~/__tests__/browser-render'
@@ -10,6 +10,7 @@ const {
   getGameConfigMock,
   notifySuccessMock,
   openUrlMock,
+  usePreviewSessionStoreMock,
   useClipboardMock,
   useWorkspaceStoreMock,
 } = vi.hoisted(() => ({
@@ -17,6 +18,7 @@ const {
   getGameConfigMock: vi.fn(),
   notifySuccessMock: vi.fn(),
   openUrlMock: vi.fn(),
+  usePreviewSessionStoreMock: vi.fn(),
   useClipboardMock: vi.fn(),
   useWorkspaceStoreMock: vi.fn(),
 }))
@@ -44,6 +46,10 @@ vi.mock('@vueuse/core', async () => {
 
 vi.mock('~/stores/workspace', () => ({
   useWorkspaceStore: useWorkspaceStoreMock,
+}))
+
+vi.mock('~/stores/preview-session', () => ({
+  usePreviewSessionStore: usePreviewSessionStoreMock,
 }))
 
 vi.mock('~/commands/game', async () => {
@@ -82,7 +88,18 @@ let workspaceStoreState: {
     }
     path: string
   }
+}
+
+let previewSessionStoreState: {
   currentGameServeUrl: string
+  reloadVersion: number
+  refresh: () => void
+}
+
+async function flushPreviewWatchers() {
+  await Promise.resolve()
+  await nextTick()
+  await Promise.resolve()
 }
 
 function createPreviewPanelLiteI18n() {
@@ -109,6 +126,7 @@ describe('PreviewPanel', () => {
     getGameConfigMock.mockReset()
     notifySuccessMock.mockReset()
     openUrlMock.mockReset()
+    usePreviewSessionStoreMock.mockReset()
     useClipboardMock.mockReset()
     useWorkspaceStoreMock.mockReset()
 
@@ -120,9 +138,16 @@ describe('PreviewPanel', () => {
         },
         path: '/games/demo',
       },
-      currentGameServeUrl: 'http://127.0.0.1:8899',
     })
     useWorkspaceStoreMock.mockReturnValue(workspaceStoreState)
+    previewSessionStoreState = reactive({
+      currentGameServeUrl: 'http://127.0.0.1:8899',
+      reloadVersion: 0,
+      refresh() {
+        this.reloadVersion++
+      },
+    })
+    usePreviewSessionStoreMock.mockReturnValue(previewSessionStoreState)
     useClipboardMock.mockReturnValue({
       copied: ref(true),
       copy: copyMock,
@@ -178,7 +203,7 @@ describe('PreviewPanel', () => {
     expect(getGameConfigMock).toHaveBeenCalledTimes(2)
   })
 
-  it('当前游戏快照更新时间变化时会自动重新读取游戏配置', async () => {
+  it('当前游戏快照更新时间变化时不会自动重新读取游戏配置', async () => {
     renderInBrowser(PreviewPanel, {
       global: {
         plugins: [createPreviewPanelLiteI18n()],
@@ -191,6 +216,24 @@ describe('PreviewPanel', () => {
     })
 
     workspaceStoreState.currentGame.lastModified += 1
+    await flushPreviewWatchers()
+
+    expect(getGameConfigMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('预览 reloadVersion 变化时会自动重新读取游戏配置', async () => {
+    renderInBrowser(PreviewPanel, {
+      global: {
+        plugins: [createPreviewPanelLiteI18n()],
+        stubs: globalStubs,
+      },
+    })
+
+    await vi.waitFor(() => {
+      expect(getGameConfigMock).toHaveBeenCalledTimes(1)
+    })
+
+    previewSessionStoreState.refresh()
 
     await vi.waitFor(() => {
       expect(getGameConfigMock).toHaveBeenCalledTimes(2)

--- a/src/components/editor/PreviewPanel.vue
+++ b/src/components/editor/PreviewPanel.vue
@@ -7,13 +7,15 @@ import {
   DEFAULT_PREVIEW_PANEL_ASPECT_RATIO,
   resolvePreviewPanelStageSize,
 } from '~/features/editor/preview/preview-panel'
+import { usePreviewSessionStore } from '~/stores/preview-session'
 import { useWorkspaceStore } from '~/stores/workspace'
 import { handleError } from '~/utils/error-handler'
 
 const workspaceStore = useWorkspaceStore()
+const previewSessionStore = usePreviewSessionStore()
 
-const previewUrl = $computed(() => workspaceStore.currentGameServeUrl ?? '')
-const hasPreviewUrl = $computed(() => !!workspaceStore.currentGameServeUrl)
+const previewUrl = $computed(() => previewSessionStore.currentGameServeUrl ?? '')
+const hasPreviewUrl = $computed(() => !!previewSessionStore.currentGameServeUrl)
 
 const { t } = useI18n()
 const { copy, copied } = useClipboard({ source: $$(previewUrl) })
@@ -97,12 +99,8 @@ watch(
 )
 
 watch(
-  () => workspaceStore.currentGame?.lastModified,
-  (lastModified, previousLastModified) => {
-    if (lastModified === undefined || previousLastModified === undefined) {
-      return
-    }
-
+  () => previewSessionStore.reloadVersion,
+  () => {
     refreshIframe()
   },
 )
@@ -130,7 +128,7 @@ watch(
           </Tooltip>
           <Tooltip>
             <TooltipTrigger as-child>
-              <Button variant="ghost" size="icon" class="size-6" @click="refreshIframe">
+              <Button variant="ghost" size="icon" class="size-6" @click="previewSessionStore.refresh()">
                 <RotateCw class="size-4" />
                 <span class="sr-only">{{ $t('edit.previewPanel.refreshPreview') }}</span>
               </Button>

--- a/src/components/editor/StatementEditorPanel.spec.ts
+++ b/src/components/editor/StatementEditorPanel.spec.ts
@@ -35,6 +35,7 @@ const {
   useStatementAnimationEditorBridgeMock,
   useStatementEditorMock,
   useStatementEffectEditorBridgeMock,
+  usePreviewSessionStoreMock,
   useWorkspaceStoreMock,
 } = vi.hoisted(() => ({
   handleCommentChangeMock: vi.fn(),
@@ -55,6 +56,7 @@ const {
   useStatementAnimationEditorBridgeMock: vi.fn(),
   useStatementEditorMock: vi.fn(),
   useStatementEffectEditorBridgeMock: vi.fn(),
+  usePreviewSessionStoreMock: vi.fn(),
   useWorkspaceStoreMock: vi.fn(),
 }))
 
@@ -93,6 +95,10 @@ vi.mock('~/composables/useControlId', () => ({
 
 vi.mock('~/stores/edit-settings', () => ({
   useEditSettingsStore: useEditSettingsStoreMock,
+}))
+
+vi.mock('~/stores/preview-session', () => ({
+  usePreviewSessionStore: usePreviewSessionStoreMock,
 }))
 
 vi.mock('~/stores/workspace', () => ({
@@ -318,6 +324,7 @@ describe('StatementEditorPanel', () => {
     useStatementAnimationEditorBridgeMock.mockReset()
     useStatementEditorMock.mockReset()
     useStatementEffectEditorBridgeMock.mockReset()
+    usePreviewSessionStoreMock.mockReset()
     useWorkspaceStoreMock.mockReset()
 
     useEditSettingsStoreMock.mockReturnValue({
@@ -334,6 +341,8 @@ describe('StatementEditorPanel', () => {
     })
     useWorkspaceStoreMock.mockReturnValue(reactive({
       CWD: '/games/demo',
+    }))
+    usePreviewSessionStoreMock.mockReturnValue(reactive({
       currentGameServeUrl: 'http://127.0.0.1:8899',
     }))
     gameAssetDirMock.mockImplementation(async (_cwd: string, assetType: string) => `/games/demo/assets/${assetType}`)

--- a/src/components/editor/StatementEditorPanel.vue
+++ b/src/components/editor/StatementEditorPanel.vue
@@ -8,6 +8,7 @@ import { normalizeStatementPanelSingleLineValue, resolveStatementPanelPreviewMed
 import { statementEditorSurfaceKey } from '~/features/editor/statement-editor/surface-context'
 import { isStatementInteractiveTarget, useStatementEditor } from '~/features/editor/statement-editor/useStatementEditor'
 import { useEditSettingsStore } from '~/stores/edit-settings'
+import { usePreviewSessionStore } from '~/stores/preview-session'
 import { useWorkspaceStore } from '~/stores/workspace'
 
 import type { StatementUpdatePayload, StatementUpdateTarget } from '~/features/editor/statement-editor/useStatementEditor'
@@ -110,13 +111,14 @@ watch(
 )
 
 const editSettings = useEditSettingsStore()
+const previewSessionStore = usePreviewSessionStore()
 const workspaceStore = useWorkspaceStore()
 
 const previewMedia = $computed(() => {
   const previewContext = {
     cwd: workspaceStore.CWD,
     fileRootPaths: resource.fileRootPaths.value,
-    previewBaseUrl: workspaceStore.currentGameServeUrl,
+    previewBaseUrl: previewSessionStore.currentGameServeUrl,
     showSidebarAssetPreview: editSettings.showSidebarAssetPreview,
   }
 

--- a/src/components/file-picker/FilePicker.spec.ts
+++ b/src/components/file-picker/FilePicker.spec.ts
@@ -8,17 +8,20 @@ import { createBrowserClickStub, createBrowserContainerStub, renderInBrowser } f
 const {
   existsMock,
   normalizeMock,
+  previewSessionStoreState,
   readDirectoryMock,
   statMock,
   workspaceStoreState,
 } = vi.hoisted(() => ({
   existsMock: vi.fn(),
   normalizeMock: vi.fn(async (value: string) => value.replaceAll('\\', '/')),
+  previewSessionStoreState: {
+    currentGameServeUrl: 'http://127.0.0.1:8899/game/demo/',
+  },
   readDirectoryMock: vi.fn(),
   statMock: vi.fn(),
   workspaceStoreState: {
     CWD: '/games/demo',
-    currentGameServeUrl: 'http://127.0.0.1:8899/game/demo/',
   },
 }))
 
@@ -55,6 +58,10 @@ vi.mock('~/composables/useDirectoryReader', () => ({
 
 vi.mock('~/stores/workspace', () => ({
   useWorkspaceStore: () => workspaceStoreState,
+}))
+
+vi.mock('~/stores/preview-session', () => ({
+  usePreviewSessionStore: () => previewSessionStoreState,
 }))
 
 import FilePicker from './FilePicker.vue'
@@ -194,7 +201,7 @@ describe('FilePicker', () => {
       isDirectory: true,
     })
     workspaceStoreState.CWD = '/games/demo'
-    workspaceStoreState.currentGameServeUrl = 'http://127.0.0.1:8899/game/demo/'
+    previewSessionStoreState.currentGameServeUrl = 'http://127.0.0.1:8899/game/demo/'
   })
 
   it('同步外部文件路径中间态时不会立即归一化并回写父层', async () => {

--- a/src/components/file-picker/FilePicker.vue
+++ b/src/components/file-picker/FilePicker.vue
@@ -6,6 +6,7 @@ import { useFilePickerController } from '~/features/file-picker/useFilePickerCon
 import { useFilePickerHistory } from '~/features/file-picker/useFilePickerHistory'
 import { cn } from '~/lib/utils'
 import { usePreferenceStore } from '~/stores/preference'
+import { usePreviewSessionStore } from '~/stores/preview-session'
 import { useWorkspaceStore } from '~/stores/workspace'
 import { FileViewerSortBy, FileViewerSortOrder } from '~/types/file-viewer'
 
@@ -68,6 +69,7 @@ let modelValue = $(defineModel<string>({ default: '' }))
 
 const slots = useSlots()
 const preferenceStore = usePreferenceStore()
+const previewSessionStore = usePreviewSessionStore()
 const workspaceStore = useWorkspaceStore()
 const { readDirectory, ensurePathWithinRoot } = useDirectoryReader()
 
@@ -303,7 +305,7 @@ function handleFileListKeydown(event: KeyboardEvent) {
           ref="fileViewerRef"
           :items="filteredItems"
           :preview-cwd="workspaceStore.CWD"
-          :preview-base-url="workspaceStore.currentGameServeUrl"
+          :preview-base-url="previewSessionStore.currentGameServeUrl"
           :view-mode="viewMode"
           :zoom="zoomPercent"
           :sortable-headers="false"

--- a/src/services/__tests__/config-manager.test.ts
+++ b/src/services/__tests__/config-manager.test.ts
@@ -3,9 +3,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { configManager } from '~/services/config-manager'
 
 const {
+  refreshIfCurrentGameMock,
   refreshRegisteredGameSnapshotMock,
   setGameConfigMock,
 } = vi.hoisted(() => ({
+  refreshIfCurrentGameMock: vi.fn(),
   refreshRegisteredGameSnapshotMock: vi.fn(),
   setGameConfigMock: vi.fn(),
 }))
@@ -22,13 +24,20 @@ vi.mock('~/services/game-manager', () => ({
   },
 }))
 
+vi.mock('~/stores/preview-session', () => ({
+  usePreviewSessionStore: () => ({
+    refreshIfCurrentGame: refreshIfCurrentGameMock,
+  }),
+}))
+
 describe('configManager 配置管理', () => {
   beforeEach(() => {
+    refreshIfCurrentGameMock.mockReset()
     refreshRegisteredGameSnapshotMock.mockReset()
     setGameConfigMock.mockReset()
   })
 
-  it('setConfig 会写入配置并刷新已注册游戏快照', async () => {
+  it('setConfig 会写入配置、刷新已注册游戏快照并触发当前预览重载', async () => {
     await configManager.setConfig('/game', {
       entries: [
         {
@@ -47,5 +56,6 @@ describe('configManager 配置管理', () => {
       ],
     })
     expect(refreshRegisteredGameSnapshotMock).toHaveBeenCalledWith('/game')
+    expect(refreshIfCurrentGameMock).toHaveBeenCalledWith('/game')
   })
 })

--- a/src/services/config-manager.ts
+++ b/src/services/config-manager.ts
@@ -1,5 +1,6 @@
 import { gameCmds } from '~/commands/game'
 import { gameManager } from '~/services/game-manager'
+import { usePreviewSessionStore } from '~/stores/preview-session'
 
 import type { GameConfigReadResult, GameConfigWritePayload } from '~/commands/game'
 
@@ -20,6 +21,7 @@ async function getConfig(gamePath: string): Promise<GameConfigReadResult> {
 async function setConfig(gamePath: string, config: GameConfigWritePayload) {
   await gameCmds.setGameConfig(gamePath, config)
   await gameManager.refreshRegisteredGameSnapshot(gamePath)
+  usePreviewSessionStore().refreshIfCurrentGame(gamePath)
 }
 
 /**

--- a/src/services/platform/__tests__/asset-url.test.ts
+++ b/src/services/platform/__tests__/asset-url.test.ts
@@ -2,7 +2,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { getAssetUrl, resolveAssetUrl } from '~/services/platform/asset-url'
 
-const { useWorkspaceStoreMock } = vi.hoisted(() => ({
+const { usePreviewSessionStoreMock, useWorkspaceStoreMock } = vi.hoisted(() => ({
+  usePreviewSessionStoreMock: vi.fn(),
   useWorkspaceStoreMock: vi.fn(),
 }))
 
@@ -10,8 +11,15 @@ const CACHE_VERSION = Number.parseInt('1710000000000', 10)
 
 const workspaceStoreState = {
   CWD: '/games/demo',
+}
+
+const previewSessionStoreState = {
   currentGameServeUrl: 'http://127.0.0.1:8899/game/demo/',
 }
+
+vi.mock('~/stores/preview-session', () => ({
+  usePreviewSessionStore: usePreviewSessionStoreMock,
+}))
 
 vi.mock('~/stores/workspace', () => ({
   useWorkspaceStore: useWorkspaceStoreMock,
@@ -20,7 +28,8 @@ vi.mock('~/stores/workspace', () => ({
 describe('getAssetUrl 资源地址解析', () => {
   beforeEach(() => {
     workspaceStoreState.CWD = '/games/demo'
-    workspaceStoreState.currentGameServeUrl = 'http://127.0.0.1:8899/game/demo/'
+    previewSessionStoreState.currentGameServeUrl = 'http://127.0.0.1:8899/game/demo/'
+    usePreviewSessionStoreMock.mockReturnValue(previewSessionStoreState)
     useWorkspaceStoreMock.mockReturnValue(workspaceStoreState)
   })
 
@@ -78,7 +87,7 @@ describe('getAssetUrl 资源地址解析', () => {
   })
 
   it('缺少预览地址时会直接抛出错误', () => {
-    workspaceStoreState.currentGameServeUrl = ''
+    previewSessionStoreState.currentGameServeUrl = ''
 
     expect(() => getAssetUrl('/games/demo/assets/bg/intro.png')).toThrow('预览地址不存在')
   })

--- a/src/services/platform/asset-url.ts
+++ b/src/services/platform/asset-url.ts
@@ -1,3 +1,4 @@
+import { usePreviewSessionStore } from '~/stores/preview-session'
 import { useWorkspaceStore } from '~/stores/workspace'
 
 export interface AssetThumbnailOptions {
@@ -135,11 +136,12 @@ export function getAssetUrl(
   serveUrl?: string,
   thumbnail?: AssetThumbnailOptions,
 ): string {
+  const previewSessionStore = usePreviewSessionStore()
   const workspaceStore = useWorkspaceStore()
   return resolveAssetUrl(assetPath, {
     cwd: workspaceStore.CWD ?? '',
     cacheVersion,
-    previewBaseUrl: serveUrl ?? workspaceStore.currentGameServeUrl ?? '',
+    previewBaseUrl: serveUrl ?? previewSessionStore.currentGameServeUrl ?? '',
     thumbnail,
   })
 }

--- a/src/stores/__tests__/editor.test.ts
+++ b/src/stores/__tests__/editor.test.ts
@@ -55,9 +55,12 @@ const preferenceStoreMock = reactive({
   editorMode: 'text' as 'text' | 'visual',
 })
 
+const previewSessionStoreMock = reactive({
+  currentGameServeUrl: 'http://127.0.0.1:8899' as string | undefined,
+})
+
 const workspaceStoreMock = reactive({
   currentGame: { id: 'game-1', path: '/game' } as { id: string, path: string } | undefined,
-  currentGameServeUrl: 'http://127.0.0.1:8899' as string | undefined,
   cwd: '/game' as string | undefined,
   get CWD() {
     return this.cwd
@@ -94,6 +97,10 @@ vi.mock('~/stores/preference', () => ({
 
 vi.mock('~/stores/workspace', () => ({
   useWorkspaceStore: () => workspaceStoreMock,
+}))
+
+vi.mock('~/stores/preview-session', () => ({
+  usePreviewSessionStore: () => previewSessionStoreMock,
 }))
 
 vi.mock('~/composables/useFileSystemEvents', () => ({
@@ -293,8 +300,8 @@ describe('编辑器状态仓库的文本与文档流程', () => {
     tabsStore.shouldFocusEditor = false
     preferenceStoreMock.editorMode = 'text'
     workspaceStoreMock.currentGame = { id: 'game-1', path: '/game' }
-    workspaceStoreMock.currentGameServeUrl = 'http://127.0.0.1:8899'
     workspaceStoreMock.cwd = '/game'
+    previewSessionStoreMock.currentGameServeUrl = 'http://127.0.0.1:8899'
   })
 
   it('加载纯文本文件后可应用补丁、保存并支持撤销重做', async () => {
@@ -528,7 +535,7 @@ describe('编辑器状态仓库的文本与文档流程', () => {
     const tabsStore = useTabsStore()
     const path = '/game/video/preview-unavailable.mp4'
 
-    workspaceStoreMock.currentGameServeUrl = undefined
+    previewSessionStoreMock.currentGameServeUrl = undefined
     mimeGetTypeMock.mockReturnValue('video/mp4')
 
     const editorStore = useEditorStore()

--- a/src/stores/__tests__/preview-session.test.ts
+++ b/src/stores/__tests__/preview-session.test.ts
@@ -1,0 +1,119 @@
+import '~/__tests__/setup'
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { createTestGame } from '~/__tests__/factories'
+import { usePreviewSessionStore } from '~/stores/preview-session'
+
+const {
+  ensureServeUrlMock,
+  loggerErrorMock,
+} = vi.hoisted(() => ({
+  ensureServeUrlMock: vi.fn(),
+  loggerErrorMock: vi.fn(),
+}))
+
+vi.mock('~/stores/preview-runtime', () => ({
+  usePreviewRuntimeStore: () => ({
+    ensureServeUrl: ensureServeUrlMock,
+  }),
+}))
+
+vi.mock('@tauri-apps/plugin-log', () => ({
+  error: loggerErrorMock,
+}))
+
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  const promise = new Promise<T>((nextResolve) => {
+    resolve = nextResolve
+  })
+  return {
+    promise,
+    resolve,
+  }
+}
+
+describe('previewSessionStore 当前工作区预览会话仓库', () => {
+  beforeEach(() => {
+    ensureServeUrlMock.mockReset()
+    loggerErrorMock.mockReset()
+  })
+
+  it('syncCurrentGame 会解析当前游戏的 serve url，并在清空会话时重置 reloadVersion', async () => {
+    const store = usePreviewSessionStore()
+
+    ensureServeUrlMock.mockResolvedValueOnce('http://preview/game-1/')
+    await store.syncCurrentGame(createTestGame({
+      path: '/games/game-1',
+    }))
+
+    expect(ensureServeUrlMock).toHaveBeenCalledWith('/games/game-1')
+    expect(store.currentGameServeUrl).toBe('http://preview/game-1/')
+    expect(store.reloadVersion).toBe(0)
+
+    store.refresh()
+    expect(store.reloadVersion).toBe(1)
+
+    await store.syncCurrentGame(undefined)
+
+    expect(store.currentGameServeUrl).toBeUndefined()
+    expect(store.reloadVersion).toBe(0)
+
+    store.refresh()
+    expect(store.reloadVersion).toBe(0)
+  })
+
+  it('refreshIfCurrentGame 只会在路径命中当前游戏时递增 reloadVersion', async () => {
+    const store = usePreviewSessionStore()
+
+    ensureServeUrlMock.mockResolvedValue('http://preview/game-1/')
+    await store.syncCurrentGame(createTestGame({
+      path: '/games/game-1',
+    }))
+
+    store.refreshIfCurrentGame('/games/other')
+    expect(store.reloadVersion).toBe(0)
+
+    store.refreshIfCurrentGame('/games/game-1')
+    expect(store.reloadVersion).toBe(1)
+  })
+
+  it('syncCurrentGame 在预览地址缺失时会记录错误，并保留当前会话路径用于后续刷新判断', async () => {
+    const store = usePreviewSessionStore()
+
+    ensureServeUrlMock.mockResolvedValue(undefined)
+    await store.syncCurrentGame(createTestGame({
+      path: '/games/game-1',
+    }))
+
+    expect(store.currentGameServeUrl).toBeUndefined()
+    expect(loggerErrorMock).toHaveBeenCalledWith('获取预览链接失败: 预览链接不存在')
+
+    store.refreshIfCurrentGame('/games/game-1')
+    expect(store.reloadVersion).toBe(1)
+  })
+
+  it('syncCurrentGame 会忽略过期的异步预览地址结果', async () => {
+    const store = usePreviewSessionStore()
+    const firstServeUrl = createDeferred<string | undefined>()
+
+    ensureServeUrlMock.mockReturnValueOnce(firstServeUrl.promise)
+    ensureServeUrlMock.mockResolvedValueOnce('http://preview/game-2/')
+
+    const firstSyncTask = store.syncCurrentGame(createTestGame({
+      path: '/games/game-1',
+    }))
+    const secondSyncTask = store.syncCurrentGame(createTestGame({
+      path: '/games/game-2',
+    }))
+
+    await secondSyncTask
+    expect(store.currentGameServeUrl).toBe('http://preview/game-2/')
+
+    firstServeUrl.resolve('http://preview/game-1/')
+    await firstSyncTask
+
+    expect(store.currentGameServeUrl).toBe('http://preview/game-2/')
+  })
+})

--- a/src/stores/__tests__/workspace.test.ts
+++ b/src/stores/__tests__/workspace.test.ts
@@ -162,7 +162,7 @@ describe('工作区状态仓库', () => {
     expect(previewSessionStoreState.currentGameServeUrl).toBeUndefined()
   })
 
-  it('预览会话同步未提供地址时仍保留当前游戏并允许预览会话保持空地址', async () => {
+  it('预览会话同步未写入地址时仍保留当前游戏并允许预览会话保持空地址', async () => {
     const store = useWorkspaceStore()
 
     dbGetMock.mockResolvedValue(createTestGame({
@@ -177,31 +177,13 @@ describe('工作区状态仓库', () => {
     routeState.params = { gameId: 'game-2' }
     await flushWorkspaceWatchers()
 
+    expect(syncCurrentGameMock).toHaveBeenCalledWith(expect.objectContaining({
+      id: 'game-2',
+      path: '/games/game-2',
+    }))
     expect(store.currentGame).toMatchObject({
       id: 'game-2',
       path: '/games/game-2',
-    })
-    expect(previewSessionStoreState.currentGameServeUrl).toBeUndefined()
-  })
-
-  it('预览会话返回空地址时保留当前游戏并允许预览会话保持空地址', async () => {
-    const store = useWorkspaceStore()
-
-    dbGetMock.mockResolvedValue(createTestGame({
-      id: 'game-3',
-      path: '/games/game-3',
-      metadata: {
-        name: 'Game Three',
-      },
-    }))
-    syncCurrentGameMock.mockResolvedValue(undefined)
-
-    routeState.params = { gameId: 'game-3' }
-    await flushWorkspaceWatchers()
-
-    expect(store.currentGame).toMatchObject({
-      id: 'game-3',
-      path: '/games/game-3',
     })
     expect(previewSessionStoreState.currentGameServeUrl).toBeUndefined()
   })

--- a/src/stores/__tests__/workspace.test.ts
+++ b/src/stores/__tests__/workspace.test.ts
@@ -9,22 +9,25 @@ import { useWorkspaceStore } from '~/stores/workspace'
 const {
   dbGetMock,
   getGameSnapshotMock,
-  loggerErrorMock,
-  previewRuntimeStoreMock,
+  previewSessionStoreMock,
+  syncCurrentGameMock,
   useRouteMock,
 } = vi.hoisted(() => ({
   dbGetMock: vi.fn(),
   getGameSnapshotMock: vi.fn(),
-  loggerErrorMock: vi.fn(),
-  previewRuntimeStoreMock: {
-    ensureServeUrl: vi.fn(),
+  previewSessionStoreMock: {
+    currentGameServeUrl: undefined as string | undefined,
+    syncCurrentGame: vi.fn(),
   },
+  syncCurrentGameMock: vi.fn(),
   useRouteMock: vi.fn(),
 }))
 
 const routeState = reactive<{ params: Record<string, string | undefined> }>({
   params: {},
 })
+
+const previewSessionStoreState = reactive(previewSessionStoreMock)
 
 vi.mock('vue-router', () => ({
   useRoute: useRouteMock,
@@ -44,12 +47,8 @@ vi.mock('~/services/game-manager', () => ({
   },
 }))
 
-vi.mock('~/stores/preview-runtime', () => ({
-  usePreviewRuntimeStore: () => previewRuntimeStoreMock,
-}))
-
-vi.mock('@tauri-apps/plugin-log', () => ({
-  error: loggerErrorMock,
+vi.mock('~/stores/preview-session', () => ({
+  usePreviewSessionStore: () => previewSessionStoreState,
 }))
 
 async function flushWorkspaceWatchers() {
@@ -64,8 +63,9 @@ describe('工作区状态仓库', () => {
     useRouteMock.mockReturnValue(routeState)
     dbGetMock.mockReset()
     getGameSnapshotMock.mockReset()
-    loggerErrorMock.mockReset()
-    previewRuntimeStoreMock.ensureServeUrl.mockReset()
+    syncCurrentGameMock.mockReset()
+    previewSessionStoreState.currentGameServeUrl = undefined
+    previewSessionStoreState.syncCurrentGame = syncCurrentGameMock
   })
 
   it('不再暴露预览服务器状态与启动方法', async () => {
@@ -73,6 +73,7 @@ describe('工作区状态仓库', () => {
 
     expect('serverUrl' in store).toBe(false)
     expect('runServer' in store).toBe(false)
+    expect('currentGameServeUrl' in store).toBe(false)
   })
 
   it('refreshCurrentGameSnapshot 会把最新快照合并回 currentGame', async () => {
@@ -125,7 +126,7 @@ describe('工作区状态仓库', () => {
     })
   })
 
-  it('路由进入编辑页时会加载游戏并启动预览，离开时只清空当前状态', async () => {
+  it('路由进入编辑页时会加载游戏并同步预览会话，离开时只清空当前状态', async () => {
     const store = useWorkspaceStore()
 
     dbGetMock.mockResolvedValue(createTestGame({
@@ -135,27 +136,33 @@ describe('工作区状态仓库', () => {
         name: 'Game One',
       },
     }))
-    previewRuntimeStoreMock.ensureServeUrl.mockResolvedValue('http://preview/game-1')
+    syncCurrentGameMock.mockImplementation(async (game?: { path: string }) => {
+      previewSessionStoreState.currentGameServeUrl = game ? 'http://preview/game-1' : undefined
+    })
 
     routeState.params = { gameId: 'game-1' }
     await flushWorkspaceWatchers()
 
-    expect(previewRuntimeStoreMock.ensureServeUrl).toHaveBeenCalledWith('/games/game-1')
+    expect(syncCurrentGameMock).toHaveBeenCalledWith(expect.objectContaining({
+      id: 'game-1',
+      path: '/games/game-1',
+    }))
     expect(store.currentGame).toMatchObject({
       id: 'game-1',
       path: '/games/game-1',
     })
-    expect(store.currentGameServeUrl).toBe('http://preview/game-1')
+    expect(previewSessionStoreState.currentGameServeUrl).toBe('http://preview/game-1')
     expect(store.CWD).toBe('/games/game-1')
 
     routeState.params = {}
     await flushWorkspaceWatchers()
 
+    expect(syncCurrentGameMock).toHaveBeenLastCalledWith(undefined)
     expect(store.currentGame).toBeUndefined()
-    expect(store.currentGameServeUrl).toBeUndefined()
+    expect(previewSessionStoreState.currentGameServeUrl).toBeUndefined()
   })
 
-  it('预览地址获取失败时保留当前游戏并记录错误', async () => {
+  it('预览会话同步未提供地址时仍保留当前游戏并允许预览会话保持空地址', async () => {
     const store = useWorkspaceStore()
 
     dbGetMock.mockResolvedValue(createTestGame({
@@ -165,7 +172,7 @@ describe('工作区状态仓库', () => {
         name: 'Game Two',
       },
     }))
-    previewRuntimeStoreMock.ensureServeUrl.mockRejectedValue(new Error('preview unavailable'))
+    syncCurrentGameMock.mockResolvedValue(undefined)
 
     routeState.params = { gameId: 'game-2' }
     await flushWorkspaceWatchers()
@@ -174,11 +181,10 @@ describe('工作区状态仓库', () => {
       id: 'game-2',
       path: '/games/game-2',
     })
-    expect(store.currentGameServeUrl).toBeUndefined()
-    expect(loggerErrorMock).toHaveBeenCalledWith('获取预览链接失败: Error: preview unavailable')
+    expect(previewSessionStoreState.currentGameServeUrl).toBeUndefined()
   })
 
-  it('预览地址缺失时保留当前游戏并记录直接错误', async () => {
+  it('预览会话返回空地址时保留当前游戏并允许预览会话保持空地址', async () => {
     const store = useWorkspaceStore()
 
     dbGetMock.mockResolvedValue(createTestGame({
@@ -188,7 +194,7 @@ describe('工作区状态仓库', () => {
         name: 'Game Three',
       },
     }))
-    previewRuntimeStoreMock.ensureServeUrl.mockResolvedValue(undefined)
+    syncCurrentGameMock.mockResolvedValue(undefined)
 
     routeState.params = { gameId: 'game-3' }
     await flushWorkspaceWatchers()
@@ -197,7 +203,6 @@ describe('工作区状态仓库', () => {
       id: 'game-3',
       path: '/games/game-3',
     })
-    expect(store.currentGameServeUrl).toBeUndefined()
-    expect(loggerErrorMock).toHaveBeenCalledWith('获取预览链接失败: 预览链接不存在')
+    expect(previewSessionStoreState.currentGameServeUrl).toBeUndefined()
   })
 })

--- a/src/stores/editor.ts
+++ b/src/stores/editor.ts
@@ -12,6 +12,7 @@ import { useEditSettingsStore } from '~/stores/edit-settings'
 import { canExecuteEditorAutoSave, createEditorAutoSaveController } from '~/stores/editor-auto-save'
 import { createEditorPreviewSync } from '~/stores/editor-preview-sync'
 import { usePreferenceStore } from '~/stores/preference'
+import { usePreviewSessionStore } from '~/stores/preview-session'
 import { useTabsStore } from '~/stores/tabs'
 import { useWorkspaceStore } from '~/stores/workspace'
 import { AppError } from '~/types/errors'
@@ -216,6 +217,7 @@ export const useEditorStore = defineStore('editor', () => {
 
   const { t } = useI18n()
   const editSettingsStore = useEditSettingsStore()
+  const previewSessionStore = usePreviewSessionStore()
   const tabsStore = useTabsStore()
   const fileSystemEvents = useFileSystemEvents()
 
@@ -427,7 +429,7 @@ export const useEditorStore = defineStore('editor', () => {
     getEditableSession,
     getEditableState,
     getPreferredProjection: () => usePreferenceStore().editorMode,
-    getPreviewBaseUrl: () => useWorkspaceStore().currentGameServeUrl,
+    getPreviewBaseUrl: () => previewSessionStore.currentGameServeUrl,
     getSceneSelection,
     getSession: (path: string) => sessions.get(path),
     getWorkspaceRootPath: () => useWorkspaceStore().CWD,

--- a/src/stores/preview-session.ts
+++ b/src/stores/preview-session.ts
@@ -1,0 +1,78 @@
+import { defineStore } from 'pinia'
+
+import { usePreviewRuntimeStore } from '~/stores/preview-runtime'
+
+import type { Game } from '~/database/model'
+
+type PreviewGameTarget = Pick<Game, 'path'>
+
+export const usePreviewSessionStore = defineStore('previewSession', () => {
+  let currentGamePath = $ref<string>()
+  let currentGameServeUrl = $ref<string>()
+  let reloadVersion = $ref(0)
+  let syncToken = 0
+
+  const previewRuntimeStore = usePreviewRuntimeStore()
+
+  function resetState(): void {
+    currentGamePath = undefined
+    currentGameServeUrl = undefined
+    reloadVersion = 0
+  }
+
+  async function syncCurrentGame(game?: PreviewGameTarget): Promise<void> {
+    const currentToken = ++syncToken
+    if (!game) {
+      resetState()
+      return
+    }
+
+    currentGamePath = game.path
+    currentGameServeUrl = undefined
+    reloadVersion = 0
+
+    try {
+      const previewUrl = await previewRuntimeStore.ensureServeUrl(game.path)
+      if (currentToken !== syncToken) {
+        return
+      }
+
+      if (!previewUrl) {
+        logger.error('获取预览链接失败: 预览链接不存在')
+        return
+      }
+
+      currentGameServeUrl = previewUrl
+    } catch (error) {
+      if (currentToken !== syncToken) {
+        return
+      }
+
+      logger.error(`获取预览链接失败: ${error}`)
+    }
+  }
+
+  function refresh(): void {
+    if (!currentGamePath) {
+      return
+    }
+
+    reloadVersion++
+  }
+
+  function refreshIfCurrentGame(gamePath: string): void {
+    if (!gamePath || currentGamePath !== gamePath) {
+      return
+    }
+
+    refresh()
+  }
+
+  return $$({
+    currentGameServeUrl,
+    reloadVersion,
+    syncCurrentGame,
+    refresh,
+    refreshIfCurrentGame,
+  })
+})

--- a/src/stores/workspace.ts
+++ b/src/stores/workspace.ts
@@ -3,7 +3,7 @@ import { defineStore } from 'pinia'
 import { db } from '~/database/db'
 import { Game } from '~/database/model'
 import { gameManager } from '~/services/game-manager'
-import { usePreviewRuntimeStore } from '~/stores/preview-runtime'
+import { usePreviewSessionStore } from '~/stores/preview-session'
 
 import type { HomeTabId } from '~/features/home/home-tabs'
 
@@ -12,14 +12,13 @@ export const useWorkspaceStore = defineStore(
   () => {
     // 工作区状态
     let currentGame = $ref<Game>()
-    let currentGameServeUrl = $ref<string>()
 
     // UI 状态
     const activeTab = $ref<HomeTabId>('recent')
     const searchQuery = $ref<string>('')
     const activeAssetTab = $ref('')
 
-    const previewRuntimeStore = usePreviewRuntimeStore()
+    const previewSessionStore = usePreviewSessionStore()
     const CWD = $computed(() => currentGame?.path)
 
     async function refreshCurrentGameSnapshot() {
@@ -51,10 +50,8 @@ export const useWorkspaceStore = defineStore(
         isStale = true
       })
 
-      if (currentGame) {
-        currentGame = undefined
-        currentGameServeUrl = undefined
-      }
+      currentGame = undefined
+      await previewSessionStore.syncCurrentGame(undefined)
 
       if (!gameId) {
         return
@@ -66,33 +63,16 @@ export const useWorkspaceStore = defineStore(
       }
 
       currentGame = game
-      try {
-        const previewUrl = await previewRuntimeStore.ensureServeUrl(game.path)
-        if (isStale) {
-          return
-        }
-
-        if (!previewUrl) {
-          currentGameServeUrl = undefined
-          logger.error('获取预览链接失败: 预览链接不存在')
-          return
-        }
-
-        currentGameServeUrl = previewUrl
-      } catch (error) {
-        if (isStale) {
-          return
-        }
-
-        currentGameServeUrl = undefined
-        logger.error(`获取预览链接失败: ${error}`)
+      await previewSessionStore.syncCurrentGame(game)
+      if (isStale) {
+        currentGame = undefined
+        await previewSessionStore.syncCurrentGame(undefined)
       }
     })
 
     return $$({
       // 工作区状态
       currentGame,
-      currentGameServeUrl,
       CWD,
       refreshCurrentGameSnapshot,
 


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [x] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [x] 代码重构
- [ ] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

修复编辑器预览在真实内容变更并同步后触发整页刷新的问题。

这次修复没有修改文档保存会更新 `lastModified` 的既有语义，而是把“预览会话”从 `workspace` 和项目级变更时间中拆出来，收敛到独立的 `previewSessionStore`。预览相关消费者现在直接依赖该 store 提供的预览 URL 与刷新信号，`PreviewPanel` 也改为只响应显式的预览刷新版本号，不再把 `lastModified` 当成 iframe reload 信号。

同时清理了 `workspace` 上残留的预览 URL 兼容层，并补充了单元测试与浏览器测试，覆盖预览 URL 分发、路由切换、配置保存触发刷新，以及异步竞态下忽略过期预览地址结果等场景。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

问题根因是 `PreviewPanel` 把项目级 `lastModified` 误用为预览整页刷新信号，导致文本编辑器和图形编辑器只要发生真实内容变更并同步，就会触发 iframe 整页 reload。

该回归由提交 `ba82de1496edfec20ce802bcdaa5762623522dfb` 引入。那个提交本身让游戏配置编辑真正写回项目内容并更新 `lastModified`，语义是正确的；真正有问题的是预览层错误地订阅了这个项目级信号。

本次修改的目标是恢复清晰边界：
`preview-runtime` 继续负责预览服务器与站点注册这类运行时基础设施；
`previewSessionStore` 负责当前工作区的预览会话、预览 URL 和显式刷新语义；
`workspace` 只负责当前游戏与工作区状态，不再承担预览控制职责。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
