### PR TITLE
✨ 引入 VFS 核心后端与项目配置命令

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5678,13 +5678,13 @@ dependencies = [
 name = "webgal-craft"
 version = "0.0.0"
 dependencies = [
- "anyhow",
  "axum",
  "futures",
  "image",
  "log",
+ "mime_guess",
+ "percent-encoding",
  "portpicker",
- "regex",
  "serde",
  "serde_json",
  "tauri",
@@ -5700,6 +5700,7 @@ dependencies = [
  "tauri-plugin-single-instance",
  "tauri-plugin-updater",
  "tauri-plugin-window-state",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tower",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5682,8 +5682,6 @@ dependencies = [
  "futures",
  "image",
  "log",
- "mime_guess",
- "percent-encoding",
  "portpicker",
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -30,13 +30,14 @@ tokio = { version = "1.50", features = ["rt", "sync", "fs"] }
 tower = "0.5"
 tower-http = { version = "0.6", features = ["fs"] }
 portpicker = "0.1"
-regex = "1.12"
 thiserror = "2.0"
-anyhow = "1.0"
 image = { version = "0.25", default-features = false, features = ["png", "jpeg", "gif", "webp", "ico"] }
 trash = "5.2"
 futures = "0.3"
 urlencoding = "2.1"
+mime_guess = "2.0"
+percent-encoding = "2.3"
+tempfile = "3.15"
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-single-instance = "2.4"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -35,8 +35,6 @@ image = { version = "0.25", default-features = false, features = ["png", "jpeg",
 trash = "5.2"
 futures = "0.3"
 urlencoding = "2.1"
-mime_guess = "2.0"
-percent-encoding = "2.3"
 tempfile = "3.15"
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]

--- a/src-tauri/src/commands/error.rs
+++ b/src-tauri/src/commands/error.rs
@@ -2,6 +2,8 @@ use std::io;
 
 use thiserror::Error;
 
+use crate::vfs::VfsError;
+
 #[derive(Debug, Error)]
 pub enum AppError {
     #[error(transparent)]
@@ -20,6 +22,19 @@ pub enum AppError {
     Window(String),
 
     #[error(transparent)]
+    Vfs(#[from] VfsError),
+
+    #[error("项目配置 schema 版本过新：发现 v{found}，最高支持 v{max_supported}")]
+    SchemaVersionTooNew { found: u32, max_supported: u32 },
+
+    #[error("项目配置无效：{reason}")]
+    InvalidProjectConfig { reason: String },
+
+    #[error("站点未注册")]
+    #[allow(dead_code)] // PR3 server 重构启用
+    SiteNotRegistered,
+
+    #[error(transparent)]
     Tauri(#[from] tauri::Error),
 }
 
@@ -32,6 +47,10 @@ impl AppError {
             Self::Server(_) => "SERVER_ERROR",
             Self::Config(_) => "CONFIG_ERROR",
             Self::Window(_) => "WINDOW_ERROR",
+            Self::Vfs(error) => error.code(),
+            Self::SchemaVersionTooNew { .. } => "SCHEMA_VERSION_TOO_NEW",
+            Self::InvalidProjectConfig { .. } => "INVALID_PROJECT_CONFIG",
+            Self::SiteNotRegistered => "SITE_NOT_REGISTERED",
             Self::Tauri(_) => "TAURI_ERROR",
         }
     }
@@ -43,9 +62,25 @@ impl serde::Serialize for AppError {
         S: serde::ser::Serializer,
     {
         use serde::ser::SerializeStruct;
-        let mut s = serializer.serialize_struct("AppError", 2)?;
+
+        let mut s = serializer.serialize_struct("AppError", 4)?;
         s.serialize_field("code", self.code())?;
         s.serialize_field("message", &self.to_string())?;
+
+        match self {
+            Self::SchemaVersionTooNew {
+                found,
+                max_supported,
+            } => {
+                s.serialize_field("found", found)?;
+                s.serialize_field("maxSupported", max_supported)?;
+            }
+            Self::InvalidProjectConfig { reason } => {
+                s.serialize_field("reason", reason)?;
+            }
+            _ => {}
+        }
+
         s.end()
     }
 }
@@ -67,6 +102,14 @@ mod tests {
         assert_eq!(AppError::Server("server".into()).code(), "SERVER_ERROR");
         assert_eq!(AppError::Config("config".into()).code(), "CONFIG_ERROR");
         assert_eq!(AppError::Window("window".into()).code(), "WINDOW_ERROR");
+        assert_eq!(
+            AppError::SchemaVersionTooNew {
+                found: 2,
+                max_supported: 1,
+            }
+            .code(),
+            "SCHEMA_VERSION_TOO_NEW"
+        );
     }
 
     #[test]
@@ -79,6 +122,25 @@ mod tests {
             json!({
                 "code": "CONFIG_ERROR",
                 "message": "配置错误: 缺少配置",
+            })
+        );
+    }
+
+    #[test]
+    fn app_error_serialization_preserves_structured_fields() {
+        let serialized = serde_json::to_value(AppError::SchemaVersionTooNew {
+            found: 3,
+            max_supported: 1,
+        })
+        .expect("schema version error should serialize");
+
+        assert_eq!(
+            serialized,
+            json!({
+                "code": "SCHEMA_VERSION_TOO_NEW",
+                "message": "项目配置 schema 版本过新：发现 v3，最高支持 v1",
+                "found": 3,
+                "maxSupported": 1,
             })
         );
     }

--- a/src-tauri/src/commands/error.rs
+++ b/src-tauri/src/commands/error.rs
@@ -30,10 +30,6 @@ pub enum AppError {
     #[error("项目配置无效：{reason}")]
     InvalidProjectConfig { reason: String },
 
-    #[error("站点未注册")]
-    #[allow(dead_code)] // PR3 server 重构启用
-    SiteNotRegistered,
-
     #[error(transparent)]
     Tauri(#[from] tauri::Error),
 }
@@ -50,7 +46,6 @@ impl AppError {
             Self::Vfs(error) => error.code(),
             Self::SchemaVersionTooNew { .. } => "SCHEMA_VERSION_TOO_NEW",
             Self::InvalidProjectConfig { .. } => "INVALID_PROJECT_CONFIG",
-            Self::SiteNotRegistered => "SITE_NOT_REGISTERED",
             Self::Tauri(_) => "TAURI_ERROR",
         }
     }

--- a/src-tauri/src/commands/fs.rs
+++ b/src-tauri/src/commands/fs.rs
@@ -454,7 +454,8 @@ mod tests {
 
         fs::create_dir_all(src.join("template")).expect("template dir should be created");
         fs::write(src.join("config.txt"), "config").expect("root file should be written");
-        fs::write(src.join("template").join("start.txt"), "tpl").expect("tpl file should be written");
+        fs::write(src.join("template").join("start.txt"), "tpl")
+            .expect("tpl file should be written");
 
         copy_dir_all(
             &src,

--- a/src-tauri/src/commands/fs.rs
+++ b/src-tauri/src/commands/fs.rs
@@ -26,11 +26,7 @@ pub enum CopyEvent {
     },
 }
 
-fn count_files_with_excludes(
-    path: &Path,
-    excludes: &[PathBuf],
-    rel: &Path,
-) -> AppResult<usize> {
+fn count_files_with_excludes(path: &Path, excludes: &[PathBuf], rel: &Path) -> AppResult<usize> {
     let mut count = 0;
     for entry in fs::read_dir(path)? {
         let entry = entry?;

--- a/src-tauri/src/commands/fs.rs
+++ b/src-tauri/src/commands/fs.rs
@@ -62,12 +62,16 @@ struct ProgressTracker {
 }
 
 /// 递归复制文件夹
+///
+/// `overwrite` 为 false 时使用 create_new 语义，仅在目标不存在时复制，保护已有用户修改；
+/// 为 true 时覆盖目标文件，用于安装/创建等需要刷新内容的流程。
 fn copy_dir_all(
     src: &Path,
     dst: &Path,
     progress_tracker: &mut Option<&mut ProgressTracker>,
     excludes: &[std::path::PathBuf],
     rel: &Path,
+    overwrite: bool,
 ) -> io::Result<()> {
     if !dst.exists() {
         fs::create_dir_all(dst)?;
@@ -86,20 +90,35 @@ fn copy_dir_all(
         }
 
         if ty.is_dir() {
-            copy_dir_all(&src_path, &dst_path, progress_tracker, excludes, &entry_rel)?;
+            copy_dir_all(
+                &src_path,
+                &dst_path,
+                progress_tracker,
+                excludes,
+                &entry_rel,
+                overwrite,
+            )?;
         } else {
-            // create_new 语义：仅在目标不存在时复制；保护已有用户修改
-            match OpenOptions::new()
-                .write(true)
-                .create_new(true)
-                .open(&dst_path)
-            {
+            let open_result = if overwrite {
+                OpenOptions::new()
+                    .write(true)
+                    .create(true)
+                    .truncate(true)
+                    .open(&dst_path)
+            } else {
+                OpenOptions::new()
+                    .write(true)
+                    .create_new(true)
+                    .open(&dst_path)
+            };
+
+            match open_result {
                 Ok(mut dst_file) => {
                     let mut src_file = fs::File::open(&src_path)?;
                     io::copy(&mut src_file, &mut dst_file)?;
                 }
-                Err(error) if error.kind() == ErrorKind::AlreadyExists => {
-                    // 目标已存在：跳过，不覆盖
+                Err(error) if !overwrite && error.kind() == ErrorKind::AlreadyExists => {
+                    // 目标已存在且未启用覆盖：保留用户已有修改
                 }
                 Err(error) => return Err(error),
             }
@@ -132,6 +151,7 @@ pub async fn copy_directory_with_progress(
     destination: String,
     on_event: Channel<CopyEvent>,
     excludes: Option<Vec<String>>,
+    overwrite: Option<bool>,
 ) -> AppResult<()> {
     let source_path = Path::new(&source);
     let destination_path = Path::new(&destination);
@@ -149,6 +169,7 @@ pub async fn copy_directory_with_progress(
         .into_iter()
         .map(std::path::PathBuf::from)
         .collect();
+    let overwrite = overwrite.unwrap_or(false);
 
     // 计算总文件数
     let total_files = count_files_with_excludes(source_path, &exclude_paths, Path::new(""))?;
@@ -168,6 +189,7 @@ pub async fn copy_directory_with_progress(
         &mut Some(&mut progress_tracker),
         &exclude_paths,
         Path::new(""),
+        overwrite,
     ) {
         progress_tracker
             .sender
@@ -200,7 +222,14 @@ pub async fn copy_directory(source: String, destination: String) -> AppResult<()
     }
 
     // 递归复制目录
-    copy_dir_all(source_path, destination_path, &mut None, &[], Path::new(""))?;
+    copy_dir_all(
+        source_path,
+        destination_path,
+        &mut None,
+        &[],
+        Path::new(""),
+        false,
+    )?;
 
     Ok(())
 }
@@ -427,7 +456,7 @@ mod tests {
         fs::write(dst.join("game").join("config.txt"), "user-modified")
             .expect("dst config should be written");
 
-        copy_dir_all(&src, &dst, &mut None, &[], Path::new(""))
+        copy_dir_all(&src, &dst, &mut None, &[], Path::new(""), false)
             .expect("copy_dir_all should succeed with create_new semantics");
 
         let preserved = fs::read_to_string(dst.join("game").join("config.txt"))
@@ -463,11 +492,42 @@ mod tests {
             &mut None,
             &[PathBuf::from("template")],
             Path::new(""),
+            false,
         )
         .expect("copy_dir_all should succeed with excludes");
 
         assert!(dst.join("config.txt").exists());
         assert!(!dst.join("template").exists());
+
+        fs::remove_dir_all(&src).expect("src temp dir should be removed");
+        fs::remove_dir_all(&dst).expect("dst temp dir should be removed");
+    }
+
+    #[test]
+    fn copy_dir_all_overwrites_existing_files_when_requested() {
+        use std::path::Path;
+
+        let src = create_temp_dir("webgal-craft-copy-overwrite-src");
+        let dst = create_temp_dir("webgal-craft-copy-overwrite-dst");
+
+        fs::create_dir_all(src.join("game")).expect("src game dir should be created");
+        fs::write(src.join("game").join("config.txt"), "engine-new")
+            .expect("src config should be written");
+
+        // 模拟上一次安装失败留下的旧版本残留
+        fs::create_dir_all(dst.join("game")).expect("dst game dir should be created");
+        fs::write(dst.join("game").join("config.txt"), "stale-leftover")
+            .expect("stale file should be written");
+
+        copy_dir_all(&src, &dst, &mut None, &[], Path::new(""), true)
+            .expect("copy_dir_all should succeed in overwrite mode");
+
+        let refreshed = fs::read_to_string(dst.join("game").join("config.txt"))
+            .expect("overwritten file should remain readable");
+        assert_eq!(
+            refreshed, "engine-new",
+            "overwrite mode must replace stale destination contents"
+        );
 
         fs::remove_dir_all(&src).expect("src temp dir should be removed");
         fs::remove_dir_all(&dst).expect("dst temp dir should be removed");

--- a/src-tauri/src/commands/fs.rs
+++ b/src-tauri/src/commands/fs.rs
@@ -1,4 +1,8 @@
-use std::{fs, io, path::Path};
+use std::{
+    fs::{self, OpenOptions},
+    io::{self, ErrorKind},
+    path::Path,
+};
 
 /// 检测文件是否为二进制文件
 /// 读取前 8192 字节，若包含 null byte 则判定为二进制
@@ -22,14 +26,26 @@ pub enum CopyEvent {
     },
 }
 
+#[cfg(test)]
 pub fn count_files(path: String) -> AppResult<usize> {
-    let path = Path::new(&path);
+    count_files_with_excludes(Path::new(&path), &[], Path::new(""))
+}
+
+fn count_files_with_excludes(
+    path: &Path,
+    excludes: &[std::path::PathBuf],
+    rel: &Path,
+) -> AppResult<usize> {
     let mut count = 0;
     for entry in fs::read_dir(path)? {
         let entry = entry?;
         let ty = entry.file_type()?;
+        let entry_rel = rel.join(entry.file_name());
+        if excludes.iter().any(|excluded| excluded == &entry_rel) {
+            continue;
+        }
         if ty.is_dir() {
-            count += count_files(entry.path().to_string_lossy().to_string())?;
+            count += count_files_with_excludes(&entry.path(), excludes, &entry_rel)?;
         } else {
             count += 1;
         }
@@ -50,6 +66,8 @@ fn copy_dir_all(
     src: &Path,
     dst: &Path,
     progress_tracker: &mut Option<&mut ProgressTracker>,
+    excludes: &[std::path::PathBuf],
+    rel: &Path,
 ) -> io::Result<()> {
     if !dst.exists() {
         fs::create_dir_all(dst)?;
@@ -60,13 +78,33 @@ fn copy_dir_all(
         let ty = entry.file_type()?;
         let src_path = entry.path();
         let dst_path = dst.join(entry.file_name());
+        let entry_rel = rel.join(entry.file_name());
+
+        // 命中排除列表（按源相对路径）时跳过
+        if excludes.iter().any(|excluded| excluded == &entry_rel) {
+            continue;
+        }
 
         if ty.is_dir() {
-            copy_dir_all(&src_path, &dst_path, progress_tracker)?;
+            copy_dir_all(&src_path, &dst_path, progress_tracker, excludes, &entry_rel)?;
         } else {
-            fs::copy(&src_path, &dst_path)?;
+            // create_new 语义：仅在目标不存在时复制；保护已有用户修改
+            match OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&dst_path)
+            {
+                Ok(mut dst_file) => {
+                    let mut src_file = fs::File::open(&src_path)?;
+                    io::copy(&mut src_file, &mut dst_file)?;
+                }
+                Err(error) if error.kind() == ErrorKind::AlreadyExists => {
+                    // 目标已存在：跳过，不覆盖
+                }
+                Err(error) => return Err(error),
+            }
 
-            // 更新进度
+            // 更新进度（无论是否实际复制都计入分子，避免进度卡顿）
             if let Some(tracker) = progress_tracker {
                 tracker.copied_files += 1;
                 let progress =
@@ -93,6 +131,7 @@ pub async fn copy_directory_with_progress(
     source: String,
     destination: String,
     on_event: Channel<CopyEvent>,
+    excludes: Option<Vec<String>>,
 ) -> AppResult<()> {
     let source_path = Path::new(&source);
     let destination_path = Path::new(&destination);
@@ -105,8 +144,14 @@ pub async fn copy_directory_with_progress(
         return Err(AppError::Server(format!("源路径不是目录: {}", source)));
     }
 
+    let exclude_paths: Vec<std::path::PathBuf> = excludes
+        .unwrap_or_default()
+        .into_iter()
+        .map(std::path::PathBuf::from)
+        .collect();
+
     // 计算总文件数
-    let total_files = count_files(source.clone())?;
+    let total_files = count_files_with_excludes(source_path, &exclude_paths, Path::new(""))?;
 
     // 创建进度跟踪器
     let mut progress_tracker = ProgressTracker {
@@ -121,6 +166,8 @@ pub async fn copy_directory_with_progress(
         source_path,
         destination_path,
         &mut Some(&mut progress_tracker),
+        &exclude_paths,
+        Path::new(""),
     ) {
         progress_tracker
             .sender
@@ -153,7 +200,7 @@ pub async fn copy_directory(source: String, destination: String) -> AppResult<()
     }
 
     // 递归复制目录
-    copy_dir_all(source_path, destination_path, &mut None)?;
+    copy_dir_all(source_path, destination_path, &mut None, &[], Path::new(""))?;
 
     Ok(())
 }
@@ -246,7 +293,10 @@ mod tests {
         time::{SystemTime, UNIX_EPOCH},
     };
 
-    use super::{count_files, is_binary_file, read_image_dimensions, validate_directory_structure};
+    use super::{
+        copy_dir_all, count_files, is_binary_file, read_image_dimensions,
+        validate_directory_structure,
+    };
 
     const PNG_1X1_BYTES: &[u8] = &[
         137, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 13, 73, 72, 68, 82, 0, 0, 0, 1, 0, 0, 0, 1, 8, 6,
@@ -352,5 +402,73 @@ mod tests {
 
         assert!(!text_is_binary);
         assert!(binary_is_binary);
+    }
+
+    #[test]
+    fn copy_dir_all_skips_existing_files_and_copies_missing_ones() {
+        use std::path::Path;
+
+        let src = create_temp_dir("webgal-craft-copy-src");
+        let dst = create_temp_dir("webgal-craft-copy-dst");
+
+        fs::create_dir_all(src.join("game")).expect("src game dir should be created");
+        fs::create_dir_all(src.join("game").join("scene"))
+            .expect("nested src dir should be created");
+        fs::write(src.join("game").join("config.txt"), "engine-default")
+            .expect("src config should be written");
+        fs::write(
+            src.join("game").join("scene").join("start.txt"),
+            "engine-scene",
+        )
+        .expect("src scene should be written");
+
+        // 目标已经存在的用户修改文件——必须保留
+        fs::create_dir_all(dst.join("game")).expect("dst game dir should be created");
+        fs::write(dst.join("game").join("config.txt"), "user-modified")
+            .expect("dst config should be written");
+
+        copy_dir_all(&src, &dst, &mut None, &[], Path::new(""))
+            .expect("copy_dir_all should succeed with create_new semantics");
+
+        let preserved = fs::read_to_string(dst.join("game").join("config.txt"))
+            .expect("preserved file should remain readable");
+        assert_eq!(
+            preserved, "user-modified",
+            "create_new must not overwrite existing user files"
+        );
+
+        let copied = fs::read_to_string(dst.join("game").join("scene").join("start.txt"))
+            .expect("missing file should have been copied from source");
+        assert_eq!(copied, "engine-scene");
+
+        fs::remove_dir_all(&src).expect("src temp dir should be removed");
+        fs::remove_dir_all(&dst).expect("dst temp dir should be removed");
+    }
+
+    #[test]
+    fn copy_dir_all_respects_excludes() {
+        use std::path::{Path, PathBuf};
+
+        let src = create_temp_dir("webgal-craft-copy-excludes-src");
+        let dst = create_temp_dir("webgal-craft-copy-excludes-dst");
+
+        fs::create_dir_all(src.join("template")).expect("template dir should be created");
+        fs::write(src.join("config.txt"), "config").expect("root file should be written");
+        fs::write(src.join("template").join("start.txt"), "tpl").expect("tpl file should be written");
+
+        copy_dir_all(
+            &src,
+            &dst,
+            &mut None,
+            &[PathBuf::from("template")],
+            Path::new(""),
+        )
+        .expect("copy_dir_all should succeed with excludes");
+
+        assert!(dst.join("config.txt").exists());
+        assert!(!dst.join("template").exists());
+
+        fs::remove_dir_all(&src).expect("src temp dir should be removed");
+        fs::remove_dir_all(&dst).expect("dst temp dir should be removed");
     }
 }

--- a/src-tauri/src/commands/fs.rs
+++ b/src-tauri/src/commands/fs.rs
@@ -1,7 +1,7 @@
 use std::{
     fs::{self, OpenOptions},
     io::{self, ErrorKind},
-    path::Path,
+    path::{Path, PathBuf},
 };
 
 /// 检测文件是否为二进制文件
@@ -26,25 +26,19 @@ pub enum CopyEvent {
     },
 }
 
-#[cfg(test)]
-pub fn count_files(path: String) -> AppResult<usize> {
-    count_files_with_excludes(Path::new(&path), &[], Path::new(""))
-}
-
 fn count_files_with_excludes(
     path: &Path,
-    excludes: &[std::path::PathBuf],
+    excludes: &[PathBuf],
     rel: &Path,
 ) -> AppResult<usize> {
     let mut count = 0;
     for entry in fs::read_dir(path)? {
         let entry = entry?;
-        let ty = entry.file_type()?;
         let entry_rel = rel.join(entry.file_name());
         if excludes.iter().any(|excluded| excluded == &entry_rel) {
             continue;
         }
-        if ty.is_dir() {
+        if entry.file_type()?.is_dir() {
             count += count_files_with_excludes(&entry.path(), excludes, &entry_rel)?;
         } else {
             count += 1;
@@ -69,7 +63,7 @@ fn copy_dir_all(
     src: &Path,
     dst: &Path,
     progress_tracker: &mut Option<&mut ProgressTracker>,
-    excludes: &[std::path::PathBuf],
+    excludes: &[PathBuf],
     rel: &Path,
     overwrite: bool,
 ) -> io::Result<()> {
@@ -84,7 +78,6 @@ fn copy_dir_all(
         let dst_path = dst.join(entry.file_name());
         let entry_rel = rel.join(entry.file_name());
 
-        // 命中排除列表（按源相对路径）时跳过
         if excludes.iter().any(|excluded| excluded == &entry_rel) {
             continue;
         }
@@ -99,36 +92,29 @@ fn copy_dir_all(
                 overwrite,
             )?;
         } else {
-            let open_result = if overwrite {
-                OpenOptions::new()
-                    .write(true)
-                    .create(true)
-                    .truncate(true)
-                    .open(&dst_path)
+            let mut options = OpenOptions::new();
+            options.write(true);
+            if overwrite {
+                options.create(true).truncate(true);
             } else {
-                OpenOptions::new()
-                    .write(true)
-                    .create_new(true)
-                    .open(&dst_path)
-            };
+                options.create_new(true);
+            }
 
-            match open_result {
+            match options.open(&dst_path) {
                 Ok(mut dst_file) => {
                     let mut src_file = fs::File::open(&src_path)?;
                     io::copy(&mut src_file, &mut dst_file)?;
                 }
-                Err(error) if !overwrite && error.kind() == ErrorKind::AlreadyExists => {
-                    // 目标已存在且未启用覆盖：保留用户已有修改
-                }
+                // 目标已存在且未启用覆盖：保留用户已有修改
+                Err(error) if !overwrite && error.kind() == ErrorKind::AlreadyExists => {}
                 Err(error) => return Err(error),
             }
 
-            // 更新进度（无论是否实际复制都计入分子，避免进度卡顿）
+            // 跳过的文件也计入分子，避免进度卡顿
             if let Some(tracker) = progress_tracker {
                 tracker.copied_files += 1;
                 let progress =
                     (tracker.copied_files as f64 / tracker.total_files as f64 * 100.0) as u32;
-                // 只有当进度变化超过1%时才发送
                 if progress - tracker.last_progress >= 1 {
                     let _ = tracker.sender.send(CopyEvent::Progress {
                         progress,
@@ -164,17 +150,15 @@ pub async fn copy_directory_with_progress(
         return Err(AppError::Server(format!("源路径不是目录: {}", source)));
     }
 
-    let exclude_paths: Vec<std::path::PathBuf> = excludes
+    let exclude_paths: Vec<PathBuf> = excludes
         .unwrap_or_default()
         .into_iter()
-        .map(std::path::PathBuf::from)
+        .map(PathBuf::from)
         .collect();
     let overwrite = overwrite.unwrap_or(false);
 
-    // 计算总文件数
     let total_files = count_files_with_excludes(source_path, &exclude_paths, Path::new(""))?;
 
-    // 创建进度跟踪器
     let mut progress_tracker = ProgressTracker {
         sender: on_event,
         total_files,
@@ -182,7 +166,6 @@ pub async fn copy_directory_with_progress(
         last_progress: 0,
     };
 
-    // 复制目录
     if let Err(e) = copy_dir_all(
         source_path,
         destination_path,
@@ -318,12 +301,12 @@ pub async fn delete_file(path: String, permanent: Option<bool>) -> AppResult<()>
 mod tests {
     use std::{
         fs,
-        path::PathBuf,
+        path::{Path, PathBuf},
         time::{SystemTime, UNIX_EPOCH},
     };
 
     use super::{
-        copy_dir_all, count_files, is_binary_file, read_image_dimensions,
+        copy_dir_all, count_files_with_excludes, is_binary_file, read_image_dimensions,
         validate_directory_structure,
     };
 
@@ -374,7 +357,7 @@ mod tests {
             .expect("nested file should be created");
         fs::write(nested.join("script.txt"), "script").expect("deep file should be created");
 
-        let file_count = count_files(root.to_string_lossy().into_owned())
+        let file_count = count_files_with_excludes(&root, &[], Path::new(""))
             .expect("file count should include nested files");
 
         fs::remove_dir_all(&root).expect("temp directory should be removed");
@@ -435,8 +418,6 @@ mod tests {
 
     #[test]
     fn copy_dir_all_skips_existing_files_and_copies_missing_ones() {
-        use std::path::Path;
-
         let src = create_temp_dir("webgal-craft-copy-src");
         let dst = create_temp_dir("webgal-craft-copy-dst");
 
@@ -476,8 +457,6 @@ mod tests {
 
     #[test]
     fn copy_dir_all_respects_excludes() {
-        use std::path::{Path, PathBuf};
-
         let src = create_temp_dir("webgal-craft-copy-excludes-src");
         let dst = create_temp_dir("webgal-craft-copy-excludes-dst");
 
@@ -505,8 +484,6 @@ mod tests {
 
     #[test]
     fn copy_dir_all_overwrites_existing_files_when_requested() {
-        use std::path::Path;
-
         let src = create_temp_dir("webgal-craft-copy-overwrite-src");
         let dst = create_temp_dir("webgal-craft-copy-overwrite-dst");
 

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,7 +1,9 @@
 pub mod error;
 pub mod fs;
 pub mod game;
+pub mod project_config;
 pub mod server;
+pub mod vfs;
 pub mod window;
 
 pub use error::{AppError, AppResult};

--- a/src-tauri/src/commands/project_config.rs
+++ b/src-tauri/src/commands/project_config.rs
@@ -1,0 +1,18 @@
+use std::path::Path;
+
+use crate::vfs::{read_project_config, write_project_config, ProjectConfig};
+
+use super::AppResult;
+
+#[tauri::command]
+pub fn read_project_config_cmd(project_path: String) -> AppResult<ProjectConfig> {
+    read_project_config(Path::new(&project_path))
+}
+
+#[tauri::command]
+pub async fn write_project_config_cmd(
+    project_path: String,
+    config: ProjectConfig,
+) -> AppResult<()> {
+    write_project_config(Path::new(&project_path), &config).await
+}

--- a/src-tauri/src/commands/vfs.rs
+++ b/src-tauri/src/commands/vfs.rs
@@ -165,24 +165,12 @@ pub fn clean_template_upper(project_path: String) -> AppResult<()> {
 
 #[cfg(test)]
 mod tests {
-    use std::{
-        fs,
-        path::{Path, PathBuf},
-        time::{SystemTime, UNIX_EPOCH},
-    };
+    use std::path::{Path, PathBuf};
+
+    use tempfile::tempdir;
 
     use super::{build_overlay, sanitize_rename_target};
     use crate::vfs::VfsError;
-
-    fn create_temp_dir(prefix: &str) -> PathBuf {
-        let unique = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("system clock should be after unix epoch")
-            .as_nanos();
-        let dir = std::env::temp_dir().join(format!("{prefix}-{unique}"));
-        fs::create_dir_all(&dir).expect("temp directory should be created");
-        dir
-    }
 
     #[test]
     fn sanitize_rename_target_rejects_nested_or_traversal_names() {
@@ -207,10 +195,10 @@ mod tests {
 
     #[test]
     fn build_overlay_allows_engines_without_template_directory() {
-        let upper = create_temp_dir("webgal-craft-vfs-command-upper");
-        let engine = create_temp_dir("webgal-craft-vfs-command-engine");
-        let upper_str = upper.to_str().expect("temp path should be valid UTF-8");
-        let engine_str = engine.to_str().expect("temp path should be valid UTF-8");
+        let upper = tempdir().expect("upper temp dir should be created");
+        let engine = tempdir().expect("engine temp dir should be created");
+        let upper_str = upper.path().to_str().expect("temp path should be valid UTF-8");
+        let engine_str = engine.path().to_str().expect("temp path should be valid UTF-8");
 
         assert!(
             build_overlay(upper_str, engine_str, None).is_ok(),

--- a/src-tauri/src/commands/vfs.rs
+++ b/src-tauri/src/commands/vfs.rs
@@ -11,11 +11,10 @@ fn build_overlay(
     engine_path: &str,
     template_path: Option<String>,
 ) -> Result<OverlayFs, VfsError> {
-    let template = template_path
-        .map(PathBuf::from)
-        .filter(|p| p.is_dir())
-        .or_else(|| resolve_default_template_path(Some(Path::new(engine_path))))
-        .filter(|p| p.is_dir());
+    let template = match template_path {
+        Some(explicit) => Some(PathBuf::from(explicit)),
+        None => resolve_default_template_path(Some(Path::new(engine_path))).filter(|p| p.is_dir()),
+    };
     OverlayFs::new(
         PathBuf::from(project_path),
         Some(PathBuf::from(engine_path)),

--- a/src-tauri/src/commands/vfs.rs
+++ b/src-tauri/src/commands/vfs.rs
@@ -1,86 +1,26 @@
-use std::{
-    collections::HashMap,
-    path::{Path, PathBuf},
-    sync::RwLock,
-};
-
-use tauri::State;
+use std::path::{Path, PathBuf};
 
 use crate::vfs::{
-    self, resolve_default_template_path, sanitize_logical_path, CachedCanonicals, OverlayFs,
-    VfsDirEntry, VfsError,
+    self, resolve_default_template_path, sanitize_logical_path, OverlayFs, VfsDirEntry, VfsError,
 };
 
 use super::AppResult;
-
-/// canonicalize 结果缓存，按 (project, engine, template) 路径组合索引
-#[derive(Default)]
-pub struct OverlayFactoryCache {
-    entries: RwLock<HashMap<OverlayCacheKey, CachedCanonicals>>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct OverlayCacheKey {
-    project_path: PathBuf,
-    engine_path: PathBuf,
-    template_path: Option<PathBuf>,
-}
-
-impl OverlayFactoryCache {
-    fn get_or_compute(
-        &self,
-        project_path: &Path,
-        engine_path: &Path,
-        template_path: Option<PathBuf>,
-    ) -> Result<CachedCanonicals, VfsError> {
-        let key = OverlayCacheKey {
-            project_path: project_path.to_path_buf(),
-            engine_path: engine_path.to_path_buf(),
-            template_path: template_path.clone(),
-        };
-
-        {
-            let entries = self.entries.read().unwrap_or_else(|e| {
-                log::warn!("OverlayFactoryCache 读锁中毒，恢复访问");
-                e.into_inner()
-            });
-            if let Some(cached) = entries.get(&key) {
-                return Ok(cached.clone());
-            }
-        }
-
-        let cached = CachedCanonicals::compute(
-            project_path.to_path_buf(),
-            Some(engine_path.to_path_buf()),
-            template_path,
-        )?;
-
-        {
-            let mut entries = self.entries.write().unwrap_or_else(|e| {
-                log::warn!("OverlayFactoryCache 写锁中毒，恢复访问");
-                e.into_inner()
-            });
-            entries.insert(key, cached.clone());
-        }
-
-        Ok(cached)
-    }
-}
 
 fn build_overlay(
     project_path: &str,
     engine_path: &str,
     template_path: Option<String>,
-    factory_cache: &OverlayFactoryCache,
 ) -> Result<OverlayFs, VfsError> {
     let template = template_path
         .map(PathBuf::from)
         .filter(|p| p.is_dir())
         .or_else(|| resolve_default_template_path(Some(Path::new(engine_path))))
         .filter(|p| p.is_dir());
-    let cached =
-        factory_cache.get_or_compute(Path::new(project_path), Path::new(engine_path), template)?;
-    Ok(OverlayFs::from_cached(&cached))
+    OverlayFs::new(
+        PathBuf::from(project_path),
+        Some(PathBuf::from(engine_path)),
+        template,
+    )
 }
 
 fn sanitize_rename_target(parent: &Path, new_name: &str) -> Result<PathBuf, VfsError> {
@@ -113,55 +53,51 @@ fn to_logical_path_string(path: &Path) -> String {
 
 #[tauri::command]
 pub fn resolve_vfs_path(
-    factory_cache: State<'_, OverlayFactoryCache>,
     project_path: String,
     engine_path: String,
     template_path: Option<String>,
     rel_path: String,
 ) -> AppResult<String> {
     let logical_path = sanitize_logical_path(&rel_path)?;
-    let overlay = build_overlay(&project_path, &engine_path, template_path, &factory_cache)?;
+    let overlay = build_overlay(&project_path, &engine_path, template_path)?;
     let resolved = overlay.resolve_physical_path(&logical_path)?;
     Ok(to_physical_path_string(&resolved.physical_path))
 }
 
 #[tauri::command]
 pub fn list_vfs_dir(
-    factory_cache: State<'_, OverlayFactoryCache>,
     project_path: String,
     engine_path: String,
     template_path: Option<String>,
     rel_path: String,
 ) -> AppResult<Vec<VfsDirEntry>> {
     let logical_dir = sanitize_logical_path(&rel_path)?;
-    let overlay = build_overlay(&project_path, &engine_path, template_path, &factory_cache)?;
+    let overlay = build_overlay(&project_path, &engine_path, template_path)?;
     overlay.list_entries(&logical_dir).map_err(Into::into)
 }
 
 #[tauri::command]
 pub fn ensure_vfs_writable(
-    factory_cache: State<'_, OverlayFactoryCache>,
     project_path: String,
     engine_path: String,
     template_path: Option<String>,
     rel_path: String,
 ) -> AppResult<String> {
     let logical_path = sanitize_logical_path(&rel_path)?;
-    let overlay = build_overlay(&project_path, &engine_path, template_path, &factory_cache)?;
+    let overlay = build_overlay(&project_path, &engine_path, template_path)?;
     let path = overlay.ensure_writable(&logical_path)?;
     Ok(to_physical_path_string(&path))
 }
 
 #[tauri::command]
 pub fn delete_vfs_path(
-    factory_cache: State<'_, OverlayFactoryCache>,
     project_path: String,
     engine_path: String,
     template_path: Option<String>,
     rel_path: String,
 ) -> AppResult<()> {
     let logical_path = sanitize_logical_path(&rel_path)?;
-    let overlay = build_overlay(&project_path, &engine_path, template_path, &factory_cache)?;
+    let overlay = build_overlay(&project_path, &engine_path, template_path)?;
     overlay.remove_logical_path(&logical_path)?;
     log::debug!("VFS 删除: {}", logical_path.display());
     Ok(())
@@ -169,7 +105,6 @@ pub fn delete_vfs_path(
 
 #[tauri::command]
 pub fn rename_vfs_path(
-    factory_cache: State<'_, OverlayFactoryCache>,
     project_path: String,
     engine_path: String,
     template_path: Option<String>,
@@ -179,7 +114,7 @@ pub fn rename_vfs_path(
     let logical_path = sanitize_logical_path(&rel_path)?;
     let parent = logical_path.parent().unwrap_or_else(|| Path::new(""));
     let target_path = sanitize_rename_target(parent, &new_name)?;
-    let overlay = build_overlay(&project_path, &engine_path, template_path, &factory_cache)?;
+    let overlay = build_overlay(&project_path, &engine_path, template_path)?;
     overlay.rename_logical_path(&logical_path, &target_path)?;
     log::debug!("VFS 重命名: {} -> {}", logical_path.display(), target_path.display());
     Ok(to_logical_path_string(&target_path))
@@ -187,7 +122,6 @@ pub fn rename_vfs_path(
 
 #[tauri::command]
 pub fn move_vfs_path(
-    factory_cache: State<'_, OverlayFactoryCache>,
     project_path: String,
     engine_path: String,
     template_path: Option<String>,
@@ -196,7 +130,7 @@ pub fn move_vfs_path(
 ) -> AppResult<String> {
     let logical_path = sanitize_logical_path(&rel_path)?;
     let target_path = sanitize_move_target(&target_rel_path)?;
-    let overlay = build_overlay(&project_path, &engine_path, template_path, &factory_cache)?;
+    let overlay = build_overlay(&project_path, &engine_path, template_path)?;
     overlay.rename_logical_path(&logical_path, &target_path)?;
     log::debug!("VFS 移动: {} -> {}", logical_path.display(), target_path.display());
     Ok(to_logical_path_string(&target_path))
@@ -204,7 +138,6 @@ pub fn move_vfs_path(
 
 #[tauri::command]
 pub fn copy_vfs_path(
-    factory_cache: State<'_, OverlayFactoryCache>,
     project_path: String,
     engine_path: String,
     template_path: Option<String>,
@@ -213,7 +146,7 @@ pub fn copy_vfs_path(
 ) -> AppResult<String> {
     let logical_path = sanitize_logical_path(&rel_path)?;
     let target_path = sanitize_logical_path(&target_rel_path)?;
-    let overlay = build_overlay(&project_path, &engine_path, template_path, &factory_cache)?;
+    let overlay = build_overlay(&project_path, &engine_path, template_path)?;
     overlay.copy_logical_path(&logical_path, &target_path)?;
     log::debug!("VFS 复制: {} -> {}", logical_path.display(), target_path.display());
     Ok(to_logical_path_string(&target_path))
@@ -238,7 +171,7 @@ mod tests {
         time::{SystemTime, UNIX_EPOCH},
     };
 
-    use super::{build_overlay, sanitize_rename_target, OverlayFactoryCache};
+    use super::{build_overlay, sanitize_rename_target};
     use crate::vfs::VfsError;
 
     fn create_temp_dir(prefix: &str) -> PathBuf {
@@ -280,7 +213,7 @@ mod tests {
         let engine_str = engine.to_str().expect("temp path should be valid UTF-8");
 
         assert!(
-            build_overlay(upper_str, engine_str, None, &OverlayFactoryCache::default()).is_ok(),
+            build_overlay(upper_str, engine_str, None).is_ok(),
             "missing game/template should not break non-template VFS commands"
         );
     }

--- a/src-tauri/src/commands/vfs.rs
+++ b/src-tauri/src/commands/vfs.rs
@@ -116,7 +116,11 @@ pub fn rename_vfs_path(
     let target_path = sanitize_rename_target(parent, &new_name)?;
     let overlay = build_overlay(&project_path, &engine_path, template_path)?;
     overlay.rename_logical_path(&logical_path, &target_path)?;
-    log::debug!("VFS 重命名: {} -> {}", logical_path.display(), target_path.display());
+    log::debug!(
+        "VFS 重命名: {} -> {}",
+        logical_path.display(),
+        target_path.display()
+    );
     Ok(to_logical_path_string(&target_path))
 }
 
@@ -132,7 +136,11 @@ pub fn move_vfs_path(
     let target_path = sanitize_move_target(&target_rel_path)?;
     let overlay = build_overlay(&project_path, &engine_path, template_path)?;
     overlay.rename_logical_path(&logical_path, &target_path)?;
-    log::debug!("VFS 移动: {} -> {}", logical_path.display(), target_path.display());
+    log::debug!(
+        "VFS 移动: {} -> {}",
+        logical_path.display(),
+        target_path.display()
+    );
     Ok(to_logical_path_string(&target_path))
 }
 
@@ -148,7 +156,11 @@ pub fn copy_vfs_path(
     let target_path = sanitize_logical_path(&target_rel_path)?;
     let overlay = build_overlay(&project_path, &engine_path, template_path)?;
     overlay.copy_logical_path(&logical_path, &target_path)?;
-    log::debug!("VFS 复制: {} -> {}", logical_path.display(), target_path.display());
+    log::debug!(
+        "VFS 复制: {} -> {}",
+        logical_path.display(),
+        target_path.display()
+    );
     Ok(to_logical_path_string(&target_path))
 }
 
@@ -197,8 +209,14 @@ mod tests {
     fn build_overlay_allows_engines_without_template_directory() {
         let upper = tempdir().expect("upper temp dir should be created");
         let engine = tempdir().expect("engine temp dir should be created");
-        let upper_str = upper.path().to_str().expect("temp path should be valid UTF-8");
-        let engine_str = engine.path().to_str().expect("temp path should be valid UTF-8");
+        let upper_str = upper
+            .path()
+            .to_str()
+            .expect("temp path should be valid UTF-8");
+        let engine_str = engine
+            .path()
+            .to_str()
+            .expect("temp path should be valid UTF-8");
 
         assert!(
             build_overlay(upper_str, engine_str, None).is_ok(),

--- a/src-tauri/src/commands/vfs.rs
+++ b/src-tauri/src/commands/vfs.rs
@@ -1,0 +1,287 @@
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+    sync::RwLock,
+};
+
+use tauri::State;
+
+use crate::vfs::{
+    self, resolve_default_template_path, sanitize_logical_path, CachedCanonicals, OverlayFs,
+    VfsDirEntry, VfsError,
+};
+
+use super::AppResult;
+
+/// canonicalize 结果缓存，按 (project, engine, template) 路径组合索引
+#[derive(Default)]
+pub struct OverlayFactoryCache {
+    entries: RwLock<HashMap<OverlayCacheKey, CachedCanonicals>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct OverlayCacheKey {
+    project_path: PathBuf,
+    engine_path: PathBuf,
+    template_path: Option<PathBuf>,
+}
+
+impl OverlayFactoryCache {
+    fn get_or_compute(
+        &self,
+        project_path: &Path,
+        engine_path: &Path,
+        template_path: Option<PathBuf>,
+    ) -> Result<CachedCanonicals, VfsError> {
+        let key = OverlayCacheKey {
+            project_path: project_path.to_path_buf(),
+            engine_path: engine_path.to_path_buf(),
+            template_path: template_path.clone(),
+        };
+
+        {
+            let entries = self.entries.read().unwrap_or_else(|e| {
+                log::warn!("OverlayFactoryCache 读锁中毒，恢复访问");
+                e.into_inner()
+            });
+            if let Some(cached) = entries.get(&key) {
+                return Ok(cached.clone());
+            }
+        }
+
+        let cached = CachedCanonicals::compute(
+            project_path.to_path_buf(),
+            Some(engine_path.to_path_buf()),
+            template_path,
+        )?;
+
+        {
+            let mut entries = self.entries.write().unwrap_or_else(|e| {
+                log::warn!("OverlayFactoryCache 写锁中毒，恢复访问");
+                e.into_inner()
+            });
+            entries.insert(key, cached.clone());
+        }
+
+        Ok(cached)
+    }
+}
+
+fn build_overlay(
+    project_path: &str,
+    engine_path: &str,
+    template_path: Option<String>,
+    factory_cache: &OverlayFactoryCache,
+) -> Result<OverlayFs, VfsError> {
+    let template = template_path
+        .map(PathBuf::from)
+        .filter(|p| p.is_dir())
+        .or_else(|| resolve_default_template_path(Some(Path::new(engine_path))))
+        .filter(|p| p.is_dir());
+    let cached =
+        factory_cache.get_or_compute(Path::new(project_path), Path::new(engine_path), template)?;
+    Ok(OverlayFs::from_cached(&cached))
+}
+
+fn sanitize_rename_target(parent: &Path, new_name: &str) -> Result<PathBuf, VfsError> {
+    let sanitized = sanitize_logical_path(new_name)?;
+    if sanitized.as_os_str().is_empty() || sanitized.components().count() != 1 {
+        return Err(VfsError::PathDenied);
+    }
+
+    Ok(parent.join(sanitized))
+}
+
+fn sanitize_move_target(target_rel_path: &str) -> Result<PathBuf, VfsError> {
+    let sanitized = sanitize_logical_path(target_rel_path)?;
+    if sanitized.as_os_str().is_empty() {
+        return Err(VfsError::PathDenied);
+    }
+
+    Ok(sanitized)
+}
+
+/// VFS 命令对外暴露两种路径：物理绝对路径（保留平台分隔符，供前端 `convertFileSrc` 等消费）
+/// 与逻辑相对路径（始终 `/`，作为下次 VFS 调用的 `relPath`）。
+fn to_physical_path_string(path: &Path) -> String {
+    path.to_string_lossy().into_owned()
+}
+
+fn to_logical_path_string(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
+}
+
+#[tauri::command]
+pub fn resolve_vfs_path(
+    factory_cache: State<'_, OverlayFactoryCache>,
+    project_path: String,
+    engine_path: String,
+    template_path: Option<String>,
+    rel_path: String,
+) -> AppResult<String> {
+    let logical_path = sanitize_logical_path(&rel_path)?;
+    let overlay = build_overlay(&project_path, &engine_path, template_path, &factory_cache)?;
+    let resolved = overlay.resolve_physical_path(&logical_path)?;
+    Ok(to_physical_path_string(&resolved.physical_path))
+}
+
+#[tauri::command]
+pub fn list_vfs_dir(
+    factory_cache: State<'_, OverlayFactoryCache>,
+    project_path: String,
+    engine_path: String,
+    template_path: Option<String>,
+    rel_path: String,
+) -> AppResult<Vec<VfsDirEntry>> {
+    let logical_dir = sanitize_logical_path(&rel_path)?;
+    let overlay = build_overlay(&project_path, &engine_path, template_path, &factory_cache)?;
+    overlay.list_entries(&logical_dir).map_err(Into::into)
+}
+
+#[tauri::command]
+pub fn ensure_vfs_writable(
+    factory_cache: State<'_, OverlayFactoryCache>,
+    project_path: String,
+    engine_path: String,
+    template_path: Option<String>,
+    rel_path: String,
+) -> AppResult<String> {
+    let logical_path = sanitize_logical_path(&rel_path)?;
+    let overlay = build_overlay(&project_path, &engine_path, template_path, &factory_cache)?;
+    let path = overlay.ensure_writable(&logical_path)?;
+    Ok(to_physical_path_string(&path))
+}
+
+#[tauri::command]
+pub fn delete_vfs_path(
+    factory_cache: State<'_, OverlayFactoryCache>,
+    project_path: String,
+    engine_path: String,
+    template_path: Option<String>,
+    rel_path: String,
+) -> AppResult<()> {
+    let logical_path = sanitize_logical_path(&rel_path)?;
+    let overlay = build_overlay(&project_path, &engine_path, template_path, &factory_cache)?;
+    overlay.remove_logical_path(&logical_path)?;
+    log::debug!("VFS 删除: {}", logical_path.display());
+    Ok(())
+}
+
+#[tauri::command]
+pub fn rename_vfs_path(
+    factory_cache: State<'_, OverlayFactoryCache>,
+    project_path: String,
+    engine_path: String,
+    template_path: Option<String>,
+    rel_path: String,
+    new_name: String,
+) -> AppResult<String> {
+    let logical_path = sanitize_logical_path(&rel_path)?;
+    let parent = logical_path.parent().unwrap_or_else(|| Path::new(""));
+    let target_path = sanitize_rename_target(parent, &new_name)?;
+    let overlay = build_overlay(&project_path, &engine_path, template_path, &factory_cache)?;
+    overlay.rename_logical_path(&logical_path, &target_path)?;
+    log::debug!("VFS 重命名: {} -> {}", logical_path.display(), target_path.display());
+    Ok(to_logical_path_string(&target_path))
+}
+
+#[tauri::command]
+pub fn move_vfs_path(
+    factory_cache: State<'_, OverlayFactoryCache>,
+    project_path: String,
+    engine_path: String,
+    template_path: Option<String>,
+    rel_path: String,
+    target_rel_path: String,
+) -> AppResult<String> {
+    let logical_path = sanitize_logical_path(&rel_path)?;
+    let target_path = sanitize_move_target(&target_rel_path)?;
+    let overlay = build_overlay(&project_path, &engine_path, template_path, &factory_cache)?;
+    overlay.rename_logical_path(&logical_path, &target_path)?;
+    log::debug!("VFS 移动: {} -> {}", logical_path.display(), target_path.display());
+    Ok(to_logical_path_string(&target_path))
+}
+
+#[tauri::command]
+pub fn copy_vfs_path(
+    factory_cache: State<'_, OverlayFactoryCache>,
+    project_path: String,
+    engine_path: String,
+    template_path: Option<String>,
+    rel_path: String,
+    target_rel_path: String,
+) -> AppResult<String> {
+    let logical_path = sanitize_logical_path(&rel_path)?;
+    let target_path = sanitize_logical_path(&target_rel_path)?;
+    let overlay = build_overlay(&project_path, &engine_path, template_path, &factory_cache)?;
+    overlay.copy_logical_path(&logical_path, &target_path)?;
+    log::debug!("VFS 复制: {} -> {}", logical_path.display(), target_path.display());
+    Ok(to_logical_path_string(&target_path))
+}
+
+#[tauri::command]
+pub fn is_template_dirty(project_path: String) -> AppResult<bool> {
+    vfs::is_template_dirty(Path::new(&project_path)).map_err(Into::into)
+}
+
+#[tauri::command]
+pub fn clean_template_upper(project_path: String) -> AppResult<()> {
+    log::debug!("VFS 清理模板 upper: {project_path}");
+    vfs::clean_template_upper(Path::new(&project_path)).map_err(Into::into)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        fs,
+        path::{Path, PathBuf},
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    use super::{build_overlay, sanitize_rename_target, OverlayFactoryCache};
+    use crate::vfs::VfsError;
+
+    fn create_temp_dir(prefix: &str) -> PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock should be after unix epoch")
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!("{prefix}-{unique}"));
+        fs::create_dir_all(&dir).expect("temp directory should be created");
+        dir
+    }
+
+    #[test]
+    fn sanitize_rename_target_rejects_nested_or_traversal_names() {
+        assert!(matches!(
+            sanitize_rename_target(Path::new("game/scene"), "../secret.txt"),
+            Err(VfsError::PathDenied)
+        ));
+        assert!(matches!(
+            sanitize_rename_target(Path::new("game/scene"), "nested/file.txt"),
+            Err(VfsError::PathDenied)
+        ));
+    }
+
+    #[test]
+    fn sanitize_rename_target_accepts_single_safe_segment() {
+        assert_eq!(
+            sanitize_rename_target(Path::new("game/scene"), "next.txt")
+                .expect("safe rename target should pass"),
+            PathBuf::from("game/scene").join("next.txt")
+        );
+    }
+
+    #[test]
+    fn build_overlay_allows_engines_without_template_directory() {
+        let upper = create_temp_dir("webgal-craft-vfs-command-upper");
+        let engine = create_temp_dir("webgal-craft-vfs-command-engine");
+        let upper_str = upper.to_str().expect("temp path should be valid UTF-8");
+        let engine_str = engine.to_str().expect("temp path should be valid UTF-8");
+
+        assert!(
+            build_overlay(upper_str, engine_str, None, &OverlayFactoryCache::default()).is_ok(),
+            "missing game/template should not break non-template VFS commands"
+        );
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,7 +3,6 @@ mod commands;
 mod vfs;
 mod window;
 use commands::server::ServerState;
-use commands::vfs::OverlayFactoryCache;
 #[cfg(target_os = "windows")]
 use tauri_plugin_prevent_default::PlatformOptions;
 use tokio::sync::Mutex;
@@ -18,7 +17,6 @@ pub fn run() {
         _window.open_devtools();
 
         app.manage(Mutex::new(ServerState::default()));
-        app.manage(OverlayFactoryCache::default());
 
         Ok(())
     });

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,7 +1,9 @@
 use tauri::Manager;
 mod commands;
+mod vfs;
 mod window;
 use commands::server::ServerState;
+use commands::vfs::OverlayFactoryCache;
 #[cfg(target_os = "windows")]
 use tauri_plugin_prevent_default::PlatformOptions;
 use tokio::sync::Mutex;
@@ -16,6 +18,7 @@ pub fn run() {
         _window.open_devtools();
 
         app.manage(Mutex::new(ServerState::default()));
+        app.manage(OverlayFactoryCache::default());
 
         Ok(())
     });
@@ -68,6 +71,19 @@ pub fn run() {
             // game
             commands::game::get_game_config,
             commands::game::set_game_config,
+            // project config
+            commands::project_config::read_project_config_cmd,
+            commands::project_config::write_project_config_cmd,
+            // vfs
+            commands::vfs::resolve_vfs_path,
+            commands::vfs::list_vfs_dir,
+            commands::vfs::ensure_vfs_writable,
+            commands::vfs::delete_vfs_path,
+            commands::vfs::rename_vfs_path,
+            commands::vfs::move_vfs_path,
+            commands::vfs::copy_vfs_path,
+            commands::vfs::is_template_dirty,
+            commands::vfs::clean_template_upper,
             // server
             commands::server::start_server,
             commands::server::add_static_site,

--- a/src-tauri/src/vfs.rs
+++ b/src-tauri/src/vfs.rs
@@ -574,17 +574,20 @@ impl OverlayFs {
             return Ok(false);
         }
 
-        let mut prefix = PathBuf::new();
+        // 单次遍历：逐级 push 新组件，校验该新组件未被替换为符号链接，再检查其下的 .wh 标记。
+        // 由于父级路径在前一次迭代中已校验过，无需每次从 upper 根重复扫描整条祖先链。
+        let mut current = self.whiteout_root.clone();
+        self.validate_owned_segment(&current)?;
+
         for component in &components {
-            let marker = self
-                .whiteout_root
-                .join(&prefix)
-                .join(format!(".wh.{component}"));
-            self.validate_project_owned_path(&marker)?;
+            let marker = current.join(format!(".wh.{component}"));
+            self.validate_owned_segment(&marker)?;
             if marker.exists() {
                 return Ok(true);
             }
-            prefix.push(component);
+
+            current.push(component);
+            self.validate_owned_segment(&current)?;
         }
 
         Ok(false)
@@ -670,20 +673,26 @@ impl OverlayFs {
 
         for component in components {
             current.push(component);
-            if !current.exists() {
-                continue;
-            }
-
-            let metadata = fs::symlink_metadata(&current)?;
-            if metadata.file_type().is_symlink() {
-                log::warn!("路径被拒绝（符号链接）: {}", current.display());
-                return Err(VfsError::PathDenied);
-            }
-
-            validate_physical_path(&current, &self.upper_canonical)?;
+            self.validate_owned_segment(&current)?;
         }
 
         Ok(())
+    }
+
+    /// 校验单层路径片段未被替换为符号链接且未指向 upper 之外。
+    /// 调用方负责按层级递增地传入路径，避免 `validate_project_owned_path` 在每次调用时重复扫描祖先。
+    fn validate_owned_segment(&self, path: &Path) -> Result<(), VfsError> {
+        if !path.exists() {
+            return Ok(());
+        }
+
+        let metadata = fs::symlink_metadata(path)?;
+        if metadata.file_type().is_symlink() {
+            log::warn!("路径被拒绝（符号链接）: {}", path.display());
+            return Err(VfsError::PathDenied);
+        }
+
+        validate_physical_path(path, &self.upper_canonical)
     }
 }
 

--- a/src-tauri/src/vfs.rs
+++ b/src-tauri/src/vfs.rs
@@ -139,19 +139,18 @@ impl VfsError {
     }
 }
 
-/// 缓存 canonicalize 结果，避免热路径上重复系统调用
-#[derive(Debug, Clone)]
-pub struct CachedCanonicals {
-    pub upper: PathBuf,
-    pub upper_canonical: PathBuf,
-    pub engine_lower: Option<PathBuf>,
-    pub engine_lower_canonical: Option<PathBuf>,
-    pub template_lower: Option<PathBuf>,
-    pub template_lower_canonical: Option<PathBuf>,
+pub struct OverlayFs {
+    upper: PathBuf,
+    upper_canonical: PathBuf,
+    engine_lower: Option<PathBuf>,
+    engine_lower_canonical: Option<PathBuf>,
+    template_lower: Option<PathBuf>,
+    template_lower_canonical: Option<PathBuf>,
+    whiteout_root: PathBuf,
 }
 
-impl CachedCanonicals {
-    pub fn compute(
+impl OverlayFs {
+    pub fn new(
         upper: PathBuf,
         engine_lower: Option<PathBuf>,
         template_lower: Option<PathBuf>,
@@ -165,6 +164,7 @@ impl CachedCanonicals {
             .as_ref()
             .map(|path| path.canonicalize())
             .transpose()?;
+        let whiteout_root = upper.join(VFS_METADATA_DIR).join(WHITEOUTS_DIR);
 
         Ok(Self {
             upper,
@@ -173,43 +173,8 @@ impl CachedCanonicals {
             engine_lower_canonical,
             template_lower,
             template_lower_canonical,
-        })
-    }
-}
-
-pub struct OverlayFs {
-    upper: PathBuf,
-    upper_canonical: PathBuf,
-    engine_lower: Option<PathBuf>,
-    engine_lower_canonical: Option<PathBuf>,
-    template_lower: Option<PathBuf>,
-    template_lower_canonical: Option<PathBuf>,
-    whiteout_root: PathBuf,
-}
-
-impl OverlayFs {
-    #[cfg(test)]
-    pub fn new(
-        upper: PathBuf,
-        engine_lower: Option<PathBuf>,
-        template_lower: Option<PathBuf>,
-    ) -> Result<Self, VfsError> {
-        let cached = CachedCanonicals::compute(upper, engine_lower, template_lower)?;
-        Ok(Self::from_cached(&cached))
-    }
-
-    /// 使用已缓存的 canonical 路径构造 OverlayFs，跳过 canonicalize 系统调用
-    pub fn from_cached(cached: &CachedCanonicals) -> Self {
-        let whiteout_root = cached.upper.join(VFS_METADATA_DIR).join(WHITEOUTS_DIR);
-        Self {
-            upper: cached.upper.clone(),
-            upper_canonical: cached.upper_canonical.clone(),
-            engine_lower: cached.engine_lower.clone(),
-            engine_lower_canonical: cached.engine_lower_canonical.clone(),
-            template_lower: cached.template_lower.clone(),
-            template_lower_canonical: cached.template_lower_canonical.clone(),
             whiteout_root,
-        }
+        })
     }
 
     #[allow(dead_code)] // PR3 server 重构启用

--- a/src-tauri/src/vfs.rs
+++ b/src-tauri/src/vfs.rs
@@ -139,6 +139,8 @@ pub struct OverlayFs {
 }
 
 impl OverlayFs {
+    /// 构造 overlay 实例。`upper`、以及传入的 `engine_lower` / `template_lower` 必须指向已存在的目录，
+    /// 否则 canonicalize 会立即返回 IO 错误。调用方应在创建项目目录之后再构造。
     pub fn new(
         upper: PathBuf,
         engine_lower: Option<PathBuf>,

--- a/src-tauri/src/vfs.rs
+++ b/src-tauri/src/vfs.rs
@@ -6,7 +6,6 @@ use std::{
     path::{Component, Path, PathBuf},
 };
 
-use percent_encoding::percent_decode_str;
 use serde::{Deserialize, Serialize};
 use tempfile::NamedTempFile;
 use thiserror::Error;
@@ -48,13 +47,6 @@ pub enum TemplateBinding {
     EngineBuiltin {
         engine: EngineRef,
     },
-}
-
-#[derive(Debug, Clone)]
-#[allow(dead_code)] // PR3 server 重构启用
-pub struct ResolvedFile {
-    pub physical_path: PathBuf,
-    pub content_type: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -174,23 +166,6 @@ impl OverlayFs {
             template_lower,
             template_lower_canonical,
             whiteout_root,
-        })
-    }
-
-    #[allow(dead_code)] // PR3 server 重构启用
-    pub fn resolve_file(&self, logical_path: &Path) -> Result<ResolvedFile, VfsError> {
-        let resolved = self.resolve_physical_path(logical_path)?;
-        let metadata = fs::metadata(&resolved.physical_path)?;
-
-        if !metadata.is_file() {
-            return Err(VfsError::NotFound);
-        }
-
-        Ok(ResolvedFile {
-            content_type: mime_guess::from_path(&resolved.physical_path)
-                .first_or_octet_stream()
-                .to_string(),
-            physical_path: resolved.physical_path,
         })
     }
 
@@ -696,17 +671,36 @@ impl OverlayFs {
     }
 }
 
-#[allow(dead_code)] // PR3 server 重构启用
-pub fn sanitize_request_path(raw_path: &str) -> Result<PathBuf, VfsError> {
-    let decoded = percent_decode_str(raw_path)
-        .decode_utf8()
-        .map_err(|_| VfsError::PathDenied)?;
-
-    sanitize_path_like(decoded.as_ref(), true)
-}
-
 pub fn sanitize_logical_path(raw_path: &str) -> Result<PathBuf, VfsError> {
-    sanitize_path_like(raw_path, false)
+    if raw_path.contains('\0') || raw_path.contains('\\') || raw_path.contains("//") {
+        log::warn!("路径被拒绝（非法字符）: {raw_path:?}");
+        return Err(VfsError::PathDenied);
+    }
+
+    let trimmed = raw_path.trim_start_matches('/');
+    if trimmed.is_empty() {
+        return Ok(PathBuf::new());
+    }
+
+    let path = Path::new(trimmed);
+    let mut normalized = PathBuf::new();
+
+    for component in path.components() {
+        match component {
+            Component::Normal(segment) => {
+                let segment = segment.to_str().ok_or(VfsError::PathDenied)?;
+                validate_path_segment(segment)?;
+                normalized.push(segment);
+            }
+            _ => return Err(VfsError::PathDenied),
+        }
+    }
+
+    if is_internal_metadata_path(&normalized) {
+        return Err(VfsError::PathDenied);
+    }
+
+    Ok(normalized)
 }
 
 #[inline]
@@ -876,42 +870,6 @@ pub(crate) async fn atomic_write(target: &Path, content: &[u8]) -> std::io::Resu
     .map_err(std::io::Error::other)?
 }
 
-fn sanitize_path_like(raw_path: &str, empty_maps_to_index: bool) -> Result<PathBuf, VfsError> {
-    if raw_path.contains('\0') || raw_path.contains('\\') || raw_path.contains("//") {
-        log::warn!("路径被拒绝（非法字符）: {raw_path:?}");
-        return Err(VfsError::PathDenied);
-    }
-
-    let trimmed = raw_path.trim_start_matches('/');
-    if trimmed.is_empty() {
-        return if empty_maps_to_index {
-            Ok(PathBuf::from("index.html"))
-        } else {
-            Ok(PathBuf::new())
-        };
-    }
-
-    let path = Path::new(trimmed);
-    let mut normalized = PathBuf::new();
-
-    for component in path.components() {
-        match component {
-            Component::Normal(segment) => {
-                let segment = segment.to_str().ok_or(VfsError::PathDenied)?;
-                validate_path_segment(segment)?;
-                normalized.push(segment);
-            }
-            _ => return Err(VfsError::PathDenied),
-        }
-    }
-
-    if is_internal_metadata_path(&normalized) {
-        return Err(VfsError::PathDenied);
-    }
-
-    Ok(normalized)
-}
-
 fn validate_path_segment(segment: &str) -> Result<(), VfsError> {
     if segment.is_empty()
         || segment.contains(':')
@@ -1065,9 +1023,9 @@ fn is_same_or_descendant_path(path: &Path, base: &Path) -> Result<bool, VfsError
 #[cfg(test)]
 mod tests {
     use super::{
-        classify_path, read_project_config, sanitize_logical_path, sanitize_request_path,
-        validate_project_config, AppError, EngineRef, OverlayFs, PathCategory, ProjectConfig,
-        TemplateBinding, VfsDirEntry, VfsError, VfsSource,
+        classify_path, read_project_config, sanitize_logical_path, validate_project_config,
+        AppError, EngineRef, OverlayFs, PathCategory, ProjectConfig, TemplateBinding, VfsDirEntry,
+        VfsError, VfsSource,
     };
     #[cfg(windows)]
     use std::process::Command;
@@ -1108,31 +1066,19 @@ mod tests {
     }
 
     #[test]
-    fn sanitize_request_path_maps_root_to_index_html() {
-        assert_eq!(
-            sanitize_request_path("").expect("empty path should map to index.html"),
-            PathBuf::from("index.html")
-        );
-        assert_eq!(
-            sanitize_request_path("/").expect("root path should map to index.html"),
-            PathBuf::from("index.html")
-        );
-    }
-
-    #[test]
-    fn sanitize_request_path_rejects_path_traversal_and_reserved_names() {
-        assert!(sanitize_request_path("../secret.txt").is_err());
-        assert!(sanitize_request_path("icons\\favicon.ico").is_err());
-        assert!(sanitize_request_path("CON").is_err());
-        assert!(sanitize_request_path("assets:evil").is_err());
-    }
-
-    #[test]
     fn sanitize_logical_path_keeps_empty_path_for_directory_listing() {
         assert_eq!(
             sanitize_logical_path("").expect("empty logical path should stay empty"),
             PathBuf::new()
         );
+    }
+
+    #[test]
+    fn sanitize_logical_path_rejects_path_traversal_and_reserved_names() {
+        assert!(sanitize_logical_path("../secret.txt").is_err());
+        assert!(sanitize_logical_path("icons\\favicon.ico").is_err());
+        assert!(sanitize_logical_path("CON").is_err());
+        assert!(sanitize_logical_path("assets:evil").is_err());
     }
 
     #[test]

--- a/src-tauri/src/vfs.rs
+++ b/src-tauri/src/vfs.rs
@@ -204,7 +204,7 @@ impl OverlayFs {
         if category.prefers_upper_layer() || self.engine_lower.is_none() {
             let upper_path = self.upper.join(logical_path);
             if upper_path.exists() {
-                validate_read_path_fast(&upper_path, &self.upper_canonical)?;
+                validate_physical_path(&upper_path, &self.upper_canonical)?;
                 return Ok(ResolvedPhysicalPath {
                     physical_path: upper_path,
                     canonical_root: self.upper_canonical.clone(),
@@ -219,7 +219,7 @@ impl OverlayFs {
         // 尝试 lower 层
         if let Some((lower_path, lower_canonical)) = self.resolve_lower_path(logical_path) {
             if lower_path.exists() {
-                validate_read_path_fast(&lower_path, lower_canonical)?;
+                validate_physical_path(&lower_path, lower_canonical)?;
                 return Ok(ResolvedPhysicalPath {
                     physical_path: lower_path,
                     canonical_root: lower_canonical.to_path_buf(),
@@ -230,7 +230,7 @@ impl OverlayFs {
         // 无 lower 层时回退到 upper（引擎运行时文件可能只存在于 upper）
         let upper_path = self.upper.join(logical_path);
         if upper_path.exists() {
-            validate_read_path_fast(&upper_path, &self.upper_canonical)?;
+            validate_physical_path(&upper_path, &self.upper_canonical)?;
             return Ok(ResolvedPhysicalPath {
                 physical_path: upper_path,
                 canonical_root: self.upper_canonical.clone(),
@@ -958,17 +958,6 @@ fn validate_physical_path(physical_path: &Path, root_canonical: &Path) -> Result
     }
 
     Ok(())
-}
-
-/// 读取请求的快速路径校验：使用字符串前缀检查代替 canonicalize
-///
-/// 前提：root_canonical 在站点注册时已缓存，且根目录内不含指向外部的符号链接。
-/// 仅适用于读取请求，写入请求仍需完整的 canonicalize 校验。
-fn validate_read_path_fast(physical_path: &Path, root_canonical: &Path) -> Result<(), VfsError> {
-    if physical_path.starts_with(root_canonical) {
-        return Ok(());
-    }
-    validate_physical_path(physical_path, root_canonical)
 }
 
 fn copy_path(source: &Path, destination: &Path) -> Result<(), VfsError> {

--- a/src-tauri/src/vfs.rs
+++ b/src-tauri/src/vfs.rs
@@ -1744,10 +1744,7 @@ mod tests {
         .expect("overlay should be created");
 
         let error = overlay
-            .rename_logical_path(
-                Path::new("game/scene/a.txt"),
-                Path::new("game/scene/b.txt"),
-            )
+            .rename_logical_path(Path::new("game/scene/a.txt"), Path::new("game/scene/b.txt"))
             .expect_err("rename to existing target should fail");
 
         assert_eq!(error.code(), "ALREADY_EXISTS");

--- a/src-tauri/src/vfs.rs
+++ b/src-tauri/src/vfs.rs
@@ -44,8 +44,6 @@ pub struct EngineRef {
 pub enum TemplateBinding {
     Standalone {
         name: String,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        version: Option<String>,
     },
     EngineBuiltin {
         engine: EngineRef,
@@ -1208,7 +1206,6 @@ mod tests {
             engine: None,
             template: Some(TemplateBinding::Standalone {
                 name: "Modern".into(),
-                version: None,
             }),
             version: 1,
         };

--- a/src-tauri/src/vfs.rs
+++ b/src-tauri/src/vfs.rs
@@ -41,12 +41,8 @@ pub struct EngineRef {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "kind", rename_all = "camelCase")]
 pub enum TemplateBinding {
-    Standalone {
-        name: String,
-    },
-    EngineBuiltin {
-        engine: EngineRef,
-    },
+    Standalone { name: String },
+    EngineBuiltin { engine: EngineRef },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -372,7 +368,12 @@ impl OverlayFs {
                 )?;
             }
         } else if let Some(engine_dir) = self.engine_dir_for_list(logical_dir) {
-            self.extend_from_lower(logical_dir, &engine_dir, VfsSource::EngineLower, &mut entries)?;
+            self.extend_from_lower(
+                logical_dir,
+                &engine_dir,
+                VfsSource::EngineLower,
+                &mut entries,
+            )?;
         }
 
         self.extend_template_root_entry(logical_dir, &mut entries)?;

--- a/src-tauri/src/vfs.rs
+++ b/src-tauri/src/vfs.rs
@@ -758,7 +758,11 @@ pub fn read_project_config(project_path: &Path) -> AppResult<ProjectConfig> {
 pub async fn write_project_config(project_path: &Path, config: &ProjectConfig) -> AppResult<()> {
     validate_project_config(config)?;
 
-    let content = serde_json::to_string_pretty(config)
+    // 强制 version 为当前 schema 版本，避免上层调用方意外写入未来版本号导致项目无法被本程序读回
+    let mut config = config.clone();
+    config.version = CURRENT_SCHEMA_VERSION;
+
+    let content = serde_json::to_string_pretty(&config)
         .map_err(|error| AppError::Config(format!("project.wgcp 序列化失败: {error}")))?;
     atomic_write(&project_path.join(PROJECT_CONFIG_FILE), content.as_bytes()).await?;
     Ok(())
@@ -1025,8 +1029,8 @@ fn is_same_or_descendant_path(path: &Path, base: &Path) -> Result<bool, VfsError
 mod tests {
     use super::{
         classify_path, read_project_config, sanitize_logical_path, validate_project_config,
-        AppError, EngineRef, OverlayFs, PathCategory, ProjectConfig, TemplateBinding, VfsDirEntry,
-        VfsError, VfsSource,
+        write_project_config, AppError, EngineRef, OverlayFs, PathCategory, ProjectConfig,
+        TemplateBinding, VfsDirEntry, VfsError, VfsSource, CURRENT_SCHEMA_VERSION,
     };
     #[cfg(windows)]
     use std::process::Command;
@@ -1194,6 +1198,28 @@ mod tests {
 
         let error = read_project_config(&dir).expect_err("invalid config should fail");
         assert!(matches!(error, AppError::InvalidProjectConfig { .. }));
+    }
+
+    #[test]
+    fn write_project_config_pins_version_to_current_schema() {
+        let dir_dir = create_temp_dir();
+        let dir = dir_dir.path().to_path_buf();
+        let config = ProjectConfig {
+            version: CURRENT_SCHEMA_VERSION + 5,
+            engine: None,
+            template: None,
+        };
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("tokio runtime should build");
+        runtime
+            .block_on(write_project_config(&dir, &config))
+            .expect("write should succeed");
+
+        let written = read_project_config(&dir).expect("written config should be readable");
+        assert_eq!(written.version, CURRENT_SCHEMA_VERSION);
     }
 
     #[test]

--- a/src-tauri/src/vfs.rs
+++ b/src-tauri/src/vfs.rs
@@ -171,15 +171,9 @@ impl OverlayFs {
     ) -> Result<ResolvedPhysicalPath, VfsError> {
         let category = classify_path(logical_path);
 
-        // upper 优先时，先检查 upper 层
         if category.prefers_upper_layer() || self.engine_lower.is_none() {
-            let upper_path = self.upper.join(logical_path);
-            if upper_path.exists() {
-                validate_physical_path(&upper_path, &self.upper_canonical)?;
-                return Ok(ResolvedPhysicalPath {
-                    physical_path: upper_path,
-                    canonical_root: self.upper_canonical.clone(),
-                });
+            if let Some(resolved) = self.try_resolve_upper(logical_path)? {
+                return Ok(resolved);
             }
 
             if category.uses_whiteout() && self.is_whiteouted(logical_path)? {
@@ -187,7 +181,6 @@ impl OverlayFs {
             }
         }
 
-        // 尝试 lower 层
         if let Some((lower_path, lower_canonical)) = self.resolve_lower_path(logical_path) {
             if lower_path.exists() {
                 validate_physical_path(&lower_path, lower_canonical)?;
@@ -199,16 +192,27 @@ impl OverlayFs {
         }
 
         // 无 lower 层时回退到 upper（引擎运行时文件可能只存在于 upper）
-        let upper_path = self.upper.join(logical_path);
-        if upper_path.exists() {
-            validate_physical_path(&upper_path, &self.upper_canonical)?;
-            return Ok(ResolvedPhysicalPath {
-                physical_path: upper_path,
-                canonical_root: self.upper_canonical.clone(),
-            });
+        if let Some(resolved) = self.try_resolve_upper(logical_path)? {
+            return Ok(resolved);
         }
 
         Err(VfsError::NotFound)
+    }
+
+    fn try_resolve_upper(
+        &self,
+        logical_path: &Path,
+    ) -> Result<Option<ResolvedPhysicalPath>, VfsError> {
+        let upper_path = self.upper.join(logical_path);
+        if !upper_path.exists() {
+            return Ok(None);
+        }
+
+        validate_physical_path(&upper_path, &self.upper_canonical)?;
+        Ok(Some(ResolvedPhysicalPath {
+            physical_path: upper_path,
+            canonical_root: self.upper_canonical.clone(),
+        }))
     }
 
     pub fn ensure_writable(&self, logical_path: &Path) -> Result<PathBuf, VfsError> {
@@ -896,15 +900,11 @@ fn validate_path_segment(segment: &str) -> Result<(), VfsError> {
 }
 
 fn is_internal_metadata_path(path: &Path) -> bool {
-    let mut components = path.components();
-    let Some(Component::Normal(first)) = components.next() else {
-        return false;
-    };
-    let Some(first) = first.to_str() else {
-        return false;
-    };
-
-    matches!(first, VFS_METADATA_DIR | PROJECT_CONFIG_FILE)
+    matches!(
+        path.components().next(),
+        Some(Component::Normal(first))
+            if matches!(first.to_str(), Some(VFS_METADATA_DIR | PROJECT_CONFIG_FILE))
+    )
 }
 
 fn validate_physical_path(physical_path: &Path, root_canonical: &Path) -> Result<(), VfsError> {

--- a/src-tauri/src/vfs.rs
+++ b/src-tauri/src/vfs.rs
@@ -122,6 +122,7 @@ impl VfsError {
             Self::PathDenied => "PATH_DENIED",
             Self::NotFound => "NOT_FOUND",
             Self::WriteToEngineRuntime => "WRITE_TO_ENGINE_RUNTIME",
+            Self::Io(error) if error.kind() == ErrorKind::AlreadyExists => "ALREADY_EXISTS",
             Self::Io(_) => "VFS_ERROR",
         }
     }
@@ -1715,6 +1716,39 @@ mod tests {
             .expect_err("engine runtime source should be rejected");
 
         assert!(matches!(error, VfsError::WriteToEngineRuntime));
+    }
+
+    #[test]
+    fn rename_logical_path_reports_already_exists_with_dedicated_code() {
+        let upper_dir = create_temp_dir();
+        let upper = upper_dir.path().to_path_buf();
+        let engine_dir = create_temp_dir();
+        let engine = engine_dir.path().to_path_buf();
+
+        fs::create_dir_all(engine.join("game").join("template"))
+            .expect("template directory should be created");
+        fs::create_dir_all(upper.join("game").join("scene"))
+            .expect("scene directory should be created");
+        fs::write(upper.join("game").join("scene").join("a.txt"), "a")
+            .expect("source file should be written");
+        fs::write(upper.join("game").join("scene").join("b.txt"), "b")
+            .expect("conflict target should already exist");
+
+        let overlay = OverlayFs::new(
+            upper,
+            Some(engine.clone()),
+            Some(engine.join("game").join("template")),
+        )
+        .expect("overlay should be created");
+
+        let error = overlay
+            .rename_logical_path(
+                Path::new("game/scene/a.txt"),
+                Path::new("game/scene/b.txt"),
+            )
+            .expect_err("rename to existing target should fail");
+
+        assert_eq!(error.code(), "ALREADY_EXISTS");
     }
 
     #[test]

--- a/src-tauri/src/vfs.rs
+++ b/src-tauri/src/vfs.rs
@@ -1,0 +1,1813 @@
+use std::{
+    collections::BTreeMap,
+    fs,
+    io::ErrorKind,
+    io::Write,
+    path::{Component, Path, PathBuf},
+};
+
+use percent_encoding::percent_decode_str;
+use serde::{Deserialize, Serialize};
+use tempfile::NamedTempFile;
+use thiserror::Error;
+
+use crate::commands::{AppError, AppResult};
+
+const PROJECT_CONFIG_FILE: &str = "project.wgcp";
+const CURRENT_SCHEMA_VERSION: u32 = 1;
+const VFS_METADATA_DIR: &str = ".wgc-vfs";
+const WHITEOUTS_DIR: &str = "whiteouts";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ProjectConfig {
+    pub version: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub engine: Option<EngineRef>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub template: Option<TemplateBinding>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ProjectConfigVersionProbe {
+    version: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct EngineRef {
+    pub id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub enum TemplateBinding {
+    Standalone {
+        name: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        version: Option<String>,
+    },
+    EngineBuiltin {
+        engine: EngineRef,
+    },
+}
+
+#[derive(Debug, Clone)]
+#[allow(dead_code)] // PR3 server 重构启用
+pub struct ResolvedFile {
+    pub physical_path: PathBuf,
+    pub content_type: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedPhysicalPath {
+    pub physical_path: PathBuf,
+    pub(crate) canonical_root: PathBuf,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PathCategory {
+    EngineRuntime,
+    EngineOverride,
+    TemplateContent,
+    GameContent,
+    Unclassified,
+}
+
+impl PathCategory {
+    /// upper 层是否应优先于 lower 层（用于 overlay 解析）
+    fn prefers_upper_layer(self) -> bool {
+        matches!(
+            self,
+            Self::EngineOverride | Self::TemplateContent | Self::GameContent
+        )
+    }
+
+    fn uses_whiteout(self) -> bool {
+        matches!(self, Self::TemplateContent | Self::GameContent)
+    }
+
+    fn ensure_mutable(self) -> Result<(), VfsError> {
+        if matches!(
+            self,
+            Self::EngineOverride | Self::TemplateContent | Self::GameContent
+        ) {
+            Ok(())
+        } else {
+            Err(VfsError::WriteToEngineRuntime)
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum VfsSource {
+    Upper,
+    EngineLower,
+    TemplateLower,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct VfsDirEntry {
+    pub name: String,
+    pub is_dir: bool,
+    pub source: VfsSource,
+}
+
+#[derive(Debug, Error)]
+pub enum VfsError {
+    #[error("路径被拒绝：不安全的路径")]
+    PathDenied,
+
+    #[error("文件未找到")]
+    NotFound,
+
+    #[error("写入被拒绝：引擎运行时文件不可覆盖")]
+    WriteToEngineRuntime,
+
+    #[error("IO 错误: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+impl VfsError {
+    pub fn code(&self) -> &'static str {
+        match self {
+            Self::PathDenied => "PATH_DENIED",
+            Self::NotFound => "NOT_FOUND",
+            Self::WriteToEngineRuntime => "WRITE_TO_ENGINE_RUNTIME",
+            Self::Io(_) => "VFS_ERROR",
+        }
+    }
+}
+
+/// 缓存 canonicalize 结果，避免热路径上重复系统调用
+#[derive(Debug, Clone)]
+pub struct CachedCanonicals {
+    pub upper: PathBuf,
+    pub upper_canonical: PathBuf,
+    pub engine_lower: Option<PathBuf>,
+    pub engine_lower_canonical: Option<PathBuf>,
+    pub template_lower: Option<PathBuf>,
+    pub template_lower_canonical: Option<PathBuf>,
+}
+
+impl CachedCanonicals {
+    pub fn compute(
+        upper: PathBuf,
+        engine_lower: Option<PathBuf>,
+        template_lower: Option<PathBuf>,
+    ) -> Result<Self, VfsError> {
+        let upper_canonical = upper.canonicalize()?;
+        let engine_lower_canonical = engine_lower
+            .as_ref()
+            .map(|path| path.canonicalize())
+            .transpose()?;
+        let template_lower_canonical = template_lower
+            .as_ref()
+            .map(|path| path.canonicalize())
+            .transpose()?;
+
+        Ok(Self {
+            upper,
+            upper_canonical,
+            engine_lower,
+            engine_lower_canonical,
+            template_lower,
+            template_lower_canonical,
+        })
+    }
+}
+
+pub struct OverlayFs {
+    upper: PathBuf,
+    upper_canonical: PathBuf,
+    engine_lower: Option<PathBuf>,
+    engine_lower_canonical: Option<PathBuf>,
+    template_lower: Option<PathBuf>,
+    template_lower_canonical: Option<PathBuf>,
+    whiteout_root: PathBuf,
+}
+
+impl OverlayFs {
+    #[cfg(test)]
+    pub fn new(
+        upper: PathBuf,
+        engine_lower: Option<PathBuf>,
+        template_lower: Option<PathBuf>,
+    ) -> Result<Self, VfsError> {
+        let cached = CachedCanonicals::compute(upper, engine_lower, template_lower)?;
+        Ok(Self::from_cached(&cached))
+    }
+
+    /// 使用已缓存的 canonical 路径构造 OverlayFs，跳过 canonicalize 系统调用
+    pub fn from_cached(cached: &CachedCanonicals) -> Self {
+        let whiteout_root = cached.upper.join(VFS_METADATA_DIR).join(WHITEOUTS_DIR);
+        Self {
+            upper: cached.upper.clone(),
+            upper_canonical: cached.upper_canonical.clone(),
+            engine_lower: cached.engine_lower.clone(),
+            engine_lower_canonical: cached.engine_lower_canonical.clone(),
+            template_lower: cached.template_lower.clone(),
+            template_lower_canonical: cached.template_lower_canonical.clone(),
+            whiteout_root,
+        }
+    }
+
+    #[allow(dead_code)] // PR3 server 重构启用
+    pub fn resolve_file(&self, logical_path: &Path) -> Result<ResolvedFile, VfsError> {
+        let resolved = self.resolve_physical_path(logical_path)?;
+        let metadata = fs::metadata(&resolved.physical_path)?;
+
+        if !metadata.is_file() {
+            return Err(VfsError::NotFound);
+        }
+
+        Ok(ResolvedFile {
+            content_type: mime_guess::from_path(&resolved.physical_path)
+                .first_or_octet_stream()
+                .to_string(),
+            physical_path: resolved.physical_path,
+        })
+    }
+
+    pub fn resolve_physical_path(
+        &self,
+        logical_path: &Path,
+    ) -> Result<ResolvedPhysicalPath, VfsError> {
+        let category = classify_path(logical_path);
+
+        // upper 优先时，先检查 upper 层
+        if category.prefers_upper_layer() || self.engine_lower.is_none() {
+            let upper_path = self.upper.join(logical_path);
+            if upper_path.exists() {
+                validate_read_path_fast(&upper_path, &self.upper_canonical)?;
+                return Ok(ResolvedPhysicalPath {
+                    physical_path: upper_path,
+                    canonical_root: self.upper_canonical.clone(),
+                });
+            }
+
+            if category.uses_whiteout() && self.is_whiteouted(logical_path)? {
+                return Err(VfsError::NotFound);
+            }
+        }
+
+        // 尝试 lower 层
+        if let Some((lower_path, lower_canonical)) = self.resolve_lower_path(logical_path) {
+            if lower_path.exists() {
+                validate_read_path_fast(&lower_path, lower_canonical)?;
+                return Ok(ResolvedPhysicalPath {
+                    physical_path: lower_path,
+                    canonical_root: lower_canonical.to_path_buf(),
+                });
+            }
+        }
+
+        // 无 lower 层时回退到 upper（引擎运行时文件可能只存在于 upper）
+        let upper_path = self.upper.join(logical_path);
+        if upper_path.exists() {
+            validate_read_path_fast(&upper_path, &self.upper_canonical)?;
+            return Ok(ResolvedPhysicalPath {
+                physical_path: upper_path,
+                canonical_root: self.upper_canonical.clone(),
+            });
+        }
+
+        Err(VfsError::NotFound)
+    }
+
+    pub fn ensure_writable(&self, logical_path: &Path) -> Result<PathBuf, VfsError> {
+        let category = classify_path(logical_path);
+        category.ensure_mutable()?;
+        let upper_path = self.validate_upper_path(logical_path)?;
+        self.clear_whiteout(logical_path)?;
+
+        if category == PathCategory::EngineOverride {
+            ensure_parent_dir(&upper_path)?;
+            return Ok(upper_path);
+        }
+
+        // TemplateContent | GameContent
+        if upper_path.exists() {
+            return Ok(upper_path);
+        }
+
+        if let Some((lower_path, lower_canonical)) = self.resolve_lower_path(logical_path) {
+            if lower_path.exists() {
+                validate_physical_path(&lower_path, lower_canonical)?;
+                copy_path(&lower_path, &upper_path)?;
+                return Ok(upper_path);
+            }
+        }
+
+        ensure_parent_dir(&upper_path)?;
+        Ok(upper_path)
+    }
+
+    pub fn logical_path_is_directory(&self, logical_path: &Path) -> Result<bool, VfsError> {
+        let resolved = self.resolve_physical_path(logical_path)?;
+        Ok(fs::metadata(resolved.physical_path)?.is_dir())
+    }
+
+    pub fn remove_logical_path(&self, logical_path: &Path) -> Result<(), VfsError> {
+        let category = classify_path(logical_path);
+        category.ensure_mutable()?;
+
+        let upper_path = self.validate_upper_path(logical_path)?;
+        let lower_exists = self
+            .resolve_lower_path(logical_path)
+            .is_some_and(|(lower_path, _)| lower_path.exists());
+
+        if category == PathCategory::EngineOverride {
+            if upper_path.exists() {
+                remove_path(&upper_path)?;
+                self.clear_whiteout(logical_path)?;
+                return Ok(());
+            }
+
+            return if lower_exists {
+                Err(VfsError::WriteToEngineRuntime)
+            } else {
+                Err(VfsError::NotFound)
+            };
+        }
+
+        // TemplateContent | GameContent
+        if upper_path.exists() {
+            remove_path(&upper_path)?;
+        }
+
+        if lower_exists {
+            self.create_whiteout(logical_path)?;
+        } else {
+            self.clear_whiteout(logical_path)?;
+        }
+
+        Ok(())
+    }
+
+    pub fn rename_logical_path(&self, from: &Path, to: &Path) -> Result<(), VfsError> {
+        let source_category = classify_path(from);
+        let target_category = classify_path(to);
+        source_category.ensure_mutable()?;
+        target_category.ensure_mutable()?;
+
+        if from == to {
+            return Ok(());
+        }
+
+        if self.logical_path_exists(to)? {
+            return Err(already_exists_error());
+        }
+
+        let source_upper = self.validate_upper_path(from)?;
+        let source_lower = self
+            .resolve_lower_path(from)
+            .filter(|(lower_path, _)| lower_path.exists());
+        let target_upper = self.validate_upper_path(to)?;
+
+        if !source_upper.exists() && source_lower.is_none() && !self.is_whiteouted(from)? {
+            return Err(VfsError::NotFound);
+        }
+
+        self.ensure_directory_target_is_not_nested(from, to)?;
+        ensure_parent_dir(&target_upper)?;
+
+        if source_category == PathCategory::EngineOverride {
+            if !source_upper.exists() {
+                return if source_lower.is_some() {
+                    Err(VfsError::WriteToEngineRuntime)
+                } else {
+                    Err(VfsError::NotFound)
+                };
+            }
+
+            fs::rename(&source_upper, &target_upper)?;
+            self.clear_whiteout(from)?;
+        } else {
+            // TemplateContent | GameContent
+            if source_upper.exists() {
+                if source_lower.is_some() && source_upper.is_dir() {
+                    self.copy_overlay_path(from, to)?;
+                    remove_path(&source_upper)?;
+                } else {
+                    fs::rename(&source_upper, &target_upper)?;
+                }
+            } else if source_lower.is_some() {
+                self.copy_overlay_path(from, to)?;
+            } else {
+                return Err(VfsError::NotFound);
+            }
+
+            if source_lower.is_some() {
+                self.create_whiteout(from)?;
+            }
+        }
+
+        self.clear_whiteout(to)?;
+        Ok(())
+    }
+
+    pub fn copy_logical_path(&self, from: &Path, to: &Path) -> Result<(), VfsError> {
+        classify_path(from).ensure_mutable()?;
+        classify_path(to).ensure_mutable()?;
+
+        if self.logical_path_exists(to)? {
+            return Err(already_exists_error());
+        }
+
+        self.ensure_directory_target_is_not_nested(from, to)?;
+        self.copy_overlay_path(from, to)
+    }
+
+    pub fn list_entries(&self, logical_dir: &Path) -> Result<Vec<VfsDirEntry>, VfsError> {
+        let mut entries = BTreeMap::<String, VfsDirEntry>::new();
+
+        if classify_path(logical_dir) == PathCategory::TemplateContent {
+            if let Some(template_dir) = self.template_dir_for_list(logical_dir) {
+                self.extend_from_lower(
+                    logical_dir,
+                    &template_dir,
+                    VfsSource::TemplateLower,
+                    &mut entries,
+                )?;
+            }
+        } else if let Some(engine_dir) = self.engine_dir_for_list(logical_dir) {
+            self.extend_from_lower(logical_dir, &engine_dir, VfsSource::EngineLower, &mut entries)?;
+        }
+
+        self.extend_template_root_entry(logical_dir, &mut entries)?;
+
+        let upper_dir = self.upper.join(logical_dir);
+        if upper_dir.is_dir() {
+            for entry in fs::read_dir(&upper_dir)? {
+                let entry = entry?;
+                let name = entry.file_name().to_string_lossy().to_string();
+                let child_logical = join_logical(logical_dir, &name);
+                let child_category = classify_path(&child_logical);
+
+                if is_internal_metadata_path(&child_logical)
+                    || !child_category.prefers_upper_layer()
+                {
+                    continue;
+                }
+
+                let is_dir = entry.file_type()?.is_dir();
+                entries.insert(
+                    name.clone(),
+                    VfsDirEntry {
+                        is_dir,
+                        name,
+                        source: VfsSource::Upper,
+                    },
+                );
+            }
+        }
+
+        let mut result = entries.into_values().collect::<Vec<_>>();
+        result.sort_by(|left, right| {
+            right
+                .is_dir
+                .cmp(&left.is_dir)
+                .then_with(|| left.name.cmp(&right.name))
+        });
+
+        Ok(result)
+    }
+
+    fn extend_template_root_entry(
+        &self,
+        logical_dir: &Path,
+        entries: &mut BTreeMap<String, VfsDirEntry>,
+    ) -> Result<(), VfsError> {
+        if logical_dir != Path::new("game") {
+            return Ok(());
+        }
+
+        let Some(template_lower) = self.template_lower.as_ref() else {
+            return Ok(());
+        };
+
+        if !template_lower.is_dir() {
+            return Ok(());
+        }
+
+        let template_logical = Path::new("game").join("template");
+        if self.is_whiteouted(&template_logical)? {
+            return Ok(());
+        }
+
+        entries
+            .entry(String::from("template"))
+            .or_insert(VfsDirEntry {
+                is_dir: true,
+                name: String::from("template"),
+                source: VfsSource::TemplateLower,
+            });
+
+        Ok(())
+    }
+
+    fn extend_from_lower(
+        &self,
+        logical_dir: &Path,
+        lower_dir: &Path,
+        source: VfsSource,
+        entries: &mut BTreeMap<String, VfsDirEntry>,
+    ) -> Result<(), VfsError> {
+        if !lower_dir.is_dir() {
+            return Ok(());
+        }
+
+        for entry in fs::read_dir(lower_dir)? {
+            let entry = entry?;
+            let name = entry.file_name().to_string_lossy().to_string();
+            let child_logical = join_logical(logical_dir, &name);
+            let child_category = classify_path(&child_logical);
+
+            if is_internal_metadata_path(&child_logical)
+                || (child_category.uses_whiteout() && self.is_whiteouted(&child_logical)?)
+            {
+                continue;
+            }
+
+            let is_dir = entry.file_type()?.is_dir();
+            let entry_source = if source == VfsSource::EngineLower
+                && logical_dir == Path::new("game")
+                && name == "template"
+                && self.template_lower.is_some()
+            {
+                VfsSource::TemplateLower
+            } else {
+                source
+            };
+
+            entries.entry(name.clone()).or_insert(VfsDirEntry {
+                is_dir,
+                name,
+                source: entry_source,
+            });
+        }
+
+        Ok(())
+    }
+
+    fn resolve_lower_path(&self, logical_path: &Path) -> Option<(PathBuf, &Path)> {
+        match classify_path(logical_path) {
+            PathCategory::TemplateContent => {
+                let template_lower = self.template_lower.as_ref()?;
+                let template_canonical = self.template_lower_canonical.as_ref()?;
+                let relative = strip_template_prefix(logical_path)?;
+                Some((template_lower.join(relative), template_canonical))
+            }
+            PathCategory::EngineRuntime
+            | PathCategory::EngineOverride
+            | PathCategory::Unclassified => {
+                let engine_lower = self.engine_lower.as_ref()?;
+                let engine_canonical = self.engine_lower_canonical.as_ref()?;
+                Some((engine_lower.join(logical_path), engine_canonical))
+            }
+            PathCategory::GameContent => None,
+        }
+    }
+
+    fn engine_dir_for_list(&self, logical_dir: &Path) -> Option<PathBuf> {
+        if classify_path(logical_dir) == PathCategory::GameContent {
+            return None;
+        }
+
+        let engine_lower = self.engine_lower.as_ref()?;
+        Some(engine_lower.join(logical_dir))
+    }
+
+    fn template_dir_for_list(&self, logical_dir: &Path) -> Option<PathBuf> {
+        let template_lower = self.template_lower.as_ref()?;
+        let relative = strip_template_prefix(logical_dir)?;
+        Some(template_lower.join(relative))
+    }
+
+    fn create_whiteout(&self, logical_path: &Path) -> Result<(), VfsError> {
+        let marker_path = self.whiteout_marker_path(logical_path);
+        self.validate_project_owned_path(&marker_path)?;
+        ensure_parent_dir(&marker_path)?;
+        fs::write(marker_path, [])?;
+        Ok(())
+    }
+
+    fn clear_whiteout(&self, logical_path: &Path) -> Result<(), VfsError> {
+        let marker_path = self.whiteout_marker_path(logical_path);
+        self.validate_project_owned_path(&marker_path)?;
+        if marker_path.exists() {
+            fs::remove_file(marker_path)?;
+        }
+        Ok(())
+    }
+
+    fn is_whiteouted(&self, logical_path: &Path) -> Result<bool, VfsError> {
+        let components = collect_normal_components(logical_path)?;
+
+        if components.is_empty() {
+            return Ok(false);
+        }
+
+        let mut prefix = PathBuf::new();
+        for component in &components {
+            let marker = self
+                .whiteout_root
+                .join(&prefix)
+                .join(format!(".wh.{component}"));
+            self.validate_project_owned_path(&marker)?;
+            if marker.exists() {
+                return Ok(true);
+            }
+            prefix.push(component);
+        }
+
+        Ok(false)
+    }
+
+    fn whiteout_marker_path(&self, logical_path: &Path) -> PathBuf {
+        let parent = logical_path.parent().unwrap_or_else(|| Path::new(""));
+        let name = logical_path.file_name().unwrap_or_default();
+        self.whiteout_root
+            .join(parent)
+            .join(format!(".wh.{}", name.to_string_lossy()))
+    }
+
+    fn logical_path_exists(&self, logical_path: &Path) -> Result<bool, VfsError> {
+        let category = classify_path(logical_path);
+        if self.validate_upper_path(logical_path)?.exists() {
+            return Ok(true);
+        }
+
+        if category.uses_whiteout() && self.is_whiteouted(logical_path)? {
+            return Ok(false);
+        }
+
+        Ok(self
+            .resolve_lower_path(logical_path)
+            .is_some_and(|(lower_path, _)| lower_path.exists()))
+    }
+
+    fn copy_overlay_path(&self, from: &Path, to: &Path) -> Result<(), VfsError> {
+        let resolved = self.resolve_physical_path(from)?;
+        let target_upper = self.validate_upper_path(to)?;
+        let metadata = fs::metadata(&resolved.physical_path)?;
+
+        if metadata.is_dir() {
+            if is_same_or_descendant_path(to, from)? {
+                return Err(VfsError::PathDenied);
+            }
+
+            if target_upper.starts_with(&resolved.physical_path) {
+                return Err(VfsError::PathDenied);
+            }
+
+            fs::create_dir_all(&target_upper)?;
+
+            for entry in self.list_entries(from)? {
+                let child_from = from.join(&entry.name);
+                let child_to = to.join(&entry.name);
+                self.copy_overlay_path(&child_from, &child_to)?;
+            }
+        } else {
+            validate_physical_path(&resolved.physical_path, &resolved.canonical_root)?;
+            copy_path(&resolved.physical_path, &target_upper)?;
+        }
+
+        self.clear_whiteout(to)?;
+        Ok(())
+    }
+
+    fn ensure_directory_target_is_not_nested(
+        &self,
+        from: &Path,
+        to: &Path,
+    ) -> Result<(), VfsError> {
+        if self.logical_path_is_directory(from)? && is_same_or_descendant_path(to, from)? {
+            return Err(VfsError::PathDenied);
+        }
+
+        Ok(())
+    }
+
+    fn validate_upper_path(&self, logical_path: &Path) -> Result<PathBuf, VfsError> {
+        let upper_path = self.upper.join(logical_path);
+        self.validate_project_owned_path(&upper_path)?;
+        Ok(upper_path)
+    }
+
+    fn validate_project_owned_path(&self, path: &Path) -> Result<(), VfsError> {
+        let components = collect_normal_components(
+            path.strip_prefix(&self.upper)
+                .map_err(|_| VfsError::PathDenied)?,
+        )?;
+        let mut current = self.upper.clone();
+
+        for component in components {
+            current.push(component);
+            if !current.exists() {
+                continue;
+            }
+
+            let metadata = fs::symlink_metadata(&current)?;
+            if metadata.file_type().is_symlink() {
+                log::warn!("路径被拒绝（符号链接）: {}", current.display());
+                return Err(VfsError::PathDenied);
+            }
+
+            validate_physical_path(&current, &self.upper_canonical)?;
+        }
+
+        Ok(())
+    }
+}
+
+#[allow(dead_code)] // PR3 server 重构启用
+pub fn sanitize_request_path(raw_path: &str) -> Result<PathBuf, VfsError> {
+    let decoded = percent_decode_str(raw_path)
+        .decode_utf8()
+        .map_err(|_| VfsError::PathDenied)?;
+
+    sanitize_path_like(decoded.as_ref(), true)
+}
+
+pub fn sanitize_logical_path(raw_path: &str) -> Result<PathBuf, VfsError> {
+    sanitize_path_like(raw_path, false)
+}
+
+#[inline]
+pub(crate) fn classify_path(path: &Path) -> PathCategory {
+    let mut components = path.components();
+    let first = match components.next() {
+        Some(Component::Normal(segment)) => segment.to_str().unwrap_or(""),
+        _ => return PathCategory::Unclassified,
+    };
+
+    match first {
+        "index.html" | "assets" | "manifest.json" | "webgal-serviceworker.js" => {
+            PathCategory::EngineRuntime
+        }
+        "icons" => PathCategory::EngineOverride,
+        "game"
+            if matches!(
+                components.next(),
+                Some(Component::Normal(segment)) if segment.to_str() == Some("template")
+            ) =>
+        {
+            PathCategory::TemplateContent
+        }
+        "game" => PathCategory::GameContent,
+        _ => PathCategory::Unclassified,
+    }
+}
+
+pub fn read_project_config(project_path: &Path) -> AppResult<ProjectConfig> {
+    let config_path = project_path.join(PROJECT_CONFIG_FILE);
+    let content = fs::read_to_string(&config_path)?;
+    let version = serde_json::from_str::<ProjectConfigVersionProbe>(&content)
+        .map(|probe| probe.version)
+        .map_err(invalid_project_config_parse_error)?;
+
+    if version > CURRENT_SCHEMA_VERSION {
+        return Err(AppError::SchemaVersionTooNew {
+            found: version,
+            max_supported: CURRENT_SCHEMA_VERSION,
+        });
+    }
+
+    let config: ProjectConfig =
+        serde_json::from_str(&content).map_err(invalid_project_config_parse_error)?;
+
+    validate_project_config(&config)?;
+    Ok(config)
+}
+
+pub async fn write_project_config(project_path: &Path, config: &ProjectConfig) -> AppResult<()> {
+    validate_project_config(config)?;
+
+    let content = serde_json::to_string_pretty(config)
+        .map_err(|error| AppError::Config(format!("project.wgcp 序列化失败: {error}")))?;
+    atomic_write(&project_path.join(PROJECT_CONFIG_FILE), content.as_bytes()).await?;
+    Ok(())
+}
+
+pub fn resolve_default_template_path(engine_path: Option<&Path>) -> Option<PathBuf> {
+    engine_path.map(|path| path.join("game").join("template"))
+}
+
+struct TemplatePaths {
+    upper: PathBuf,
+    whiteout_dir: PathBuf,
+    whiteout_marker: PathBuf,
+}
+
+fn template_paths(project_path: &Path) -> TemplatePaths {
+    let whiteout_base = project_path
+        .join(VFS_METADATA_DIR)
+        .join(WHITEOUTS_DIR)
+        .join("game");
+
+    TemplatePaths {
+        upper: project_path.join("game").join("template"),
+        whiteout_dir: whiteout_base.join("template"),
+        whiteout_marker: whiteout_base.join(".wh.template"),
+    }
+}
+
+/// 检查项目的模板子树是否被用户修改过
+///
+/// 脏状态命中条件：
+/// 1. `game/template/` 下存在任何 upper 文件或目录
+/// 2. `.wgc-vfs/whiteouts/` 下存在 `game/template/**` 相关 whiteout
+pub fn is_template_dirty(project_path: &Path) -> Result<bool, VfsError> {
+    let paths = template_paths(project_path);
+
+    if paths.upper.is_dir() && has_any_content(&paths.upper)? {
+        return Ok(true);
+    }
+
+    if paths.whiteout_dir.is_dir() && has_any_content(&paths.whiteout_dir)? {
+        return Ok(true);
+    }
+
+    Ok(paths.whiteout_marker.exists())
+}
+
+/// 清理模板子树的所有 upper override 和相关 whiteout
+///
+/// 用于模板切换时重置用户对模板文件的全部修改。
+pub fn clean_template_upper(project_path: &Path) -> Result<(), VfsError> {
+    let paths = template_paths(project_path);
+
+    if paths.upper.is_dir() {
+        for entry in fs::read_dir(&paths.upper)? {
+            remove_path(&entry?.path())?;
+        }
+    }
+
+    if paths.whiteout_dir.is_dir() {
+        fs::remove_dir_all(&paths.whiteout_dir)?;
+    }
+
+    if paths.whiteout_marker.exists() {
+        fs::remove_file(&paths.whiteout_marker)?;
+    }
+
+    Ok(())
+}
+
+fn has_any_content(dir: &Path) -> Result<bool, VfsError> {
+    Ok(fs::read_dir(dir)?.next().is_some())
+}
+
+fn validate_project_config(config: &ProjectConfig) -> AppResult<()> {
+    if config.version == 0 {
+        return Err(AppError::InvalidProjectConfig {
+            reason: "version 字段无效".into(),
+        });
+    }
+
+    if config.template.is_some() && config.engine.is_none() {
+        return Err(AppError::InvalidProjectConfig {
+            reason: "template 字段不能在缺少 engine 时出现".into(),
+        });
+    }
+
+    Ok(())
+}
+
+fn invalid_project_config_parse_error(error: serde_json::Error) -> AppError {
+    AppError::InvalidProjectConfig {
+        reason: format!("project.wgcp 解析失败: {error}"),
+    }
+}
+
+pub(crate) async fn atomic_write(target: &Path, content: &[u8]) -> std::io::Result<()> {
+    let target = target.to_path_buf();
+    let content = content.to_vec();
+
+    tokio::task::spawn_blocking(move || {
+        let parent = target
+            .parent()
+            .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::InvalidInput, "无父目录"))?;
+
+        let mut file = NamedTempFile::new_in(parent)?;
+        file.write_all(&content)?;
+        file.flush()?;
+        file.as_file().sync_all()?;
+        file.persist(&target).map_err(|error| error.error)?;
+        Ok(())
+    })
+    .await
+    .map_err(std::io::Error::other)?
+}
+
+fn sanitize_path_like(raw_path: &str, empty_maps_to_index: bool) -> Result<PathBuf, VfsError> {
+    if raw_path.contains('\0') || raw_path.contains('\\') || raw_path.contains("//") {
+        log::warn!("路径被拒绝（非法字符）: {raw_path:?}");
+        return Err(VfsError::PathDenied);
+    }
+
+    let trimmed = raw_path.trim_start_matches('/');
+    if trimmed.is_empty() {
+        return if empty_maps_to_index {
+            Ok(PathBuf::from("index.html"))
+        } else {
+            Ok(PathBuf::new())
+        };
+    }
+
+    let path = Path::new(trimmed);
+    let mut normalized = PathBuf::new();
+
+    for component in path.components() {
+        match component {
+            Component::Normal(segment) => {
+                let segment = segment.to_str().ok_or(VfsError::PathDenied)?;
+                validate_path_segment(segment)?;
+                normalized.push(segment);
+            }
+            _ => return Err(VfsError::PathDenied),
+        }
+    }
+
+    if is_internal_metadata_path(&normalized) {
+        return Err(VfsError::PathDenied);
+    }
+
+    Ok(normalized)
+}
+
+fn validate_path_segment(segment: &str) -> Result<(), VfsError> {
+    if segment.is_empty()
+        || segment.contains(':')
+        || segment.ends_with('.')
+        || segment.ends_with(' ')
+    {
+        log::warn!("路径段被拒绝（无效格式）: {segment:?}");
+        return Err(VfsError::PathDenied);
+    }
+
+    let upper = segment.split('.').next().unwrap_or("").to_ascii_uppercase();
+    const RESERVED: &[&str] = &[
+        "CON", "PRN", "AUX", "NUL", "COM1", "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8",
+        "COM9", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9",
+    ];
+
+    if RESERVED.contains(&upper.as_str()) {
+        log::warn!("路径段被拒绝（Windows 保留名称）: {segment:?}");
+        return Err(VfsError::PathDenied);
+    }
+
+    Ok(())
+}
+
+fn is_internal_metadata_path(path: &Path) -> bool {
+    let mut components = path.components();
+    let Some(Component::Normal(first)) = components.next() else {
+        return false;
+    };
+    let Some(first) = first.to_str() else {
+        return false;
+    };
+
+    matches!(first, VFS_METADATA_DIR | PROJECT_CONFIG_FILE)
+}
+
+fn validate_physical_path(physical_path: &Path, root_canonical: &Path) -> Result<(), VfsError> {
+    let canonical = if physical_path.exists() {
+        physical_path.canonicalize()?
+    } else {
+        let parent = physical_path.parent().ok_or(VfsError::PathDenied)?;
+        let file_name = physical_path.file_name().ok_or(VfsError::PathDenied)?;
+        parent.canonicalize()?.join(file_name)
+    };
+
+    if !canonical.starts_with(root_canonical) {
+        log::warn!(
+            "路径逃逸被阻止: {} 不在 {} 之内",
+            canonical.display(),
+            root_canonical.display()
+        );
+        return Err(VfsError::PathDenied);
+    }
+
+    Ok(())
+}
+
+/// 读取请求的快速路径校验：使用字符串前缀检查代替 canonicalize
+///
+/// 前提：root_canonical 在站点注册时已缓存，且根目录内不含指向外部的符号链接。
+/// 仅适用于读取请求，写入请求仍需完整的 canonicalize 校验。
+fn validate_read_path_fast(physical_path: &Path, root_canonical: &Path) -> Result<(), VfsError> {
+    if physical_path.starts_with(root_canonical) {
+        return Ok(());
+    }
+    validate_physical_path(physical_path, root_canonical)
+}
+
+fn copy_path(source: &Path, destination: &Path) -> Result<(), VfsError> {
+    ensure_parent_dir(destination)?;
+
+    if source.is_dir() {
+        copy_dir_recursive(source, destination)?;
+    } else {
+        fs::copy(source, destination)?;
+    }
+
+    Ok(())
+}
+
+fn copy_dir_recursive(source: &Path, destination: &Path) -> Result<(), VfsError> {
+    fs::create_dir_all(destination)?;
+
+    for entry in fs::read_dir(source)? {
+        let entry = entry?;
+        let source_path = entry.path();
+        let destination_path = destination.join(entry.file_name());
+
+        if entry.file_type()?.is_dir() {
+            copy_dir_recursive(&source_path, &destination_path)?;
+        } else {
+            fs::copy(source_path, destination_path)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn remove_path(path: &Path) -> Result<(), VfsError> {
+    if path.is_dir() {
+        fs::remove_dir_all(path)?;
+    } else {
+        fs::remove_file(path)?;
+    }
+
+    Ok(())
+}
+
+fn ensure_parent_dir(path: &Path) -> Result<(), VfsError> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    Ok(())
+}
+
+fn already_exists_error() -> VfsError {
+    VfsError::Io(std::io::Error::new(
+        ErrorKind::AlreadyExists,
+        "目标路径已存在",
+    ))
+}
+
+fn strip_template_prefix(path: &Path) -> Option<&Path> {
+    path.strip_prefix(Path::new("game").join("template")).ok()
+}
+
+fn join_logical(parent: &Path, child: &str) -> PathBuf {
+    if parent.as_os_str().is_empty() {
+        PathBuf::from(child)
+    } else {
+        parent.join(child)
+    }
+}
+
+fn collect_normal_components(path: &Path) -> Result<Vec<String>, VfsError> {
+    path.components()
+        .map(|component| match component {
+            Component::Normal(segment) => segment
+                .to_str()
+                .map(String::from)
+                .ok_or(VfsError::PathDenied),
+            _ => Err(VfsError::PathDenied),
+        })
+        .collect()
+}
+
+fn is_same_or_descendant_path(path: &Path, base: &Path) -> Result<bool, VfsError> {
+    let path_components = collect_normal_components(path)?;
+    let base_components = collect_normal_components(base)?;
+
+    if base_components.len() > path_components.len() {
+        return Ok(false);
+    }
+
+    Ok(path_components
+        .iter()
+        .zip(base_components.iter())
+        .all(|(path_component, base_component)| path_component == base_component))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        classify_path, read_project_config, sanitize_logical_path, sanitize_request_path,
+        validate_project_config, AppError, EngineRef, OverlayFs, PathCategory, ProjectConfig,
+        TemplateBinding, VfsDirEntry, VfsError, VfsSource,
+    };
+    #[cfg(windows)]
+    use std::process::Command;
+    use std::{
+        fs,
+        path::{Path, PathBuf},
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    fn create_temp_dir(prefix: &str) -> PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock should be after unix epoch")
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!("{prefix}-{unique}"));
+        fs::create_dir_all(&dir).expect("temp directory should be created");
+        dir
+    }
+
+    #[cfg(unix)]
+    fn create_dir_link(target: &Path, link: &Path) {
+        std::os::unix::fs::symlink(target, link).expect("directory symlink should be created");
+    }
+
+    #[cfg(windows)]
+    fn create_dir_link(target: &Path, link: &Path) {
+        let command = format!(
+            "$link = '{}'; $target = '{}'; New-Item -ItemType Junction -Path $link -Target $target | Out-Null",
+            link.display(),
+            target.display(),
+        );
+        let status = Command::new("powershell")
+            .args(["-NoProfile", "-Command", &command])
+            .status()
+            .expect("junction command should run");
+
+        assert!(status.success(), "directory junction should be created");
+    }
+
+    #[test]
+    fn sanitize_request_path_maps_root_to_index_html() {
+        assert_eq!(
+            sanitize_request_path("").expect("empty path should map to index.html"),
+            PathBuf::from("index.html")
+        );
+        assert_eq!(
+            sanitize_request_path("/").expect("root path should map to index.html"),
+            PathBuf::from("index.html")
+        );
+    }
+
+    #[test]
+    fn sanitize_request_path_rejects_path_traversal_and_reserved_names() {
+        assert!(sanitize_request_path("../secret.txt").is_err());
+        assert!(sanitize_request_path("icons\\favicon.ico").is_err());
+        assert!(sanitize_request_path("CON").is_err());
+        assert!(sanitize_request_path("assets:evil").is_err());
+    }
+
+    #[test]
+    fn sanitize_logical_path_keeps_empty_path_for_directory_listing() {
+        assert_eq!(
+            sanitize_logical_path("").expect("empty logical path should stay empty"),
+            PathBuf::new()
+        );
+    }
+
+    #[test]
+    fn classify_path_matches_phase_one_contract() {
+        assert_eq!(
+            classify_path(Path::new("index.html")),
+            PathCategory::EngineRuntime
+        );
+        assert_eq!(
+            classify_path(Path::new("assets/js/main.js")),
+            PathCategory::EngineRuntime
+        );
+        assert_eq!(
+            classify_path(Path::new("manifest.json")),
+            PathCategory::EngineRuntime
+        );
+        assert_eq!(
+            classify_path(Path::new("icons/favicon.ico")),
+            PathCategory::EngineOverride
+        );
+        assert_eq!(
+            classify_path(Path::new("game/template/start.txt")),
+            PathCategory::TemplateContent
+        );
+        assert_eq!(
+            classify_path(Path::new("game/scene/start.txt")),
+            PathCategory::GameContent
+        );
+    }
+
+    #[test]
+    fn validate_project_config_rejects_template_without_engine() {
+        let config = ProjectConfig {
+            engine: None,
+            template: Some(TemplateBinding::Standalone {
+                name: "Modern".into(),
+                version: None,
+            }),
+            version: 1,
+        };
+
+        assert!(matches!(
+            validate_project_config(&config),
+            Err(AppError::InvalidProjectConfig { .. })
+        ));
+    }
+
+    #[test]
+    fn read_project_config_rejects_future_schema_version() {
+        let dir = create_temp_dir("webgal-craft-project-config");
+        fs::write(
+            dir.join("project.wgcp"),
+            r#"{"version":99,"engine":{"name":"WebGAL","version":"4.5.0"}}"#,
+        )
+        .expect("project config should be written");
+
+        let error = read_project_config(&dir).expect_err("future schema version should fail");
+        assert!(matches!(error, AppError::SchemaVersionTooNew { .. }));
+    }
+
+    #[test]
+    fn read_project_config_reports_future_schema_before_shape_validation() {
+        let dir = create_temp_dir("webgal-craft-project-config-future-shape");
+        fs::write(
+            dir.join("project.wgcp"),
+            r#"{
+              "version": 99,
+              "engine": "future-schema"
+            }"#,
+        )
+        .expect("project config should be written");
+
+        let error = read_project_config(&dir)
+            .expect_err("future schema should not be downgraded to invalid config");
+        assert!(matches!(error, AppError::SchemaVersionTooNew { .. }));
+    }
+
+    #[test]
+    fn read_project_config_parses_full_structure() {
+        let dir = create_temp_dir("webgal-craft-project-config-full");
+        fs::write(
+            dir.join("project.wgcp"),
+            r#"{
+              "version": 1,
+              "engine": { "id": "open-webgal.webgal", "version": "4.5.0" },
+              "template": {
+                "kind": "engineBuiltin",
+                "engine": { "id": "open-webgal.webgal", "version": "4.5.0" }
+              }
+            }"#,
+        )
+        .expect("project config should be written");
+
+        let config = read_project_config(&dir).expect("project config should parse");
+
+        assert_eq!(
+            config.engine,
+            Some(EngineRef {
+                id: "open-webgal.webgal".into(),
+                version: Some("4.5.0".into()),
+            })
+        );
+        assert!(matches!(
+            config.template,
+            Some(TemplateBinding::EngineBuiltin { .. })
+        ));
+    }
+
+    #[test]
+    fn read_project_config_reports_invalid_project_config_for_parse_errors() {
+        let dir = create_temp_dir("webgal-craft-project-config-invalid");
+        fs::write(dir.join("project.wgcp"), r#"{"version":"broken"}"#)
+            .expect("project config should be written");
+
+        let error = read_project_config(&dir).expect_err("invalid config should fail");
+        assert!(matches!(error, AppError::InvalidProjectConfig { .. }));
+    }
+
+    #[test]
+    fn list_entries_includes_template_children() {
+        let upper = create_temp_dir("webgal-craft-vfs-upper");
+        let engine = create_temp_dir("webgal-craft-vfs-engine");
+
+        fs::create_dir_all(engine.join("game").join("template"))
+            .expect("template directory should be created");
+        fs::write(
+            engine.join("game").join("template").join("style.css"),
+            "body {}",
+        )
+        .expect("template file should be written");
+
+        let overlay = OverlayFs::new(
+            upper,
+            Some(engine.clone()),
+            Some(engine.join("game").join("template")),
+        )
+        .expect("overlay should be created");
+
+        let entries = overlay
+            .list_entries(Path::new("game/template"))
+            .expect("template entries should be listed");
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].name, "style.css");
+    }
+
+    #[test]
+    fn resolve_physical_path_prefers_engine_runtime_lower_over_upper() {
+        let upper = create_temp_dir("webgal-craft-vfs-runtime-upper");
+        let engine = create_temp_dir("webgal-craft-vfs-runtime-engine");
+
+        fs::create_dir_all(engine.join("game").join("template"))
+            .expect("template directory should be created");
+        fs::write(upper.join("manifest.json"), "{\"name\":\"upper\"}")
+            .expect("upper manifest should be written");
+        fs::write(engine.join("manifest.json"), "{\"name\":\"engine\"}")
+            .expect("engine manifest should be written");
+
+        let overlay = OverlayFs::new(
+            upper,
+            Some(engine.clone()),
+            Some(engine.join("game").join("template")),
+        )
+        .expect("overlay should be created");
+
+        let resolved = overlay
+            .resolve_physical_path(Path::new("manifest.json"))
+            .expect("manifest should resolve from engine lower");
+
+        assert_eq!(resolved.physical_path, engine.join("manifest.json"));
+        assert_eq!(
+            resolved.canonical_root,
+            engine.canonicalize().expect("engine should canonicalize")
+        );
+    }
+
+    #[test]
+    fn list_entries_ignores_upper_engine_runtime_and_unclassified_entries() {
+        let upper = create_temp_dir("webgal-craft-vfs-root-upper");
+        let engine = create_temp_dir("webgal-craft-vfs-root-engine");
+
+        fs::create_dir_all(engine.join("game").join("template"))
+            .expect("template directory should be created");
+        fs::write(upper.join("manifest.json"), "{\"name\":\"upper\"}")
+            .expect("upper manifest should be written");
+        fs::write(upper.join("notes.txt"), "upper only")
+            .expect("upper unclassified file should be written");
+        fs::write(engine.join("manifest.json"), "{\"name\":\"engine\"}")
+            .expect("engine manifest should be written");
+
+        let overlay = OverlayFs::new(
+            upper,
+            Some(engine.clone()),
+            Some(engine.join("game").join("template")),
+        )
+        .expect("overlay should be created");
+
+        let entries = overlay
+            .list_entries(Path::new(""))
+            .expect("root entries should be listed");
+
+        assert!(
+            entries.iter().any(|entry| entry.name == "manifest.json"),
+            "manifest should be visible"
+        );
+        assert!(!entries.iter().any(|entry| entry.name == "notes.txt"));
+    }
+
+    #[test]
+    fn ensure_writable_does_not_materialize_engine_override_files() {
+        let upper = create_temp_dir("webgal-craft-vfs-icons-upper");
+        let engine = create_temp_dir("webgal-craft-vfs-icons-engine");
+
+        fs::create_dir_all(engine.join("game").join("template"))
+            .expect("template directory should be created");
+        fs::create_dir_all(engine.join("icons")).expect("icons directory should be created");
+        fs::write(engine.join("icons").join("favicon.ico"), "lower icon")
+            .expect("engine icon should be written");
+
+        let overlay = OverlayFs::new(
+            upper.clone(),
+            Some(engine.clone()),
+            Some(engine.join("game").join("template")),
+        )
+        .expect("overlay should be created");
+
+        let writable_path = overlay
+            .ensure_writable(Path::new("icons/favicon.ico"))
+            .expect("engine override should resolve to upper path");
+
+        assert_eq!(writable_path, upper.join("icons").join("favicon.ico"));
+        assert!(!writable_path.exists());
+    }
+
+    #[test]
+    fn ensure_writable_rejects_linked_upper_parent_chain() {
+        let upper = create_temp_dir("webgal-craft-vfs-linked-upper");
+        let engine = create_temp_dir("webgal-craft-vfs-linked-engine");
+        let escape = create_temp_dir("webgal-craft-vfs-linked-escape");
+
+        fs::create_dir_all(upper.join("game")).expect("upper game dir should exist");
+        fs::create_dir_all(engine.join("game").join("template"))
+            .expect("template directory should be created");
+        create_dir_link(&escape, &upper.join("game").join("scene"));
+
+        let overlay = OverlayFs::new(
+            upper,
+            Some(engine.clone()),
+            Some(engine.join("game").join("template")),
+        )
+        .expect("overlay should be created");
+
+        let error = overlay
+            .ensure_writable(Path::new("game/scene/start.txt"))
+            .expect_err("linked parent chain should be rejected");
+
+        assert!(matches!(error, VfsError::PathDenied));
+        assert!(
+            !escape.join("start.txt").exists(),
+            "materialize should not escape through a linked parent directory"
+        );
+    }
+
+    #[test]
+    fn remove_logical_path_on_engine_override_reveals_engine_lower_again() {
+        let upper = create_temp_dir("webgal-craft-vfs-icons-remove-upper");
+        let engine = create_temp_dir("webgal-craft-vfs-icons-remove-engine");
+
+        fs::create_dir_all(engine.join("game").join("template"))
+            .expect("template directory should be created");
+        fs::create_dir_all(engine.join("icons")).expect("engine icons directory should be created");
+        fs::create_dir_all(upper.join("icons")).expect("upper icons directory should be created");
+        fs::write(engine.join("icons").join("favicon.ico"), "engine icon")
+            .expect("engine icon should be written");
+        fs::write(upper.join("icons").join("favicon.ico"), "upper icon")
+            .expect("upper icon should be written");
+
+        let overlay = OverlayFs::new(
+            upper,
+            Some(engine.clone()),
+            Some(engine.join("game").join("template")),
+        )
+        .expect("overlay should be created");
+
+        overlay
+            .remove_logical_path(Path::new("icons/favicon.ico"))
+            .expect("deleting upper override should fall back to lower");
+
+        let resolved = overlay
+            .resolve_physical_path(Path::new("icons/favicon.ico"))
+            .expect("engine icon should be visible again");
+
+        assert_eq!(
+            resolved.physical_path,
+            engine.join("icons").join("favicon.ico")
+        );
+        assert_eq!(
+            resolved.canonical_root,
+            engine.canonicalize().expect("engine should canonicalize")
+        );
+    }
+
+    #[test]
+    fn ensure_writable_for_game_content_ignores_engine_lower() {
+        let upper = create_temp_dir("webgal-craft-vfs-whiteout-upper");
+        let engine = create_temp_dir("webgal-craft-vfs-whiteout-engine");
+
+        fs::create_dir_all(engine.join("game").join("scene"))
+            .expect("scene directory should be created");
+        fs::create_dir_all(engine.join("game").join("template"))
+            .expect("template directory should be created");
+        fs::write(
+            engine.join("game").join("scene").join("start.txt"),
+            "lower scene",
+        )
+        .expect("scene file should be written");
+
+        let overlay = OverlayFs::new(
+            upper.clone(),
+            Some(engine.clone()),
+            Some(engine.join("game").join("template")),
+        )
+        .expect("overlay should be created");
+
+        let writable_path = overlay
+            .ensure_writable(Path::new("game/scene/start.txt"))
+            .expect("game content should become writable in upper");
+
+        assert_eq!(
+            writable_path,
+            upper.join("game").join("scene").join("start.txt")
+        );
+        assert!(
+            !writable_path.exists(),
+            "GameContent no longer materializes engine lower files"
+        );
+        assert!(
+            writable_path
+                .parent()
+                .expect("writable path should have a parent")
+                .is_dir(),
+            "ensure_writable should create the target parent directory"
+        );
+        assert!(matches!(
+            overlay.resolve_physical_path(Path::new("game/scene/start.txt")),
+            Err(VfsError::NotFound)
+        ));
+    }
+
+    #[test]
+    fn remove_logical_path_rejects_linked_whiteout_parent_chain() {
+        let upper = create_temp_dir("webgal-craft-vfs-whiteout-link-upper");
+        let engine = create_temp_dir("webgal-craft-vfs-whiteout-link-engine");
+        let escape = create_temp_dir("webgal-craft-vfs-whiteout-link-escape");
+
+        fs::create_dir_all(engine.join("game").join("scene"))
+            .expect("scene directory should be created");
+        fs::create_dir_all(engine.join("game").join("template"))
+            .expect("template directory should be created");
+        fs::write(
+            engine.join("game").join("scene").join("start.txt"),
+            "lower scene",
+        )
+        .expect("scene file should be written");
+        create_dir_link(&escape, &upper.join(".wgc-vfs"));
+
+        let overlay = OverlayFs::new(
+            upper,
+            Some(engine.clone()),
+            Some(engine.join("game").join("template")),
+        )
+        .expect("overlay should be created");
+
+        let error = overlay
+            .remove_logical_path(Path::new("game/scene/start.txt"))
+            .expect_err("linked whiteout metadata path should be rejected");
+
+        assert!(matches!(error, VfsError::PathDenied));
+        assert!(
+            !escape
+                .join("whiteouts")
+                .join("game")
+                .join("scene")
+                .join(".wh.start.txt")
+                .exists(),
+            "whiteout writes should not escape through linked metadata directories"
+        );
+    }
+
+    #[test]
+    fn copy_logical_path_uses_overlay_view_for_template_directories() {
+        let upper = create_temp_dir("webgal-craft-vfs-copy-upper");
+        let engine = create_temp_dir("webgal-craft-vfs-copy-engine");
+
+        fs::create_dir_all(engine.join("game").join("template").join("scene"))
+            .expect("template directory should be created");
+        fs::write(
+            engine
+                .join("game")
+                .join("template")
+                .join("scene")
+                .join("a.txt"),
+            "A",
+        )
+        .expect("visible lower file should be written");
+        fs::write(
+            engine
+                .join("game")
+                .join("template")
+                .join("scene")
+                .join("b.txt"),
+            "B",
+        )
+        .expect("hidden lower file should be written");
+
+        let overlay = OverlayFs::new(
+            upper.clone(),
+            Some(engine.clone()),
+            Some(engine.join("game").join("template")),
+        )
+        .expect("overlay should be created");
+
+        overlay
+            .remove_logical_path(Path::new("game/template/scene/b.txt"))
+            .expect("lower file should be whiteouted");
+        overlay
+            .copy_logical_path(
+                Path::new("game/template/scene"),
+                Path::new("game/template/scene-copy"),
+            )
+            .expect("directory copy should succeed");
+
+        assert!(upper
+            .join("game")
+            .join("template")
+            .join("scene-copy")
+            .join("a.txt")
+            .is_file());
+        assert!(!upper
+            .join("game")
+            .join("template")
+            .join("scene-copy")
+            .join("b.txt")
+            .exists());
+    }
+
+    #[test]
+    fn copy_logical_path_rejects_moving_directory_into_its_own_descendant() {
+        let upper = create_temp_dir("webgal-craft-vfs-copy-descendant-upper");
+        let engine = create_temp_dir("webgal-craft-vfs-copy-descendant-engine");
+
+        fs::create_dir_all(upper.join("game").join("scene"))
+            .expect("scene directory should be created");
+        fs::create_dir_all(engine.join("game").join("template"))
+            .expect("template directory should be created");
+        fs::write(upper.join("game").join("scene").join("start.txt"), "scene")
+            .expect("scene file should be written");
+
+        let overlay = OverlayFs::new(
+            upper,
+            Some(engine.clone()),
+            Some(engine.join("game").join("template")),
+        )
+        .expect("overlay should be created");
+
+        let error = overlay
+            .copy_logical_path(Path::new("game/scene"), Path::new("game/scene/nested"))
+            .expect_err("copying a directory into its own descendant should be rejected");
+
+        assert!(matches!(error, VfsError::PathDenied));
+    }
+
+    #[test]
+    fn rename_logical_path_preserves_template_lower_children_for_partially_materialized_directories(
+    ) {
+        let upper = create_temp_dir("webgal-craft-vfs-rename-mixed-upper");
+        let engine = create_temp_dir("webgal-craft-vfs-rename-mixed-engine");
+
+        fs::create_dir_all(upper.join("game").join("template").join("scene"))
+            .expect("upper scene directory should be created");
+        fs::create_dir_all(engine.join("game").join("template").join("scene"))
+            .expect("template directory should be created");
+
+        fs::write(
+            upper
+                .join("game")
+                .join("template")
+                .join("scene")
+                .join("edited.txt"),
+            "upper scene",
+        )
+        .expect("upper scene file should be written");
+        fs::write(
+            engine
+                .join("game")
+                .join("template")
+                .join("scene")
+                .join("lower.txt"),
+            "lower scene",
+        )
+        .expect("engine scene file should be written");
+
+        let overlay = OverlayFs::new(
+            upper.clone(),
+            Some(engine.clone()),
+            Some(engine.join("game").join("template")),
+        )
+        .expect("overlay should be created");
+
+        overlay
+            .rename_logical_path(
+                Path::new("game/template/scene"),
+                Path::new("game/template/scene-renamed"),
+            )
+            .expect("directory rename should succeed");
+
+        assert!(upper
+            .join("game")
+            .join("template")
+            .join("scene-renamed")
+            .join("edited.txt")
+            .is_file());
+        assert!(upper
+            .join("game")
+            .join("template")
+            .join("scene-renamed")
+            .join("lower.txt")
+            .is_file());
+        assert!(!upper.join("game").join("template").join("scene").exists());
+        assert!(matches!(
+            overlay.resolve_physical_path(Path::new("game/template/scene/lower.txt")),
+            Err(VfsError::NotFound)
+        ));
+    }
+
+    #[test]
+    fn rename_logical_path_rejects_moving_directory_into_its_own_descendant() {
+        let upper = create_temp_dir("webgal-craft-vfs-rename-descendant-upper");
+        let engine = create_temp_dir("webgal-craft-vfs-rename-descendant-engine");
+
+        fs::create_dir_all(upper.join("game").join("scene"))
+            .expect("scene directory should be created");
+        fs::create_dir_all(engine.join("game").join("template"))
+            .expect("template directory should be created");
+        fs::write(upper.join("game").join("scene").join("start.txt"), "scene")
+            .expect("scene file should be written");
+
+        let overlay = OverlayFs::new(
+            upper,
+            Some(engine.clone()),
+            Some(engine.join("game").join("template")),
+        )
+        .expect("overlay should be created");
+
+        let error = overlay
+            .rename_logical_path(Path::new("game/scene"), Path::new("game/scene/nested"))
+            .expect_err("moving a directory into its own descendant should be rejected");
+
+        assert!(matches!(error, VfsError::PathDenied));
+    }
+
+    #[test]
+    fn rename_logical_path_rejects_engine_runtime_source() {
+        let upper = create_temp_dir("webgal-craft-vfs-rename-upper");
+        let engine = create_temp_dir("webgal-craft-vfs-rename-engine");
+
+        fs::create_dir_all(engine.join("game").join("template"))
+            .expect("template directory should be created");
+        fs::write(engine.join("index.html"), "<html></html>")
+            .expect("runtime file should be written");
+
+        let overlay = OverlayFs::new(
+            upper,
+            Some(engine.clone()),
+            Some(engine.join("game").join("template")),
+        )
+        .expect("overlay should be created");
+
+        let error = overlay
+            .rename_logical_path(Path::new("index.html"), Path::new("game/index.html"))
+            .expect_err("engine runtime source should be rejected");
+
+        assert!(matches!(error, VfsError::WriteToEngineRuntime));
+    }
+
+    #[test]
+    fn remove_logical_path_rejects_lower_only_engine_override() {
+        let upper = create_temp_dir("webgal-craft-vfs-lower-only-icons-upper");
+        let engine = create_temp_dir("webgal-craft-vfs-lower-only-icons-engine");
+
+        fs::create_dir_all(engine.join("game").join("template"))
+            .expect("template directory should be created");
+        fs::create_dir_all(engine.join("icons")).expect("icons directory should be created");
+        fs::write(engine.join("icons").join("favicon.ico"), "lower icon")
+            .expect("engine icon should be written");
+
+        let overlay = OverlayFs::new(
+            upper,
+            Some(engine.clone()),
+            Some(engine.join("game").join("template")),
+        )
+        .expect("overlay should be created");
+
+        let error = overlay
+            .remove_logical_path(Path::new("icons/favicon.ico"))
+            .expect_err("lower-only engine override deletion should be rejected");
+
+        assert!(matches!(error, VfsError::WriteToEngineRuntime));
+    }
+
+    #[test]
+    fn vfs_dir_entry_serializes_with_camel_case_fields() {
+        let entry = VfsDirEntry {
+            name: String::from("scene"),
+            is_dir: true,
+            source: VfsSource::Upper,
+        };
+
+        let serialized =
+            serde_json::to_value(&entry).expect("vfs dir entry should serialize to json value");
+
+        assert_eq!(
+            serialized.get("name").and_then(serde_json::Value::as_str),
+            Some("scene")
+        );
+        assert_eq!(
+            serialized.get("isDir").and_then(serde_json::Value::as_bool),
+            Some(true)
+        );
+        assert_eq!(
+            serialized.get("source").and_then(serde_json::Value::as_str),
+            Some("upper")
+        );
+        assert!(
+            serialized.get("is_dir").is_none(),
+            "frontend contract should not leak Rust snake_case fields"
+        );
+    }
+}

--- a/src-tauri/src/vfs.rs
+++ b/src-tauri/src/vfs.rs
@@ -1032,17 +1032,12 @@ mod tests {
     use std::{
         fs,
         path::{Path, PathBuf},
-        time::{SystemTime, UNIX_EPOCH},
     };
 
-    fn create_temp_dir(prefix: &str) -> PathBuf {
-        let unique = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("system clock should be after unix epoch")
-            .as_nanos();
-        let dir = std::env::temp_dir().join(format!("{prefix}-{unique}"));
-        fs::create_dir_all(&dir).expect("temp directory should be created");
-        dir
+    use tempfile::TempDir;
+
+    fn create_temp_dir() -> TempDir {
+        tempfile::tempdir().expect("temp directory should be created")
     }
 
     #[cfg(unix)]
@@ -1127,7 +1122,8 @@ mod tests {
 
     #[test]
     fn read_project_config_rejects_future_schema_version() {
-        let dir = create_temp_dir("webgal-craft-project-config");
+        let dir_dir = create_temp_dir();
+        let dir = dir_dir.path().to_path_buf();
         fs::write(
             dir.join("project.wgcp"),
             r#"{"version":99,"engine":{"name":"WebGAL","version":"4.5.0"}}"#,
@@ -1140,7 +1136,8 @@ mod tests {
 
     #[test]
     fn read_project_config_reports_future_schema_before_shape_validation() {
-        let dir = create_temp_dir("webgal-craft-project-config-future-shape");
+        let dir_dir = create_temp_dir();
+        let dir = dir_dir.path().to_path_buf();
         fs::write(
             dir.join("project.wgcp"),
             r#"{
@@ -1157,7 +1154,8 @@ mod tests {
 
     #[test]
     fn read_project_config_parses_full_structure() {
-        let dir = create_temp_dir("webgal-craft-project-config-full");
+        let dir_dir = create_temp_dir();
+        let dir = dir_dir.path().to_path_buf();
         fs::write(
             dir.join("project.wgcp"),
             r#"{
@@ -1188,7 +1186,8 @@ mod tests {
 
     #[test]
     fn read_project_config_reports_invalid_project_config_for_parse_errors() {
-        let dir = create_temp_dir("webgal-craft-project-config-invalid");
+        let dir_dir = create_temp_dir();
+        let dir = dir_dir.path().to_path_buf();
         fs::write(dir.join("project.wgcp"), r#"{"version":"broken"}"#)
             .expect("project config should be written");
 
@@ -1198,8 +1197,10 @@ mod tests {
 
     #[test]
     fn list_entries_includes_template_children() {
-        let upper = create_temp_dir("webgal-craft-vfs-upper");
-        let engine = create_temp_dir("webgal-craft-vfs-engine");
+        let upper_dir = create_temp_dir();
+        let upper = upper_dir.path().to_path_buf();
+        let engine_dir = create_temp_dir();
+        let engine = engine_dir.path().to_path_buf();
 
         fs::create_dir_all(engine.join("game").join("template"))
             .expect("template directory should be created");
@@ -1226,8 +1227,10 @@ mod tests {
 
     #[test]
     fn resolve_physical_path_prefers_engine_runtime_lower_over_upper() {
-        let upper = create_temp_dir("webgal-craft-vfs-runtime-upper");
-        let engine = create_temp_dir("webgal-craft-vfs-runtime-engine");
+        let upper_dir = create_temp_dir();
+        let upper = upper_dir.path().to_path_buf();
+        let engine_dir = create_temp_dir();
+        let engine = engine_dir.path().to_path_buf();
 
         fs::create_dir_all(engine.join("game").join("template"))
             .expect("template directory should be created");
@@ -1256,8 +1259,10 @@ mod tests {
 
     #[test]
     fn list_entries_ignores_upper_engine_runtime_and_unclassified_entries() {
-        let upper = create_temp_dir("webgal-craft-vfs-root-upper");
-        let engine = create_temp_dir("webgal-craft-vfs-root-engine");
+        let upper_dir = create_temp_dir();
+        let upper = upper_dir.path().to_path_buf();
+        let engine_dir = create_temp_dir();
+        let engine = engine_dir.path().to_path_buf();
 
         fs::create_dir_all(engine.join("game").join("template"))
             .expect("template directory should be created");
@@ -1288,8 +1293,10 @@ mod tests {
 
     #[test]
     fn ensure_writable_does_not_materialize_engine_override_files() {
-        let upper = create_temp_dir("webgal-craft-vfs-icons-upper");
-        let engine = create_temp_dir("webgal-craft-vfs-icons-engine");
+        let upper_dir = create_temp_dir();
+        let upper = upper_dir.path().to_path_buf();
+        let engine_dir = create_temp_dir();
+        let engine = engine_dir.path().to_path_buf();
 
         fs::create_dir_all(engine.join("game").join("template"))
             .expect("template directory should be created");
@@ -1314,9 +1321,12 @@ mod tests {
 
     #[test]
     fn ensure_writable_rejects_linked_upper_parent_chain() {
-        let upper = create_temp_dir("webgal-craft-vfs-linked-upper");
-        let engine = create_temp_dir("webgal-craft-vfs-linked-engine");
-        let escape = create_temp_dir("webgal-craft-vfs-linked-escape");
+        let upper_dir = create_temp_dir();
+        let upper = upper_dir.path().to_path_buf();
+        let engine_dir = create_temp_dir();
+        let engine = engine_dir.path().to_path_buf();
+        let escape_dir = create_temp_dir();
+        let escape = escape_dir.path().to_path_buf();
 
         fs::create_dir_all(upper.join("game")).expect("upper game dir should exist");
         fs::create_dir_all(engine.join("game").join("template"))
@@ -1343,8 +1353,10 @@ mod tests {
 
     #[test]
     fn remove_logical_path_on_engine_override_reveals_engine_lower_again() {
-        let upper = create_temp_dir("webgal-craft-vfs-icons-remove-upper");
-        let engine = create_temp_dir("webgal-craft-vfs-icons-remove-engine");
+        let upper_dir = create_temp_dir();
+        let upper = upper_dir.path().to_path_buf();
+        let engine_dir = create_temp_dir();
+        let engine = engine_dir.path().to_path_buf();
 
         fs::create_dir_all(engine.join("game").join("template"))
             .expect("template directory should be created");
@@ -1382,8 +1394,10 @@ mod tests {
 
     #[test]
     fn ensure_writable_for_game_content_ignores_engine_lower() {
-        let upper = create_temp_dir("webgal-craft-vfs-whiteout-upper");
-        let engine = create_temp_dir("webgal-craft-vfs-whiteout-engine");
+        let upper_dir = create_temp_dir();
+        let upper = upper_dir.path().to_path_buf();
+        let engine_dir = create_temp_dir();
+        let engine = engine_dir.path().to_path_buf();
 
         fs::create_dir_all(engine.join("game").join("scene"))
             .expect("scene directory should be created");
@@ -1429,9 +1443,12 @@ mod tests {
 
     #[test]
     fn remove_logical_path_rejects_linked_whiteout_parent_chain() {
-        let upper = create_temp_dir("webgal-craft-vfs-whiteout-link-upper");
-        let engine = create_temp_dir("webgal-craft-vfs-whiteout-link-engine");
-        let escape = create_temp_dir("webgal-craft-vfs-whiteout-link-escape");
+        let upper_dir = create_temp_dir();
+        let upper = upper_dir.path().to_path_buf();
+        let engine_dir = create_temp_dir();
+        let engine = engine_dir.path().to_path_buf();
+        let escape_dir = create_temp_dir();
+        let escape = escape_dir.path().to_path_buf();
 
         fs::create_dir_all(engine.join("game").join("scene"))
             .expect("scene directory should be created");
@@ -1469,8 +1486,10 @@ mod tests {
 
     #[test]
     fn copy_logical_path_uses_overlay_view_for_template_directories() {
-        let upper = create_temp_dir("webgal-craft-vfs-copy-upper");
-        let engine = create_temp_dir("webgal-craft-vfs-copy-engine");
+        let upper_dir = create_temp_dir();
+        let upper = upper_dir.path().to_path_buf();
+        let engine_dir = create_temp_dir();
+        let engine = engine_dir.path().to_path_buf();
 
         fs::create_dir_all(engine.join("game").join("template").join("scene"))
             .expect("template directory should be created");
@@ -1526,8 +1545,10 @@ mod tests {
 
     #[test]
     fn copy_logical_path_rejects_moving_directory_into_its_own_descendant() {
-        let upper = create_temp_dir("webgal-craft-vfs-copy-descendant-upper");
-        let engine = create_temp_dir("webgal-craft-vfs-copy-descendant-engine");
+        let upper_dir = create_temp_dir();
+        let upper = upper_dir.path().to_path_buf();
+        let engine_dir = create_temp_dir();
+        let engine = engine_dir.path().to_path_buf();
 
         fs::create_dir_all(upper.join("game").join("scene"))
             .expect("scene directory should be created");
@@ -1553,8 +1574,10 @@ mod tests {
     #[test]
     fn rename_logical_path_preserves_template_lower_children_for_partially_materialized_directories(
     ) {
-        let upper = create_temp_dir("webgal-craft-vfs-rename-mixed-upper");
-        let engine = create_temp_dir("webgal-craft-vfs-rename-mixed-engine");
+        let upper_dir = create_temp_dir();
+        let upper = upper_dir.path().to_path_buf();
+        let engine_dir = create_temp_dir();
+        let engine = engine_dir.path().to_path_buf();
 
         fs::create_dir_all(upper.join("game").join("template").join("scene"))
             .expect("upper scene directory should be created");
@@ -1615,8 +1638,10 @@ mod tests {
 
     #[test]
     fn rename_logical_path_rejects_moving_directory_into_its_own_descendant() {
-        let upper = create_temp_dir("webgal-craft-vfs-rename-descendant-upper");
-        let engine = create_temp_dir("webgal-craft-vfs-rename-descendant-engine");
+        let upper_dir = create_temp_dir();
+        let upper = upper_dir.path().to_path_buf();
+        let engine_dir = create_temp_dir();
+        let engine = engine_dir.path().to_path_buf();
 
         fs::create_dir_all(upper.join("game").join("scene"))
             .expect("scene directory should be created");
@@ -1641,8 +1666,10 @@ mod tests {
 
     #[test]
     fn rename_logical_path_rejects_engine_runtime_source() {
-        let upper = create_temp_dir("webgal-craft-vfs-rename-upper");
-        let engine = create_temp_dir("webgal-craft-vfs-rename-engine");
+        let upper_dir = create_temp_dir();
+        let upper = upper_dir.path().to_path_buf();
+        let engine_dir = create_temp_dir();
+        let engine = engine_dir.path().to_path_buf();
 
         fs::create_dir_all(engine.join("game").join("template"))
             .expect("template directory should be created");
@@ -1665,8 +1692,10 @@ mod tests {
 
     #[test]
     fn remove_logical_path_rejects_lower_only_engine_override() {
-        let upper = create_temp_dir("webgal-craft-vfs-lower-only-icons-upper");
-        let engine = create_temp_dir("webgal-craft-vfs-lower-only-icons-engine");
+        let upper_dir = create_temp_dir();
+        let upper = upper_dir.path().to_path_buf();
+        let engine_dir = create_temp_dir();
+        let engine = engine_dir.path().to_path_buf();
 
         fs::create_dir_all(engine.join("game").join("template"))
             .expect("template directory should be created");

--- a/src/commands/fs.ts
+++ b/src/commands/fs.ts
@@ -32,12 +32,15 @@ async function copyDirectory(source: string, destination: string): Promise<void>
 
 /**
  * 带进度条的递归复制目录
+ *
+ * `overwrite` 默认 false：使用 create_new 语义，保留目标已有文件；
+ * 安装/创建等需要刷新内容的流程应显式传 true，避免上次失败残留与新内容混杂。
  */
 async function copyDirectoryWithProgress(
   source: string,
   destination: string,
   onProgress: (progress: number) => void,
-  excludes?: string[],
+  options?: { excludes?: string[], overwrite?: boolean },
 ): Promise<void> {
   const channel = new Channel<CopyEvent>()
   let channelError: AppError | undefined
@@ -63,7 +66,8 @@ async function copyDirectoryWithProgress(
       source,
       destination,
       onEvent: channel,
-      excludes,
+      excludes: options?.excludes,
+      overwrite: options?.overwrite,
     })
   } catch (error) {
     throw AppError.fromInvoke('copy_directory_with_progress', error)

--- a/src/commands/fs.ts
+++ b/src/commands/fs.ts
@@ -37,6 +37,7 @@ async function copyDirectoryWithProgress(
   source: string,
   destination: string,
   onProgress: (progress: number) => void,
+  excludes?: string[],
 ): Promise<void> {
   const channel = new Channel<CopyEvent>()
   let channelError: AppError | undefined
@@ -62,6 +63,7 @@ async function copyDirectoryWithProgress(
       source,
       destination,
       onEvent: channel,
+      excludes,
     })
   } catch (error) {
     throw AppError.fromInvoke('copy_directory_with_progress', error)

--- a/src/commands/project-config.ts
+++ b/src/commands/project-config.ts
@@ -1,0 +1,16 @@
+import { safeInvoke } from '~/utils/invoke'
+
+import type { ProjectConfig } from '~/types/project-config'
+
+function readProjectConfig(projectPath: string): Promise<ProjectConfig> {
+  return safeInvoke('read_project_config_cmd', { projectPath })
+}
+
+function writeProjectConfig(projectPath: string, config: ProjectConfig): Promise<void> {
+  return safeInvoke('write_project_config_cmd', { projectPath, config })
+}
+
+export const projectConfigCmds = {
+  readProjectConfig,
+  writeProjectConfig,
+}

--- a/src/commands/vfs.ts
+++ b/src/commands/vfs.ts
@@ -10,24 +10,24 @@ interface VfsLayerArgs {
   templatePath?: string
 }
 
-function resolvePath(projectPath: string, enginePath: string, relPath: string, templatePath?: string): Promise<string> {
-  return safeInvoke('resolve_vfs_path', { projectPath, enginePath, templatePath, relPath })
+function resolvePath(args: VfsLayerArgs): Promise<string> {
+  return safeInvoke('resolve_vfs_path', { ...args })
 }
 
-function listDir(projectPath: string, enginePath: string, relPath: string, templatePath?: string): Promise<VfsDirEntry[]> {
-  return safeInvoke('list_vfs_dir', { projectPath, enginePath, templatePath, relPath })
+function listDir(args: VfsLayerArgs): Promise<VfsDirEntry[]> {
+  return safeInvoke('list_vfs_dir', { ...args })
 }
 
-function ensureWritable(projectPath: string, enginePath: string, relPath: string, templatePath?: string): Promise<string> {
-  return safeInvoke('ensure_vfs_writable', { projectPath, enginePath, templatePath, relPath })
+function ensureWritable(args: VfsLayerArgs): Promise<string> {
+  return safeInvoke('ensure_vfs_writable', { ...args })
 }
 
-function deletePath(projectPath: string, enginePath: string, relPath: string, templatePath?: string): Promise<void> {
-  return safeInvoke('delete_vfs_path', { projectPath, enginePath, templatePath, relPath })
+function deletePath(args: VfsLayerArgs): Promise<void> {
+  return safeInvoke('delete_vfs_path', { ...args })
 }
 
-function renamePath(projectPath: string, enginePath: string, relPath: string, newName: string, templatePath?: string): Promise<string> {
-  return safeInvoke('rename_vfs_path', { projectPath, enginePath, templatePath, relPath, newName })
+function renamePath(args: VfsLayerArgs & { newName: string }): Promise<string> {
+  return safeInvoke('rename_vfs_path', { ...args })
 }
 
 function movePath(args: VfsLayerArgs & { targetRelPath: string }): Promise<string> {

--- a/src/commands/vfs.ts
+++ b/src/commands/vfs.ts
@@ -1,0 +1,59 @@
+import { safeInvoke } from '~/utils/invoke'
+
+import type { VfsDirEntry } from '~/types/project-config'
+
+/** VFS 命令共用的层叠路径参数 */
+interface VfsLayerArgs {
+  projectPath: string
+  enginePath: string
+  relPath: string
+  templatePath?: string
+}
+
+function resolvePath(projectPath: string, enginePath: string, relPath: string, templatePath?: string): Promise<string> {
+  return safeInvoke('resolve_vfs_path', { projectPath, enginePath, templatePath, relPath })
+}
+
+function listDir(projectPath: string, enginePath: string, relPath: string, templatePath?: string): Promise<VfsDirEntry[]> {
+  return safeInvoke('list_vfs_dir', { projectPath, enginePath, templatePath, relPath })
+}
+
+function ensureWritable(projectPath: string, enginePath: string, relPath: string, templatePath?: string): Promise<string> {
+  return safeInvoke('ensure_vfs_writable', { projectPath, enginePath, templatePath, relPath })
+}
+
+function deletePath(projectPath: string, enginePath: string, relPath: string, templatePath?: string): Promise<void> {
+  return safeInvoke('delete_vfs_path', { projectPath, enginePath, templatePath, relPath })
+}
+
+function renamePath(projectPath: string, enginePath: string, relPath: string, newName: string, templatePath?: string): Promise<string> {
+  return safeInvoke('rename_vfs_path', { projectPath, enginePath, templatePath, relPath, newName })
+}
+
+function movePath(args: VfsLayerArgs & { targetRelPath: string }): Promise<string> {
+  return safeInvoke('move_vfs_path', { ...args })
+}
+
+function copyPath(args: VfsLayerArgs & { targetRelPath: string }): Promise<string> {
+  return safeInvoke('copy_vfs_path', { ...args })
+}
+
+function isTemplateDirty(projectPath: string): Promise<boolean> {
+  return safeInvoke('is_template_dirty', { projectPath })
+}
+
+function cleanTemplateUpper(projectPath: string): Promise<void> {
+  return safeInvoke('clean_template_upper', { projectPath })
+}
+
+export const vfsCmds = {
+  resolvePath,
+  listDir,
+  ensureWritable,
+  deletePath,
+  renamePath,
+  movePath,
+  copyPath,
+  isTemplateDirty,
+  cleanTemplateUpper,
+}

--- a/src/services/engine-manager.ts
+++ b/src/services/engine-manager.ts
@@ -165,7 +165,7 @@ async function installEngine(enginePath: string): Promise<void> {
   try {
     await fsCmds.copyDirectoryWithProgress(enginePath, targetPath, (progress) => {
       resourceStore.updateProgress(id, progress)
-    })
+    }, { overwrite: true })
     logger.info(`[引擎 ${engineName}] 复制引擎文件完成`)
 
     const installedSnapshot = await getEngineSnapshot(targetPath)

--- a/src/services/game-manager.ts
+++ b/src/services/game-manager.ts
@@ -249,7 +249,7 @@ async function createGame(gameName: string, gamePath: string, enginePath: string
   try {
     await fsCmds.copyDirectoryWithProgress(enginePath, gamePath, (progress) => {
       resourceStore.updateProgress(id, progress)
-    })
+    }, { overwrite: true })
     logger.info(`[游戏 ${gameName}] 复制引擎文件完成`)
 
     // 3. 设置游戏配置

--- a/src/types/project-config.ts
+++ b/src/types/project-config.ts
@@ -1,0 +1,30 @@
+export interface EngineRef {
+  id: string
+  version?: string
+}
+
+export interface StandaloneTemplateBinding {
+  kind: 'standalone'
+  name: string
+}
+
+export interface EngineBuiltinTemplateBinding {
+  kind: 'engineBuiltin'
+  engine: EngineRef
+}
+
+export type TemplateBinding = StandaloneTemplateBinding | EngineBuiltinTemplateBinding
+
+export interface ProjectConfig {
+  version: number
+  engine?: EngineRef
+  template?: TemplateBinding
+}
+
+export type VfsSource = 'upper' | 'engineLower' | 'templateLower'
+
+export interface VfsDirEntry {
+  name: string
+  isDir: boolean
+  source: VfsSource
+}


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [ ] 错误修复
- [x] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [x] 测试用例
- [x] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [x] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

本 PR 引入了项目级 VFS 核心能力，并补齐前后端项目配置读写命令，为后续基于逻辑路径的文件浏览、模板覆盖和资源编辑提供统一基础。

主要改动包括：

- 在 Tauri 侧新增 `OverlayFs`，支持项目 upper 层、引擎 lower 层、模板 lower 层的三层叠加解析
- 新增 VFS 命令：
  - `resolve_vfs_path`
  - `list_vfs_dir`
  - `ensure_vfs_writable`
  - `delete_vfs_path`
  - `rename_vfs_path`
  - `move_vfs_path`
  - `copy_vfs_path`
  - `is_template_dirty`
  - `clean_template_upper`
- 新增项目配置模型与命令，支持读取/写入 `project.wgcp`
- 前端补充 `vfsCmds`、`projectConfigCmds` 以及对应类型定义，打通调用链路
- 为 overlay 构建增加 canonicalize 缓存，减少热路径上的重复系统调用
- 调整目录复制逻辑为 `create_new` 语义，复制模板/引擎内容时不会覆盖已有用户文件，并支持排除路径

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

当前项目缺少一套面向“项目文件 + 引擎默认内容 + 模板默认内容”的统一虚拟文件系统抽象，导致后续文件树展示、模板覆盖、只读下层保护、脏状态判断等能力难以在一致规则下实现。

这个 PR 先落地 VFS 核心层，解决以下基础问题：

- 用逻辑相对路径统一描述项目内资源，避免前端直接依赖底层物理路径组织
- 明确 upper/lower 层优先级与 whiteout 规则，支持“覆盖但不直接修改下层内容”
- 对引擎运行时文件提供写保护，避免误写只读资源
- 通过项目配置文件保存引擎与模板绑定信息，为后续项目加载和资源解析提供依据

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->

- 当前分支主要完成的是 VFS core 与命令层打底，尚未覆盖完整的上层业务接入
- 默认模板目录会结合引擎路径自动推断；当模板目录不存在时，非模板相关 VFS 命令仍可正常工作
- VFS 对外同时区分：
  - 物理绝对路径：用于前端 `convertFileSrc` 等直接消费
  - 逻辑相对路径：用于后续 VFS 命令调用，统一使用 `/` 分隔符

### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [x] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
