### PR TITLE
✨ 支持站点级 VFS 预览服务及 engine/template 动态注入

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5682,6 +5682,8 @@ dependencies = [
  "futures",
  "image",
  "log",
+ "mime_guess",
+ "percent-encoding",
  "portpicker",
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5682,7 +5682,6 @@ dependencies = [
  "futures",
  "image",
  "log",
- "mime_guess",
  "percent-encoding",
  "portpicker",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -36,6 +36,8 @@ trash = "5.2"
 futures = "0.3"
 urlencoding = "2.1"
 tempfile = "3.15"
+mime_guess = "2.0"
+percent-encoding = "2.3"
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-single-instance = "2.4"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -36,7 +36,6 @@ trash = "5.2"
 futures = "0.3"
 urlencoding = "2.1"
 tempfile = "3.15"
-mime_guess = "2.0"
 percent-encoding = "2.3"
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]

--- a/src-tauri/src/commands/error.rs
+++ b/src-tauri/src/commands/error.rs
@@ -109,6 +109,7 @@ mod tests {
             .code(),
             "SCHEMA_VERSION_TOO_NEW"
         );
+        assert_eq!(AppError::SiteNotRegistered.code(), "SITE_NOT_REGISTERED");
     }
 
     #[test]

--- a/src-tauri/src/commands/error.rs
+++ b/src-tauri/src/commands/error.rs
@@ -30,6 +30,9 @@ pub enum AppError {
     #[error("项目配置无效：{reason}")]
     InvalidProjectConfig { reason: String },
 
+    #[error("站点未注册")]
+    SiteNotRegistered,
+
     #[error(transparent)]
     Tauri(#[from] tauri::Error),
 }
@@ -46,6 +49,7 @@ impl AppError {
             Self::Vfs(error) => error.code(),
             Self::SchemaVersionTooNew { .. } => "SCHEMA_VERSION_TOO_NEW",
             Self::InvalidProjectConfig { .. } => "INVALID_PROJECT_CONFIG",
+            Self::SiteNotRegistered => "SITE_NOT_REGISTERED",
             Self::Tauri(_) => "TAURI_ERROR",
         }
     }

