### PR TITLE
✨ 新增 VFS 共享基础设施与通用路径/错误处理

### DIFF
--- a/src/components/ui/context-menu/ContextMenuItem.vue
+++ b/src/components/ui/context-menu/ContextMenuItem.vue
@@ -20,7 +20,7 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits)
   <ContextMenuItem
     v-bind="forwarded"
     :class="cn(
-      'relative flex cursor-default select-none items-center rounded-sm px-2.5 py-1.25 text-13px outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      'relative flex cursor-default select-none items-center rounded-sm px-2.5 py-1.25 text-[13px] outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
       inset && 'pl-8',
       props.class,
     )"

--- a/src/components/ui/dropdown-menu/DropdownMenuItem.vue
+++ b/src/components/ui/dropdown-menu/DropdownMenuItem.vue
@@ -16,7 +16,7 @@ const forwardedProps = useForwardProps(delegatedProps)
   <DropdownMenuItem
     v-bind="forwardedProps"
     :class="cn(
-      'relative flex cursor-default select-none items-center rounded-sm gap-2 px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&>svg]:size-4 [&>svg]:shrink-0',
+      'relative flex cursor-default select-none items-center rounded-sm gap-2 px-2 py-1.5 text-[13px] outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&>svg]:size-4 [&>svg]:shrink-0',
       inset && 'pl-8',
       props.class,
     )"

--- a/src/components/ui/select/SelectLabel.vue
+++ b/src/components/ui/select/SelectLabel.vue
@@ -8,7 +8,7 @@ const props = defineProps<SelectLabelProps & { class?: HTMLAttributes["class"] }
 </script>
 
 <template>
-  <SelectLabel :class="cn('px-2 py-1.5 text-sm font-semibold', props.class)">
+  <SelectLabel :class="cn('text-muted-foreground px-2 py-1.5 text-xs', props.class)">
     <slot />
   </SelectLabel>
 </template>

--- a/src/composables/useDeleteConfirmation.ts
+++ b/src/composables/useDeleteConfirmation.ts
@@ -1,0 +1,75 @@
+import type { ModelRef } from 'vue'
+import type { Game } from '~/database/model'
+
+interface UseDeleteConfirmationOptions {
+  /** 控制对话框开关的 v-model ref */
+  open: ModelRef<boolean | undefined>
+  /** 返回用于监听变化的标识符（如 engine.id、groupName） */
+  identifier: () => unknown
+  /** 检查是否可删除，返回关联的游戏列表 */
+  checkDelete: () => Promise<{ associatedGames?: Game[] }>
+  /** 执行实际删除操作 */
+  performDelete: () => Promise<void>
+  /** 删除成功后的提示信息 */
+  successMessage: () => string
+  /** 删除失败时的兜底错误信息 */
+  fallbackErrorMessage: () => string
+  /** 日志前缀，用于 logger.error */
+  logPrefix: string
+}
+
+export function useDeleteConfirmation(options: UseDeleteConfirmationOptions) {
+  let associatedGames = $ref<Game[]>([])
+  let isCheckingDelete = $ref(false)
+
+  const isDeleteBlocked = $computed(() => associatedGames.length > 0)
+  const isConfirmDisabled = $computed(() => isCheckingDelete || isDeleteBlocked)
+
+  async function loadDeleteCheck(): Promise<void> {
+    isCheckingDelete = true
+    try {
+      const result = await options.checkDelete()
+      associatedGames = result.associatedGames ?? []
+    } catch (error) {
+      associatedGames = []
+      logger.error(`${options.logPrefix}: ${error}`)
+    } finally {
+      isCheckingDelete = false
+    }
+  }
+
+  watch(() => [options.open.value, options.identifier()], ([isOpen]) => {
+    if (!isOpen) {
+      associatedGames = []
+      isCheckingDelete = false
+      return
+    }
+
+    void loadDeleteCheck()
+  }, { immediate: true })
+
+  function handleConfirm() {
+    if (isConfirmDisabled) {
+      return
+    }
+
+    void options.performDelete()
+      .then(() => {
+        options.open.value = false
+        notify.success(options.successMessage())
+      })
+      .catch((error) => {
+        notify.error(error instanceof Error
+          ? error.message
+          : options.fallbackErrorMessage())
+      })
+  }
+
+  return $$({
+    associatedGames,
+    isCheckingDelete,
+    isDeleteBlocked,
+    isConfirmDisabled,
+    handleConfirm,
+  })
+}

