### PR TITLE
🐛 修复动画时间线刻度对齐与拖拽边界行为

### DIFF
--- a/src/components/editor/animation/AnimationTimeline.spec.ts
+++ b/src/components/editor/animation/AnimationTimeline.spec.ts
@@ -125,7 +125,7 @@ describe('AnimationTimeline', () => {
     document.body.innerHTML = ''
   })
 
-  it('顶部刻度和底部结束标记在关键时间点共享同一横向锚点', () => {
+  it('结束标记与顶部刻度共享锚点，并在时间轴边界保持正确对齐', () => {
     renderTimeline({
       keyframes: zeroStartThreeKeyframes,
       totalDuration: 450,
@@ -140,10 +140,20 @@ describe('AnimationTimeline', () => {
       expect(endMarker?.style.left).toBe(rulerMark?.style.left)
     }
 
-    const zeroRulerMark = document.querySelector<HTMLElement>('[data-animation-ruler-mark="0"]')
     const zeroEndMarker = document.querySelector<HTMLElement>('[data-animation-end-marker="0"]')
-    expect(zeroRulerMark?.style.left).toBe('0%')
     expect(zeroEndMarker?.style.left).toBe('0%')
+
+    const zeroEndMarkerLabel = zeroEndMarker?.querySelector<HTMLElement>('span')
+    const middleEndMarkerLabel = document
+      .querySelector<HTMLElement>('[data-animation-end-marker="200"]')
+      ?.querySelector<HTMLElement>('span')
+    const lastEndMarkerLabel = document
+      .querySelector<HTMLElement>('[data-animation-end-marker="450"]')
+      ?.querySelector<HTMLElement>('span')
+
+    expect(zeroEndMarkerLabel?.className).toContain('translate-x-0')
+    expect(middleEndMarkerLabel?.className).toContain('-translate-x-1/2')
+    expect(lastEndMarkerLabel?.className).toContain('-translate-x-full')
   })
 
   it('最后一个时间块可以贴到时间轨道末端，不为显式末端缓冲区预留空白', () => {
@@ -160,6 +170,25 @@ describe('AnimationTimeline', () => {
     const width = Number.parseFloat(lastSpan!.style.width)
 
     expect(left + width).toBeCloseTo(100)
+  })
+
+  it('单个结束标记仍然使用末端对齐，避免贴在右边界时向外溢出', () => {
+    renderTimeline({
+      keyframes: [
+        {
+          cumulativeTime: 320,
+          duration: 320,
+          id: 1,
+        },
+      ],
+      totalDuration: 320,
+    })
+
+    const endMarker = document.querySelector<HTMLElement>('[data-animation-end-marker="320"]')
+    const endMarkerLabel = endMarker?.querySelector<HTMLElement>('span')
+
+    expect(endMarkerLabel).not.toBeNull()
+    expect(endMarkerLabel?.className).toContain('-translate-x-full')
   })
 
   it('被最小宽度撑开的 9ms 起始帧可以继续拖拽回 0ms', () => {

--- a/src/components/editor/animation/AnimationTimeline.spec.ts
+++ b/src/components/editor/animation/AnimationTimeline.spec.ts
@@ -1,0 +1,187 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent, h } from 'vue'
+
+import { renderInBrowser } from '~/__tests__/browser-render'
+
+import AnimationTimeline from './AnimationTimeline.vue'
+
+import type { AnimationEditorKeyframe } from '~/features/editor/animation/animation-inspector'
+
+const useElementSizeMock = vi.hoisted(() => vi.fn(() => ({
+  height: { value: 108 },
+  width: { value: 640 },
+})))
+
+vi.mock('@vueuse/core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@vueuse/core')>()
+  return {
+    ...actual,
+    useElementSize: useElementSizeMock,
+  }
+})
+
+const ScrollAreaStub = defineComponent({
+  name: 'StubScrollArea',
+  setup(_, { expose, slots }) {
+    const viewportElement = document.createElement('div')
+    Object.defineProperty(viewportElement, 'clientWidth', {
+      configurable: true,
+      value: 640,
+    })
+
+    expose({
+      viewport: {
+        viewportElement,
+      },
+    })
+
+    return () => h('div', slots.default?.())
+  },
+})
+
+function createPointerEvent(type: string, overrides: PointerEventInit = {}): PointerEvent {
+  return new PointerEvent(type, {
+    bubbles: true,
+    button: 0,
+    buttons: type === 'pointerup' || type === 'pointercancel' ? 0 : 1,
+    cancelable: true,
+    clientX: 0,
+    pointerId: 1,
+    pointerType: 'mouse',
+    ...overrides,
+  })
+}
+
+const linearTwoKeyframes: AnimationEditorKeyframe[] = [
+  {
+    cumulativeTime: 120,
+    duration: 120,
+    id: 1,
+  },
+  {
+    cumulativeTime: 320,
+    duration: 200,
+    ease: 'linear',
+    id: 2,
+  },
+]
+
+const zeroStartThreeKeyframes: AnimationEditorKeyframe[] = [
+  {
+    cumulativeTime: 0,
+    duration: 0,
+    id: 1,
+  },
+  {
+    cumulativeTime: 200,
+    duration: 200,
+    id: 2,
+  },
+  {
+    cumulativeTime: 450,
+    duration: 250,
+    id: 3,
+  },
+]
+
+const narrowStartKeyframes: AnimationEditorKeyframe[] = [
+  {
+    cumulativeTime: 9,
+    duration: 9,
+    id: 1,
+  },
+  {
+    cumulativeTime: 209,
+    duration: 200,
+    id: 2,
+  },
+]
+
+function renderTimeline(options: {
+  keyframes: readonly AnimationEditorKeyframe[]
+  onResizeDuration?: (payload: { duration: number, flush: boolean, id: number }) => void
+  selectedId?: number
+  totalDuration: number
+}) {
+  renderInBrowser(AnimationTimeline, {
+    props: {
+      keyframes: options.keyframes,
+      onResizeDuration: options.onResizeDuration,
+      selectedId: options.selectedId ?? 1,
+      totalDuration: options.totalDuration,
+    },
+    global: {
+      stubs: {
+        ScrollArea: ScrollAreaStub,
+        ScrollBar: true,
+      },
+    },
+  })
+}
+
+describe('AnimationTimeline', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+    document.body.innerHTML = ''
+  })
+
+  it('顶部刻度和底部结束标记在关键时间点共享同一横向锚点', () => {
+    renderTimeline({
+      keyframes: zeroStartThreeKeyframes,
+      totalDuration: 450,
+    })
+
+    for (const time of [0, 200]) {
+      const rulerMark = document.querySelector<HTMLElement>(`[data-animation-ruler-mark="${time}"]`)
+      const endMarker = document.querySelector<HTMLElement>(`[data-animation-end-marker="${time}"]`)
+
+      expect(rulerMark).not.toBeNull()
+      expect(endMarker).not.toBeNull()
+      expect(endMarker?.style.left).toBe(rulerMark?.style.left)
+    }
+
+    const zeroRulerMark = document.querySelector<HTMLElement>('[data-animation-ruler-mark="0"]')
+    const zeroEndMarker = document.querySelector<HTMLElement>('[data-animation-end-marker="0"]')
+    expect(zeroRulerMark?.style.left).toBe('0%')
+    expect(zeroEndMarker?.style.left).toBe('0%')
+  })
+
+  it('最后一个时间块可以贴到时间轨道末端，不为显式末端缓冲区预留空白', () => {
+    renderTimeline({
+      keyframes: linearTwoKeyframes,
+      totalDuration: 320,
+    })
+
+    const lastSpan = [...document.querySelectorAll<HTMLElement>('button[type="button"]')].at(-1)
+
+    expect(lastSpan).not.toBeNull()
+
+    const left = Number.parseFloat(lastSpan!.style.left)
+    const width = Number.parseFloat(lastSpan!.style.width)
+
+    expect(left + width).toBeCloseTo(100)
+  })
+
+  it('被最小宽度撑开的 9ms 起始帧可以继续拖拽回 0ms', () => {
+    const onResizeDuration = vi.fn()
+
+    renderTimeline({
+      keyframes: narrowStartKeyframes,
+      onResizeDuration,
+      totalDuration: 209,
+    })
+
+    const handle = document.querySelector<HTMLElement>('[data-span-id="1"]')
+    expect(handle).not.toBeNull()
+
+    handle!.dispatchEvent(createPointerEvent('pointerdown', { clientX: 100 }))
+    globalThis.dispatchEvent(createPointerEvent('pointermove', { clientX: 91 }))
+    globalThis.dispatchEvent(createPointerEvent('pointerup', { clientX: 91 }))
+
+    expect(onResizeDuration).toHaveBeenCalledWith({
+      duration: 0,
+      flush: true,
+      id: 1,
+    })
+  })
+})

--- a/src/components/editor/animation/AnimationTimeline.vue
+++ b/src/components/editor/animation/AnimationTimeline.vue
@@ -367,7 +367,7 @@ function resolveEndMarkerAlignment(time: number): 'center' | 'end' | 'start' {
 function getTimeAnchorStyle(left: string): Record<string, string> {
   return {
     left,
-    width: '0',
+    width: '0px',
   }
 }
 

--- a/src/components/editor/animation/AnimationTimeline.vue
+++ b/src/components/editor/animation/AnimationTimeline.vue
@@ -328,7 +328,21 @@ function getDistortedPosition(time: number): number {
   return 100
 }
 
-function resolveEdgeAlignedClass(index: number, total: number): string {
+function resolveEdgeAlignedClass(
+  index: number,
+  total: number,
+  alignment?: 'center' | 'end' | 'start',
+): string {
+  if (alignment === 'start') {
+    return 'translate-x-0'
+  }
+  if (alignment === 'end') {
+    return '-translate-x-full'
+  }
+  if (alignment === 'center') {
+    return '-translate-x-1/2'
+  }
+
   if (index === 0) {
     return 'translate-x-0'
   }
@@ -337,6 +351,17 @@ function resolveEdgeAlignedClass(index: number, total: number): string {
   }
 
   return '-translate-x-1/2'
+}
+
+function resolveEndMarkerAlignment(time: number): 'center' | 'end' | 'start' {
+  if (props.totalDuration <= 0 || time <= 0) {
+    return 'start'
+  }
+  if (time >= props.totalDuration) {
+    return 'end'
+  }
+
+  return 'center'
 }
 
 function getTimeAnchorStyle(left: string): Record<string, string> {
@@ -504,11 +529,11 @@ onUnmounted(() => {
         >
           <div
             class="border-x-4 border-b-6 border-x-transparent border-b-muted-foreground/70 h-0 w-0 left-0 top-20 absolute"
-            :class="resolveEdgeAlignedClass(index, dedupedEndMarkers.length)"
+            :class="resolveEdgeAlignedClass(index, dedupedEndMarkers.length, resolveEndMarkerAlignment(item.span.end))"
           />
           <span
             class="text-10px text-muted-foreground font-mono whitespace-nowrap left-0 top-22 absolute tabular-nums"
-            :class="resolveEdgeAlignedClass(index, dedupedEndMarkers.length)"
+            :class="resolveEdgeAlignedClass(index, dedupedEndMarkers.length, resolveEndMarkerAlignment(item.span.end))"
           >
             {{ item.span.end }}{{ $t('edit.visualEditor.animation.unitMs') }}
           </span>

--- a/src/components/editor/animation/AnimationTimeline.vue
+++ b/src/components/editor/animation/AnimationTimeline.vue
@@ -9,6 +9,7 @@ import {
   MIN_START_SPAN_PX,
   resolveAnimationTimelineAnchoredScrollLeft,
   resolveAnimationTimelineContainerWidth,
+  resolveAnimationTimelineResizeMsPerPixel,
   resolveZeroDurationSpanLayoutPercents,
 } from './animation-timeline-layout'
 
@@ -162,9 +163,7 @@ const layout = $computed((): SpanLayout[] => {
   })
 })
 
-const containerWidth = $computed(() => {
-  return resolveAnimationTimelineContainerWidth(viewportWidth, zoomLevel, spans)
-})
+const containerWidth = $computed(() => resolveAnimationTimelineContainerWidth(viewportWidth, zoomLevel, spans))
 
 const rulerStep = $computed(() => {
   if (props.totalDuration <= 1000) {
@@ -232,15 +231,11 @@ const resizeDrag = usePointerDrag<ResizeDragState>({
     }
 
     const frameWidthPx = Math.max((spanLayout.width / 100) * containerWidth, 1)
-    const referenceDuration = spanLayout.span.duration > 0
-      ? spanLayout.span.duration
-      : Math.max(Math.round(frameWidthPx), 1)
-
     emit('select', spanId)
     return {
       id: spanId,
       lastDuration: spanLayout.span.duration,
-      msPerPixel: referenceDuration / frameWidthPx,
+      msPerPixel: resolveAnimationTimelineResizeMsPerPixel(spanLayout.span.duration, frameWidthPx),
       startClientX: event.clientX,
       startDuration: spanLayout.span.duration,
     }
@@ -314,6 +309,9 @@ function getDistortedPosition(time: number): number {
   if (props.totalDuration <= 0 || layout.length === 0) {
     return 0
   }
+  if (time <= 0) {
+    return 0
+  }
 
   for (const item of layout) {
     const { span, left, width } = item
@@ -330,11 +328,30 @@ function getDistortedPosition(time: number): number {
   return 100
 }
 
-function getEndMarkerClass(index: number, total: number): string {
-  if (index === total - 1) {
-    return '-translate-x-full items-end text-right'
+function resolveEdgeAlignedClass(index: number, total: number): string {
+  if (index === 0) {
+    return 'translate-x-0'
   }
-  return '-translate-x-1/2 items-center'
+  if (index === total - 1) {
+    return '-translate-x-full'
+  }
+
+  return '-translate-x-1/2'
+}
+
+function getTimeAnchorStyle(left: string): Record<string, string> {
+  return {
+    left,
+    width: '0',
+  }
+}
+
+function getResizeHandleClass(index: number, total: number): string {
+  if (index === total - 1) {
+    return 'w-1.5 -translate-x-full'
+  }
+
+  return 'w-3 -translate-x-1/2'
 }
 
 function handleWheel(event: WheelEvent) {
@@ -396,7 +413,7 @@ onUnmounted(() => {
   <div class="h-full min-h-0 relative">
     <ScrollArea
       ref="scrollAreaRef"
-      class="border rounded-lg bg-muted/20 h-27 relative"
+      class="border rounded-lg bg-muted/20 h-28 relative"
       @wheel="handleWheel"
     >
       <div
@@ -406,7 +423,7 @@ onUnmounted(() => {
         <span class="text-xs font-medium">
           {{ $t('edit.visualEditor.animation.emptyTitle') }}
         </span>
-        <span class="text-[11px]">
+        <span class="text-11px">
           {{ $t('edit.visualEditor.animation.emptyDescription') }}
         </span>
       </div>
@@ -416,19 +433,25 @@ onUnmounted(() => {
         :style="{ width: `${containerWidth}px` }"
       >
         <div
-          v-for="mark in rulerMarks"
+          v-for="(mark, index) in rulerMarks"
           :key="`ruler-${mark}`"
-          class="inset-y-0 absolute"
-          :style="{ left: getDistortedPercent(mark) }"
+          :data-animation-ruler-mark="String(mark)"
+          class="pointer-events-none inset-y-0 absolute"
+          :style="getTimeAnchorStyle(getDistortedPercent(mark))"
         >
-          <div class="bg-border/80 h-full w-px" />
-          <span class="text-[10px] text-muted-foreground font-mono left-1 top-0.5 absolute">
+          <div
+            class="bg-border/80 h-full w-px left-0 absolute -translate-x-1/2"
+          />
+          <span
+            class="text-10px text-muted-foreground font-mono whitespace-nowrap left-0 top-0.5 absolute tabular-nums"
+            :class="resolveEdgeAlignedClass(index, rulerMarks.length)"
+          >
             {{ mark }}{{ $t('edit.visualEditor.animation.unitMs') }}
           </span>
         </div>
 
         <template
-          v-for="item in layout"
+          v-for="(item, index) in layout"
           :key="`span-${item.span.id}`"
         >
           <button
@@ -448,24 +471,25 @@ onUnmounted(() => {
             </span>
             <span
               v-if="item.span.isHold"
-              class="text-[10px] text-muted-foreground leading-3 left-6 top-0.5 absolute"
+              class="text-10px text-muted-foreground leading-3 left-6 top-0.5 absolute"
             >
               {{ $t('edit.visualEditor.animation.startFrame') }}
             </span>
             <span
               v-if="!item.span.isHold && item.span.ease && isSpanWideEnough(item.width)"
-              class="text-[11px] text-muted-foreground leading-3 max-w-[58%] truncate right-1 top-0.5 absolute"
+              class="text-11px text-muted-foreground leading-3 max-w-[58%] truncate right-1 top-0.5 absolute"
             >
               {{ getEaseLabel(item.span.ease) }}
             </span>
-            <span class="text-[11px] text-muted-foreground leading-3 bottom-0.5 left-1 absolute">
+            <span class="text-11px text-muted-foreground leading-3 bottom-0.5 left-1 absolute">
               {{ item.span.duration }}{{ $t('edit.visualEditor.animation.unitMs') }}
             </span>
           </button>
 
           <div
             :data-span-id="item.span.id"
-            class="h-10 w-3 cursor-ew-resize top-9 absolute z-10 -translate-x-1/2"
+            class="h-10 cursor-ew-resize top-9 absolute z-10"
+            :class="getResizeHandleClass(index, layout.length)"
             :style="{ left: `${item.left + item.width}%` }"
             @pointerdown="handleResizePointerDown"
           />
@@ -474,12 +498,18 @@ onUnmounted(() => {
         <div
           v-for="(item, index) in dedupedEndMarkers"
           :key="`time-end-${item.span.id}`"
-          class="flex flex-col pointer-events-none bottom-0.5 absolute"
-          :class="getEndMarkerClass(index, dedupedEndMarkers.length)"
-          :style="{ left: `${item.left + item.width}%` }"
+          :data-animation-end-marker="String(item.span.end)"
+          class="pointer-events-none inset-y-0 absolute"
+          :style="getTimeAnchorStyle(getDistortedPercent(item.span.end))"
         >
-          <div class="border-x-[4px] border-b-[6px] border-x-transparent border-b-muted-foreground/70 h-0 w-0" />
-          <span class="text-[10px] text-muted-foreground font-mono mt-0.5 tabular-nums">
+          <div
+            class="border-x-4 border-b-6 border-x-transparent border-b-muted-foreground/70 h-0 w-0 left-0 top-20 absolute"
+            :class="resolveEdgeAlignedClass(index, dedupedEndMarkers.length)"
+          />
+          <span
+            class="text-10px text-muted-foreground font-mono whitespace-nowrap left-0 top-22 absolute tabular-nums"
+            :class="resolveEdgeAlignedClass(index, dedupedEndMarkers.length)"
+          >
             {{ item.span.end }}{{ $t('edit.visualEditor.animation.unitMs') }}
           </span>
         </div>

--- a/src/components/editor/animation/__tests__/animation-timeline-layout.test.ts
+++ b/src/components/editor/animation/__tests__/animation-timeline-layout.test.ts
@@ -5,6 +5,7 @@ import {
   MIN_START_SPAN_PX,
   resolveAnimationTimelineAnchoredScrollLeft,
   resolveAnimationTimelineContainerWidth,
+  resolveAnimationTimelineResizeMsPerPixel,
   resolveZeroDurationSpanLayoutPercents,
 } from '../animation-timeline-layout'
 
@@ -65,5 +66,37 @@ describe('resolveAnimationTimelineAnchoredScrollLeft 计算逻辑', () => {
     })
 
     expect(nextScrollLeft).toBe(60)
+  })
+
+  it('默认不引入末端缓冲区，缩放锚点按时间轨道宽度计算', () => {
+    const nextScrollLeft = resolveAnimationTimelineAnchoredScrollLeft({
+      contentPosition: 80,
+      cursorX: 20,
+      nextZoom: 2,
+      previousZoom: 1,
+      spans: [
+        { isHold: true },
+        { isHold: false },
+      ],
+      viewportWidth: 200,
+    })
+
+    expect(nextScrollLeft).toBe(140)
+  })
+})
+
+describe('resolveAnimationTimelineResizeMsPerPixel 计算逻辑', () => {
+  it('零时长帧使用至少 1ms/px 的拖拽比例，确保可以从 0ms 拉出', () => {
+    expect(resolveAnimationTimelineResizeMsPerPixel(0, 64)).toBe(1)
+  })
+
+  it('当时间块因最小宽度被撑开时，拖拽比例仍保持至少 1ms/px，避免重新拖拽后卡在任意小正数', () => {
+    expect(resolveAnimationTimelineResizeMsPerPixel(9, 32)).toBe(1)
+    expect(resolveAnimationTimelineResizeMsPerPixel(32, 32)).toBe(1)
+    expect(resolveAnimationTimelineResizeMsPerPixel(9, 32.25)).toBeGreaterThanOrEqual(1)
+  })
+
+  it('当时间块未被最小宽度撑开时，仍按真实时长与宽度比例计算', () => {
+    expect(resolveAnimationTimelineResizeMsPerPixel(120, 32)).toBe(3.75)
   })
 })

--- a/src/components/editor/animation/animation-timeline-layout.ts
+++ b/src/components/editor/animation/animation-timeline-layout.ts
@@ -82,3 +82,13 @@ export function resolveAnimationTimelineAnchoredScrollLeft(options: {
 
   return (options.contentPosition * widthRatio) - options.cursorX
 }
+
+export function resolveAnimationTimelineResizeMsPerPixel(duration: number, frameWidthPx: number): number {
+  const safeFrameWidthPx = Math.max(frameWidthPx, 1)
+  const minimumReferenceDuration = Math.max(Math.ceil(safeFrameWidthPx), 1)
+  const referenceDuration = duration > 0
+    ? Math.max(duration, minimumReferenceDuration)
+    : minimumReferenceDuration
+
+  return referenceDuration / safeFrameWidthPx
+}

--- a/src/composables/__tests__/usePointerDrag.test.ts
+++ b/src/composables/__tests__/usePointerDrag.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { usePointerDrag } from '../usePointerDrag'
+
+type ListenerMap = Record<string, Set<EventListenerOrEventListenerObject>>
+
+interface PointerLikeEvent {
+  buttons?: number
+  clientX?: number
+  pointerId: number
+  pointerType?: string
+}
+
+const originalAddEventListener = globalThis.addEventListener
+const originalRemoveEventListener = globalThis.removeEventListener
+const listenerMap: ListenerMap = {}
+
+function createPointerEvent(overrides: PointerLikeEvent): PointerEvent {
+  const { pointerId, ...rest } = overrides
+
+  return {
+    buttons: 1,
+    clientX: 0,
+    pointerId,
+    pointerType: 'mouse',
+    ...rest,
+  } as PointerEvent
+}
+
+function invokeListener(listener: EventListenerOrEventListenerObject, payload: PointerLikeEvent) {
+  if (typeof listener === 'function') {
+    listener(createPointerEvent(payload) as unknown as Event)
+    return
+  }
+
+  listener.handleEvent(createPointerEvent(payload) as unknown as Event)
+}
+
+function dispatchPointerEvent(eventName: string, payload: PointerLikeEvent) {
+  const listeners = listenerMap[eventName]
+  if (!listeners) {
+    return
+  }
+
+  for (const listener of listeners) {
+    invokeListener(listener, payload)
+  }
+}
+
+beforeEach(() => {
+  const mockedGlobal = globalThis as unknown as {
+    addEventListener: typeof globalThis.addEventListener
+    removeEventListener: typeof globalThis.removeEventListener
+  }
+
+  mockedGlobal.addEventListener = ((event: string, listener: EventListenerOrEventListenerObject) => {
+    if (!listenerMap[event]) {
+      listenerMap[event] = new Set()
+    }
+
+    listenerMap[event].add(listener)
+  }) as typeof globalThis.addEventListener
+
+  mockedGlobal.removeEventListener = ((event: string, listener: EventListenerOrEventListenerObject) => {
+    listenerMap[event]?.delete(listener)
+  }) as typeof globalThis.removeEventListener
+})
+
+afterEach(() => {
+  for (const key of Object.keys(listenerMap)) {
+    listenerMap[key].clear()
+    delete listenerMap[key]
+  }
+
+  globalThis.addEventListener = originalAddEventListener
+  globalThis.removeEventListener = originalRemoveEventListener
+})
+
+describe('usePointerDrag 行为', () => {
+  it('正常收到 pointerup 时会结束拖拽', () => {
+    const onEnd = vi.fn()
+    const onMove = vi.fn()
+    const drag = usePointerDrag({
+      onEnd,
+      onMove,
+      onStart: event => ({ startX: event.clientX }),
+    })
+
+    drag.start(createPointerEvent({ clientX: 10, pointerId: 7 }))
+    dispatchPointerEvent('pointermove', { clientX: 20, pointerId: 7 })
+    dispatchPointerEvent('pointerup', { clientX: 20, pointerId: 7 })
+
+    expect(onMove).toHaveBeenCalledTimes(1)
+    expect(onEnd).toHaveBeenCalledTimes(1)
+    expect(drag.active).toBe(false)
+  })
+
+  it('丢失 pointerup 后再次移动且未按住按键时会自动结束拖拽', () => {
+    const onEnd = vi.fn()
+    const onMove = vi.fn()
+    const drag = usePointerDrag({
+      onEnd,
+      onMove,
+      onStart: event => ({ startX: event.clientX }),
+    })
+
+    drag.start(createPointerEvent({ clientX: 10, pointerId: 9 }))
+
+    dispatchPointerEvent('pointermove', {
+      buttons: 1,
+      clientX: 40,
+      pointerId: 9,
+    })
+    dispatchPointerEvent('pointermove', {
+      buttons: 0,
+      clientX: 42,
+      pointerId: 9,
+    })
+
+    expect(onMove).toHaveBeenCalledTimes(1)
+    expect(onEnd).toHaveBeenCalledTimes(1)
+    expect(drag.active).toBe(false)
+  })
+})

--- a/src/composables/usePointerDrag.ts
+++ b/src/composables/usePointerDrag.ts
@@ -25,6 +25,12 @@ export function usePointerDrag<S>(callbacks: PointerDragCallbacks<S>): UsePointe
     if (!state || event.pointerId !== pointerId) {
       return
     }
+
+    if (event.buttons === 0) {
+      stop(event)
+      return
+    }
+
     callbacks.onMove(event, state)
   }
 

--- a/src/features/editor/animation/__tests__/useVisualEditorAnimation.test.ts
+++ b/src/features/editor/animation/__tests__/useVisualEditorAnimation.test.ts
@@ -10,21 +10,20 @@ interface VisualAnimationState {
   path: string
 }
 
-function createState(path: string): VisualAnimationState {
+function createState(path: string, frames: AnimationFrame[] = [{ duration: 200 }]): VisualAnimationState {
   return reactive({
-    frames: [{
-      duration: 200,
-    }],
+    frames,
     path,
   })
 }
 
 function createFixture(options: {
+  frames?: AnimationFrame[]
   path?: string
   redoApplied?: boolean
   undoApplied?: boolean
 } = {}) {
-  const state = createState(options.path ?? '/game/animation/opening.json')
+  const state = createState(options.path ?? '/game/animation/opening.json', options.frames)
   const scope = effectScope()
   const applyAnimationFrameDelete = vi.fn()
   const applyAnimationFrameInsert = vi.fn()
@@ -52,6 +51,7 @@ function createFixture(options: {
   }
 
   return {
+    applyAnimationFrameUpdate,
     controller,
     redoDocument,
     scheduleAutoSaveIfEnabled,
@@ -111,6 +111,46 @@ describe('useVisualEditorAnimation 行为', () => {
     expect(redoDocument).toHaveBeenCalledWith('/game/animation/opening.json')
     expect(scheduleAutoSaveIfEnabled).not.toHaveBeenCalled()
 
+    scope.stop()
+  })
+
+  it('原始时长为 0 的帧在拖拽草稿后回到 0ms 时会清掉草稿而不产生无效写回', () => {
+    const { applyAnimationFrameUpdate, controller, scheduleAutoSaveIfEnabled, scope } = createFixture({
+      frames: [{ duration: 0 }],
+    })
+
+    controller.handleTimelineResizeDuration({
+      duration: 32,
+      flush: false,
+      id: 1,
+    })
+
+    expect(controller.session.selectedFrameDurationDraft).toEqual({
+      duration: 32,
+      frameId: 1,
+    })
+
+    controller.handleTimelineResizeDuration({
+      duration: 0,
+      flush: false,
+      id: 1,
+    })
+
+    expect(controller.session.selectedFrameDurationDraft).toEqual({
+      duration: 0,
+      frameId: 1,
+    })
+
+    controller.handleTimelineResizeDuration({
+      duration: 0,
+      flush: true,
+      id: 1,
+    })
+
+    expect(controller.session.selectedFrameDurationDraft).toBeUndefined()
+    expect(applyAnimationFrameUpdate).not.toHaveBeenCalled()
+    expect(scheduleAutoSaveIfEnabled).not.toHaveBeenCalled()
+    expect(controller.session.selectedFrameId).toBe(1)
     scope.stop()
   })
 })

--- a/src/features/editor/animation/useVisualEditorAnimation.ts
+++ b/src/features/editor/animation/useVisualEditorAnimation.ts
@@ -174,18 +174,28 @@ export function useVisualEditorAnimation(options: UseVisualEditorAnimationOption
     }
 
     const currentFrame = state.value.frames[change.frameIndex]
-    if (currentFrame?.duration === change.duration) {
-      return
-    }
+    const persistedDuration = Math.max(currentFrame?.duration ?? 0, 0)
+    const draftDuration = session.selectedFrameDurationDraft?.frameId === change.frameId
+      ? session.selectedFrameDurationDraft.duration
+      : undefined
+    const resolvedDuration = draftDuration ?? persistedDuration
 
     session.selectedFrameId = change.frameId
 
     if (!payload.flush) {
+      if (resolvedDuration === change.duration) {
+        return
+      }
+
       scheduleSelectedFrameDurationDraft(change.frameId, change.duration)
       return
     }
 
     resetSelectedFrameDurationDraft()
+    if (persistedDuration === change.duration) {
+      return
+    }
+
     options.applyAnimationFrameUpdate(state.value.path, change.frameIndex, { duration: change.duration })
     options.scheduleAutoSaveIfEnabled(state.value.path)
   }


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [x] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [ ] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

修复可视化编辑器动画时间线中的一组对齐和拖拽问题，主要包括：

- 统一顶部时间线刻度、时间块、底部时间标记的时间锚点计算，修复顶部刻度与另外两套时间不对齐的问题
- 修复时间块在一次拖拽中被拉长后再拖回时，可能停在任意正数毫秒、无法稳定回到 `0ms` 的问题
- 修复拖拽过程中移出时间线区域并在外部释放后，旧拖拽状态未正确结束的问题

同时补充并整理了相关单元测试和 browser 测试，覆盖时间轴布局、拖拽比例计算、拖拽释放兜底和时间线交互回归场景。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

当前动画时间线存在几类相互关联的问题：

- 顶部时间刻度与中部时间块、底部结束标记未使用一致的时间锚点，导致视觉上不对齐
- 当时间块因最小宽度被撑开时，拖拽换算比例与实际状态不一致，导致回拖时可能卡在任意小正数毫秒
- 当 `pointerup` 在时间线区域外丢失时，拖拽状态不会被正确释放，后续鼠标移动仍会错误地继续拖拽

这次修改的目标是把时间线的时间坐标、边界表现和拖拽状态机收敛成一套一致且可验证的行为。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