--- a/src-tauri/src/commands/server.rs
+++ b/src-tauri/src/commands/server.rs
@@ -195,9 +195,8 @@ async fn handle_static_request(
 
     let overlay = OverlayFs::from_cached(&site);
 
-    let resolve_logical = logical_path.clone();
     let resolved_file =
-        match tokio::task::spawn_blocking(move || overlay.resolve_file(&resolve_logical)).await {
+        match tokio::task::spawn_blocking(move || overlay.resolve_file(&logical_path)).await {
             Ok(Ok(file)) => file,
             Ok(Err(error)) => return finalize_cors(map_vfs_error(&error).into_response(), origin),
             Err(_) => {
@@ -216,12 +215,15 @@ async fn handle_static_request(
         }
     }
 
-    let Some(request) = build_file_request(
-        build_static_asset_uri(&logical_path.to_string_lossy().replace('\\', "/")),
-        &headers,
-    ) else {
-        return finalize_cors(StatusCode::INTERNAL_SERVER_ERROR.into_response(), origin);
-    };
+    let mut request = Request::builder()
+        .uri("/")
+        .body(Body::empty())
+        .expect("空请求构造不会失败");
+    for header_name in [RANGE, ORIGIN] {
+        if let Some(value) = headers.get(&header_name) {
+            request.headers_mut().insert(header_name, value.clone());
+        }
+    }
     let response = ServeFile::new(&resolved_file.physical_path)
         .oneshot(request)
         .await
@@ -235,18 +237,6 @@ async fn handle_static_request(
         }
     }
     finalize_cors(response, origin)
-}
-
-fn build_file_request(uri: String, headers: &HeaderMap) -> Option<Request<Body>> {
-    let mut request = Request::builder().uri(uri).body(Body::empty()).ok()?;
-
-    for header_name in [RANGE, ORIGIN] {
-        if let Some(value) = headers.get(&header_name) {
-            request.headers_mut().insert(header_name, value.clone());
-        }
-    }
-
-    Some(request)
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -279,15 +269,6 @@ struct EncodedThumbnail {
 enum CacheControlPolicy {
     StaticAsset,
     Thumbnail,
-}
-
-fn build_static_asset_uri(path: &str) -> String {
-    let encoded_path = path
-        .split('/')
-        .map(|segment| urlencoding::encode(segment))
-        .collect::<Vec<_>>()
-        .join("/");
-    format!("/{encoded_path}")
 }
 
 fn parse_static_asset_query(query: Option<&str>) -> StaticAssetQuery {

--- a/src-tauri/src/commands/server.rs
+++ b/src-tauri/src/commands/server.rs
@@ -195,9 +195,9 @@ async fn handle_static_request(
 
     let overlay = OverlayFs::from_cached(&site);
 
-    let resolved_file =
+    let physical_path =
         match tokio::task::spawn_blocking(move || overlay.resolve_file(&logical_path)).await {
-            Ok(Ok(file)) => file,
+            Ok(Ok(path)) => path,
             Ok(Err(error)) => return finalize_cors(map_vfs_error(&error).into_response(), origin),
             Err(_) => {
                 return finalize_cors(StatusCode::INTERNAL_SERVER_ERROR.into_response(), origin)
@@ -205,8 +205,7 @@ async fn handle_static_request(
         };
 
     if let Some(thumbnail_request) = resolve_thumbnail_request(&query) {
-        if let Some(response) =
-            try_build_thumbnail_response(&resolved_file.physical_path, thumbnail_request).await
+        if let Some(response) = try_build_thumbnail_response(&physical_path, thumbnail_request).await
         {
             return finalize_cors(
                 apply_cache_control(response, CacheControlPolicy::Thumbnail),
@@ -224,19 +223,16 @@ async fn handle_static_request(
             request.headers_mut().insert(header_name, value.clone());
         }
     }
-    let response = ServeFile::new(&resolved_file.physical_path)
+    let response = ServeFile::new(&physical_path)
         .oneshot(request)
         .await
         .map(IntoResponse::into_response)
         .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response());
 
-    let mut response = apply_cache_control(response, CacheControlPolicy::StaticAsset);
-    if !response.headers().contains_key(CONTENT_TYPE) {
-        if let Ok(value) = HeaderValue::from_str(&resolved_file.content_type) {
-            response.headers_mut().insert(CONTENT_TYPE, value);
-        }
-    }
-    finalize_cors(response, origin)
+    finalize_cors(
+        apply_cache_control(response, CacheControlPolicy::StaticAsset),
+        origin,
+    )
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]

--- a/src-tauri/src/commands/server.rs
+++ b/src-tauri/src/commands/server.rs
@@ -163,7 +163,6 @@ fn append_cors_headers(response: &mut Response, origin: Option<&'static str>) {
         .insert(VARY, HeaderValue::from_static("Origin"));
 }
 
-/// 为响应追加 CORS 头并返回，用于 `handle_static_request` 中统一的出口路径
 fn finalize_cors(mut response: Response, origin: Option<&'static str>) -> Response {
     append_cors_headers(&mut response, origin);
     response
@@ -215,15 +214,15 @@ async fn handle_static_request(
         }
     }
 
-    let mut request = Request::builder()
-        .uri("/")
-        .body(Body::empty())
-        .expect("空请求构造不会失败");
+    let mut request_builder = Request::builder().uri("/");
     for header_name in [RANGE, ORIGIN] {
         if let Some(value) = headers.get(&header_name) {
-            request.headers_mut().insert(header_name, value.clone());
+            request_builder = request_builder.header(header_name, value);
         }
     }
+    let request = request_builder
+        .body(Body::empty())
+        .expect("空请求构造不会失败");
     let response = ServeFile::new(&physical_path)
         .oneshot(request)
         .await
@@ -526,16 +525,14 @@ fn normalize_project_path(path: &str) -> AppResult<(String, PathBuf)> {
 }
 
 fn validate_dir_path(path: Option<String>) -> AppResult<Option<PathBuf>> {
-    match path {
-        Some(path) => {
-            let path_buf = PathBuf::from(path);
-            if !path_buf.is_dir() {
-                return Err(AppError::Server("路径必须是目录".into()));
-            }
-            Ok(Some(path_buf))
-        }
-        None => Ok(None),
+    let Some(path) = path else {
+        return Ok(None);
+    };
+    let path_buf = PathBuf::from(path);
+    if !path_buf.is_dir() {
+        return Err(AppError::Server("路径必须是目录".into()));
     }
+    Ok(Some(path_buf))
 }
 
 #[tauri::command]
@@ -548,10 +545,9 @@ pub async fn add_static_site(
     let state_guard = state.lock().await;
     let (hash, project_path) = normalize_project_path(&project_path)?;
     let engine_path = validate_dir_path(engine_path)?;
-    let template_path = match validate_dir_path(template_path)? {
-        Some(path) => Some(path),
-        None => resolve_default_template_path(engine_path.as_deref()).filter(|path| path.is_dir()),
-    };
+    let template_path = validate_dir_path(template_path)?
+        .or_else(|| resolve_default_template_path(engine_path.as_deref()))
+        .filter(|path| path.is_dir());
 
     let cached_canonicals =
         CachedCanonicals::compute(project_path.clone(), engine_path, template_path)?;

--- a/src-tauri/src/commands/server.rs
+++ b/src-tauri/src/commands/server.rs
@@ -585,11 +585,15 @@ pub async fn update_site_engine(
         return Err(AppError::SiteNotRegistered);
     };
 
-    *site = CachedCanonicals::compute(
-        site.upper.clone(),
-        engine_path,
-        site.template_lower.clone(),
-    )?;
+    // 若旧模板沿用的是旧引擎的内置默认值，则随引擎切换重新派生；用户显式指定的模板保持不变
+    let prev_default_template = resolve_default_template_path(site.engine_lower.as_deref());
+    let template_path = if site.template_lower == prev_default_template {
+        resolve_default_template_path(engine_path.as_deref()).filter(|path| path.is_dir())
+    } else {
+        site.template_lower.clone()
+    };
+
+    *site = CachedCanonicals::compute(site.upper.clone(), engine_path, template_path)?;
 
     Ok(())
 }

--- a/src-tauri/src/commands/server.rs
+++ b/src-tauri/src/commands/server.rs
@@ -1,27 +1,23 @@
-// 服务器模块：提供静态文件服务和WebSocket通信功能
-// 主要功能：
-// 1. 静态文件服务：支持多个静态站点托管
-// 2. WebSocket通信：支持广播和单播消息
-// 3. 服务器管理：启动、停止和状态管理
-
 use std::{
     collections::HashMap,
     hash::{Hash, Hasher},
     io::Cursor,
     net::SocketAddr,
-    path::{Component, Path, PathBuf},
+    path::{Path, PathBuf},
     sync::Arc,
 };
 
 use axum::{
+    body::Body,
     extract::{
         ws::{Message, WebSocket, WebSocketUpgrade},
         ConnectInfo, Path as AxumPath, State as AxumState,
     },
     http::{
-        header::{ACCESS_CONTROL_ALLOW_ORIGIN, CACHE_CONTROL, CONTENT_TYPE, ORIGIN, VARY},
+        header::{ACCESS_CONTROL_ALLOW_ORIGIN, CACHE_CONTROL, CONTENT_TYPE, ORIGIN, RANGE, VARY},
         HeaderMap, HeaderValue, Request, StatusCode, Uri,
     },
+    middleware::Next,
     response::{IntoResponse, Redirect, Response},
     routing::get,
     Router,
@@ -36,7 +32,11 @@ use tokio::{
     task::JoinHandle,
 };
 use tower::util::ServiceExt;
-use tower_http::services::ServeDir;
+use tower_http::services::ServeFile;
+
+use crate::vfs::{
+    resolve_default_template_path, sanitize_request_path, CachedCanonicals, OverlayFs, VfsError,
+};
 
 use super::{AppError, AppResult};
 
@@ -47,34 +47,17 @@ const STATIC_FILE_ALLOWED_CORS_ORIGINS: [&str; 4] = [
     "tauri://localhost",
 ];
 
-/// 应用程序状态
-/// 包含：
-/// - sites: 静态站点映射表，键为站点哈希，值为(路径, 服务实例)元组
-/// - broadcast_tx: 广播消息发送器，用于向所有客户端发送消息
-/// - unicast_clients: WebSocket客户端映射表，用于单播消息发送
 struct AppState {
-    sites: RwLock<HashMap<String, (PathBuf, ServeDir)>>,
-    // 广播通道用于高效广播
+    sites: RwLock<HashMap<String, CachedCanonicals>>,
     broadcast_tx: broadcast::Sender<Message>,
-    // 独立通道映射用于单播
     unicast_clients: Mutex<HashMap<SocketAddr, mpsc::UnboundedSender<Message>>>,
 }
 
-/// 服务器状态管理
-/// 包含：
-/// - app_state: 应用程序状态，包含站点信息和消息通道
-/// - server_handle: 服务器运行句柄，用于控制服务器生命周期
-/// - server_address: 服务器监听地址，用于客户端连接
 pub struct ServerState {
     app_state: Arc<AppState>,
     server_handle: Option<ServerHandle>,
-    server_address: Option<SocketAddr>,
 }
 
-/// 服务器控制句柄
-/// 用于管理服务器的生命周期，包含：
-/// - join_handle: 异步任务句柄，用于等待服务器关闭
-/// - shutdown_tx: 关闭信号发送器，用于触发服务器优雅关闭
 struct ServerHandle {
     join_handle: JoinHandle<()>,
     shutdown_tx: oneshot::Sender<()>,
@@ -83,9 +66,8 @@ struct ServerHandle {
 const MAX_THUMBNAIL_DIMENSION: u32 = 2048;
 const JPEG_THUMBNAIL_QUALITY: u8 = 85;
 
-impl Default for ServerState {
-    fn default() -> Self {
-        // 创建广播通道（容量100条消息）
+impl ServerState {
+    pub fn new() -> Self {
         let (broadcast_tx, _) = broadcast::channel(100);
 
         Self {
@@ -95,18 +77,10 @@ impl Default for ServerState {
                 unicast_clients: Mutex::new(HashMap::new()),
             }),
             server_handle: None,
-            server_address: None,
         }
     }
 }
 
-/// WebSocket连接处理函数
-/// 处理新的WebSocket连接请求，并升级HTTP连接为WebSocket连接
-/// 参数：
-/// - ws: WebSocket升级请求
-/// - state: 应用程序状态
-/// - addr: 客户端地址
-/// - on_message: 消息处理通道
 async fn handle_ws(
     ws: WebSocketUpgrade,
     AxumState(state): AxumState<Arc<AppState>>,
@@ -116,17 +90,6 @@ async fn handle_ws(
     ws.on_upgrade(move |socket| handle_ws_socket(socket, state, addr, on_message))
 }
 
-/// WebSocket连接建立后的处理函数
-/// 实现功能：
-/// 1. 消息接收和广播：处理客户端消息并转发给其他客户端
-/// 2. 客户端注册和注销：管理客户端连接状态
-/// 3. 错误处理和连接关闭：确保资源正确释放
-///
-/// 参数：
-/// - socket: WebSocket连接实例
-/// - state: 应用程序状态
-/// - addr: 客户端地址
-/// - on_message: 消息处理通道
 async fn handle_ws_socket(
     socket: WebSocket,
     state: Arc<AppState>,
@@ -134,93 +97,60 @@ async fn handle_ws_socket(
     on_message: Channel<String>,
 ) {
     let (mut ws_tx, mut ws_rx) = socket.split();
-
-    // 创建单播通道
     let (unicast_tx, mut unicast_rx) = mpsc::unbounded_channel();
-
-    // 注册客户端
     state.unicast_clients.lock().await.insert(addr, unicast_tx);
-
-    // 订阅广播
     let mut broadcast_rx = state.broadcast_tx.subscribe();
 
-    // 消息处理任务
     let recv_task = tokio::spawn({
         let on_message = on_message.clone();
         async move {
-            while let Some(Ok(msg)) = ws_rx.next().await {
-                match msg {
+            while let Some(Ok(message)) = ws_rx.next().await {
+                match message {
                     Message::Text(text) => {
                         let _ = on_message.send(text.to_string());
                     }
-                    Message::Close(_) => {
-                        break;
-                    }
-                    _ => {
-                        continue;
-                    }
+                    Message::Close(_) => break,
+                    _ => continue,
                 }
             }
         }
     });
 
-    // 发送任务（综合广播和单播）
     let send_task = tokio::spawn(async move {
         loop {
             tokio::select! {
-                // 处理广播消息
-                Ok(msg) = broadcast_rx.recv() => {
-                    if ws_tx.send(msg).await.is_err() {
+                Ok(message) = broadcast_rx.recv() => {
+                    if ws_tx.send(message).await.is_err() {
                         break;
                     }
                 }
-                // 处理单播消息
-                Some(msg) = unicast_rx.recv() => {
-                    if ws_tx.send(msg).await.is_err() {
+                Some(message) = unicast_rx.recv() => {
+                    if ws_tx.send(message).await.is_err() {
                         break;
                     }
                 }
-                // 退出条件
                 else => break,
             }
         }
     });
 
-    // 等待任务完成
     tokio::select! {
         _ = recv_task => (),
         _ = send_task => (),
     }
 
-    // 注销客户端
     state.unicast_clients.lock().await.remove(&addr);
-    println!("Client disconnected: {}", addr);
 }
 
-/// 处理静态文件请求
-/// 根据站点哈希和请求路径返回对应的静态文件
-///
-/// 参数：
-/// - state: 应用程序状态
-/// - hash: 站点哈希值
-/// - path: 请求的文件路径
-///
-/// 返回：
-/// - 成功：静态文件响应
-/// - 失败：HTTP状态码
-fn resolve_static_file_cors_origin(origin: Option<&str>) -> Option<&'static str> {
-    let origin = origin?;
+fn resolve_cors_origin(headers: &HeaderMap) -> Option<&'static str> {
+    let origin = headers.get(ORIGIN)?.to_str().ok()?;
     STATIC_FILE_ALLOWED_CORS_ORIGINS
         .iter()
         .copied()
-        .find(|allowed_origin| *allowed_origin == origin)
+        .find(|allowed| *allowed == origin)
 }
 
-fn resolve_static_file_cors_origin_from_headers(headers: &HeaderMap) -> Option<&'static str> {
-    resolve_static_file_cors_origin(headers.get(ORIGIN).and_then(|origin| origin.to_str().ok()))
-}
-
-fn append_static_file_cors_headers(response: &mut Response, origin: Option<&'static str>) {
+fn append_cors_headers(response: &mut Response, origin: Option<&'static str>) {
     if let Some(allowed_origin) = origin {
         response.headers_mut().insert(
             ACCESS_CONTROL_ALLOW_ORIGIN,
@@ -233,55 +163,90 @@ fn append_static_file_cors_headers(response: &mut Response, origin: Option<&'sta
         .insert(VARY, HeaderValue::from_static("Origin"));
 }
 
+/// 为响应追加 CORS 头并返回，用于 `handle_static_request` 中统一的出口路径
+fn finalize_cors(mut response: Response, origin: Option<&'static str>) -> Response {
+    append_cors_headers(&mut response, origin);
+    response
+}
+
 async fn handle_static_request(
     AxumState(state): AxumState<Arc<AppState>>,
     AxumPath(hash): AxumPath<String>,
     uri: Uri,
-    path: Option<String>,
-    origin: Option<&'static str>,
+    request_path: Option<String>,
+    headers: HeaderMap,
 ) -> Response {
-    let sites = state.sites.read().await;
+    let origin = resolve_cors_origin(&headers);
     let query = parse_static_asset_query(uri.query());
 
-    if let Some((site_root, serve_dir)) = sites.get(&hash) {
-        let serve_dir = serve_dir.to_owned();
-        let site_root = site_root.clone();
-        drop(sites);
+    let site = {
+        let sites = state.sites.read().await;
+        sites.get(&hash).cloned()
+    };
 
-        if let Some(thumbnail_request) = resolve_thumbnail_request(&query) {
-            if let Some(response) =
-                try_build_thumbnail_response(site_root.clone(), path.clone(), thumbnail_request)
-                    .await
-            {
-                let mut response = apply_cache_control(response, CacheControlPolicy::Thumbnail);
-                append_static_file_cors_headers(&mut response, origin);
-                return response;
-            }
-        }
+    let Some(site) = site else {
+        return finalize_cors(StatusCode::NOT_FOUND.into_response(), origin);
+    };
 
-        let uri = build_static_asset_uri(path.as_deref());
+    let logical_path = match sanitize_request_path(request_path.as_deref().unwrap_or("")) {
+        Ok(path) => path,
+        Err(error) => return finalize_cors(map_vfs_error(&error).into_response(), origin),
+    };
 
-        match serve_dir
-            .oneshot(Request::builder().uri(uri).body(()).unwrap())
-            .await
-        {
-            Ok(response) => {
-                let mut response =
-                    apply_cache_control(response.into_response(), CacheControlPolicy::StaticAsset);
-                append_static_file_cors_headers(&mut response, origin);
-                response
-            }
+    let overlay = OverlayFs::from_cached(&site);
+
+    let resolve_logical = logical_path.clone();
+    let resolved_file =
+        match tokio::task::spawn_blocking(move || overlay.resolve_file(&resolve_logical)).await {
+            Ok(Ok(file)) => file,
+            Ok(Err(error)) => return finalize_cors(map_vfs_error(&error).into_response(), origin),
             Err(_) => {
-                let mut response = StatusCode::INTERNAL_SERVER_ERROR.into_response();
-                append_static_file_cors_headers(&mut response, origin);
-                response
+                return finalize_cors(StatusCode::INTERNAL_SERVER_ERROR.into_response(), origin)
             }
+        };
+
+    if let Some(thumbnail_request) = resolve_thumbnail_request(&query) {
+        if let Some(response) =
+            try_build_thumbnail_response(&resolved_file.physical_path, thumbnail_request).await
+        {
+            return finalize_cors(
+                apply_cache_control(response, CacheControlPolicy::Thumbnail),
+                origin,
+            );
         }
-    } else {
-        let mut response = StatusCode::NOT_FOUND.into_response();
-        append_static_file_cors_headers(&mut response, origin);
-        response
     }
+
+    let Some(request) = build_file_request(
+        build_static_asset_uri(&logical_path.to_string_lossy().replace('\\', "/")),
+        &headers,
+    ) else {
+        return finalize_cors(StatusCode::INTERNAL_SERVER_ERROR.into_response(), origin);
+    };
+    let response = ServeFile::new(&resolved_file.physical_path)
+        .oneshot(request)
+        .await
+        .map(IntoResponse::into_response)
+        .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response());
+
+    let mut response = apply_cache_control(response, CacheControlPolicy::StaticAsset);
+    if !response.headers().contains_key(CONTENT_TYPE) {
+        if let Ok(value) = HeaderValue::from_str(&resolved_file.content_type) {
+            response.headers_mut().insert(CONTENT_TYPE, value);
+        }
+    }
+    finalize_cors(response, origin)
+}
+
+fn build_file_request(uri: String, headers: &HeaderMap) -> Option<Request<Body>> {
+    let mut request = Request::builder().uri(uri).body(Body::empty()).ok()?;
+
+    for header_name in [RANGE, ORIGIN] {
+        if let Some(value) = headers.get(&header_name) {
+            request.headers_mut().insert(header_name, value.clone());
+        }
+    }
+
+    Some(request)
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -316,18 +281,13 @@ enum CacheControlPolicy {
     Thumbnail,
 }
 
-fn build_static_asset_uri(path: Option<&str>) -> String {
-    match path {
-        Some(path) => {
-            let encoded_path = path
-                .split('/')
-                .map(|segment| urlencoding::encode(segment))
-                .collect::<Vec<_>>()
-                .join("/");
-            format!("/{encoded_path}")
-        }
-        None => "/".to_string(),
-    }
+fn build_static_asset_uri(path: &str) -> String {
+    let encoded_path = path
+        .split('/')
+        .map(|segment| urlencoding::encode(segment))
+        .collect::<Vec<_>>()
+        .join("/");
+    format!("/{encoded_path}")
 }
 
 fn parse_static_asset_query(query: Option<&str>) -> StaticAssetQuery {
@@ -380,19 +340,19 @@ fn resolve_thumbnail_request(query: &StaticAssetQuery) -> Option<ThumbnailReques
 }
 
 async fn try_build_thumbnail_response(
-    site_root: PathBuf,
-    path: Option<String>,
+    physical_path: &Path,
     thumbnail_request: ThumbnailRequest,
 ) -> Option<Response> {
-    let file_path = resolve_static_asset_path(&site_root, path.as_deref())?;
-    if !supports_thumbnail(&file_path) {
+    if !supports_thumbnail(physical_path) {
         return None;
     }
 
-    let encoded_thumbnail =
-        tokio::task::spawn_blocking(move || build_thumbnail(&file_path, thumbnail_request))
-            .await
-            .ok()??;
+    let encoded_thumbnail = tokio::task::spawn_blocking({
+        let path = physical_path.to_path_buf();
+        move || build_thumbnail(&path, thumbnail_request)
+    })
+    .await
+    .ok()??;
 
     let mut response = Response::new(encoded_thumbnail.body.into());
     response.headers_mut().insert(
@@ -402,36 +362,15 @@ async fn try_build_thumbnail_response(
     Some(response)
 }
 
-fn resolve_static_asset_path(site_root: &Path, path: Option<&str>) -> Option<PathBuf> {
-    let path = path?;
-    let relative_path = Path::new(path);
-
-    if relative_path.is_absolute() {
-        return None;
-    }
-
-    let mut resolved_path = site_root.to_path_buf();
-
-    for component in relative_path.components() {
-        match component {
-            Component::Normal(segment) => resolved_path.push(segment),
-            Component::CurDir => {}
-            _ => return None,
-        }
-    }
-
-    Some(resolved_path)
-}
-
 fn supports_thumbnail(path: &Path) -> bool {
-    let Some(extension) = path.extension().and_then(|extension| extension.to_str()) else {
-        return false;
-    };
-
-    matches!(
-        extension.to_ascii_lowercase().as_str(),
-        "png" | "jpg" | "jpeg" | "gif" | "webp" | "ico"
-    )
+    path.extension()
+        .and_then(|ext| ext.to_str())
+        .is_some_and(|ext| {
+            matches!(
+                ext.to_ascii_lowercase().as_str(),
+                "png" | "jpg" | "jpeg" | "gif" | "webp" | "ico"
+            )
+        })
 }
 
 fn build_thumbnail(path: &Path, request: ThumbnailRequest) -> Option<EncodedThumbnail> {
@@ -467,37 +406,37 @@ fn build_thumbnail(path: &Path, request: ThumbnailRequest) -> Option<EncodedThum
     })
 }
 
-fn apply_cache_control(mut response: Response, cache_policy: CacheControlPolicy) -> Response {
-    let cache_control = resolve_cache_control_value(cache_policy);
+fn apply_cache_control(mut response: Response, policy: CacheControlPolicy) -> Response {
+    let value = match policy {
+        CacheControlPolicy::StaticAsset => "no-store, no-cache, must-revalidate, max-age=0",
+        CacheControlPolicy::Thumbnail => "public, max-age=86400",
+    };
     response
         .headers_mut()
-        .insert(CACHE_CONTROL, HeaderValue::from_static(cache_control));
+        .insert(CACHE_CONTROL, HeaderValue::from_static(value));
     response
 }
 
-fn resolve_cache_control_value(cache_policy: CacheControlPolicy) -> &'static str {
-    match cache_policy {
-        CacheControlPolicy::StaticAsset => "no-store, no-cache, must-revalidate, max-age=0",
-        CacheControlPolicy::Thumbnail => "public, max-age=86400",
+fn map_vfs_error(error: &VfsError) -> StatusCode {
+    match error {
+        VfsError::PathDenied | VfsError::WriteToEngineRuntime => StatusCode::FORBIDDEN,
+        VfsError::NotFound => StatusCode::NOT_FOUND,
+        VfsError::Io(_) => StatusCode::INTERNAL_SERVER_ERROR,
     }
 }
 
-/// 启动HTTP服务器
-/// 功能：
-/// 1. 停止已存在的服务器实例
-/// 2. 绑定指定端口（如果端口被占用则自动选择新端口）
-/// 3. 设置路由和中间件
-/// 4. 启动服务器并返回访问地址
-///
-/// 参数：
-/// - state: 服务器状态
-/// - host: 服务器主机地址
-/// - port: 服务器端口号
-/// - on_message: 消息处理通道
-///
-/// 返回：
-/// - 成功：服务器访问地址
-/// - 失败：错误信息
+#[cfg(debug_assertions)]
+async fn timing_middleware(request: Request<Body>, next: Next) -> Response {
+    let path = request.uri().path().to_owned();
+    let start = std::time::Instant::now();
+    let response = next.run(request).await;
+    let elapsed = start.elapsed();
+    if elapsed > std::time::Duration::from_millis(10) {
+        log::debug!("慢请求: {} - {:?}", path, elapsed);
+    }
+    response
+}
+
 #[tauri::command]
 pub async fn start_server(
     state: TauriState<'_, Mutex<ServerState>>,
@@ -507,13 +446,11 @@ pub async fn start_server(
 ) -> AppResult<String> {
     let mut state_guard = state.lock().await;
 
-    // 停止已存在的服务器
     if let Some(handle) = state_guard.server_handle.take() {
         let _ = handle.shutdown_tx.send(());
         handle.join_handle.await.ok();
     }
 
-    // 获取可用端口
     let address = format!("{host}:{port}");
     let listener = match TcpListener::bind(&address).await {
         Ok(listener) => listener,
@@ -525,8 +462,8 @@ pub async fn start_server(
     };
 
     let addr = listener.local_addr()?;
+    log::info!("HTTP 服务器监听: {addr}");
 
-    // 构建路由
     let app = Router::new()
         .route(
             "/api/webgalsync",
@@ -540,14 +477,7 @@ pub async fn start_server(
                  hash: AxumPath<String>,
                  uri: Uri,
                  headers: HeaderMap| async move {
-                    handle_static_request(
-                        state,
-                        hash,
-                        uri,
-                        None,
-                        resolve_static_file_cors_origin_from_headers(&headers),
-                    )
-                    .await
+                    handle_static_request(state, hash, uri, None, headers).await
                 },
             ),
         )
@@ -559,23 +489,18 @@ pub async fn start_server(
                  uri: Uri,
                  headers: HeaderMap| async move {
                     let (hash, path) = path.0;
-                    handle_static_request(
-                        state,
-                        AxumPath(hash),
-                        uri,
-                        Some(path),
-                        resolve_static_file_cors_origin_from_headers(&headers),
-                    )
-                    .await
+                    handle_static_request(state, AxumPath(hash), uri, Some(path), headers).await
                 },
             ),
         )
         .with_state(state_guard.app_state.clone());
 
-    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+    #[cfg(debug_assertions)]
+    let app = app.layer(axum::middleware::from_fn(timing_middleware));
 
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
     let join_handle = tokio::spawn(async move {
-        axum::serve(
+        if let Err(e) = axum::serve(
             listener,
             app.into_make_service_with_connect_info::<SocketAddr>(),
         )
@@ -583,7 +508,9 @@ pub async fn start_server(
             shutdown_rx.await.ok();
         })
         .await
-        .unwrap();
+        {
+            log::error!("HTTP 服务器异常: {e}");
+        }
     });
 
     state_guard.server_handle = Some(ServerHandle {
@@ -591,34 +518,14 @@ pub async fn start_server(
         shutdown_tx,
     });
 
-    state_guard.server_address = Some(addr);
-
-    println!("Server started at: {}", addr);
     Ok(format!("http://{addr}"))
 }
 
-/// 将不带斜杠的URL重定向到带斜杠的URL
-/// 例如：/game/abc -> /game/abc/
-///
-/// 参数：
-/// - uri: 原始请求URI
-///
-/// 返回：
-/// - 重定向响应
 async fn handle_redirect(uri: Uri) -> Result<Redirect, StatusCode> {
     Ok(Redirect::permanent(&format!("{}/", uri.path())))
 }
 
-/// 标准化路径并生成唯一哈希值
-/// 用于标识和管理静态站点
-///
-/// 参数：
-/// - path: 待处理的路径字符串
-///
-/// 返回：
-/// - 成功：(站点哈希值, 标准化后的路径)
-/// - 失败：错误信息
-fn normalize_and_hash_path(path: &str) -> AppResult<(String, PathBuf)> {
+fn normalize_project_path(path: &str) -> AppResult<(String, PathBuf)> {
     let path_buf = PathBuf::from(path);
 
     if !path_buf.exists() {
@@ -631,65 +538,119 @@ fn normalize_and_hash_path(path: &str) -> AppResult<(String, PathBuf)> {
 
     let canonical_path = path_buf
         .canonicalize()
-        .map_err(|e| AppError::Server(format!("无法标准化路径: {e}")))?;
+        .map_err(|error| AppError::Server(format!("无法标准化路径: {error}")))?;
 
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
     canonical_path.hash(&mut hasher);
     let hash = format!("{:x}", hasher.finish());
 
-    Ok((hash, canonical_path))
+    Ok((hash, path_buf))
 }
 
-/// 添加静态站点
-/// 将指定目录注册为静态站点，并返回站点哈希值
-///
-/// 参数：
-/// - state: 服务器状态
-/// - path: 静态站点目录路径
-///
-/// 返回：
-/// - 成功：站点哈希值
-/// - 失败：错误信息
+fn validate_dir_path(path: Option<String>) -> AppResult<Option<PathBuf>> {
+    match path {
+        Some(path) => {
+            let path_buf = PathBuf::from(path);
+            if !path_buf.is_dir() {
+                return Err(AppError::Server("路径必须是目录".into()));
+            }
+            Ok(Some(path_buf))
+        }
+        None => Ok(None),
+    }
+}
+
 #[tauri::command]
 pub async fn add_static_site(
     state: TauriState<'_, Mutex<ServerState>>,
-    path: String,
+    project_path: String,
+    engine_path: Option<String>,
+    template_path: Option<String>,
 ) -> AppResult<String> {
     let state_guard = state.lock().await;
-    let (hash, path_buf) = normalize_and_hash_path(&path)?;
+    let (hash, project_path) = normalize_project_path(&project_path)?;
+    let engine_path = validate_dir_path(engine_path)?;
+    let template_path = match validate_dir_path(template_path)? {
+        Some(path) => Some(path),
+        None => resolve_default_template_path(engine_path.as_deref()).filter(|path| path.is_dir()),
+    };
 
-    let mut sites = state_guard.app_state.sites.write().await;
+    let cached_canonicals =
+        CachedCanonicals::compute(project_path.clone(), engine_path, template_path)?;
 
-    // 如果站点已存在，直接返回其哈希值
-    if sites.contains_key(&hash) {
-        return Ok(hash);
-    }
+    state_guard
+        .app_state
+        .sites
+        .write()
+        .await
+        .insert(hash.clone(), cached_canonicals);
 
-    // 创建服务目录实例
-    let serve_dir = ServeDir::new(&path_buf).append_index_html_on_directories(true);
-
-    sites.insert(hash.clone(), (path_buf, serve_dir));
-
+    log::debug!("注册站点: {hash} -> {}", project_path.display());
     Ok(hash)
 }
 
-/// 广播消息
-/// 向所有连接的WebSocket客户端发送消息
-///
-/// 参数：
-/// - state: 服务器状态
-/// - message: 要广播的消息内容
-///
-/// 返回：
-/// - 成功：空值
-/// - 失败：错误信息
+#[tauri::command]
+pub async fn update_site_engine(
+    state: TauriState<'_, Mutex<ServerState>>,
+    project_path: String,
+    new_engine_path: Option<String>,
+) -> AppResult<()> {
+    let state_guard = state.lock().await;
+    let (hash, _) = normalize_project_path(&project_path)?;
+    let engine_path = validate_dir_path(new_engine_path)?;
+
+    let mut sites = state_guard.app_state.sites.write().await;
+    let Some(site) = sites.get_mut(&hash) else {
+        log::warn!(
+            "update_site_engine: 站点未注册 hash={hash} project={}",
+            project_path
+        );
+        return Err(AppError::SiteNotRegistered);
+    };
+
+    *site = CachedCanonicals::compute(
+        site.upper.clone(),
+        engine_path,
+        site.template_lower.clone(),
+    )?;
+
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn update_site_template(
+    state: TauriState<'_, Mutex<ServerState>>,
+    project_path: String,
+    new_template_path: Option<String>,
+) -> AppResult<()> {
+    let state_guard = state.lock().await;
+    let (hash, _) = normalize_project_path(&project_path)?;
+    let template_path = validate_dir_path(new_template_path)?;
+
+    let mut sites = state_guard.app_state.sites.write().await;
+    let Some(site) = sites.get_mut(&hash) else {
+        log::warn!(
+            "update_site_template: 站点未注册 hash={hash} project={}",
+            project_path
+        );
+        return Err(AppError::SiteNotRegistered);
+    };
+
+    *site = CachedCanonicals::compute(
+        site.upper.clone(),
+        site.engine_lower.clone(),
+        template_path,
+    )?;
+
+    Ok(())
+}
+
 #[tauri::command]
 pub async fn broadcast_message(
     state: TauriState<'_, Mutex<ServerState>>,
     message: String,
 ) -> AppResult<()> {
     let state_guard = state.lock().await;
-    // 使用广播通道高效发送
     state_guard
         .app_state
         .broadcast_tx
@@ -698,17 +659,6 @@ pub async fn broadcast_message(
     Ok(())
 }
 
-/// 单播消息
-/// 向指定的WebSocket客户端发送消息
-///
-/// 参数：
-/// - state: 服务器状态
-/// - client_addr: 目标客户端地址（格式：IP:端口）
-/// - message: 要发送的消息内容
-///
-/// 返回：
-/// - 成功：空值
-/// - 失败：错误信息
 #[tauri::command]
 pub async fn unicast_message(
     state: TauriState<'_, Mutex<ServerState>>,
@@ -717,37 +667,24 @@ pub async fn unicast_message(
 ) -> AppResult<()> {
     let state_guard = state.lock().await;
     let clients = state_guard.app_state.unicast_clients.lock().await;
-
-    // 解析地址
     let addr: SocketAddr = client_addr
         .parse()
         .map_err(|_| AppError::Server("Invalid client address".into()))?;
 
-    if let Some(tx) = clients.get(&addr) {
-        tx.send(Message::Text(message.into()))
-            .map_err(|_| AppError::Server("Failed to send unicast message".into()))?;
-        Ok(())
-    } else {
-        Err(AppError::Server("Client not found".into()))
-    }
+    let tx = clients
+        .get(&addr)
+        .ok_or_else(|| AppError::Server("Client not found".into()))?;
+
+    tx.send(Message::Text(message.into()))
+        .map_err(|_| AppError::Server("Failed to send unicast message".into()))
 }
 
-/// 获取已连接的客户端列表
-/// 返回所有连接的WebSocket客户端的地址列表
-///
-/// 参数：
-/// - state: 服务器状态
-///
-/// 返回：
-/// - 成功：客户端地址列表
-/// - 失败：错误信息
 #[tauri::command]
 pub async fn get_connected_clients(
     state: TauriState<'_, Mutex<ServerState>>,
 ) -> AppResult<Vec<String>> {
     let state_guard = state.lock().await;
     let clients = state_guard.app_state.unicast_clients.lock().await;
-
     Ok(clients.keys().map(|addr| addr.to_string()).collect())
 }
 
@@ -756,7 +693,7 @@ mod tests {
     use axum::{
         body::Body,
         http::{
-            header::{ACCESS_CONTROL_ALLOW_ORIGIN, ORIGIN, VARY},
+            header::{ACCESS_CONTROL_ALLOW_ORIGIN, CACHE_CONTROL, ORIGIN, VARY},
             HeaderMap, HeaderValue,
         },
         response::Response,
@@ -764,82 +701,61 @@ mod tests {
     use std::path::Path;
 
     use super::{
-        append_static_file_cors_headers, resolve_cache_control_value,
-        resolve_static_file_cors_origin, resolve_static_file_cors_origin_from_headers,
-        resolve_thumbnail_request, supports_thumbnail, CacheControlPolicy, StaticAssetQuery,
-        ThumbnailRequest, ThumbnailResizeMode,
+        append_cors_headers, apply_cache_control, resolve_cors_origin, resolve_thumbnail_request,
+        supports_thumbnail, CacheControlPolicy, StaticAssetQuery, ThumbnailRequest,
+        ThumbnailResizeMode,
     };
 
-    #[test]
-    fn resolve_static_file_cors_origin_allows_known_app_origins() {
-        assert_eq!(
-            resolve_static_file_cors_origin(Some("http://localhost:1420")),
-            Some("http://localhost:1420")
-        );
-        assert_eq!(
-            resolve_static_file_cors_origin(Some("http://127.0.0.1:1420")),
-            Some("http://127.0.0.1:1420")
-        );
-        assert_eq!(
-            resolve_static_file_cors_origin(Some("http://tauri.localhost")),
-            Some("http://tauri.localhost")
-        );
-        assert_eq!(
-            resolve_static_file_cors_origin(Some("tauri://localhost")),
-            Some("tauri://localhost")
-        );
-    }
-
-    #[test]
-    fn resolve_static_file_cors_origin_rejects_unknown_origins() {
-        assert_eq!(resolve_static_file_cors_origin(None), None);
-        assert_eq!(
-            resolve_static_file_cors_origin(Some("http://localhost:3000")),
-            None
-        );
-        assert_eq!(
-            resolve_static_file_cors_origin(Some("https://example.com")),
-            None
-        );
-        assert_eq!(resolve_static_file_cors_origin(Some("null")), None);
-    }
-
-    #[test]
-    fn resolve_static_file_cors_origin_from_headers_returns_allowed_origin() {
+    fn headers_with_origin(origin: &'static str) -> HeaderMap {
         let mut headers = HeaderMap::new();
-        headers.insert(ORIGIN, HeaderValue::from_static("http://localhost:1420"));
+        headers.insert(ORIGIN, HeaderValue::from_static(origin));
+        headers
+    }
 
+    #[test]
+    fn resolve_cors_origin_allows_known_app_origins() {
+        for origin in [
+            "http://localhost:1420",
+            "http://127.0.0.1:1420",
+            "http://tauri.localhost",
+            "tauri://localhost",
+        ] {
+            assert_eq!(
+                resolve_cors_origin(&headers_with_origin(origin)),
+                Some(origin),
+                "origin {origin} should be allowed"
+            );
+        }
+    }
+
+    #[test]
+    fn resolve_cors_origin_rejects_unknown_origins() {
+        assert_eq!(resolve_cors_origin(&HeaderMap::new()), None);
         assert_eq!(
-            resolve_static_file_cors_origin_from_headers(&headers),
-            Some("http://localhost:1420")
+            resolve_cors_origin(&headers_with_origin("http://localhost:3000")),
+            None
+        );
+        assert_eq!(
+            resolve_cors_origin(&headers_with_origin("https://example.com")),
+            None
         );
     }
 
     #[test]
-    fn resolve_static_file_cors_origin_from_headers_rejects_missing_or_invalid_origin() {
-        let missing_headers = HeaderMap::new();
-        assert_eq!(
-            resolve_static_file_cors_origin_from_headers(&missing_headers),
-            None
-        );
-
-        let mut invalid_headers = HeaderMap::new();
-        invalid_headers.insert(
+    fn resolve_cors_origin_rejects_non_utf8_origin() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
             ORIGIN,
             HeaderValue::from_bytes(b"http://localhost:1420\xff").unwrap(),
         );
 
-        assert_eq!(
-            resolve_static_file_cors_origin_from_headers(&invalid_headers),
-            None
-        );
+        assert_eq!(resolve_cors_origin(&headers), None);
     }
 
     #[test]
-    fn append_static_file_cors_headers_sets_origin_and_vary_for_allowed_origin() {
+    fn append_cors_headers_sets_origin_and_vary_for_allowed_origin() {
         let mut response = Response::new(Body::empty());
-
-        append_static_file_cors_headers(&mut response, Some("http://localhost:1420"));
+        append_cors_headers(&mut response, Some("http://localhost:1420"));
 
         assert_eq!(
             response.headers().get(ACCESS_CONTROL_ALLOW_ORIGIN),
@@ -852,10 +768,9 @@ mod tests {
     }
 
     #[test]
-    fn append_static_file_cors_headers_keeps_vary_without_allow_origin_when_origin_is_missing() {
+    fn append_cors_headers_keeps_vary_without_allow_origin_when_origin_is_missing() {
         let mut response = Response::new(Body::empty());
-
-        append_static_file_cors_headers(&mut response, None);
+        append_cors_headers(&mut response, None);
 
         assert_eq!(response.headers().get(ACCESS_CONTROL_ALLOW_ORIGIN), None);
         assert_eq!(
@@ -865,18 +780,23 @@ mod tests {
     }
 
     #[test]
-    fn generated_thumbnails_use_public_cache() {
+    fn cache_control_values_match_product_contract() {
+        let thumbnail_response =
+            apply_cache_control(Response::new(Body::empty()), CacheControlPolicy::Thumbnail);
         assert_eq!(
-            resolve_cache_control_value(CacheControlPolicy::Thumbnail),
-            "public, max-age=86400"
+            thumbnail_response.headers().get(CACHE_CONTROL),
+            Some(&HeaderValue::from_static("public, max-age=86400"))
         );
-    }
 
-    #[test]
-    fn static_assets_disable_cache_even_when_content_is_media() {
+        let static_response = apply_cache_control(
+            Response::new(Body::empty()),
+            CacheControlPolicy::StaticAsset,
+        );
         assert_eq!(
-            resolve_cache_control_value(CacheControlPolicy::StaticAsset),
-            "no-store, no-cache, must-revalidate, max-age=0"
+            static_response.headers().get(CACHE_CONTROL),
+            Some(&HeaderValue::from_static(
+                "no-store, no-cache, must-revalidate, max-age=0"
+            ))
         );
     }
 

--- a/src-tauri/src/commands/server.rs
+++ b/src-tauri/src/commands/server.rs
@@ -205,7 +205,8 @@ async fn handle_static_request(
         };
 
     if let Some(thumbnail_request) = resolve_thumbnail_request(&query) {
-        if let Some(response) = try_build_thumbnail_response(&physical_path, thumbnail_request).await
+        if let Some(response) =
+            try_build_thumbnail_response(&physical_path, thumbnail_request).await
         {
             return finalize_cors(
                 apply_cache_control(response, CacheControlPolicy::Thumbnail),
@@ -617,11 +618,8 @@ pub async fn update_site_template(
         return Err(AppError::SiteNotRegistered);
     };
 
-    *site = CachedCanonicals::compute(
-        site.upper.clone(),
-        site.engine_lower.clone(),
-        template_path,
-    )?;
+    *site =
+        CachedCanonicals::compute(site.upper.clone(), site.engine_lower.clone(), template_path)?;
 
     Ok(())
 }

--- a/src-tauri/src/commands/vfs.rs
+++ b/src-tauri/src/commands/vfs.rs
@@ -247,6 +247,7 @@ mod tests {
     use std::{
         fs,
         path::{Path, PathBuf},
+        sync::atomic::{AtomicU64, Ordering},
         time::{SystemTime, UNIX_EPOCH},
     };
 
@@ -254,11 +255,13 @@ mod tests {
     use crate::vfs::VfsError;
 
     fn create_temp_dir(prefix: &str) -> PathBuf {
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
         let unique = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("system clock should be after unix epoch")
             .as_nanos();
-        let dir = std::env::temp_dir().join(format!("{prefix}-{unique}"));
+        let seq = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!("{prefix}-{unique}-{seq}"));
         fs::create_dir_all(&dir).expect("temp directory should be created");
         dir
     }

--- a/src-tauri/src/commands/vfs.rs
+++ b/src-tauri/src/commands/vfs.rs
@@ -39,14 +39,13 @@ impl OverlayFactoryCache {
             template_path: template_path.clone(),
         };
 
+        if let Some(cached) = self
+            .entries
+            .read()
+            .unwrap_or_else(recover_poisoned)
+            .get(&key)
         {
-            let entries = self.entries.read().unwrap_or_else(|e| {
-                log::warn!("OverlayFactoryCache 读锁中毒，恢复访问");
-                e.into_inner()
-            });
-            if let Some(cached) = entries.get(&key) {
-                return Ok(cached.clone());
-            }
+            return Ok(cached.clone());
         }
 
         let cached = CachedCanonicals::compute(
@@ -55,16 +54,18 @@ impl OverlayFactoryCache {
             template_path,
         )?;
 
-        {
-            let mut entries = self.entries.write().unwrap_or_else(|e| {
-                log::warn!("OverlayFactoryCache 写锁中毒，恢复访问");
-                e.into_inner()
-            });
-            entries.insert(key, cached.clone());
-        }
+        self.entries
+            .write()
+            .unwrap_or_else(recover_poisoned)
+            .insert(key, cached.clone());
 
         Ok(cached)
     }
+}
+
+fn recover_poisoned<T>(error: std::sync::PoisonError<T>) -> T {
+    log::warn!("OverlayFactoryCache 锁中毒，恢复访问");
+    error.into_inner()
 }
 
 fn build_overlay(

--- a/src-tauri/src/commands/vfs.rs
+++ b/src-tauri/src/commands/vfs.rs
@@ -181,7 +181,11 @@ pub fn rename_vfs_path(
     let target_path = sanitize_rename_target(parent, &new_name)?;
     let overlay = build_overlay(&project_path, &engine_path, template_path, &factory_cache)?;
     overlay.rename_logical_path(&logical_path, &target_path)?;
-    log::debug!("VFS 重命名: {} -> {}", logical_path.display(), target_path.display());
+    log::debug!(
+        "VFS 重命名: {} -> {}",
+        logical_path.display(),
+        target_path.display()
+    );
     Ok(to_logical_path_string(&target_path))
 }
 
@@ -198,7 +202,11 @@ pub fn move_vfs_path(
     let target_path = sanitize_move_target(&target_rel_path)?;
     let overlay = build_overlay(&project_path, &engine_path, template_path, &factory_cache)?;
     overlay.rename_logical_path(&logical_path, &target_path)?;
-    log::debug!("VFS 移动: {} -> {}", logical_path.display(), target_path.display());
+    log::debug!(
+        "VFS 移动: {} -> {}",
+        logical_path.display(),
+        target_path.display()
+    );
     Ok(to_logical_path_string(&target_path))
 }
 
@@ -215,7 +223,11 @@ pub fn copy_vfs_path(
     let target_path = sanitize_logical_path(&target_rel_path)?;
     let overlay = build_overlay(&project_path, &engine_path, template_path, &factory_cache)?;
     overlay.copy_logical_path(&logical_path, &target_path)?;
-    log::debug!("VFS 复制: {} -> {}", logical_path.display(), target_path.display());
+    log::debug!(
+        "VFS 复制: {} -> {}",
+        logical_path.display(),
+        target_path.display()
+    );
     Ok(to_logical_path_string(&target_path))
 }
 

--- a/src-tauri/src/commands/vfs.rs
+++ b/src-tauri/src/commands/vfs.rs
@@ -1,25 +1,86 @@
-use std::path::{Path, PathBuf};
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+    sync::RwLock,
+};
+
+use tauri::State;
 
 use crate::vfs::{
-    self, resolve_default_template_path, sanitize_logical_path, OverlayFs, VfsDirEntry, VfsError,
+    self, resolve_default_template_path, sanitize_logical_path, CachedCanonicals, OverlayFs,
+    VfsDirEntry, VfsError,
 };
 
 use super::AppResult;
+
+/// canonicalize 结果缓存，按 (project, engine, template) 路径组合索引
+#[derive(Default)]
+pub struct OverlayFactoryCache {
+    entries: RwLock<HashMap<OverlayCacheKey, CachedCanonicals>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct OverlayCacheKey {
+    project_path: PathBuf,
+    engine_path: PathBuf,
+    template_path: Option<PathBuf>,
+}
+
+impl OverlayFactoryCache {
+    fn get_or_compute(
+        &self,
+        project_path: &Path,
+        engine_path: &Path,
+        template_path: Option<PathBuf>,
+    ) -> Result<CachedCanonicals, VfsError> {
+        let key = OverlayCacheKey {
+            project_path: project_path.to_path_buf(),
+            engine_path: engine_path.to_path_buf(),
+            template_path: template_path.clone(),
+        };
+
+        {
+            let entries = self.entries.read().unwrap_or_else(|e| {
+                log::warn!("OverlayFactoryCache 读锁中毒，恢复访问");
+                e.into_inner()
+            });
+            if let Some(cached) = entries.get(&key) {
+                return Ok(cached.clone());
+            }
+        }
+
+        let cached = CachedCanonicals::compute(
+            project_path.to_path_buf(),
+            Some(engine_path.to_path_buf()),
+            template_path,
+        )?;
+
+        {
+            let mut entries = self.entries.write().unwrap_or_else(|e| {
+                log::warn!("OverlayFactoryCache 写锁中毒，恢复访问");
+                e.into_inner()
+            });
+            entries.insert(key, cached.clone());
+        }
+
+        Ok(cached)
+    }
+}
 
 fn build_overlay(
     project_path: &str,
     engine_path: &str,
     template_path: Option<String>,
+    factory_cache: &OverlayFactoryCache,
 ) -> Result<OverlayFs, VfsError> {
-    let template = match template_path {
-        Some(explicit) => Some(PathBuf::from(explicit)),
-        None => resolve_default_template_path(Some(Path::new(engine_path))).filter(|p| p.is_dir()),
-    };
-    OverlayFs::new(
-        PathBuf::from(project_path),
-        Some(PathBuf::from(engine_path)),
-        template,
-    )
+    let template = template_path
+        .map(PathBuf::from)
+        .filter(|p| p.is_dir())
+        .or_else(|| resolve_default_template_path(Some(Path::new(engine_path))))
+        .filter(|p| p.is_dir());
+    let cached =
+        factory_cache.get_or_compute(Path::new(project_path), Path::new(engine_path), template)?;
+    Ok(OverlayFs::from_cached(&cached))
 }
 
 fn sanitize_rename_target(parent: &Path, new_name: &str) -> Result<PathBuf, VfsError> {
@@ -52,51 +113,55 @@ fn to_logical_path_string(path: &Path) -> String {
 
 #[tauri::command]
 pub fn resolve_vfs_path(
+    factory_cache: State<'_, OverlayFactoryCache>,
     project_path: String,
     engine_path: String,
     template_path: Option<String>,
     rel_path: String,
 ) -> AppResult<String> {
     let logical_path = sanitize_logical_path(&rel_path)?;
-    let overlay = build_overlay(&project_path, &engine_path, template_path)?;
+    let overlay = build_overlay(&project_path, &engine_path, template_path, &factory_cache)?;
     let resolved = overlay.resolve_physical_path(&logical_path)?;
     Ok(to_physical_path_string(&resolved.physical_path))
 }
 
 #[tauri::command]
 pub fn list_vfs_dir(
+    factory_cache: State<'_, OverlayFactoryCache>,
     project_path: String,
     engine_path: String,
     template_path: Option<String>,
     rel_path: String,
 ) -> AppResult<Vec<VfsDirEntry>> {
     let logical_dir = sanitize_logical_path(&rel_path)?;
-    let overlay = build_overlay(&project_path, &engine_path, template_path)?;
+    let overlay = build_overlay(&project_path, &engine_path, template_path, &factory_cache)?;
     overlay.list_entries(&logical_dir).map_err(Into::into)
 }
 
 #[tauri::command]
 pub fn ensure_vfs_writable(
+    factory_cache: State<'_, OverlayFactoryCache>,
     project_path: String,
     engine_path: String,
     template_path: Option<String>,
     rel_path: String,
 ) -> AppResult<String> {
     let logical_path = sanitize_logical_path(&rel_path)?;
-    let overlay = build_overlay(&project_path, &engine_path, template_path)?;
+    let overlay = build_overlay(&project_path, &engine_path, template_path, &factory_cache)?;
     let path = overlay.ensure_writable(&logical_path)?;
     Ok(to_physical_path_string(&path))
 }
 
 #[tauri::command]
 pub fn delete_vfs_path(
+    factory_cache: State<'_, OverlayFactoryCache>,
     project_path: String,
     engine_path: String,
     template_path: Option<String>,
     rel_path: String,
 ) -> AppResult<()> {
     let logical_path = sanitize_logical_path(&rel_path)?;
-    let overlay = build_overlay(&project_path, &engine_path, template_path)?;
+    let overlay = build_overlay(&project_path, &engine_path, template_path, &factory_cache)?;
     overlay.remove_logical_path(&logical_path)?;
     log::debug!("VFS 删除: {}", logical_path.display());
     Ok(())
@@ -104,6 +169,7 @@ pub fn delete_vfs_path(
 
 #[tauri::command]
 pub fn rename_vfs_path(
+    factory_cache: State<'_, OverlayFactoryCache>,
     project_path: String,
     engine_path: String,
     template_path: Option<String>,
@@ -113,18 +179,15 @@ pub fn rename_vfs_path(
     let logical_path = sanitize_logical_path(&rel_path)?;
     let parent = logical_path.parent().unwrap_or_else(|| Path::new(""));
     let target_path = sanitize_rename_target(parent, &new_name)?;
-    let overlay = build_overlay(&project_path, &engine_path, template_path)?;
+    let overlay = build_overlay(&project_path, &engine_path, template_path, &factory_cache)?;
     overlay.rename_logical_path(&logical_path, &target_path)?;
-    log::debug!(
-        "VFS 重命名: {} -> {}",
-        logical_path.display(),
-        target_path.display()
-    );
+    log::debug!("VFS 重命名: {} -> {}", logical_path.display(), target_path.display());
     Ok(to_logical_path_string(&target_path))
 }
 
 #[tauri::command]
 pub fn move_vfs_path(
+    factory_cache: State<'_, OverlayFactoryCache>,
     project_path: String,
     engine_path: String,
     template_path: Option<String>,
@@ -133,18 +196,15 @@ pub fn move_vfs_path(
 ) -> AppResult<String> {
     let logical_path = sanitize_logical_path(&rel_path)?;
     let target_path = sanitize_move_target(&target_rel_path)?;
-    let overlay = build_overlay(&project_path, &engine_path, template_path)?;
+    let overlay = build_overlay(&project_path, &engine_path, template_path, &factory_cache)?;
     overlay.rename_logical_path(&logical_path, &target_path)?;
-    log::debug!(
-        "VFS 移动: {} -> {}",
-        logical_path.display(),
-        target_path.display()
-    );
+    log::debug!("VFS 移动: {} -> {}", logical_path.display(), target_path.display());
     Ok(to_logical_path_string(&target_path))
 }
 
 #[tauri::command]
 pub fn copy_vfs_path(
+    factory_cache: State<'_, OverlayFactoryCache>,
     project_path: String,
     engine_path: String,
     template_path: Option<String>,
@@ -153,13 +213,9 @@ pub fn copy_vfs_path(
 ) -> AppResult<String> {
     let logical_path = sanitize_logical_path(&rel_path)?;
     let target_path = sanitize_logical_path(&target_rel_path)?;
-    let overlay = build_overlay(&project_path, &engine_path, template_path)?;
+    let overlay = build_overlay(&project_path, &engine_path, template_path, &factory_cache)?;
     overlay.copy_logical_path(&logical_path, &target_path)?;
-    log::debug!(
-        "VFS 复制: {} -> {}",
-        logical_path.display(),
-        target_path.display()
-    );
+    log::debug!("VFS 复制: {} -> {}", logical_path.display(), target_path.display());
     Ok(to_logical_path_string(&target_path))
 }
 
@@ -176,12 +232,24 @@ pub fn clean_template_upper(project_path: String) -> AppResult<()> {
 
 #[cfg(test)]
 mod tests {
-    use std::path::{Path, PathBuf};
+    use std::{
+        fs,
+        path::{Path, PathBuf},
+        time::{SystemTime, UNIX_EPOCH},
+    };
 
-    use tempfile::tempdir;
-
-    use super::{build_overlay, sanitize_rename_target};
+    use super::{build_overlay, sanitize_rename_target, OverlayFactoryCache};
     use crate::vfs::VfsError;
+
+    fn create_temp_dir(prefix: &str) -> PathBuf {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock should be after unix epoch")
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!("{prefix}-{unique}"));
+        fs::create_dir_all(&dir).expect("temp directory should be created");
+        dir
+    }
 
     #[test]
     fn sanitize_rename_target_rejects_nested_or_traversal_names() {
@@ -206,19 +274,13 @@ mod tests {
 
     #[test]
     fn build_overlay_allows_engines_without_template_directory() {
-        let upper = tempdir().expect("upper temp dir should be created");
-        let engine = tempdir().expect("engine temp dir should be created");
-        let upper_str = upper
-            .path()
-            .to_str()
-            .expect("temp path should be valid UTF-8");
-        let engine_str = engine
-            .path()
-            .to_str()
-            .expect("temp path should be valid UTF-8");
+        let upper = create_temp_dir("webgal-craft-vfs-command-upper");
+        let engine = create_temp_dir("webgal-craft-vfs-command-engine");
+        let upper_str = upper.to_str().expect("temp path should be valid UTF-8");
+        let engine_str = engine.to_str().expect("temp path should be valid UTF-8");
 
         assert!(
-            build_overlay(upper_str, engine_str, None).is_ok(),
+            build_overlay(upper_str, engine_str, None, &OverlayFactoryCache::default()).is_ok(),
             "missing game/template should not break non-template VFS commands"
         );
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,6 +3,7 @@ mod commands;
 mod vfs;
 mod window;
 use commands::server::ServerState;
+use commands::vfs::OverlayFactoryCache;
 #[cfg(target_os = "windows")]
 use tauri_plugin_prevent_default::PlatformOptions;
 use tokio::sync::Mutex;
@@ -16,7 +17,8 @@ pub fn run() {
         #[cfg(debug_assertions)]
         _window.open_devtools();
 
-        app.manage(Mutex::new(ServerState::default()));
+        app.manage(OverlayFactoryCache::default());
+        app.manage(Mutex::new(ServerState::new()));
 
         Ok(())
     });
@@ -85,6 +87,8 @@ pub fn run() {
             // server
             commands::server::start_server,
             commands::server::add_static_site,
+            commands::server::update_site_engine,
+            commands::server::update_site_template,
             commands::server::broadcast_message,
             commands::server::unicast_message,
             commands::server::get_connected_clients,

--- a/src-tauri/src/vfs.rs
+++ b/src-tauri/src/vfs.rs
@@ -46,12 +46,6 @@ pub enum TemplateBinding {
     EngineBuiltin { engine: EngineRef },
 }
 
-#[derive(Debug, Clone)]
-pub struct ResolvedFile {
-    pub physical_path: PathBuf,
-    pub content_type: String,
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ResolvedPhysicalPath {
     pub physical_path: PathBuf,
@@ -210,7 +204,7 @@ impl OverlayFs {
         }
     }
 
-    pub fn resolve_file(&self, logical_path: &Path) -> Result<ResolvedFile, VfsError> {
+    pub fn resolve_file(&self, logical_path: &Path) -> Result<PathBuf, VfsError> {
         let resolved = self.resolve_physical_path(logical_path)?;
         let metadata = fs::metadata(&resolved.physical_path)?;
 
@@ -218,12 +212,7 @@ impl OverlayFs {
             return Err(VfsError::NotFound);
         }
 
-        Ok(ResolvedFile {
-            content_type: mime_guess::from_path(&resolved.physical_path)
-                .first_or_octet_stream()
-                .to_string(),
-            physical_path: resolved.physical_path,
-        })
+        Ok(resolved.physical_path)
     }
 
     pub fn resolve_physical_path(

--- a/src-tauri/src/vfs.rs
+++ b/src-tauri/src/vfs.rs
@@ -6,6 +6,7 @@ use std::{
     path::{Component, Path, PathBuf},
 };
 
+use percent_encoding::percent_decode_str;
 use serde::{Deserialize, Serialize};
 use tempfile::NamedTempFile;
 use thiserror::Error;
@@ -43,6 +44,12 @@ pub struct EngineRef {
 pub enum TemplateBinding {
     Standalone { name: String },
     EngineBuiltin { engine: EngineRef },
+}
+
+#[derive(Debug, Clone)]
+pub struct ResolvedFile {
+    pub physical_path: PathBuf,
+    pub content_type: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -128,20 +135,19 @@ impl VfsError {
     }
 }
 
-pub struct OverlayFs {
-    upper: PathBuf,
-    upper_canonical: PathBuf,
-    engine_lower: Option<PathBuf>,
-    engine_lower_canonical: Option<PathBuf>,
-    template_lower: Option<PathBuf>,
-    template_lower_canonical: Option<PathBuf>,
-    whiteout_root: PathBuf,
+/// 缓存 canonicalize 结果，避免热路径上重复系统调用
+#[derive(Debug, Clone)]
+pub struct CachedCanonicals {
+    pub upper: PathBuf,
+    pub upper_canonical: PathBuf,
+    pub engine_lower: Option<PathBuf>,
+    pub engine_lower_canonical: Option<PathBuf>,
+    pub template_lower: Option<PathBuf>,
+    pub template_lower_canonical: Option<PathBuf>,
 }
 
-impl OverlayFs {
-    /// 构造 overlay 实例。`upper`、以及传入的 `engine_lower` / `template_lower` 必须指向已存在的目录，
-    /// 否则 canonicalize 会立即返回 IO 错误。调用方应在创建项目目录之后再构造。
-    pub fn new(
+impl CachedCanonicals {
+    pub fn compute(
         upper: PathBuf,
         engine_lower: Option<PathBuf>,
         template_lower: Option<PathBuf>,
@@ -155,7 +161,6 @@ impl OverlayFs {
             .as_ref()
             .map(|path| path.canonicalize())
             .transpose()?;
-        let whiteout_root = upper.join(VFS_METADATA_DIR).join(WHITEOUTS_DIR);
 
         Ok(Self {
             upper,
@@ -164,7 +169,60 @@ impl OverlayFs {
             engine_lower_canonical,
             template_lower,
             template_lower_canonical,
+        })
+    }
+}
+
+pub struct OverlayFs {
+    upper: PathBuf,
+    upper_canonical: PathBuf,
+    engine_lower: Option<PathBuf>,
+    engine_lower_canonical: Option<PathBuf>,
+    template_lower: Option<PathBuf>,
+    template_lower_canonical: Option<PathBuf>,
+    whiteout_root: PathBuf,
+}
+
+impl OverlayFs {
+    /// 构造 overlay 实例。`upper`、以及传入的 `engine_lower` / `template_lower` 必须指向已存在的目录，
+    /// 否则 canonicalize 会立即返回 IO 错误。调用方应在创建项目目录之后再构造。
+    #[cfg(test)]
+    pub fn new(
+        upper: PathBuf,
+        engine_lower: Option<PathBuf>,
+        template_lower: Option<PathBuf>,
+    ) -> Result<Self, VfsError> {
+        let cached = CachedCanonicals::compute(upper, engine_lower, template_lower)?;
+        Ok(Self::from_cached(&cached))
+    }
+
+    /// 使用已缓存的 canonical 路径构造 OverlayFs，跳过 canonicalize 系统调用
+    pub fn from_cached(cached: &CachedCanonicals) -> Self {
+        let whiteout_root = cached.upper.join(VFS_METADATA_DIR).join(WHITEOUTS_DIR);
+        Self {
+            upper: cached.upper.clone(),
+            upper_canonical: cached.upper_canonical.clone(),
+            engine_lower: cached.engine_lower.clone(),
+            engine_lower_canonical: cached.engine_lower_canonical.clone(),
+            template_lower: cached.template_lower.clone(),
+            template_lower_canonical: cached.template_lower_canonical.clone(),
             whiteout_root,
+        }
+    }
+
+    pub fn resolve_file(&self, logical_path: &Path) -> Result<ResolvedFile, VfsError> {
+        let resolved = self.resolve_physical_path(logical_path)?;
+        let metadata = fs::metadata(&resolved.physical_path)?;
+
+        if !metadata.is_file() {
+            return Err(VfsError::NotFound);
+        }
+
+        Ok(ResolvedFile {
+            content_type: mime_guess::from_path(&resolved.physical_path)
+                .first_or_octet_stream()
+                .to_string(),
+            physical_path: resolved.physical_path,
         })
     }
 
@@ -677,6 +735,18 @@ impl OverlayFs {
 
         validate_physical_path(path, &self.upper_canonical)
     }
+}
+
+pub fn sanitize_request_path(raw_path: &str) -> Result<PathBuf, VfsError> {
+    let decoded = percent_decode_str(raw_path)
+        .decode_utf8()
+        .map_err(|_| VfsError::PathDenied)?;
+
+    let trimmed = decoded.trim_start_matches('/');
+    if trimmed.is_empty() {
+        return Ok(PathBuf::from("index.html"));
+    }
+    sanitize_logical_path(trimmed)
 }
 
 pub fn sanitize_logical_path(raw_path: &str) -> Result<PathBuf, VfsError> {

--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -3,9 +3,8 @@ import { Channel, invoke } from '@tauri-apps/api/core'
 import { AppError } from '~/types/errors'
 import { safeInvoke } from '~/utils/invoke'
 
-/**
- * 启动静态文件服务器
- */
+import type { StaticSiteConfig } from '~/types/server'
+
 async function startServer(host: string, port: number): Promise<string> {
   try {
     const channel = new Channel<string>()
@@ -21,25 +20,35 @@ async function startServer(host: string, port: number): Promise<string> {
   }
 }
 
-async function addStaticSite(path: string): Promise<string> {
-  return safeInvoke<string>('add_static_site', { path })
+function addStaticSite(config: StaticSiteConfig): Promise<string> {
+  return safeInvoke('add_static_site', { ...config })
 }
 
-async function broadcastMessage(message: string): Promise<void> {
-  return safeInvoke<void>('broadcast_message', { message })
+function updateSiteEngine(projectPath: string, newEnginePath?: string): Promise<void> {
+  return safeInvoke('update_site_engine', { projectPath, newEnginePath })
 }
 
-async function unicastMessage(clientAddr: string, message: string): Promise<void> {
-  return safeInvoke<void>('unicast_message', { clientAddr, message })
+function updateSiteTemplate(projectPath: string, newTemplatePath?: string): Promise<void> {
+  return safeInvoke('update_site_template', { projectPath, newTemplatePath })
 }
 
-async function getConnectedClients(): Promise<string[]> {
-  return safeInvoke<string[]>('get_connected_clients')
+function broadcastMessage(message: string): Promise<void> {
+  return safeInvoke('broadcast_message', { message })
+}
+
+function unicastMessage(clientAddr: string, message: string): Promise<void> {
+  return safeInvoke('unicast_message', { clientAddr, message })
+}
+
+function getConnectedClients(): Promise<string[]> {
+  return safeInvoke('get_connected_clients')
 }
 
 export const serverCmds = {
   startServer,
   addStaticSite,
+  updateSiteEngine,
+  updateSiteTemplate,
   broadcastMessage,
   unicastMessage,
   getConnectedClients,

--- a/src/components/modals/DiscoveredResourcesModal.vue
+++ b/src/components/modals/DiscoveredResourcesModal.vue
@@ -58,7 +58,7 @@ watch(
     const addedPaths = paths.filter(path => !previousPathSet.has(path))
     selectedPaths = new Set([...keptPaths, ...addedPaths])
 
-    void previewRuntimeStore.ensureServeUrls(paths)
+    void previewRuntimeStore.ensureServeUrls(paths.map(projectPath => ({ projectPath })))
   },
   { immediate: true },
 )

--- a/src/composables/__tests__/useResourcePreviewPrimer.test.ts
+++ b/src/composables/__tests__/useResourcePreviewPrimer.test.ts
@@ -77,7 +77,10 @@ describe('useResourcePreviewPrimer', () => {
     stopPrimer = useResourcePreviewPrimer()
     await flushPrimerWatchers()
 
-    expect(ensureServeUrlsMock).toHaveBeenCalledWith(['/games/alpha', '/engines/fresh'])
+    expect(ensureServeUrlsMock).toHaveBeenCalledWith([
+      { projectPath: '/games/alpha' },
+      { projectPath: '/engines/fresh' },
+    ])
   })
 
   it('没有资源时不会触发预热', async () => {
@@ -98,7 +101,7 @@ describe('useResourcePreviewPrimer', () => {
     ]
     await flushPrimerWatchers()
 
-    expect(ensureServeUrlsMock).toHaveBeenCalledWith(['/games/alpha'])
+    expect(ensureServeUrlsMock).toHaveBeenCalledWith([{ projectPath: '/games/alpha' }])
   })
 
   it('预热失败时会记录错误而不是吞掉拒绝', async () => {

--- a/src/composables/useResourcePreviewPrimer.ts
+++ b/src/composables/useResourcePreviewPrimer.ts
@@ -5,19 +5,19 @@ export function useResourcePreviewPrimer(): () => void {
   const previewRuntimeStore = usePreviewRuntimeStore()
   const resourceStore = useResourceStore()
 
-  const previewPaths = computed(() => [
-    ...(resourceStore.games ?? []).map(game => game.path),
-    ...(resourceStore.engines ?? []).map(engine => engine.path),
+  const previewSites = computed(() => [
+    ...(resourceStore.games ?? []).map(game => ({ projectPath: game.path })),
+    ...(resourceStore.engines ?? []).map(engine => ({ projectPath: engine.path })),
   ])
 
   return watch(
-    previewPaths,
-    (paths) => {
-      if (paths.length === 0) {
+    previewSites,
+    (sites) => {
+      if (sites.length === 0) {
         return
       }
 
-      void previewRuntimeStore.ensureServeUrls(paths).catch((error) => {
+      void previewRuntimeStore.ensureServeUrls(sites).catch((error) => {
         void logger.error(`资源预览预热失败: ${error}`)
       })
     },

--- a/src/stores/__tests__/preview-runtime.test.ts
+++ b/src/stores/__tests__/preview-runtime.test.ts
@@ -39,10 +39,10 @@ describe('previewRuntimeStore 预览运行时状态仓库', () => {
     expect('serverUrl' in store).toBe(false)
     expect(store.getServeUrl('/games/alpha')).toBeUndefined()
 
-    await expect(store.ensureServeUrl('/games/alpha')).resolves.toBe(
+    await expect(store.ensureServeUrl({ projectPath: '/games/alpha' })).resolves.toBe(
       'http://127.0.0.1:8899/game/game-alpha/',
     )
-    await expect(store.ensureServeUrl('/games/alpha')).resolves.toBe(
+    await expect(store.ensureServeUrl({ projectPath: '/games/alpha' })).resolves.toBe(
       'http://127.0.0.1:8899/game/game-alpha/',
     )
 
@@ -59,8 +59,8 @@ describe('previewRuntimeStore 预览运行时状态仓库', () => {
     const store = usePreviewRuntimeStore()
 
     const [firstUrl, secondUrl] = await Promise.all([
-      store.ensureServeUrl('/games/alpha'),
-      store.ensureServeUrl('/games/alpha'),
+      store.ensureServeUrl({ projectPath: '/games/alpha' }),
+      store.ensureServeUrl({ projectPath: '/games/alpha' }),
     ])
 
     expect(firstUrl).toBe('http://127.0.0.1:8899/game/game-alpha/')
@@ -74,7 +74,7 @@ describe('previewRuntimeStore 预览运行时状态仓库', () => {
     startServerMock.mockRejectedValue(new Error('occupied'))
     const store = usePreviewRuntimeStore()
 
-    await expect(store.ensureServeUrl('/games/alpha')).resolves.toBeUndefined()
+    await expect(store.ensureServeUrl({ projectPath: '/games/alpha' })).resolves.toBeUndefined()
 
     expect(loggerErrorMock).toHaveBeenCalledWith('服务器启动失败: Error: occupied')
   })
@@ -84,7 +84,7 @@ describe('previewRuntimeStore 预览运行时状态仓库', () => {
     addStaticSiteMock.mockRejectedValue(new Error('register failed'))
     const store = usePreviewRuntimeStore()
 
-    await expect(store.ensureServeUrl('/games/alpha')).resolves.toBeUndefined()
+    await expect(store.ensureServeUrl({ projectPath: '/games/alpha' })).resolves.toBeUndefined()
 
     expect(loggerErrorMock).toHaveBeenCalledWith(
       '注册静态站点失败: /games/alpha - Error: register failed',
@@ -98,7 +98,10 @@ describe('previewRuntimeStore 预览运行时状态仓库', () => {
       .mockRejectedValueOnce(new Error('register failed'))
     const store = usePreviewRuntimeStore()
 
-    await store.ensureServeUrls(['/games/alpha', '/engines/beta'])
+    await store.ensureServeUrls([
+      { projectPath: '/games/alpha' },
+      { projectPath: '/engines/beta' },
+    ])
 
     expect(loggerErrorMock).toHaveBeenCalledWith(
       '注册静态站点失败: /engines/beta - Error: register failed',
@@ -110,7 +113,12 @@ describe('previewRuntimeStore 预览运行时状态仓库', () => {
     addStaticSiteMock.mockResolvedValue('game-alpha')
     const store = usePreviewRuntimeStore()
 
-    await store.ensureServeUrls(['', '/games/alpha ', '/games/alpha ', '/games/alpha'])
+    await store.ensureServeUrls([
+      { projectPath: '' },
+      { projectPath: '/games/alpha ' },
+      { projectPath: '/games/alpha ' },
+      { projectPath: '/games/alpha' },
+    ])
 
     expect(startServerMock).toHaveBeenCalledTimes(1)
     expect(addStaticSiteMock).toHaveBeenCalledTimes(2)
@@ -126,7 +134,7 @@ describe('previewRuntimeStore 预览运行时状态仓库', () => {
 
     expect(serveUrl.value).toBeUndefined()
 
-    await store.ensureServeUrls(['/games/alpha'])
+    await store.ensureServeUrls([{ projectPath: '/games/alpha' }])
 
     expect(serveUrl.value).toBe('http://127.0.0.1:8899/game/game-alpha/')
   })

--- a/src/stores/__tests__/preview-runtime.test.ts
+++ b/src/stores/__tests__/preview-runtime.test.ts
@@ -1,7 +1,6 @@
 import '~/__tests__/setup'
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { computed } from 'vue'
 
 import { usePreviewRuntimeStore } from '~/stores/preview-runtime'
 
@@ -28,9 +27,7 @@ vi.mock('@tauri-apps/plugin-log', () => ({
 
 describe('previewRuntimeStore 预览运行时状态仓库', () => {
   beforeEach(() => {
-    addStaticSiteMock.mockReset()
-    loggerErrorMock.mockReset()
-    startServerMock.mockReset()
+    vi.resetAllMocks()
   })
 
   it('ensureServeUrl 会按需启动预览服务器并缓存 serve url', async () => {
@@ -52,7 +49,7 @@ describe('previewRuntimeStore 预览运行时状态仓库', () => {
     expect(startServerMock).toHaveBeenCalledTimes(1)
     expect(startServerMock).toHaveBeenCalledWith('127.0.0.1', 8899)
     expect(addStaticSiteMock).toHaveBeenCalledTimes(1)
-    expect(addStaticSiteMock).toHaveBeenCalledWith('/games/alpha')
+    expect(addStaticSiteMock).toHaveBeenCalledWith({ projectPath: '/games/alpha' })
     expect(store.getServeUrl('/games/alpha')).toBe('http://127.0.0.1:8899/game/game-alpha/')
   })
 
@@ -117,8 +114,8 @@ describe('previewRuntimeStore 预览运行时状态仓库', () => {
 
     expect(startServerMock).toHaveBeenCalledTimes(1)
     expect(addStaticSiteMock).toHaveBeenCalledTimes(2)
-    expect(addStaticSiteMock).toHaveBeenNthCalledWith(1, '/games/alpha ')
-    expect(addStaticSiteMock).toHaveBeenNthCalledWith(2, '/games/alpha')
+    expect(addStaticSiteMock).toHaveBeenNthCalledWith(1, { projectPath: '/games/alpha ' })
+    expect(addStaticSiteMock).toHaveBeenNthCalledWith(2, { projectPath: '/games/alpha' })
   })
 
   it('getServeUrl 会在站点预热完成后触发依赖它的响应式更新', async () => {

--- a/src/stores/__tests__/preview-session.test.ts
+++ b/src/stores/__tests__/preview-session.test.ts
@@ -48,7 +48,7 @@ describe('previewSessionStore 当前工作区预览会话仓库', () => {
       path: '/games/game-1',
     }))
 
-    expect(ensureServeUrlMock).toHaveBeenCalledWith('/games/game-1')
+    expect(ensureServeUrlMock).toHaveBeenCalledWith({ projectPath: '/games/game-1' })
     expect(store.currentGameServeUrl).toBe('http://preview/game-1/')
     expect(store.reloadVersion).toBe(0)
 

--- a/src/stores/preview-runtime.ts
+++ b/src/stores/preview-runtime.ts
@@ -2,15 +2,37 @@ import { defineStore } from 'pinia'
 
 import { serverCmds } from '~/commands/server'
 
+import type { StaticSiteConfig } from '~/types/server'
+
 function buildServeUrl(siteId: string, serverUrl: string): string {
   return new URL(`game/${siteId}/`, serverUrl).href
 }
 
+type StaticSiteInput = StaticSiteConfig | string
+
+function normalizeSiteConfig(input: StaticSiteInput): StaticSiteConfig {
+  if (typeof input === 'string') {
+    return { projectPath: input }
+  }
+
+  return input
+}
+
+function buildSiteSignature(config: StaticSiteConfig): string {
+  return JSON.stringify([
+    config.projectPath,
+    config.enginePath ?? '',
+    config.templatePath ?? '',
+  ])
+}
+
 export const usePreviewRuntimeStore = defineStore('previewRuntime', () => {
+  // 非响应式内部状态：服务器 URL 和启动任务无需触发 UI 更新
   let serverUrl: string | undefined
   let pendingServerStart: Promise<string | undefined> | undefined
 
   const serveUrls = reactive(new Map<string, string>())
+  const siteSignatures = reactive(new Map<string, string>())
   const pendingRegistrations = new Map<string, Promise<string | undefined>>()
 
   async function ensureServer(): Promise<string | undefined> {
@@ -51,40 +73,47 @@ export const usePreviewRuntimeStore = defineStore('previewRuntime', () => {
     return serveUrls.get(path)
   }
 
-  async function registerServeUrl(path: string, currentServerUrl: string): Promise<string | undefined> {
-    const cachedServeUrl = serveUrls.get(path)
-    if (cachedServeUrl) {
+  async function registerServeUrl(
+    input: StaticSiteInput,
+    currentServerUrl: string,
+  ): Promise<string | undefined> {
+    const site = normalizeSiteConfig(input)
+    const signature = buildSiteSignature(site)
+    const cachedServeUrl = serveUrls.get(site.projectPath)
+    if (cachedServeUrl && siteSignatures.get(site.projectPath) === signature) {
       return cachedServeUrl
     }
 
-    const pendingRegistration = pendingRegistrations.get(path)
+    const pendingRegistration = pendingRegistrations.get(signature)
     if (pendingRegistration) {
       return await pendingRegistration
     }
 
     const registrationTask = (async () => {
       try {
-        const siteId = await serverCmds.addStaticSite(path)
+        const siteId = await serverCmds.addStaticSite(site)
         const serveUrl = buildServeUrl(siteId, currentServerUrl)
-        serveUrls.set(path, serveUrl)
+        serveUrls.set(site.projectPath, serveUrl)
+        siteSignatures.set(site.projectPath, signature)
         return serveUrl
       } catch (error) {
-        logger.error(`注册静态站点失败: ${path} - ${error}`)
+        logger.error(`注册静态站点失败: ${site.projectPath} - ${error}`)
         return
       }
     })()
 
-    pendingRegistrations.set(path, registrationTask)
+    pendingRegistrations.set(signature, registrationTask)
 
     try {
       return await registrationTask
     } finally {
-      pendingRegistrations.delete(path)
+      pendingRegistrations.delete(signature)
     }
   }
 
-  async function ensureServeUrl(path: string): Promise<string | undefined> {
-    if (!path) {
+  async function ensureServeUrl(input: StaticSiteInput): Promise<string | undefined> {
+    const site = normalizeSiteConfig(input)
+    if (!site.projectPath) {
       return undefined
     }
 
@@ -93,13 +122,18 @@ export const usePreviewRuntimeStore = defineStore('previewRuntime', () => {
       return undefined
     }
 
-    return await registerServeUrl(path, currentServerUrl)
+    return await registerServeUrl(site, currentServerUrl)
   }
 
-  async function ensureServeUrls(paths: string[]): Promise<void> {
-    const normalizedPaths = [...new Set(paths.filter(Boolean))]
+  async function ensureServeUrls(inputs: StaticSiteInput[]): Promise<void> {
+    const normalizedSites = [...new Map(
+      inputs
+        .map(input => normalizeSiteConfig(input))
+        .filter(site => !!site.projectPath)
+        .map(site => [buildSiteSignature(site), site]),
+    ).values()]
 
-    if (normalizedPaths.length === 0) {
+    if (normalizedSites.length === 0) {
       return
     }
 
@@ -109,7 +143,7 @@ export const usePreviewRuntimeStore = defineStore('previewRuntime', () => {
     }
 
     await Promise.all(
-      normalizedPaths.map(path => registerServeUrl(path, currentServerUrl)),
+      normalizedSites.map(site => registerServeUrl(site, currentServerUrl)),
     )
   }
 

--- a/src/stores/preview-runtime.ts
+++ b/src/stores/preview-runtime.ts
@@ -4,6 +4,11 @@ import { serverCmds } from '~/commands/server'
 
 import type { StaticSiteConfig } from '~/types/server'
 
+interface RegisteredSite {
+  signature: string
+  serveUrl: string
+}
+
 function buildServeUrl(siteId: string, serverUrl: string): string {
   return new URL(`game/${siteId}/`, serverUrl).href
 }
@@ -17,12 +22,11 @@ function buildSiteSignature(config: StaticSiteConfig): string {
 }
 
 export const usePreviewRuntimeStore = defineStore('previewRuntime', () => {
-  // 非响应式内部状态：服务器 URL 和启动任务无需触发 UI 更新
+  // 服务器 URL 与启动任务保持非响应式：UI 仅消费 serveUrls，避免无谓的依赖追踪
   let serverUrl: string | undefined
   let pendingServerStart: Promise<string | undefined> | undefined
 
-  const serveUrls = reactive(new Map<string, string>())
-  const siteSignatures = reactive(new Map<string, string>())
+  const registeredSites = reactive(new Map<string, RegisteredSite>())
   const pendingRegistrations = new Map<string, Promise<string | undefined>>()
 
   async function ensureServer(): Promise<string | undefined> {
@@ -60,7 +64,7 @@ export const usePreviewRuntimeStore = defineStore('previewRuntime', () => {
       return undefined
     }
 
-    return serveUrls.get(path)
+    return registeredSites.get(path)?.serveUrl
   }
 
   async function registerServeUrl(
@@ -68,9 +72,9 @@ export const usePreviewRuntimeStore = defineStore('previewRuntime', () => {
     currentServerUrl: string,
   ): Promise<string | undefined> {
     const signature = buildSiteSignature(site)
-    const cachedServeUrl = serveUrls.get(site.projectPath)
-    if (cachedServeUrl && siteSignatures.get(site.projectPath) === signature) {
-      return cachedServeUrl
+    const cached = registeredSites.get(site.projectPath)
+    if (cached?.signature === signature) {
+      return cached.serveUrl
     }
 
     const pendingRegistration = pendingRegistrations.get(signature)
@@ -82,8 +86,7 @@ export const usePreviewRuntimeStore = defineStore('previewRuntime', () => {
       try {
         const siteId = await serverCmds.addStaticSite(site)
         const serveUrl = buildServeUrl(siteId, currentServerUrl)
-        serveUrls.set(site.projectPath, serveUrl)
-        siteSignatures.set(site.projectPath, signature)
+        registeredSites.set(site.projectPath, { signature, serveUrl })
         return serveUrl
       } catch (error) {
         logger.error(`注册静态站点失败: ${site.projectPath} - ${error}`)

--- a/src/stores/preview-runtime.ts
+++ b/src/stores/preview-runtime.ts
@@ -8,16 +8,6 @@ function buildServeUrl(siteId: string, serverUrl: string): string {
   return new URL(`game/${siteId}/`, serverUrl).href
 }
 
-type StaticSiteInput = StaticSiteConfig | string
-
-function normalizeSiteConfig(input: StaticSiteInput): StaticSiteConfig {
-  if (typeof input === 'string') {
-    return { projectPath: input }
-  }
-
-  return input
-}
-
 function buildSiteSignature(config: StaticSiteConfig): string {
   return JSON.stringify([
     config.projectPath,
@@ -74,10 +64,9 @@ export const usePreviewRuntimeStore = defineStore('previewRuntime', () => {
   }
 
   async function registerServeUrl(
-    input: StaticSiteInput,
+    site: StaticSiteConfig,
     currentServerUrl: string,
   ): Promise<string | undefined> {
-    const site = normalizeSiteConfig(input)
     const signature = buildSiteSignature(site)
     const cachedServeUrl = serveUrls.get(site.projectPath)
     if (cachedServeUrl && siteSignatures.get(site.projectPath) === signature) {
@@ -111,8 +100,7 @@ export const usePreviewRuntimeStore = defineStore('previewRuntime', () => {
     }
   }
 
-  async function ensureServeUrl(input: StaticSiteInput): Promise<string | undefined> {
-    const site = normalizeSiteConfig(input)
+  async function ensureServeUrl(site: StaticSiteConfig): Promise<string | undefined> {
     if (!site.projectPath) {
       return undefined
     }
@@ -125,15 +113,14 @@ export const usePreviewRuntimeStore = defineStore('previewRuntime', () => {
     return await registerServeUrl(site, currentServerUrl)
   }
 
-  async function ensureServeUrls(inputs: StaticSiteInput[]): Promise<void> {
-    const normalizedSites = [...new Map(
-      inputs
-        .map(input => normalizeSiteConfig(input))
+  async function ensureServeUrls(sites: StaticSiteConfig[]): Promise<void> {
+    const uniqueSites = [...new Map(
+      sites
         .filter(site => !!site.projectPath)
         .map(site => [buildSiteSignature(site), site]),
     ).values()]
 
-    if (normalizedSites.length === 0) {
+    if (uniqueSites.length === 0) {
       return
     }
 
@@ -143,7 +130,7 @@ export const usePreviewRuntimeStore = defineStore('previewRuntime', () => {
     }
 
     await Promise.all(
-      normalizedSites.map(site => registerServeUrl(site, currentServerUrl)),
+      uniqueSites.map(site => registerServeUrl(site, currentServerUrl)),
     )
   }
 

--- a/src/stores/preview-session.ts
+++ b/src/stores/preview-session.ts
@@ -32,7 +32,7 @@ export const usePreviewSessionStore = defineStore('previewSession', () => {
     reloadVersion = 0
 
     try {
-      const previewUrl = await previewRuntimeStore.ensureServeUrl(game.path)
+      const previewUrl = await previewRuntimeStore.ensureServeUrl({ projectPath: game.path })
       if (currentToken !== syncToken) {
         return
       }

--- a/src/types/server.ts
+++ b/src/types/server.ts
@@ -1,0 +1,5 @@
+export interface StaticSiteConfig {
+  projectPath: string
+  enginePath?: string
+  templatePath?: string
+}


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [ ] 错误修复
- [x] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [x] 代码重构
- [x] 测试用例
- [x] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

将预览服务器从“直接暴露项目目录的静态文件服务”重构为基于 VFS overlay 的站点服务。

主要变更包括：
- `add_static_site` 改为接收站点配置对象，支持按站点注入 `projectPath`、`enginePath`、`templatePath`
- 新增 `update_site_engine` 和 `update_site_template` 命令，允许已注册站点在不重启服务的情况下更新 engine/template 绑定
- HTTP 静态资源请求改为通过 `OverlayFs` 解析逻辑路径，再使用真实物理路径返回文件
- 新增请求路径解码与校验逻辑，统一处理首页、百分号编码路径和非法路径访问
- 缩略图生成逻辑改为基于 VFS 解析后的物理文件执行，避免绕过 overlay 规则
- 为 VFS 命令侧增加 canonicalize 缓存，减少频繁构建 overlay 时的重复系统调用
- 前端预览运行时改为基于 `StaticSiteConfig` 注册站点，并使用站点签名避免重复注册
- 更新对应测试，覆盖新的调用方式和部分服务端辅助逻辑

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

当前预览服务器原本只适合直接托管单一目录，无法正确表达项目目录、engine 目录、template 目录之间的覆盖关系，也不便在站点级别动态切换 engine/template 配置。

这会带来两个问题：
- 预览态看到的资源解析结果与编辑器内 VFS 语义不一致
- 当站点配置变化时，缺少低成本、可增量更新的服务端接口

这次调整的目标是让预览服务器和 VFS 解析逻辑对齐，使预览资源访问、缩略图读取、路径安全控制都建立在同一套 overlay 语义上，同时降低热路径上的 canonicalize 开销。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->

- Rust 侧新增 `SiteNotRegistered` 错误码，用于更新未注册站点时返回明确错误
- 静态资源响应继续保留 CORS 和缓存策略控制，并补充了 `Range` 请求头透传
- Debug 模式下增加了慢请求日志，便于排查预览服务性能问题
- 本分支包含 `Cargo.toml` / `Cargo.lock` 的依赖更新，用于支持新的 VFS 路径与文件解析实现

### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [x] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