--- a/src/composables/useDeleteConfirmation.ts
+++ b/src/composables/useDeleteConfirmation.ts
@@ -21,25 +21,33 @@ interface UseDeleteConfirmationOptions {
 export function useDeleteConfirmation(options: UseDeleteConfirmationOptions) {
   let associatedGames = $ref<Game[]>([])
   let isCheckingDelete = $ref(false)
+  let isDeleting = $ref(false)
+  let checkRequestId = 0
 
   const isDeleteBlocked = $computed(() => associatedGames.length > 0)
-  const isConfirmDisabled = $computed(() => isCheckingDelete || isDeleteBlocked)
+  const isConfirmDisabled = $computed(() => isCheckingDelete || isDeleteBlocked || isDeleting)
 
   async function loadDeleteCheck(): Promise<void> {
+    const requestId = ++checkRequestId
     isCheckingDelete = true
     try {
       const result = await options.checkDelete()
+      if (requestId !== checkRequestId) return
       associatedGames = result.associatedGames ?? []
     } catch (error) {
+      if (requestId !== checkRequestId) return
       associatedGames = []
       logger.error(`${options.logPrefix}: ${error}`)
     } finally {
-      isCheckingDelete = false
+      if (requestId === checkRequestId) {
+        isCheckingDelete = false
+      }
     }
   }
 
   watch(() => [options.open.value, options.identifier()], ([isOpen]) => {
     if (!isOpen) {
+      checkRequestId++
       associatedGames = []
       isCheckingDelete = false
       return
@@ -53,7 +61,8 @@ export function useDeleteConfirmation(options: UseDeleteConfirmationOptions) {
       return
     }
 
-    void options.performDelete()
+    isDeleting = true
+    options.performDelete()
       .then(() => {
         options.open.value = false
         notify.success(options.successMessage())
@@ -62,6 +71,9 @@ export function useDeleteConfirmation(options: UseDeleteConfirmationOptions) {
         notify.error(error instanceof Error
           ? error.message
           : options.fallbackErrorMessage())
+      })
+      .finally(() => {
+        isDeleting = false
       })
   }
 

--- a/src/composables/useDeleteConfirmation.ts
+++ b/src/composables/useDeleteConfirmation.ts
@@ -32,10 +32,14 @@ export function useDeleteConfirmation(options: UseDeleteConfirmationOptions) {
     isCheckingDelete = true
     try {
       const result = await options.checkDelete()
-      if (requestId !== checkRequestId) return
+      if (requestId !== checkRequestId) {
+        return
+      }
       associatedGames = result.associatedGames ?? []
     } catch (error) {
-      if (requestId !== checkRequestId) return
+      if (requestId !== checkRequestId) {
+        return
+      }
       associatedGames = []
       logger.error(`${options.logPrefix}: ${error}`)
     } finally {

--- a/src/services/platform/__tests__/storage-defaults.test.ts
+++ b/src/services/platform/__tests__/storage-defaults.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { resolveMissingStorageSavePaths } from '~/services/platform/storage-defaults'
+
+describe('resolveMissingStorageSavePaths', () => {
+  it('所有路径都已存在时不会再请求基础目录', async () => {
+    const getBaseDir = vi.fn()
+
+    await expect(resolveMissingStorageSavePaths({
+      gameSavePath: '/games',
+      engineSavePath: '/engines',
+      templateSavePath: '/templates',
+    }, {
+      getBaseDir,
+    })).resolves.toEqual({})
+
+    expect(getBaseDir).not.toHaveBeenCalled()
+  })
+
+  it('只会为缺失的路径计算默认值', async () => {
+    const getBaseDir = vi.fn(async () => '/documents')
+    const resolveGameSavePath = vi.fn(async (baseDir: string) => `${baseDir}/WebGALCraft/games`)
+    const resolveEngineSavePath = vi.fn(async (baseDir: string) => `${baseDir}/WebGALCraft/engines`)
+    const resolveTemplateSavePath = vi.fn(async (baseDir: string) => `${baseDir}/WebGALCraft/templates`)
+
+    await expect(resolveMissingStorageSavePaths({
+      gameSavePath: '',
+      engineSavePath: '/engines',
+      templateSavePath: '',
+    }, {
+      getBaseDir,
+      resolveGameSavePath,
+      resolveEngineSavePath,
+      resolveTemplateSavePath,
+    })).resolves.toEqual({
+      gameSavePath: '/documents/WebGALCraft/games',
+      templateSavePath: '/documents/WebGALCraft/templates',
+    })
+
+    expect(getBaseDir).toHaveBeenCalledTimes(1)
+    expect(resolveGameSavePath).toHaveBeenCalledWith('/documents')
+    expect(resolveEngineSavePath).not.toHaveBeenCalled()
+    expect(resolveTemplateSavePath).toHaveBeenCalledWith('/documents')
+  })
+})

--- a/src/services/platform/app-paths.ts
+++ b/src/services/platform/app-paths.ts
@@ -2,51 +2,76 @@ import { join } from '@tauri-apps/api/path'
 
 // ==================== 游戏路径 ====================
 
+/** 项目配置: {gamePath}/project.wgcp */
+export function projectConfigPath(gamePath: string): Promise<string> {
+  return join(gamePath, 'project.wgcp')
+}
+
 /** game 根目录: {gamePath}/game */
-export function gameRootDir(gamePath: string) {
+export function gameRootDir(gamePath: string): Promise<string> {
   return join(gamePath, 'game')
 }
 
+/** 游戏配置: {gamePath}/game/config.txt */
+export function gameConfigPath(gamePath: string): Promise<string> {
+  return join(gamePath, 'game', 'config.txt')
+}
+
 /** 场景目录: {gamePath}/game/scene */
-export function gameSceneDir(gamePath: string) {
+export function gameSceneDir(gamePath: string): Promise<string> {
   return join(gamePath, 'game', 'scene')
 }
 
 /** 资产目录: {gamePath}/game/{assetType} */
-export function gameAssetDir(gamePath: string, assetType: string) {
+export function gameAssetDir(gamePath: string, assetType: string): Promise<string> {
   return join(gamePath, 'game', assetType)
 }
 
 /** 游戏图标: {gamePath}/icons/favicon.ico */
-export function gameIconPath(gamePath: string) {
+export function gameIconPath(gamePath: string): Promise<string> {
   return join(gamePath, 'icons', 'favicon.ico')
 }
 
 /** 游戏封面: {gamePath}/game/background/{fileName} */
-export function gameCoverPath(gamePath: string, fileName: string) {
+export function gameCoverPath(gamePath: string, fileName: string): Promise<string> {
   return join(gamePath, 'game', 'background', fileName)
 }
 
 // ==================== 引擎路径 ====================
 
 /** 引擎图标: {enginePath}/icons/favicon.ico */
-export function engineIconPath(enginePath: string) {
+export function engineIconPath(enginePath: string): Promise<string> {
   return join(enginePath, 'icons', 'favicon.ico')
 }
 
 /** 引擎清单: {enginePath}/manifest.json */
-export function engineManifestPath(enginePath: string) {
+export function engineManifestPath(enginePath: string): Promise<string> {
   return join(enginePath, 'manifest.json')
+}
+
+/** 模板清单: {templatePath}/template.json */
+export function templateManifestPath(templatePath: string): Promise<string> {
+  return join(templatePath, 'template.json')
+}
+
+/** 引擎内建模板目录: {enginePath}/game/template */
+export function engineTemplateDir(enginePath: string): Promise<string> {
+  return join(enginePath, 'game', 'template')
 }
 
 // ==================== 应用存储路径 ====================
 
 /** 默认游戏存储: {baseDir}/WebGALCraft/games */
-export function defaultGameSavePath(baseDir: string) {
+export function defaultGameSavePath(baseDir: string): Promise<string> {
   return join(baseDir, 'WebGALCraft', 'games')
 }
 
 /** 默认引擎存储: {baseDir}/WebGALCraft/engines */
-export function defaultEngineSavePath(baseDir: string) {
+export function defaultEngineSavePath(baseDir: string): Promise<string> {
   return join(baseDir, 'WebGALCraft', 'engines')
+}
+
+/** 默认模板存储: {baseDir}/WebGALCraft/templates */
+export function defaultTemplateSavePath(baseDir: string): Promise<string> {
+  return join(baseDir, 'WebGALCraft', 'templates')
 }

--- a/src/services/platform/asset-url.ts
+++ b/src/services/platform/asset-url.ts
@@ -1,5 +1,6 @@
 import { usePreviewSessionStore } from '~/stores/preview-session'
 import { useWorkspaceStore } from '~/stores/workspace'
+import { normalizeFsPath } from '~/utils/path'
 
 export interface AssetThumbnailOptions {
   width: number
@@ -18,10 +19,6 @@ interface ResolvedPath {
   root: string
   segments: string[]
   escapedBase?: boolean
-}
-
-function normalizeFsPath(input: string): string {
-  return input.replaceAll('\\', '/')
 }
 
 function parsePath(input: string): ResolvedPath {

--- a/src/services/platform/storage-defaults.ts
+++ b/src/services/platform/storage-defaults.ts
@@ -1,0 +1,49 @@
+import { documentDir } from '@tauri-apps/api/path'
+
+import { defaultEngineSavePath, defaultGameSavePath, defaultTemplateSavePath } from './app-paths'
+
+export interface StorageSavePathState {
+  gameSavePath: string
+  engineSavePath: string
+  templateSavePath: string
+}
+
+interface ResolveMissingStorageSavePathsOptions {
+  getBaseDir?: () => Promise<string>
+  resolveGameSavePath?: (baseDir: string) => Promise<string>
+  resolveEngineSavePath?: (baseDir: string) => Promise<string>
+  resolveTemplateSavePath?: (baseDir: string) => Promise<string>
+}
+
+const DEFAULTS: Record<
+  keyof StorageSavePathState,
+  { resolverKey: keyof ResolveMissingStorageSavePathsOptions, fallback: (baseDir: string) => Promise<string> }
+> = {
+  gameSavePath: { resolverKey: 'resolveGameSavePath', fallback: defaultGameSavePath },
+  engineSavePath: { resolverKey: 'resolveEngineSavePath', fallback: defaultEngineSavePath },
+  templateSavePath: { resolverKey: 'resolveTemplateSavePath', fallback: defaultTemplateSavePath },
+}
+
+export async function resolveMissingStorageSavePaths(
+  storageSettings: StorageSavePathState,
+  options: ResolveMissingStorageSavePathsOptions = {},
+): Promise<Partial<StorageSavePathState>> {
+  const missingKeys = (Object.keys(DEFAULTS) as (keyof StorageSavePathState)[])
+    .filter(key => storageSettings[key] === '')
+
+  if (missingKeys.length === 0) {
+    return {}
+  }
+
+  const baseDir = await (options.getBaseDir ?? documentDir)()
+  const resolvedEntries = await Promise.all(
+    missingKeys.map(async (key) => {
+      const { resolverKey, fallback } = DEFAULTS[key]
+      const resolver = options[resolverKey] as ((baseDir: string) => Promise<string>) | undefined
+      const value = await (resolver ?? fallback)(baseDir)
+      return [key, value] as const
+    }),
+  )
+
+  return Object.fromEntries(resolvedEntries)
+}

--- a/src/types/__tests__/errors.test.ts
+++ b/src/types/__tests__/errors.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+
+import { AppError } from '~/types/errors'
+
+describe('AppError.fromInvoke', () => {
+  it('保留 schema version 过新错误的结构化字段', () => {
+    const error = AppError.fromInvoke('read_project_config_cmd', {
+      code: 'SCHEMA_VERSION_TOO_NEW',
+      message: '项目配置 schema 版本过新：发现 v3，最高支持 v1',
+      found: 3,
+      maxSupported: 1,
+    })
+
+    expect(error.code).toBe('SCHEMA_VERSION_TOO_NEW')
+    expect(error.details).toEqual({
+      found: 3,
+      maxSupported: 1,
+    })
+  })
+
+  it('保留项目配置错误的结构化字段', () => {
+    const error = AppError.fromInvoke('read_project_config_cmd', {
+      code: 'INVALID_PROJECT_CONFIG',
+      message: '项目配置无效：缺少 engine',
+      reason: '缺少 engine',
+    })
+
+    expect(error.code).toBe('INVALID_PROJECT_CONFIG')
+    expect(error.details).toEqual({
+      reason: '缺少 engine',
+    })
+  })
+})

--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -1,58 +1,60 @@
-/** 后端 Rust 侧错误码 */
-type BackendErrorCode =
-  | 'IO_ERROR'
-  | 'IMAGE_ERROR'
-  | 'SERVER_ERROR'
-  | 'CONFIG_ERROR'
-  | 'WINDOW_ERROR'
-  | 'TAURI_ERROR'
+/** 所有合法错误码，同时用于类型派生和运行时校验 */
+const ERROR_CODES = [
+  // 后端 Rust 侧错误码
+  'IO_ERROR', 'IMAGE_ERROR', 'SERVER_ERROR', 'CONFIG_ERROR', 'WINDOW_ERROR', 'TAURI_ERROR',
+  'PATH_DENIED', 'NOT_FOUND', 'WRITE_TO_ENGINE_RUNTIME', 'VFS_ERROR', 'SCHEMA_VERSION_TOO_NEW', 'INVALID_PROJECT_CONFIG', 'SITE_NOT_REGISTERED',
+  // 前端通用错误码
+  'UNKNOWN', 'DIR_NOT_FOUND', 'PATH_TRAVERSAL', 'FS_ERROR', 'EDITOR_ERROR', 'INVALID_STRUCTURE', 'DUPLICATE_RESOURCE',
+] as const
 
-/** 前端通用错误码 */
-type FrontendErrorCode =
-  | 'UNKNOWN'
-  | 'DIR_NOT_FOUND'
-  | 'PATH_TRAVERSAL'
-  | 'FS_ERROR'
-  | 'EDITOR_ERROR'
-  | 'INVALID_STRUCTURE'
-
-export type ErrorCode = BackendErrorCode | FrontendErrorCode
+export type ErrorCode = typeof ERROR_CODES[number]
 
 /** 后端返回的结构化错误 */
 export interface BackendError {
   code: string
   message: string
+  [key: string]: unknown
+}
+
+export interface AppErrorDetails {
+  found?: number
+  maxSupported?: number
+  reason?: string
+  [key: string]: unknown
 }
 
 export function isBackendError(value: unknown): value is BackendError {
-  if (typeof value !== 'object' || value === null) {
-    return false
-  }
-  const obj = value as Record<string, unknown>
-  return typeof obj.code === 'string' && typeof obj.message === 'string'
+  return typeof value === 'object'
+    && value !== null
+    && 'code' in value
+    && 'message' in value
+    && typeof value.code === 'string'
+    && typeof value.message === 'string'
 }
 
-/** 用于运行时校验后端返回的错误码 */
-const VALID_ERROR_CODES: ReadonlySet<string> = new Set<ErrorCode>([
-  'IO_ERROR', 'IMAGE_ERROR', 'SERVER_ERROR', 'CONFIG_ERROR', 'WINDOW_ERROR', 'TAURI_ERROR',
-  'UNKNOWN', 'DIR_NOT_FOUND', 'PATH_TRAVERSAL', 'FS_ERROR', 'EDITOR_ERROR', 'INVALID_STRUCTURE',
-])
+const VALID_ERROR_CODES: ReadonlySet<string> = new Set(ERROR_CODES)
 
 /** 应用统一错误类 */
 export class AppError extends Error {
   readonly code: ErrorCode
+  readonly details?: AppErrorDetails
 
-  constructor(code: ErrorCode, message: string, options?: ErrorOptions) {
+  constructor(code: ErrorCode, message: string, options?: ErrorOptions & { details?: AppErrorDetails }) {
     super(message, options)
     this.name = 'AppError'
     this.code = code
+    this.details = options?.details
   }
 
   /** 从 invoke catch 中的 unknown 值构造 */
   static fromInvoke(command: string, error: unknown): AppError {
     if (isBackendError(error)) {
       const code = VALID_ERROR_CODES.has(error.code) ? (error.code as ErrorCode) : 'UNKNOWN'
-      return new AppError(code, error.message, { cause: error })
+      const { code: _backendCode, message: _backendMessage, ...details } = error
+      return new AppError(code, error.message, {
+        cause: error,
+        details: Object.keys(details).length > 0 ? details : undefined,
+      })
     }
     const message = error instanceof Error ? error.message : String(error)
     return new AppError('UNKNOWN', `${command}: ${message}`, { cause: error })

--- a/src/types/menu-item.ts
+++ b/src/types/menu-item.ts
@@ -1,0 +1,9 @@
+import type { Component } from 'vue'
+
+export interface MenuItem {
+  icon: Component
+  label: string
+  onClick: () => void
+  disabled?: boolean
+  class?: string
+}

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -1,13 +1,65 @@
+/** 反斜杠统一为正斜杠 */
+function toForwardSlash(path: string): string {
+  return path.replaceAll('\\', '/')
+}
+
 export function toComparablePath(path: string): string {
-  return path
-    .replaceAll('\\', '/')
+  return toForwardSlash(path)
     .replace(/\/+$/, '')
     .toLocaleLowerCase()
 }
 
+export function normalizeFsPath(path: string): string {
+  return toForwardSlash(path).replace(/\/+$/, '')
+}
+
 export function normalizeRelativePath(path: string): string {
-  return path
-    .replaceAll('\\', '/')
+  return toForwardSlash(path)
     .replace(/^\/+/, '')
     .replace(/\/+$/, '')
+}
+
+/**
+ * 同步拼接路径片段，统一以 `/` 作为分隔符。
+ *
+ * 与 `@tauri-apps/api/path` 的 `join`（平台分隔符）刻意不同：
+ * 本仓库内部路径字符串一律使用 `/`，与 `getParentPath` / `getBaseName` /
+ * `normalizeFsPath` 等同模块工具保持一致；Tauri 后端、`plugin-fs`、
+ * VFS 命令均接受 `/`，无需平台分支。
+ */
+export function joinPath(...parts: string[]): string {
+  return parts
+    .filter(Boolean)
+    .join('/')
+    .replaceAll(/[/\\]+/g, '/')
+}
+
+export function getBaseName(path: string): string {
+  const normalized = toForwardSlash(path)
+  const lastSlash = normalized.lastIndexOf('/')
+  return lastSlash === -1 ? normalized : normalized.slice(lastSlash + 1)
+}
+
+export function getParentPath(path: string): string {
+  const normalized = toForwardSlash(path)
+  const lastSlash = normalized.lastIndexOf('/')
+  if (lastSlash <= 0) {
+    return normalized.slice(0, lastSlash + 1) || '/'
+  }
+  return normalized.slice(0, lastSlash)
+}
+
+export function buildUniqueEntryName(baseName: string, isDir: boolean, existingNames: ReadonlySet<string>): string {
+  let counter = 1
+  let nextName = baseName
+  const lastDotIndex = baseName.lastIndexOf('.')
+  const ext = isDir || lastDotIndex === -1 ? '' : baseName.slice(lastDotIndex)
+  const nameWithoutExt = isDir || lastDotIndex === -1 ? baseName : baseName.slice(0, lastDotIndex)
+
+  while (existingNames.has(nextName)) {
+    nextName = `${nameWithoutExt} (${counter})${ext}`
+    counter++
+  }
+
+  return nextName
 }

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -53,8 +53,9 @@ export function buildUniqueEntryName(baseName: string, isDir: boolean, existingN
   let counter = 1
   let nextName = baseName
   const lastDotIndex = baseName.lastIndexOf('.')
-  const ext = isDir || lastDotIndex === -1 ? '' : baseName.slice(lastDotIndex)
-  const nameWithoutExt = isDir || lastDotIndex === -1 ? baseName : baseName.slice(0, lastDotIndex)
+  const hasExt = !isDir && lastDotIndex > 0
+  const ext = hasExt ? baseName.slice(lastDotIndex) : ''
+  const nameWithoutExt = hasExt ? baseName.slice(0, lastDotIndex) : baseName
 
   while (existingNames.has(nextName)) {
     nextName = `${nameWithoutExt} (${counter})${ext}`


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [ ] 错误修复
- [x] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [x] 代码重构
- [ ] 测试用例
- [ ] 性能优化
- [x] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

为后续 VFS 相关功能补充一组可复用的共享基础设施，主要包括：

- 新增通用路径工具，统一处理路径标准化、同步拼接、父路径/文件名提取，以及重复名称生成逻辑
- 扩展平台路径解析能力，补充项目配置、游戏配置、模板清单、模板目录及默认模板存储路径等解析函数
- 新增存储默认值解析逻辑，用于按需补全缺失的 game / engine / template 存储目录
- 重构前端错误类型，补充更多合法错误码，并在 `AppError.fromInvoke` 中保留后端返回的结构化字段
- 新增通用删除确认 composable，封装删除前关联检查、禁用态控制和删除执行流程
- 提取通用菜单项类型，减少后续菜单定义的重复代码
- 顺手统一了部分菜单/选择器文案样式中的字号和标签表现
- 为新增的默认存储路径解析和错误结构保留逻辑补充测试

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

当前分支的目标是为 VFS 相关能力建设共享基础设施。现有代码中，路径处理、默认存储目录补全、删除确认流程以及错误对象解析存在分散实现或能力缺口，不利于后续功能复用，也会增加平台路径和结构化错误处理上的重复工作。

这次改动先把这些底层公共能力补齐，便于后续在 VFS、资源管理和项目配置相关功能中直接复用。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->

- 本次改动未直接引入完整 VFS 功能，更偏向底层能力铺设
- `AppError` 现在会保留后端错误中的额外字段，便于上层针对 schema 版本、项目配置等场景做更精确的提示和处理
- 存储目录默认值解析采用“仅补全缺失项”的策略，避免对已有设置产生覆盖

### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
