### PR TITLE
✨ 编辑器侧接入 VFS 资源浏览与模板感知

### DIFF
--- a/src/components/editor/AssetBreadcrumb.vue
+++ b/src/components/editor/AssetBreadcrumb.vue
@@ -1,33 +1,23 @@
 <script setup lang="ts">
-import { sep } from '@tauri-apps/api/path'
-
-import { gameAssetDir } from '~/services/platform/app-paths'
 import { useWorkspaceStore } from '~/stores/workspace'
+import { joinPath } from '~/utils/path'
 
 const { assetType } = defineProps<{ assetType: string }>()
 
 let currentPath = $(defineModel<string>('current-path', { required: true }))
 
 const workspaceStore = useWorkspaceStore()
-const pathSeparator = sep()
 
-const rootPath = computedAsync(async () => {
+const rootPath = $computed(() => {
   const gamePath = workspaceStore.currentGame?.path
   if (!gamePath) {
     return ''
   }
-  return await gameAssetDir(gamePath, assetType)
-}, '')
-
-function toNativePath(path: string): string {
-  if (!path || pathSeparator === '/') {
-    return path
-  }
-  return path.replaceAll('/', pathSeparator)
-}
+  return joinPath(gamePath, 'game', assetType)
+})
 
 function handleNavigate(path: string) {
-  currentPath = toNativePath(path)
+  currentPath = path
 }
 </script>
 

--- a/src/components/editor/AssetView.spec.ts
+++ b/src/components/editor/AssetView.spec.ts
@@ -20,7 +20,6 @@ const {
   fileSystemEventHandlers,
   fileSystemEventsOnMock,
   fileViewerScrollToIndexMock,
-  gameAssetDirMock,
   getFolderContentsMock,
   handleErrorMock,
   joinMock,
@@ -36,7 +35,6 @@ const {
   fileSystemEventHandlers: new Map<string, ((event: Record<string, unknown>) => void)[]>(),
   fileSystemEventsOnMock: vi.fn(),
   fileViewerScrollToIndexMock: vi.fn(),
-  gameAssetDirMock: vi.fn(),
   getFolderContentsMock: vi.fn(),
   handleErrorMock: vi.fn(),
   joinMock: vi.fn(),
@@ -166,10 +164,6 @@ vi.mock('~/services/game-fs', () => ({
     createFolder: createFolderMock,
     renameFile: renameFileMock,
   },
-}))
-
-vi.mock('~/services/platform/app-paths', () => ({
-  gameAssetDir: gameAssetDirMock,
 }))
 
 vi.mock('~/stores/file', () => ({
@@ -454,7 +448,6 @@ describe('AssetView', () => {
     createFileMock.mockReset()
     createFolderMock.mockReset()
     fileViewerScrollToIndexMock.mockReset()
-    gameAssetDirMock.mockReset()
     getFolderContentsMock.mockReset()
     handleErrorMock.mockReset()
     joinMock.mockReset()
@@ -465,15 +458,15 @@ describe('AssetView', () => {
     useTabsStoreMock.mockReset()
     useWorkspaceStoreMock.mockReset()
 
-    gameAssetDirMock.mockResolvedValue('/games/demo/assets/bg')
     getFolderContentsMock.mockResolvedValue([])
     joinMock.mockImplementation(async (...paths: string[]) => paths.filter(Boolean).join('/'))
-    createFileMock.mockResolvedValue('/project/background/新建文件.json')
-    createFolderMock.mockResolvedValue('/project/background/新建文件夹')
-    renameFileMock.mockResolvedValue('/project/background/hero-renamed.png')
+    createFileMock.mockResolvedValue('/project/game/background/新建文件.json')
+    createFolderMock.mockResolvedValue('/project/game/background/新建文件夹')
+    renameFileMock.mockResolvedValue('/project/game/background/hero-renamed.png')
 
     useFileStoreMock.mockReturnValue({
       getFolderContents: getFolderContentsMock,
+      initialized: Promise.resolve(),
     })
     usePreferenceStoreMock.mockReturnValue(reactive({
       assetViewMode: 'grid',
@@ -529,7 +522,6 @@ describe('AssetView', () => {
   })
 
   it('右键重命名会以 Popover 形式打开并调用 gameFs.renameFile', async () => {
-    gameAssetDirMock.mockResolvedValue('/project/background')
     getFolderContentsMock.mockResolvedValue([
       {
         createdAt: 1,
@@ -537,7 +529,7 @@ describe('AssetView', () => {
         mimeType: 'image/png',
         modifiedAt: 2,
         name: 'hero.png',
-        path: '/project/background/hero.png',
+        path: '/project/game/background/hero.png',
         size: 1024,
       },
     ])
@@ -567,12 +559,11 @@ describe('AssetView', () => {
     await textbox.fill('hero-renamed.png')
     await userEvent.keyboard('{Enter}')
 
-    expect(renameFileMock).toHaveBeenCalledWith('/project/background/hero.png', 'hero-renamed.png')
+    expect(renameFileMock).toHaveBeenCalledWith('/project/game/background/hero.png', 'hero-renamed.png')
     expect(handleErrorMock).not.toHaveBeenCalled()
   })
 
   it('重命名时会高亮当前项并在关闭后取消高亮', async () => {
-    gameAssetDirMock.mockResolvedValue('/project/background')
     getFolderContentsMock.mockResolvedValue([
       {
         createdAt: 1,
@@ -580,7 +571,7 @@ describe('AssetView', () => {
         mimeType: 'image/png',
         modifiedAt: 2,
         name: 'hero.png',
-        path: '/project/background/hero.png',
+        path: '/project/game/background/hero.png',
         size: 1024,
       },
       {
@@ -589,7 +580,7 @@ describe('AssetView', () => {
         mimeType: 'image/png',
         modifiedAt: 3,
         name: 'villain.png',
-        path: '/project/background/villain.png',
+        path: '/project/game/background/villain.png',
         size: 2048,
       },
     ])
@@ -627,7 +618,6 @@ describe('AssetView', () => {
   })
 
   it('网格模式下重命名 Popover 会居中对齐', async () => {
-    gameAssetDirMock.mockResolvedValue('/project/background')
     getFolderContentsMock.mockResolvedValue([
       {
         createdAt: 1,
@@ -635,7 +625,7 @@ describe('AssetView', () => {
         mimeType: 'image/png',
         modifiedAt: 2,
         name: 'hero.png',
-        path: '/project/background/hero.png',
+        path: '/project/game/background/hero.png',
         size: 1024,
       },
     ])
@@ -662,7 +652,6 @@ describe('AssetView', () => {
   })
 
   it('列表模式下重命名 Popover 仍保持左对齐', async () => {
-    gameAssetDirMock.mockResolvedValue('/project/background')
     getFolderContentsMock.mockResolvedValue([
       {
         createdAt: 1,
@@ -670,7 +659,7 @@ describe('AssetView', () => {
         mimeType: 'image/png',
         modifiedAt: 2,
         name: 'hero.png',
-        path: '/project/background/hero.png',
+        path: '/project/game/background/hero.png',
         size: 1024,
       },
     ])
@@ -701,7 +690,6 @@ describe('AssetView', () => {
   })
 
   it('重命名输入框会按内容自动宽度并只保留最大宽度约束', async () => {
-    gameAssetDirMock.mockResolvedValue('/project/background')
     getFolderContentsMock.mockResolvedValue([
       {
         createdAt: 1,
@@ -709,7 +697,7 @@ describe('AssetView', () => {
         mimeType: 'image/png',
         modifiedAt: 2,
         name: 'hero-with-a-very-long-name.png',
-        path: '/project/background/hero-with-a-very-long-name.png',
+        path: '/project/game/background/hero-with-a-very-long-name.png',
         size: 1024,
       },
     ])
@@ -753,7 +741,7 @@ describe('AssetView', () => {
           mimeType: 'image/png',
           modifiedAt: 2,
           name: 'new-file.png',
-          path: '/games/demo/assets/bg/new-file.png',
+          path: '/games/demo/game/bg/new-file.png',
           size: 2048,
         },
       ])
@@ -774,7 +762,7 @@ describe('AssetView', () => {
 
     emitFileSystemEvent('file:created', {
       type: 'file:created',
-      path: '/games/demo/assets/bg/new-file.png',
+      path: '/games/demo/game/bg/new-file.png',
     })
 
     await vi.advanceTimersByTimeAsync(100)
@@ -795,7 +783,7 @@ describe('AssetView', () => {
           mimeType: 'image/png',
           modifiedAt: 2,
           name: 'new-file.png',
-          path: '/games/demo/assets/bg/new-file.png',
+          path: '/games/demo/game/bg/new-file.png',
           size: 2048,
         },
       ])
@@ -815,11 +803,11 @@ describe('AssetView', () => {
 
     emitFileSystemEvent('file:created', {
       type: 'file:created',
-      path: '/games/demo/assets/bg/new-file.png',
+      path: '/games/demo/game/bg/new-file.png',
     })
     emitFileSystemEvent('file:created', {
       type: 'file:created',
-      path: '/games/demo/assets/bgm/ignore-me.png',
+      path: '/games/demo/game/bgm/ignore-me.png',
     })
 
     await vi.advanceTimersByTimeAsync(100)
@@ -847,14 +835,14 @@ describe('AssetView', () => {
 
     emitFileSystemEvent('directory:removed', {
       type: 'directory:removed',
-      path: '/games/demo/assets/bg',
+      path: '/games/demo/game/bg',
     })
 
     await vi.advanceTimersByTimeAsync(100)
     await nextTick()
 
     expect(getFolderContentsMock).toHaveBeenCalledTimes(2)
-    expect(getFolderContentsMock).toHaveBeenLastCalledWith('/games/demo/assets/bg/chapter-1')
+    expect(getFolderContentsMock).toHaveBeenLastCalledWith('/games/demo/game/bg/chapter-1')
   })
 
   it('父目录重命名事件也会触发当前子目录刷新', async () => {
@@ -875,15 +863,15 @@ describe('AssetView', () => {
 
     emitFileSystemEvent('directory:renamed', {
       type: 'directory:renamed',
-      oldPath: '/games/demo/assets/bg',
-      newPath: '/games/demo/assets/bg-renamed',
+      oldPath: '/games/demo/game/bg',
+      newPath: '/games/demo/game/bg-renamed',
     })
 
     await vi.advanceTimersByTimeAsync(100)
     await nextTick()
 
     expect(getFolderContentsMock).toHaveBeenCalledTimes(2)
-    expect(getFolderContentsMock).toHaveBeenLastCalledWith('/games/demo/assets/bg/chapter-1')
+    expect(getFolderContentsMock).toHaveBeenLastCalledWith('/games/demo/game/bg/chapter-1')
   })
 
   it('静默刷新覆盖普通加载后仍会正确清除 loading 状态', async () => {
@@ -903,7 +891,7 @@ describe('AssetView', () => {
           mimeType: 'image/png',
           modifiedAt: 2,
           name: 'new-file.png',
-          path: '/games/demo/assets/bg/new-file.png',
+          path: '/games/demo/game/bg/new-file.png',
           size: 2048,
         },
       ])
@@ -921,7 +909,7 @@ describe('AssetView', () => {
 
     emitFileSystemEvent('file:created', {
       type: 'file:created',
-      path: '/games/demo/assets/bg/new-file.png',
+      path: '/games/demo/game/bg/new-file.png',
     })
 
     await vi.advanceTimersByTimeAsync(100)
@@ -948,7 +936,7 @@ describe('AssetView', () => {
       resolveThirdLoad = resolve
     })
 
-    createFolderMock.mockResolvedValue('/games/demo/assets/bg/new-folder')
+    createFolderMock.mockResolvedValue('/games/demo/game/bg/new-folder')
     getFolderContentsMock
       .mockResolvedValueOnce([])
       .mockReturnValueOnce(secondLoad)
@@ -970,12 +958,11 @@ describe('AssetView', () => {
     await page.getByTestId('create-folder-and-change-path').click()
 
     await vi.waitFor(() => {
-      expect(createFolderMock).toHaveBeenCalledWith('/games/demo/assets/bg', 'edit.fileTree.defaultFolderName')
-      expect(getFolderContentsMock).toHaveBeenCalledTimes(3)
+      expect(createFolderMock).toHaveBeenCalledWith('/games/demo/game/bg', 'edit.fileTree.defaultFolderName')
+      expect(getFolderContentsMock).toHaveBeenCalledTimes(2)
     })
 
-    expect(getFolderContentsMock).toHaveBeenNthCalledWith(2, '/games/demo/assets/bg')
-    expect(getFolderContentsMock).toHaveBeenLastCalledWith('/games/demo/assets/bg/chapter-1')
+    expect(getFolderContentsMock).toHaveBeenLastCalledWith('/games/demo/game/bg/chapter-1')
     await expect.element(page.getByTestId('file-viewer-loading')).toHaveTextContent('true')
 
     resolveSecondLoad?.([])
@@ -985,8 +972,6 @@ describe('AssetView', () => {
   })
 
   it('会为文件视图空白区提供当前目录右键菜单', async () => {
-    gameAssetDirMock.mockResolvedValue('/project/background')
-
     renderInBrowser(createHarness('background'), {
       global: {
         stubs: {
@@ -996,14 +981,12 @@ describe('AssetView', () => {
       },
     })
 
-    await expect.element(page.getByTestId('file-tree-context-menu-root')).toHaveAttribute('data-item-path', '/project/background')
+    await expect.element(page.getByTestId('file-tree-context-menu-root')).toHaveAttribute('data-item-path', '/games/demo/game/background')
     await expect.element(page.getByTestId('file-tree-context-menu-root')).toHaveAttribute('data-item-name', 'background')
     await expect.element(page.getByTestId('file-tree-context-menu-root')).toHaveAttribute('data-is-root', 'true')
   })
 
   it('仅 animation 和 template 目录的右键菜单会显示创建文件入口', async () => {
-    gameAssetDirMock.mockResolvedValue('/project/assets/animation')
-
     renderInBrowser(createHarness('animation'), {
       global: {
         stubs: {
@@ -1016,7 +999,6 @@ describe('AssetView', () => {
     await expect.element(page.getByTestId('create-file-action-animation')).toBeVisible()
 
     document.body.innerHTML = ''
-    gameAssetDirMock.mockResolvedValue('/project/assets/template')
 
     renderInBrowser(createHarness('template'), {
       global: {
@@ -1030,7 +1012,6 @@ describe('AssetView', () => {
     await expect.element(page.getByTestId('create-file-action-template')).toBeVisible()
 
     document.body.innerHTML = ''
-    gameAssetDirMock.mockResolvedValue('/project/assets/background')
 
     renderInBrowser(createHarness('background'), {
       global: {
@@ -1047,8 +1028,7 @@ describe('AssetView', () => {
 
   it('animation 空白区右键菜单新建文件后会创建 .json 文件并打开重命名 Popover', async () => {
     vi.useFakeTimers()
-    gameAssetDirMock.mockResolvedValue('/project/assets/animation')
-    createFileMock.mockResolvedValue('/project/assets/animation/新建文件.json')
+    createFileMock.mockResolvedValue('/project/game/animation/新建文件.json')
     getFolderContentsMock
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce([
@@ -1058,7 +1038,7 @@ describe('AssetView', () => {
           mimeType: 'application/json',
           modifiedAt: 2,
           name: '新建文件.json',
-          path: '/project/assets/animation/新建文件.json',
+          path: '/project/game/animation/新建文件.json',
           size: 0,
         },
       ])
@@ -1083,7 +1063,7 @@ describe('AssetView', () => {
     })
     await page.getByTestId('create-file-action-animation').click()
 
-    expect(createFileMock).toHaveBeenCalledWith('/project/assets/animation', 'edit.fileTree.defaultFileStem.json')
+    expect(createFileMock).toHaveBeenCalledWith('/project/game/animation', 'edit.fileTree.defaultFileStem.json')
 
     await vi.waitFor(() => {
       expect(getFolderContentsMock).toHaveBeenCalledTimes(2)
@@ -1095,8 +1075,6 @@ describe('AssetView', () => {
   })
 
   it('template 空白区右键菜单新建文件时会使用 .scss 默认后缀', async () => {
-    gameAssetDirMock.mockResolvedValue('/project/assets/template')
-
     renderInBrowser(createHarness('template'), {
       global: {
         stubs: {
@@ -1111,12 +1089,11 @@ describe('AssetView', () => {
     })
     await page.getByTestId('create-file-action-template').click()
 
-    expect(createFileMock).toHaveBeenCalledWith('/project/assets/template', 'edit.fileTree.defaultFileStem.scss')
+    expect(createFileMock).toHaveBeenCalledWith('/games/demo/game/template', 'edit.fileTree.defaultFileStem.scss')
   })
 
   it('空白区右键菜单新建文件夹后会创建目录并打开重命名 Popover', async () => {
     vi.useFakeTimers()
-    gameAssetDirMock.mockResolvedValue('/project/background')
     getFolderContentsMock
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce([
@@ -1125,7 +1102,7 @@ describe('AssetView', () => {
           isDir: true,
           modifiedAt: 2,
           name: '新建文件夹',
-          path: '/project/background/新建文件夹',
+          path: '/project/game/background/新建文件夹',
           size: 0,
         },
       ])
@@ -1150,7 +1127,7 @@ describe('AssetView', () => {
     })
     await page.getByTestId('create-folder-action-background').click()
 
-    expect(createFolderMock).toHaveBeenCalledWith('/project/background', 'edit.fileTree.defaultFolderName')
+    expect(createFolderMock).toHaveBeenCalledWith('/project/game/background', 'edit.fileTree.defaultFolderName')
 
     await vi.waitFor(() => {
       expect(getFolderContentsMock).toHaveBeenCalledTimes(2)
@@ -1163,10 +1140,8 @@ describe('AssetView', () => {
 
   it('创建文件夹后如果已切换目录，则不会继续打开旧目录的重命名 Popover', async () => {
     vi.useFakeTimers()
-    gameAssetDirMock.mockResolvedValue('/project/background')
-    createFolderMock.mockResolvedValue('/project/background/新建文件夹')
+    createFolderMock.mockResolvedValue('/project/game/background/新建文件夹')
     getFolderContentsMock
-      .mockResolvedValueOnce([])
       .mockResolvedValueOnce([])
       .mockResolvedValueOnce([])
     useWorkspaceStoreMock.mockReturnValue(reactive({
@@ -1192,8 +1167,8 @@ describe('AssetView', () => {
     await page.getByTestId('create-folder-and-change-path').click()
 
     await vi.waitFor(() => {
-      expect(createFolderMock).toHaveBeenCalledWith('/project/background', 'edit.fileTree.defaultFolderName')
-      expect(getFolderContentsMock).toHaveBeenCalledTimes(3)
+      expect(createFolderMock).toHaveBeenCalledWith('/project/game/background', 'edit.fileTree.defaultFolderName')
+      expect(getFolderContentsMock).toHaveBeenCalledTimes(2)
     })
 
     await vi.advanceTimersByTimeAsync(1000)
@@ -1204,7 +1179,6 @@ describe('AssetView', () => {
 
   it('搜索结果中隐藏新建目录时仍会打开重命名 Popover', async () => {
     vi.useFakeTimers()
-    gameAssetDirMock.mockResolvedValue('/project/background')
     getFolderContentsMock
       .mockResolvedValueOnce([
         {
@@ -1213,7 +1187,7 @@ describe('AssetView', () => {
           mimeType: 'image/png',
           modifiedAt: 2,
           name: 'hero.png',
-          path: '/project/background/hero.png',
+          path: '/project/game/background/hero.png',
           size: 1024,
         },
       ])
@@ -1223,7 +1197,7 @@ describe('AssetView', () => {
           isDir: true,
           modifiedAt: 2,
           name: '新建文件夹',
-          path: '/project/background/新建文件夹',
+          path: '/project/game/background/新建文件夹',
           size: 0,
         },
         {
@@ -1232,7 +1206,7 @@ describe('AssetView', () => {
           mimeType: 'image/png',
           modifiedAt: 2,
           name: 'hero.png',
-          path: '/project/background/hero.png',
+          path: '/project/game/background/hero.png',
           size: 1024,
         },
       ])
@@ -1268,7 +1242,6 @@ describe('AssetView', () => {
 
   it('大型虚拟列表中新建文件夹时会先滚动到目标项再打开重命名 Popover', async () => {
     vi.useFakeTimers()
-    gameAssetDirMock.mockResolvedValue('/project/background')
     getFolderContentsMock
       .mockResolvedValueOnce([
         {
@@ -1277,7 +1250,7 @@ describe('AssetView', () => {
           mimeType: 'image/png',
           modifiedAt: 2,
           name: 'hero-1.png',
-          path: '/project/background/hero-1.png',
+          path: '/project/game/background/hero-1.png',
           size: 1024,
         },
         {
@@ -1286,7 +1259,7 @@ describe('AssetView', () => {
           mimeType: 'image/png',
           modifiedAt: 3,
           name: 'hero-2.png',
-          path: '/project/background/hero-2.png',
+          path: '/project/game/background/hero-2.png',
           size: 1024,
         },
         {
@@ -1295,7 +1268,7 @@ describe('AssetView', () => {
           mimeType: 'image/png',
           modifiedAt: 4,
           name: 'hero-3.png',
-          path: '/project/background/hero-3.png',
+          path: '/project/game/background/hero-3.png',
           size: 1024,
         },
         {
@@ -1304,7 +1277,7 @@ describe('AssetView', () => {
           mimeType: 'image/png',
           modifiedAt: 5,
           name: 'hero-4.png',
-          path: '/project/background/hero-4.png',
+          path: '/project/game/background/hero-4.png',
           size: 1024,
         },
       ])
@@ -1314,7 +1287,7 @@ describe('AssetView', () => {
           isDir: true,
           modifiedAt: 2,
           name: '新建文件夹',
-          path: '/project/background/新建文件夹',
+          path: '/project/game/background/新建文件夹',
           size: 0,
         },
         {
@@ -1323,7 +1296,7 @@ describe('AssetView', () => {
           mimeType: 'image/png',
           modifiedAt: 2,
           name: 'hero-1.png',
-          path: '/project/background/hero-1.png',
+          path: '/project/game/background/hero-1.png',
           size: 1024,
         },
         {
@@ -1332,7 +1305,7 @@ describe('AssetView', () => {
           mimeType: 'image/png',
           modifiedAt: 3,
           name: 'hero-2.png',
-          path: '/project/background/hero-2.png',
+          path: '/project/game/background/hero-2.png',
           size: 1024,
         },
         {
@@ -1341,7 +1314,7 @@ describe('AssetView', () => {
           mimeType: 'image/png',
           modifiedAt: 4,
           name: 'hero-3.png',
-          path: '/project/background/hero-3.png',
+          path: '/project/game/background/hero-3.png',
           size: 1024,
         },
         {
@@ -1350,7 +1323,7 @@ describe('AssetView', () => {
           mimeType: 'image/png',
           modifiedAt: 5,
           name: 'hero-4.png',
-          path: '/project/background/hero-4.png',
+          path: '/project/game/background/hero-4.png',
           size: 1024,
         },
       ])
@@ -1386,14 +1359,13 @@ describe('AssetView', () => {
   })
 
   it('当前目录已有默认文件夹名时会自动追加序号再创建', async () => {
-    gameAssetDirMock.mockResolvedValue('/project/background')
     getFolderContentsMock.mockResolvedValue([
       {
         createdAt: 1,
         isDir: true,
         modifiedAt: 2,
         name: 'edit.fileTree.defaultFolderName',
-        path: '/project/background/edit.fileTree.defaultFolderName',
+        path: '/games/demo/game/background/edit.fileTree.defaultFolderName',
         size: 0,
       },
     ])
@@ -1412,6 +1384,6 @@ describe('AssetView', () => {
     })
     await page.getByTestId('create-folder-action-background').click()
 
-    expect(createFolderMock).toHaveBeenCalledWith('/project/background', 'edit.fileTree.defaultFolderName 2')
+    expect(createFolderMock).toHaveBeenCalledWith('/games/demo/game/background', 'edit.fileTree.defaultFolderName 2')
   })
 })

--- a/src/components/editor/AssetView.spec.ts
+++ b/src/components/editor/AssetView.spec.ts
@@ -466,6 +466,7 @@ describe('AssetView', () => {
 
     useFileStoreMock.mockReturnValue({
       getFolderContents: getFolderContentsMock,
+      getItemByPath: () => undefined,
       initialized: Promise.resolve(),
     })
     usePreferenceStoreMock.mockReturnValue(reactive({

--- a/src/components/editor/AssetView.vue
+++ b/src/components/editor/AssetView.vue
@@ -171,6 +171,7 @@ const currentDirectoryContextMenuItem = $computed(() => {
     isDir: true,
     name: directoryName,
     path: directoryPath,
+    source: fileStore.getItemByPath(directoryPath)?.source,
   }
 })
 

--- a/src/components/editor/AssetView.vue
+++ b/src/components/editor/AssetView.vue
@@ -14,7 +14,7 @@ import { useTabsStore } from '~/stores/tabs'
 import { useWorkspaceStore } from '~/stores/workspace'
 import { FileViewerItem, FileViewerSortBy, FileViewerSortOrder } from '~/types/file-viewer'
 import { handleError } from '~/utils/error-handler'
-import { getBaseName, joinPath } from '~/utils/path'
+import { getBaseName, joinPath, normalizeFsPath } from '~/utils/path'
 
 import type { FileSystemEvent } from '~/composables/useFileSystemEvents'
 
@@ -218,15 +218,9 @@ function toFileViewerItem(item: FileSystemItem): FileViewerItem {
   }
 }
 
-function normalizeFileSystemPath(path: string): string {
-  return path
-    .replaceAll('\\', '/')
-    .replace(/\/+$/, '')
-}
-
 function isPathWithinDirectory(path: string, directoryPath: string): boolean {
-  const normalizedPath = normalizeFileSystemPath(path)
-  const normalizedDirectoryPath = normalizeFileSystemPath(directoryPath)
+  const normalizedPath = normalizeFsPath(path)
+  const normalizedDirectoryPath = normalizeFsPath(directoryPath)
 
   return normalizedPath === normalizedDirectoryPath
     || normalizedPath.startsWith(`${normalizedDirectoryPath}/`)
@@ -280,7 +274,7 @@ function handleNavigate(item: FileViewerItem): void {
     return
   }
 
-  currentPath = item.path.replace(normalizeFileSystemPath(basePath), '')
+  currentPath = normalizeFsPath(item.path).replace(normalizeFsPath(basePath), '')
 }
 
 function handleSelect(item: FileViewerItem): void {

--- a/src/components/editor/AssetView.vue
+++ b/src/components/editor/AssetView.vue
@@ -277,9 +277,13 @@ function handleNavigate(item: FileViewerItem): void {
 
   const normalizedItem = normalizeFsPath(item.path)
   const normalizedBase = normalizeFsPath(basePath)
-  currentPath = normalizedItem.startsWith(normalizedBase)
-    ? normalizedItem.slice(normalizedBase.length)
-    : normalizedItem
+  if (normalizedItem === normalizedBase) {
+    currentPath = ''
+  } else if (normalizedItem.startsWith(`${normalizedBase}/`)) {
+    currentPath = normalizedItem.slice(normalizedBase.length + 1)
+  } else {
+    currentPath = normalizedItem
+  }
 }
 
 function handleSelect(item: FileViewerItem): void {

--- a/src/components/editor/AssetView.vue
+++ b/src/components/editor/AssetView.vue
@@ -274,7 +274,11 @@ function handleNavigate(item: FileViewerItem): void {
     return
   }
 
-  currentPath = normalizeFsPath(item.path).replace(normalizeFsPath(basePath), '')
+  const normalizedItem = normalizeFsPath(item.path)
+  const normalizedBase = normalizeFsPath(basePath)
+  currentPath = normalizedItem.startsWith(normalizedBase)
+    ? normalizedItem.slice(normalizedBase.length)
+    : normalizedItem
 }
 
 function handleSelect(item: FileViewerItem): void {

--- a/src/components/editor/AssetView.vue
+++ b/src/components/editor/AssetView.vue
@@ -281,8 +281,6 @@ function handleNavigate(item: FileViewerItem): void {
     currentPath = ''
   } else if (normalizedItem.startsWith(`${normalizedBase}/`)) {
     currentPath = normalizedItem.slice(normalizedBase.length + 1)
-  } else {
-    currentPath = normalizedItem
   }
 }
 

--- a/src/components/editor/AssetView.vue
+++ b/src/components/editor/AssetView.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { File, FileImage, FileJson2, FileMusic, FileVideo, FileVolume, Folder } from '@lucide/vue'
-import { basename, join } from '@tauri-apps/api/path'
 
 import { canCreateAssetFile, resolveAssetFileNameParts } from '~/components/editor/asset-file-defaults'
 import { useAssetViewItemsLoader } from '~/components/editor/useAssetViewItemsLoader'
@@ -8,7 +7,6 @@ import { PopoverAnchor } from '~/components/ui/popover'
 import { useFileSystemEvents } from '~/composables/useFileSystemEvents'
 import { getFileTreeNameSelectionEnd, resolveFileTreeDefaultFileDraft } from '~/features/editor/file-tree/file-tree'
 import { gameFs } from '~/services/game-fs'
-import { gameAssetDir } from '~/services/platform/app-paths'
 import { FileSystemItem, useFileStore } from '~/stores/file'
 import { usePreferenceStore } from '~/stores/preference'
 import { usePreviewSessionStore } from '~/stores/preview-session'
@@ -16,6 +14,7 @@ import { useTabsStore } from '~/stores/tabs'
 import { useWorkspaceStore } from '~/stores/workspace'
 import { FileViewerItem, FileViewerSortBy, FileViewerSortOrder } from '~/types/file-viewer'
 import { handleError } from '~/utils/error-handler'
+import { getBaseName, joinPath } from '~/utils/path'
 
 import type { FileSystemEvent } from '~/composables/useFileSystemEvents'
 
@@ -112,22 +111,21 @@ onActivated(() => {
   fileViewerRef.value?.viewport?.scrollTo({ top: scrollTop })
 })
 
-const assetBasePath = computedAsync(async () => {
+const assetBasePath = $computed(() => {
   if (!workspaceStore.currentGame?.path) {
     return ''
   }
 
-  return await gameAssetDir(workspaceStore.currentGame.path, assetType)
-}, '')
+  return joinPath(workspaceStore.currentGame.path, 'game', assetType)
+})
 
-const currentDirectoryPath = computedAsync(async () => {
-  const basePath = assetBasePath.value
-  if (!basePath) {
+const currentDirectoryPath = $computed(() => {
+  if (!assetBasePath) {
     return ''
   }
 
-  return await join(basePath, currentPath)
-}, '')
+  return currentPath ? joinPath(assetBasePath, currentPath) : assetBasePath
+})
 
 const {
   errorMsg: errorMsgRef,
@@ -135,10 +133,13 @@ const {
   items: itemsRef,
   scheduleItemsRefresh,
 } = useAssetViewItemsLoader({
-  assetBasePath,
-  currentDirectoryPath,
+  assetBasePath: () => assetBasePath,
+  currentDirectoryPath: () => currentDirectoryPath,
   currentPath: () => currentPath,
-  loadDirectory: directoryPath => fileStore.getFolderContents(directoryPath),
+  loadDirectory: async (directoryPath) => {
+    await fileStore.initialized
+    return fileStore.getFolderContents(directoryPath)
+  },
   mapItem: toFileViewerItem,
 })
 
@@ -157,7 +158,7 @@ const filteredItems = $computed(() => {
 const canCreateFileInCurrentDirectory = $computed(() => canCreateAssetFile(assetType))
 
 const currentDirectoryContextMenuItem = $computed(() => {
-  const directoryPath = currentDirectoryPath.value
+  const directoryPath = currentDirectoryPath
   if (!directoryPath) {
     return
   }
@@ -193,12 +194,7 @@ const isRenameDuplicate = $computed(() => {
   )
 })
 
-watch(() => currentPath, () => {
-  fileViewerRef.value?.scrollToIndex(0)
-  closeRenamePopover()
-})
-
-watch(() => searchQuery, () => {
+watch([() => currentPath, () => searchQuery], () => {
   fileViewerRef.value?.scrollToIndex(0)
   closeRenamePopover()
 })
@@ -218,6 +214,7 @@ function toFileViewerItem(item: FileSystemItem): FileViewerItem {
     size: item.size,
     modifiedAt: item.modifiedAt,
     createdAt: item.createdAt,
+    source: item.source,
   }
 }
 
@@ -236,7 +233,7 @@ function isPathWithinDirectory(path: string, directoryPath: string): boolean {
 }
 
 function isFileSystemEventRelevant(event: FileSystemEvent): boolean {
-  const directoryPath = currentDirectoryPath.value
+  const directoryPath = currentDirectoryPath
   if (!directoryPath) {
     return false
   }
@@ -277,13 +274,13 @@ function getIconComponent(item: FileViewerItem) {
 }
 
 function handleNavigate(item: FileViewerItem): void {
-  const basePath = assetBasePath.value
+  const basePath = assetBasePath
   if (!basePath) {
     currentPath = ''
     return
   }
 
-  currentPath = item.path.replace(basePath, '')
+  currentPath = item.path.replace(normalizeFileSystemPath(basePath), '')
 }
 
 function handleSelect(item: FileViewerItem): void {
@@ -331,7 +328,7 @@ function isItemVisibleInCurrentFilter(path: string): boolean {
 }
 
 function isCurrentDirectorySnapshotActive(directoryPathSnapshot: string | undefined): boolean {
-  return !!directoryPathSnapshot && currentDirectoryPath.value === directoryPathSnapshot
+  return !!directoryPathSnapshot && currentDirectoryPath === directoryPathSnapshot
 }
 
 async function resolveRenameAnchor(
@@ -517,11 +514,11 @@ async function handleContextMenuCreateItem(
     return
   }
 
-  const currentDirectorySnapshot = currentDirectoryPath.value || item.path
+  const currentDirectorySnapshot = currentDirectoryPath || item.path
 
   try {
     const createdPath = await options.create(item.path, options.name)
-    const createdName = await basename(createdPath)
+    const createdName = getBaseName(createdPath)
 
     scheduleItemsRefresh(true)
 

--- a/src/components/editor/EditorStatusBar.spec.ts
+++ b/src/components/editor/EditorStatusBar.spec.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { page } from 'vitest/browser'
 
 import { createBrowserLocalizedI18n } from '~/__tests__/browser'
-import { createBrowserClickStub, renderInBrowser } from '~/__tests__/browser-render'
+import { renderInBrowser } from '~/__tests__/browser-render'
 
 const {
   dayjsMock,

--- a/src/components/editor/EditorStatusBar.spec.ts
+++ b/src/components/editor/EditorStatusBar.spec.ts
@@ -1,20 +1,27 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { page } from 'vitest/browser'
-import { reactive } from 'vue'
 
 import { createBrowserLocalizedI18n } from '~/__tests__/browser'
-import { renderInBrowser } from '~/__tests__/browser-render'
+import { createBrowserClickStub, renderInBrowser } from '~/__tests__/browser-render'
 
 const {
   dayjsMock,
+  dbEngineGetMock,
+  dbEngineWhereFirstMock,
   getImageDimensionsMock,
   getLanguageDisplayNameMock,
+  readProjectConfigMock,
   useEditorStoreMock,
+  useWorkspaceStoreMock,
 } = vi.hoisted(() => ({
   dayjsMock: vi.fn(),
+  dbEngineGetMock: vi.fn(),
+  dbEngineWhereFirstMock: vi.fn(),
   getImageDimensionsMock: vi.fn(),
   getLanguageDisplayNameMock: vi.fn(),
+  readProjectConfigMock: vi.fn(),
   useEditorStoreMock: vi.fn(),
+  useWorkspaceStoreMock: vi.fn(),
 }))
 
 vi.mock('~/stores/editor', () => ({
@@ -32,12 +39,48 @@ vi.mock('~/commands/fs', () => ({
   },
 }))
 
+vi.mock('~/database/db', () => ({
+  db: {
+    engines: {
+      get: dbEngineGetMock,
+      where: () => ({
+        equals: () => ({
+          first: dbEngineWhereFirstMock,
+        }),
+      }),
+    },
+  },
+}))
+
+vi.mock('~/commands/project-config', () => ({
+  projectConfigCmds: {
+    readProjectConfig: readProjectConfigMock,
+  },
+}))
+
+vi.mock('~/composables/useFileSystemEvents', () => ({
+  useFileSystemEvents: () => ({
+    emit: vi.fn(),
+    on: vi.fn(() => () => undefined),
+    reset: vi.fn(),
+  }),
+}))
+
 vi.mock('~/plugins/dayjs', () => ({
   default: dayjsMock,
+  setDayjsLocale: vi.fn(),
 }))
 
 vi.mock('~/plugins/editor', () => ({
   getLanguageDisplayName: getLanguageDisplayNameMock,
+}))
+
+vi.mock('~/stores/workspace', () => ({
+  useWorkspaceStore: useWorkspaceStoreMock,
+}))
+
+vi.mock('~/utils/error-handler', () => ({
+  handleError: vi.fn(),
 }))
 
 import EditorStatusBar from './EditorStatusBar.vue'
@@ -84,20 +127,25 @@ function createEditorStore() {
 }
 
 describe('EditorStatusBar', () => {
-  afterEach(() => {
-    vi.clearAllMocks()
-  })
-
   beforeEach(() => {
-    dayjsMock.mockReset()
-    getImageDimensionsMock.mockReset()
-    getLanguageDisplayNameMock.mockReset()
-    useEditorStoreMock.mockReset()
+    vi.resetAllMocks()
 
     dayjsMock.mockReturnValue({
       fromNow: () => 'just now',
     })
+    dbEngineGetMock.mockResolvedValue({
+      id: 'engine-1',
+      path: '/engines/webgal',
+    })
+    dbEngineWhereFirstMock.mockResolvedValue(undefined)
+    readProjectConfigMock.mockResolvedValue({ version: 1 })
     getLanguageDisplayNameMock.mockReturnValue('Markdown')
+    useWorkspaceStoreMock.mockReturnValue(reactive({
+      currentGame: {
+        id: 'game-1',
+        path: '/games/demo',
+      },
+    }))
   })
 
   it('会显示文本编辑器的保存状态、语言与行词统计', async () => {

--- a/src/components/editor/EditorStatusBar.vue
+++ b/src/components/editor/EditorStatusBar.vue
@@ -41,6 +41,10 @@ watch(() => workspaceStore.currentGame?.engineId, async (engineId) => {
     return
   }
   const engine = await db.engines.get(engineId)
+  // 异步过程中引擎可能切换，丢弃过时结果
+  if (workspaceStore.currentGame?.engineId !== engineId) {
+    return
+  }
   engineLabel = engine ? formatEngineLabel(engine) : undefined
 }, { immediate: true })
 

--- a/src/components/editor/EditorStatusBar.vue
+++ b/src/components/editor/EditorStatusBar.vue
@@ -2,8 +2,7 @@
 import { ChartSpline, FileText, Image as ImageIcon, Layers, Link2, Palette } from '@lucide/vue'
 
 import { fsCmds } from '~/commands/fs'
-import { projectConfigCmds } from '~/commands/project-config'
-import { useFileSystemEvents } from '~/composables/useFileSystemEvents'
+import { useTemplateLabel } from '~/composables/useTemplateLabel'
 import { db } from '~/database/db'
 import {
   calculateEditorStatusBarTextStats,
@@ -59,87 +58,7 @@ function openSwitchTemplate() {
   }
 }
 
-let templateLabel = $ref<string>()
-let isFollowingEngine = $ref(false)
-
-async function refreshTemplateLabel(gamePath: string | undefined) {
-  if (!gamePath) {
-    templateLabel = undefined
-    isFollowingEngine = false
-    return
-  }
-
-  try {
-    const config = await projectConfigCmds.readProjectConfig(gamePath)
-    if (workspaceStore.currentGame?.path !== gamePath) {
-      return
-    }
-
-    const binding = config.template
-
-    if (binding?.kind === 'standalone') {
-      templateLabel = binding.name
-      isFollowingEngine = false
-      return
-    }
-
-    if (binding?.kind === 'engineBuiltin') {
-      const engine = binding.engine.version === undefined
-        ? undefined
-        : await db.engines
-            .where('[engineId+version]')
-            .equals([binding.engine.id, binding.engine.version])
-            .first()
-      if (workspaceStore.currentGame?.path !== gamePath) {
-        return
-      }
-      templateLabel = engine
-        ? formatEngineLabel(engine)
-        : (binding.engine.version
-            ? `${binding.engine.id} ${binding.engine.version}`
-            : binding.engine.id)
-      isFollowingEngine = false
-      return
-    }
-
-    // 缺省 → 跟随当前引擎
-    const engineId = workspaceStore.currentGame?.engineId
-    const engine = engineId ? await db.engines.get(engineId) : undefined
-    if (workspaceStore.currentGame?.path !== gamePath) {
-      return
-    }
-    templateLabel = engine ? formatEngineLabel(engine) : undefined
-    isFollowingEngine = templateLabel !== undefined
-  } catch (error) {
-    handleError(error, { silent: true })
-    templateLabel = undefined
-    isFollowingEngine = false
-  }
-}
-
-watch(() => workspaceStore.currentGame?.path, (path) => {
-  refreshTemplateLabel(path)
-}, { immediate: true })
-
-watch(() => workspaceStore.currentGame?.engineId, () => {
-  // 引擎切换会改变 followEngine / engineBuiltin 的解析结果
-  refreshTemplateLabel(workspaceStore.currentGame?.path)
-})
-
-// 模板切换通过 directory:modified 事件广播
-const fileSystemEvents = useFileSystemEvents()
-const stopTemplateChangeListener = fileSystemEvents.on('directory:modified', (event) => {
-  const gamePath = workspaceStore.currentGame?.path
-  if (!gamePath) {
-    return
-  }
-  const normalizedEvent = event.path.replaceAll('\\', '/')
-  const normalizedRoot = `${gamePath.replaceAll('\\', '/')}/game/template`
-  if (normalizedEvent === normalizedRoot || normalizedEvent.startsWith(`${normalizedRoot}/`)) {
-    refreshTemplateLabel(gamePath)
-  }
-})
-onScopeDispose(stopTemplateChangeListener)
+const { label: templateLabel, followingEngine: isFollowingEngine } = useTemplateLabel()
 
 const editableState = $computed(() =>
   currentState && isEditableEditor(currentState) ? currentState : undefined,

--- a/src/components/editor/EditorStatusBar.vue
+++ b/src/components/editor/EditorStatusBar.vue
@@ -40,6 +40,8 @@ watch(() => workspaceStore.currentGame?.engineId, async (engineId) => {
     engineLabel = undefined
     return
   }
+  // 切换 engineId 时立即清空，避免显示旧引擎名
+  engineLabel = undefined
   const engine = await db.engines.get(engineId)
   // 异步过程中引擎可能切换，丢弃过时结果
   if (workspaceStore.currentGame?.engineId !== engineId) {
@@ -161,12 +163,12 @@ watchDebounced(() => textContent, updateStats, { debounce: 500, maxWait: 1000 })
   <div class="text-xs px-3 border-t bg-gray-50 flex h-6 items-center dark:bg-gray-900">
     <div class="flex gap-3 min-w-0 items-center">
       <button
-        v-if="isEngineBound && engineLabel"
+        v-if="isEngineBound"
         class="text-muted-foreground flex gap-1 cursor-pointer transition-colors items-center hover:text-foreground"
         @click="openSwitchEngine"
       >
         <Layers class="h-3 w-3" :stroke-width="1.5" />
-        <span class="max-w-30 truncate">{{ engineLabel }}</span>
+        <span class="max-w-30 truncate">{{ engineLabel ?? $t('edit.statusBar.engineMissing') }}</span>
       </button>
 
       <button

--- a/src/components/editor/EditorStatusBar.vue
+++ b/src/components/editor/EditorStatusBar.vue
@@ -1,7 +1,10 @@
 <script setup lang="ts">
-import { ChartSpline, FileText, Image as ImageIcon } from '@lucide/vue'
+import { ChartSpline, FileText, Image as ImageIcon, Layers, Link2, Palette } from '@lucide/vue'
 
 import { fsCmds } from '~/commands/fs'
+import { projectConfigCmds } from '~/commands/project-config'
+import { useFileSystemEvents } from '~/composables/useFileSystemEvents'
+import { db } from '~/database/db'
 import {
   calculateEditorStatusBarTextStats,
   isEditorStatusBarImagePreview,
@@ -10,20 +13,134 @@ import {
   resolveEditorStatusBarMetrics,
   shouldShowEditorStatusBarRelativeTime,
 } from '~/features/editor/status-bar/editor-status-bar'
+import { formatEngineLabel } from '~/lib/engine-label'
 import dayjs from '~/plugins/dayjs'
 import { getLanguageDisplayName } from '~/plugins/editor'
 import {
   isEditableEditor,
   useEditorStore,
 } from '~/stores/editor'
+import { useModalStore } from '~/stores/modal'
+import { useWorkspaceStore } from '~/stores/workspace'
 import { handleError } from '~/utils/error-handler'
 import { formatFileSize } from '~/utils/format'
 
 const { t, locale } = useI18n()
 
 const editorStore = useEditorStore()
+const workspaceStore = useWorkspaceStore()
+const modalStore = useModalStore()
 
 const currentState = $computed(() => editorStore.currentState)
+
+const isEngineBound = $computed(() => !!workspaceStore.currentGame?.engineId)
+
+let engineLabel = $ref<string>()
+watch(() => workspaceStore.currentGame?.engineId, async (engineId) => {
+  if (!engineId) {
+    engineLabel = undefined
+    return
+  }
+  const engine = await db.engines.get(engineId)
+  engineLabel = engine ? formatEngineLabel(engine) : undefined
+}, { immediate: true })
+
+function openSwitchEngine() {
+  const game = workspaceStore.currentGame
+  if (game) {
+    modalStore.open('SwitchEngineModal', { game })
+  }
+}
+
+function openSwitchTemplate() {
+  const game = workspaceStore.currentGame
+  if (game) {
+    modalStore.open('SwitchTemplateModal', { game })
+  }
+}
+
+let templateLabel = $ref<string>()
+let isFollowingEngine = $ref(false)
+
+async function refreshTemplateLabel(gamePath: string | undefined) {
+  if (!gamePath) {
+    templateLabel = undefined
+    isFollowingEngine = false
+    return
+  }
+
+  try {
+    const config = await projectConfigCmds.readProjectConfig(gamePath)
+    if (workspaceStore.currentGame?.path !== gamePath) {
+      return
+    }
+
+    const binding = config.template
+
+    if (binding?.kind === 'standalone') {
+      templateLabel = binding.name
+      isFollowingEngine = false
+      return
+    }
+
+    if (binding?.kind === 'engineBuiltin') {
+      const engine = binding.engine.version === undefined
+        ? undefined
+        : await db.engines
+            .where('[engineId+version]')
+            .equals([binding.engine.id, binding.engine.version])
+            .first()
+      if (workspaceStore.currentGame?.path !== gamePath) {
+        return
+      }
+      templateLabel = engine
+        ? formatEngineLabel(engine)
+        : (binding.engine.version
+            ? `${binding.engine.id} ${binding.engine.version}`
+            : binding.engine.id)
+      isFollowingEngine = false
+      return
+    }
+
+    // 缺省 → 跟随当前引擎
+    const engineId = workspaceStore.currentGame?.engineId
+    const engine = engineId ? await db.engines.get(engineId) : undefined
+    if (workspaceStore.currentGame?.path !== gamePath) {
+      return
+    }
+    templateLabel = engine ? formatEngineLabel(engine) : undefined
+    isFollowingEngine = templateLabel !== undefined
+  } catch (error) {
+    handleError(error, { silent: true })
+    templateLabel = undefined
+    isFollowingEngine = false
+  }
+}
+
+watch(() => workspaceStore.currentGame?.path, (path) => {
+  refreshTemplateLabel(path)
+}, { immediate: true })
+
+watch(() => workspaceStore.currentGame?.engineId, () => {
+  // 引擎切换会改变 followEngine / engineBuiltin 的解析结果
+  refreshTemplateLabel(workspaceStore.currentGame?.path)
+})
+
+// 模板切换通过 directory:modified 事件广播
+const fileSystemEvents = useFileSystemEvents()
+const stopTemplateChangeListener = fileSystemEvents.on('directory:modified', (event) => {
+  const gamePath = workspaceStore.currentGame?.path
+  if (!gamePath) {
+    return
+  }
+  const normalizedEvent = event.path.replaceAll('\\', '/')
+  const normalizedRoot = `${gamePath.replaceAll('\\', '/')}/game/template`
+  if (normalizedEvent === normalizedRoot || normalizedEvent.startsWith(`${normalizedRoot}/`)) {
+    refreshTemplateLabel(gamePath)
+  }
+})
+onScopeDispose(stopTemplateChangeListener)
+
 const editableState = $computed(() =>
   currentState && isEditableEditor(currentState) ? currentState : undefined,
 )
@@ -60,11 +177,8 @@ watch(() => previewState?.path, async (path) => {
 
 // 是否已保存
 const isSaved = $computed(() => isEditorStatusBarSaved(editableState))
-
-// 上次保存时间
 const lastSavedTime = $computed(() => editableState?.lastSavedTime)
 
-// 相对时间显示
 const shouldShowTime = $computed(() => shouldShowEditorStatusBarRelativeTime(isSaved, lastSavedTime))
 const { now, pause, resume } = useNow({
   interval: 30 * 1000,
@@ -89,14 +203,13 @@ const relativeTime = $computed(() => {
 })
 
 // 文件语言显示
-const fileLanguage = $computed(() => {
-  return resolveEditorStatusBarFileLanguage(editableState, {
+const fileLanguage = $computed(() =>
+  resolveEditorStatusBarFileLanguage(editableState, {
     getLanguageDisplayName,
     t,
-  })
-})
+  }),
+)
 
-// 文本内容（用于统计）
 const textContent = $computed(() => editableState?.projection === 'text' ? editableState.textContent : '')
 
 let wordCount = $ref(0)
@@ -116,17 +229,36 @@ function updateStats() {
   lineCount = nextStats.lineCount
 }
 
-// 切换文件或编辑模式时立即计算
+// 切换文件或编辑模式时立即计算；同一文件内编辑时防抖计算
 watch(() => [currentState?.path, editableState?.projection], updateStats, { immediate: true })
-
-// 同一文件内编辑时防抖计算
 watchDebounced(() => textContent, updateStats, { debounce: 500, maxWait: 1000 })
 </script>
 
 <template>
   <div class="text-xs px-3 border-t bg-gray-50 flex h-6 items-center dark:bg-gray-900">
-    <!-- 左侧：应用级信息（引擎版本等，暂留空，后续扩展） -->
-    <div class="flex gap-3 items-center" />
+    <div class="flex gap-3 min-w-0 items-center">
+      <button
+        v-if="isEngineBound && engineLabel"
+        class="text-muted-foreground flex gap-1 cursor-pointer transition-colors items-center hover:text-foreground"
+        @click="openSwitchEngine"
+      >
+        <Layers class="h-3 w-3" :stroke-width="1.5" />
+        <span class="max-w-30 truncate">{{ engineLabel }}</span>
+      </button>
+
+      <button
+        v-if="isEngineBound && templateLabel"
+        class="text-muted-foreground flex gap-1 cursor-pointer transition-colors items-center hover:text-foreground"
+        :title="isFollowingEngine
+          ? $t('edit.statusBar.templateFollowing')
+          : $t('edit.statusBar.template')"
+        @click="openSwitchTemplate"
+      >
+        <Palette class="h-3 w-3" :stroke-width="1.5" />
+        <span class="max-w-30 truncate">{{ templateLabel }}</span>
+        <Link2 v-if="isFollowingEngine" class="h-3 w-3" :stroke-width="1.5" />
+      </button>
+    </div>
 
     <!-- 右侧：文本/可视化编辑器信息 -->
     <div v-if="editableState" class="ml-auto flex gap-3 items-center">

--- a/src/components/editor/FileTree.vue
+++ b/src/components/editor/FileTree.vue
@@ -16,6 +16,8 @@ interface Props {
   getKey: (item: T) => string
   defaultExpanded?: string[]
   nameField?: keyof T | ((item: T) => string)
+  itemBadgeText?: (item: T) => string | undefined
+  itemDimmed?: (item: T) => boolean
   enableTooltip?: boolean
   tooltipContent?: (item: FlattenedItem<T>) => string
   enableContextMenu?: boolean
@@ -32,6 +34,8 @@ const {
   getKey,
   defaultExpanded = [],
   nameField,
+  itemBadgeText,
+  itemDimmed,
   enableTooltip = false,
   tooltipContent,
   enableContextMenu = true,
@@ -114,6 +118,14 @@ defineExpose({
   collapseAll,
   getViewportElement,
 })
+
+function resolveItemBadgeText(item: T): string | undefined {
+  return itemBadgeText?.(item)
+}
+
+function isItemDimmed(item: T): boolean {
+  return itemDimmed?.(item) ?? false
+}
 
 function toSelectedFileItem() {
   const currentSelectedItem = selectedItem.value as Record<string, unknown> | undefined
@@ -324,8 +336,22 @@ useShortcut(() => ({
                             @keydown.escape="handleCancelRename"
                           />
                         </template>
-                        <div v-else class="whitespace-nowrap text-ellipsis overflow-hidden">
-                          {{ getItemName((item as FlattenedItem<T>).value) }}
+                        <div
+                          v-else
+                          :class="[
+                            'flex flex-1 min-w-0 items-center gap-2',
+                            isItemDimmed((item as FlattenedItem<T>).value) ? 'opacity-70' : '',
+                          ]"
+                        >
+                          <div class="whitespace-nowrap text-ellipsis overflow-hidden">
+                            {{ getItemName((item as FlattenedItem<T>).value) }}
+                          </div>
+                          <span
+                            v-if="resolveItemBadgeText((item as FlattenedItem<T>).value)"
+                            class="text-[10px] text-muted-foreground leading-none px-1.5 py-0.5 rounded bg-muted shrink-0"
+                          >
+                            {{ resolveItemBadgeText((item as FlattenedItem<T>).value) }}
+                          </span>
                         </div>
                       </span>
                     </TreeItemLabel>

--- a/src/components/editor/FileTreeContextMenu.vue
+++ b/src/components/editor/FileTreeContextMenu.vue
@@ -3,6 +3,7 @@ interface FileItem {
   path: string
   name: string
   isDir?: boolean
+  source?: string
 }
 
 interface Props {

--- a/src/components/editor/FileTreeContextMenuContent.vue
+++ b/src/components/editor/FileTreeContextMenuContent.vue
@@ -18,12 +18,13 @@ import { useModalStore } from '~/stores/modal'
 import { settleBatch } from '~/utils/batch'
 import { handleError } from '~/utils/error-handler'
 
-import type { Component } from 'vue'
+import type { MenuItem } from '~/types/menu-item'
 
 interface FileItem {
   path: string
   name: string
   isDir?: boolean
+  source?: string
 }
 
 interface Props {
@@ -131,14 +132,6 @@ async function handleRevealInExplorer(): Promise<void> {
   }
 }
 
-interface MenuItem {
-  icon: Component
-  label: string
-  onClick: () => void
-  disabled?: boolean
-  class?: string
-}
-
 function pushSeparator(items: (MenuItem | 'separator')[]): void {
   if (items.length > 0 && items.at(-1) !== 'separator') {
     items.push('separator')
@@ -188,12 +181,14 @@ const menuItems = $computed(() => {
       icon: Trash2,
       label: t('common.delete'),
       onClick: handleDelete,
-      class: 'text-destructive text-13px! focus:text-destructive-foreground focus:bg-destructive',
+      class: 'text-destructive focus:text-destructive-foreground focus:bg-destructive',
     })
   }
 
-  pushSeparator(items)
-  items.push({ icon: FolderOpen, label: t('edit.fileTree.revealInExplorer'), onClick: handleRevealInExplorer })
+  if (item.source !== 'engineLower' && item.source !== 'templateLower') {
+    pushSeparator(items)
+    items.push({ icon: FolderOpen, label: t('edit.fileTree.revealInExplorer'), onClick: handleRevealInExplorer })
+  }
 
   return items
 })

--- a/src/components/editor/ScenePanel.spec.ts
+++ b/src/components/editor/ScenePanel.spec.ts
@@ -1,17 +1,18 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { page } from 'vitest/browser'
-import { defineComponent, h, reactive } from 'vue'
 
 import { renderInBrowser } from '~/__tests__/browser-render'
 import { createTauriPathModuleMock } from '~/__tests__/mocks/tauri-path'
 
 const {
+  fileSystemEventHandlers,
   fileSystemEventsOnMock,
   gameSceneDirMock,
   useFileStoreMock,
   useTabsStoreMock,
   useWorkspaceStoreMock,
 } = vi.hoisted(() => ({
+  fileSystemEventHandlers: new Map<string, (event: unknown) => void>(),
   fileSystemEventsOnMock: vi.fn(),
   gameSceneDirMock: vi.fn(),
   useFileStoreMock: vi.fn(),
@@ -34,7 +35,6 @@ vi.mock('~/services/platform/app-paths', () => ({
   defaultGameSavePath: vi.fn(),
   defaultTemplateSavePath: vi.fn(),
   engineIconPath: vi.fn(),
-  engineManifestPath: vi.fn(),
   engineTemplateDir: vi.fn(),
   gameAssetDir: vi.fn(async (gamePath: string, assetType: string) => `${gamePath}/game/${assetType}`),
   gameConfigPath: vi.fn(async (gamePath: string) => `${gamePath}/game/config.txt`),
@@ -102,6 +102,14 @@ const globalStubs = {
   FileTree: defineComponent({
     name: 'StubFileTree',
     props: {
+      itemBadgeText: {
+        type: Function,
+        default: undefined,
+      },
+      itemDimmed: {
+        type: Function,
+        default: undefined,
+      },
       items: {
         type: Array,
         required: true,
@@ -110,14 +118,24 @@ const globalStubs = {
     emits: ['auxclick', 'click', 'dblclick', 'update:selectedItem'],
     setup(props, { emit }) {
       function renderItems(items: TreeNode[]) {
-        return flattenNodes(items).map(item => h('button', {
-          key: item.path,
-          type: 'button',
-          onClick: () => emit('click', {
-            hasChildren: Array.isArray(item.children),
-            value: item,
-          }),
-        }, item.name))
+        return flattenNodes(items).map((item) => {
+          const badgeText = (props.itemBadgeText as ((item: TreeNode) => string | undefined) | undefined)?.(item)
+          const isDimmed = (props.itemDimmed as ((item: TreeNode) => boolean) | undefined)?.(item) ?? false
+
+          return h('div', {
+            key: item.path,
+          }, [
+            h('button', {
+              'type': 'button',
+              'data-dimmed': isDimmed ? 'true' : 'false',
+              'onClick': () => emit('click', {
+                hasChildren: Array.isArray(item.children),
+                value: item,
+              }),
+            }, item.name),
+            badgeText ? h('span', badgeText) : undefined,
+          ])
+        })
       }
 
       return () => h('div', renderItems(props.items as TreeNode[]))
@@ -153,20 +171,21 @@ function createFileStore() {
 
   return {
     getFolderContents: vi.fn(async (path: string) => entries.get(path) ?? []),
+    initialized: Promise.resolve(),
   }
 }
 
 describe('ScenePanel', () => {
-  afterEach(() => {
-    vi.clearAllMocks()
-  })
-
   beforeEach(() => {
-    fileSystemEventsOnMock.mockReset()
-    gameSceneDirMock.mockReset()
-    useFileStoreMock.mockReset()
-    useTabsStoreMock.mockReset()
-    useWorkspaceStoreMock.mockReset()
+    vi.resetAllMocks()
+    fileSystemEventHandlers.clear()
+
+    fileSystemEventsOnMock.mockImplementation((eventType: string, handler: (event: unknown) => void) => {
+      fileSystemEventHandlers.set(eventType, handler)
+      return () => {
+        fileSystemEventHandlers.delete(eventType)
+      }
+    })
 
     gameSceneDirMock.mockResolvedValue('/games/demo/game/scene')
     useFileStoreMock.mockReturnValue(createFileStore())
@@ -187,6 +206,14 @@ describe('ScenePanel', () => {
 
   it('会读取场景目录并渲染文件树', async () => {
     renderInBrowser(ScenePanel, {
+      browser: {
+        i18nMode: 'localized',
+        messages: {
+          'zh-Hans': {
+            edit: {},
+          },
+        },
+      },
       global: {
         stubs: globalStubs,
       },
@@ -212,6 +239,14 @@ describe('ScenePanel', () => {
     useTabsStoreMock.mockReturnValue(tabsStore)
 
     renderInBrowser(ScenePanel, {
+      browser: {
+        i18nMode: 'localized',
+        messages: {
+          'zh-Hans': {
+            edit: {},
+          },
+        },
+      },
       global: {
         stubs: globalStubs,
       },
@@ -220,5 +255,24 @@ describe('ScenePanel', () => {
     await page.getByText('start.txt').click()
 
     expect(tabsStore.openTab).toHaveBeenCalledWith('start.txt', '/games/demo/game/scene/start.txt')
+  })
+
+  it('会监听目录修改事件以刷新 overlay 视图', async () => {
+    renderInBrowser(ScenePanel, {
+      browser: {
+        i18nMode: 'localized',
+        messages: {
+          'zh-Hans': {
+            edit: {},
+          },
+        },
+      },
+      global: {
+        stubs: globalStubs,
+      },
+    })
+
+    await expect.element(page.getByText('start.txt')).toBeVisible()
+    expect(fileSystemEventHandlers.get('directory:modified')).toBeTypeOf('function')
   })
 })

--- a/src/components/editor/ScenePanel.vue
+++ b/src/components/editor/ScenePanel.vue
@@ -176,9 +176,12 @@ const fsRefreshEvents = [
   'directory:created', 'directory:modified', 'directory:removed', 'directory:renamed',
 ] as const
 
-for (const event of fsRefreshEvents) {
-  fileSystemEvents.on(event, debouncedRefresh)
-}
+const stopFsListeners = fsRefreshEvents.map(event => fileSystemEvents.on(event, debouncedRefresh))
+onScopeDispose(() => {
+  for (const stop of stopFsListeners) {
+    stop()
+  }
+})
 </script>
 
 <template>

--- a/src/components/editor/ScenePanel.vue
+++ b/src/components/editor/ScenePanel.vue
@@ -20,7 +20,6 @@ const fileStore = useFileStore()
 const workspaceStore = useWorkspaceStore()
 const tabsStore = useTabsStore()
 const fileSystemEvents = useFileSystemEvents()
-const { t } = useI18n()
 
 const scenePath = computedAsync(async () => {
   const gamePath = workspaceStore.currentGame?.path

--- a/src/components/editor/ScenePanel.vue
+++ b/src/components/editor/ScenePanel.vue
@@ -20,12 +20,11 @@ const fileStore = useFileStore()
 const workspaceStore = useWorkspaceStore()
 const tabsStore = useTabsStore()
 const fileSystemEvents = useFileSystemEvents()
+const { t } = useI18n()
 
 const scenePath = computedAsync(async () => {
-  if (!workspaceStore.currentGame?.path) {
-    return ''
-  }
-  return await gameSceneDir(workspaceStore.currentGame.path)
+  const gamePath = workspaceStore.currentGame?.path
+  return gamePath ? await gameSceneDir(gamePath) : ''
 })
 
 let itemsKey = $ref(0)
@@ -46,12 +45,13 @@ const items = computedAsync(async () => {
     if (!path) {
       return []
     }
+    // 等待 FileStore 初始化完成，避免在 enginePath 未就绪时加载
+    await fileStore.initialized
     // 使用 itemsKey 作为无意义依赖，强制触发 computedAsync 重新计算
     void itemsKey
-    return await loadScenePanelTreeNodes(path, async currentPath => await fileStore.getFolderContents(currentPath))
+    return await loadScenePanelTreeNodes(path, currentPath => fileStore.getFolderContents(currentPath))
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : '获取场景文件夹内容失败'
-    void logger.error(`[ScenePanel] 获取场景文件夹内容失败: ${errorMessage}`)
+    logger.error(`[ScenePanel] 获取场景文件夹内容失败: ${error instanceof Error ? error.message : error}`)
     throw error
   } finally {
     if (!isSilent) {
@@ -131,9 +131,7 @@ function scrollToSelectedItem() {
 
 watch($$(selectedItem), () => {
   if (selectedItem) {
-    nextTick(() => {
-      scrollToSelectedItem()
-    })
+    nextTick(scrollToSelectedItem)
   }
 })
 
@@ -174,12 +172,14 @@ const debouncedRefresh = useDebounceFn(() => {
   itemsKey++
 }, 100)
 
-fileSystemEvents.on('file:created', debouncedRefresh)
-fileSystemEvents.on('file:removed', debouncedRefresh)
-fileSystemEvents.on('file:renamed', debouncedRefresh)
-fileSystemEvents.on('directory:created', debouncedRefresh)
-fileSystemEvents.on('directory:removed', debouncedRefresh)
-fileSystemEvents.on('directory:renamed', debouncedRefresh)
+const fsRefreshEvents = [
+  'file:created', 'file:removed', 'file:renamed',
+  'directory:created', 'directory:modified', 'directory:removed', 'directory:renamed',
+] as const
+
+for (const event of fsRefreshEvents) {
+  fileSystemEvents.on(event, debouncedRefresh)
+}
 </script>
 
 <template>

--- a/src/components/editor/StatementEditorInline.spec.ts
+++ b/src/components/editor/StatementEditorInline.spec.ts
@@ -27,6 +27,7 @@ const {
 }))
 
 vi.mock('~/features/editor/statement-editor/useStatementEditor', () => ({
+  createStatementIdTarget: (statementId: number) => ({ kind: 'id', statementId }),
   isStatementInteractiveTarget: () => false,
   useStatementEditor: useStatementEditorMock,
 }))

--- a/src/composables/useTemplateLabel.ts
+++ b/src/composables/useTemplateLabel.ts
@@ -1,0 +1,97 @@
+import { projectConfigCmds } from '~/commands/project-config'
+import { db } from '~/database/db'
+import { formatEngineLabel } from '~/lib/engine-label'
+import { useWorkspaceStore } from '~/stores/workspace'
+import { handleError } from '~/utils/error-handler'
+import { joinPath, normalizeFsPath } from '~/utils/path'
+
+import { useFileSystemEvents } from './useFileSystemEvents'
+
+import type { TemplateBinding } from '~/types/project-config'
+
+interface TemplateLabelState {
+  label: string | undefined
+  followingEngine: boolean
+}
+
+const EMPTY_STATE: TemplateLabelState = { label: undefined, followingEngine: false }
+
+async function resolveBindingLabel(
+  binding: TemplateBinding | undefined,
+  fallbackEngineId: string | undefined,
+): Promise<TemplateLabelState> {
+  if (binding?.kind === 'standalone') {
+    return { label: binding.name, followingEngine: false }
+  }
+
+  if (binding?.kind === 'engineBuiltin') {
+    const { id, version } = binding.engine
+    const engine = version === undefined
+      ? undefined
+      : await db.engines.where('[engineId+version]').equals([id, version]).first()
+    return {
+      label: engine ? formatEngineLabel(engine) : (version ? `${id} ${version}` : id),
+      followingEngine: false,
+    }
+  }
+
+  // 缺省 → 跟随当前引擎
+  const engine = fallbackEngineId ? await db.engines.get(fallbackEngineId) : undefined
+  const label = engine ? formatEngineLabel(engine) : undefined
+  return { label, followingEngine: label !== undefined }
+}
+
+export function useTemplateLabel() {
+  const workspaceStore = useWorkspaceStore()
+  const fileSystemEvents = useFileSystemEvents()
+
+  let label = $ref<string>()
+  let followingEngine = $ref(false)
+
+  async function refresh() {
+    const gamePath = workspaceStore.currentGame?.path
+    if (!gamePath) {
+      label = EMPTY_STATE.label
+      followingEngine = EMPTY_STATE.followingEngine
+      return
+    }
+
+    try {
+      const config = await projectConfigCmds.readProjectConfig(gamePath)
+      const next = await resolveBindingLabel(config.template, workspaceStore.currentGame?.engineId)
+      // 异步过程中工程可能切换，丢弃过时结果
+      if (workspaceStore.currentGame?.path !== gamePath) {
+        return
+      }
+      label = next.label
+      followingEngine = next.followingEngine
+    } catch (error) {
+      handleError(error, { silent: true })
+      label = EMPTY_STATE.label
+      followingEngine = EMPTY_STATE.followingEngine
+    }
+  }
+
+  watch(() => workspaceStore.currentGame?.path, refresh, { immediate: true })
+  // 引擎切换会改变 followEngine / engineBuiltin 的解析结果
+  watch(() => workspaceStore.currentGame?.engineId, refresh)
+
+  // 模板切换通过 directory:modified 事件广播
+  const stopListener = fileSystemEvents.on('directory:modified', (event) => {
+    const gamePath = workspaceStore.currentGame?.path
+    if (!gamePath) {
+      return
+    }
+    const templateRoot = normalizeFsPath(joinPath(gamePath, 'game', 'template'))
+    const eventPath = normalizeFsPath(event.path)
+    if (eventPath === templateRoot || eventPath.startsWith(`${templateRoot}/`)) {
+      refresh()
+    }
+  })
+  onScopeDispose(stopListener)
+
+  return {
+    label: $$(label),
+    followingEngine: $$(followingEngine),
+  }
+}

--- a/src/composables/useTemplateLabel.ts
+++ b/src/composables/useTemplateLabel.ts
@@ -39,8 +39,8 @@ async function resolveBindingLabel(
 
   // 缺省 → 跟随当前引擎
   const engine = fallbackEngineId ? await db.engines.get(fallbackEngineId) : undefined
-  const label = engine ? formatEngineLabel(engine) : undefined
-  return { label, followingEngine: label !== undefined }
+  const label = engine ? formatEngineLabel(engine) : fallbackEngineId
+  return { label, followingEngine: !!fallbackEngineId }
 }
 
 export function useTemplateLabel() {
@@ -62,11 +62,15 @@ export function useTemplateLabel() {
       return
     }
 
+    const engineId = workspaceStore.currentGame?.engineId
     try {
       const config = await projectConfigCmds.readProjectConfig(gamePath)
-      const next = await resolveBindingLabel(config.template, workspaceStore.currentGame?.engineId)
-      // 异步过程中工程可能切换，丢弃过时结果
-      if (workspaceStore.currentGame?.path !== gamePath) {
+      const next = await resolveBindingLabel(config.template, engineId)
+      // 异步过程中工程或引擎可能切换，丢弃过时结果
+      if (
+        workspaceStore.currentGame?.path !== gamePath
+        || workspaceStore.currentGame?.engineId !== engineId
+      ) {
         return
       }
       applyState(next)

--- a/src/composables/useTemplateLabel.ts
+++ b/src/composables/useTemplateLabel.ts
@@ -16,6 +16,10 @@ interface TemplateLabelState {
 
 const EMPTY_STATE: TemplateLabelState = { label: undefined, followingEngine: false }
 
+function formatBuiltinFallbackLabel(id: string, version: string | undefined): string {
+  return version ? `${id} ${version}` : id
+}
+
 async function resolveBindingLabel(
   binding: TemplateBinding | undefined,
   fallbackEngineId: string | undefined,
@@ -29,10 +33,8 @@ async function resolveBindingLabel(
     const engine = version === undefined
       ? undefined
       : await db.engines.where('[engineId+version]').equals([id, version]).first()
-    return {
-      label: engine ? formatEngineLabel(engine) : (version ? `${id} ${version}` : id),
-      followingEngine: false,
-    }
+    const label = engine ? formatEngineLabel(engine) : formatBuiltinFallbackLabel(id, version)
+    return { label, followingEngine: false }
   }
 
   // 缺省 → 跟随当前引擎
@@ -48,11 +50,15 @@ export function useTemplateLabel() {
   let label = $ref<string>()
   let followingEngine = $ref(false)
 
+  function applyState(state: TemplateLabelState) {
+    label = state.label
+    followingEngine = state.followingEngine
+  }
+
   async function refresh() {
     const gamePath = workspaceStore.currentGame?.path
     if (!gamePath) {
-      label = EMPTY_STATE.label
-      followingEngine = EMPTY_STATE.followingEngine
+      applyState(EMPTY_STATE)
       return
     }
 
@@ -63,12 +69,10 @@ export function useTemplateLabel() {
       if (workspaceStore.currentGame?.path !== gamePath) {
         return
       }
-      label = next.label
-      followingEngine = next.followingEngine
+      applyState(next)
     } catch (error) {
       handleError(error, { silent: true })
-      label = EMPTY_STATE.label
-      followingEngine = EMPTY_STATE.followingEngine
+      applyState(EMPTY_STATE)
     }
   }
 

--- a/src/features/editor/statement-editor/__tests__/panel.test.ts
+++ b/src/features/editor/statement-editor/__tests__/panel.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import {
   normalizeStatementPanelSingleLineValue,
@@ -6,6 +6,10 @@ import {
 } from '~/features/editor/statement-editor/panel'
 
 import type { EditorField } from '~/features/editor/command-registry/schema'
+
+vi.mock('~/stores/modal', () => ({
+  useModalStore: vi.fn(),
+}))
 
 function createFileContentField(assetType: string): EditorField {
   return {

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -539,6 +539,7 @@ edit:
     frames: "{count} frames"
     statements: "{count} statements"
     engine: Engine
+    engineMissing: Engine unavailable
     template: Template
     templateFollowing: 'Template: Follow Current Engine'
   fileTree:

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -540,6 +540,7 @@ edit:
     statements: "{count} statements"
     engine: Engine
     template: Template
+    templateFollowing: 'Template: Follow Current Engine'
   fileTree:
     newFile: New File
     newFolder: New Folder

--- a/src/locales/ja.yml
+++ b/src/locales/ja.yml
@@ -540,6 +540,7 @@ edit:
     statements: "{count} ステートメント"
     engine: エンジン
     template: テンプレート
+    templateFollowing: 'テンプレート：現在のエンジンに従う'
   fileTree:
     newFile: 新しいファイル
     newFolder: 新しいフォルダー

--- a/src/locales/ja.yml
+++ b/src/locales/ja.yml
@@ -539,6 +539,7 @@ edit:
     frames: "{count} フレーム"
     statements: "{count} ステートメント"
     engine: エンジン
+    engineMissing: エンジンが利用できません
     template: テンプレート
     templateFollowing: 'テンプレート：現在のエンジンに従う'
   fileTree:

--- a/src/locales/zh-Hans.yml
+++ b/src/locales/zh-Hans.yml
@@ -540,6 +540,7 @@ edit:
     statements: "{count} 条语句"
     engine: 引擎
     template: 模板
+    templateFollowing: 模板：跟随当前引擎
   fileTree:
     newFile: 新建文件
     newFolder: 新建文件夹

--- a/src/locales/zh-Hans.yml
+++ b/src/locales/zh-Hans.yml
@@ -539,6 +539,7 @@ edit:
     frames: "{count} 帧"
     statements: "{count} 条语句"
     engine: 引擎
+    engineMissing: 引擎不可用
     template: 模板
     templateFollowing: 模板：跟随当前引擎
   fileTree:

--- a/src/locales/zh-Hant.yml
+++ b/src/locales/zh-Hant.yml
@@ -539,6 +539,7 @@ edit:
     frames: "{count} 幀"
     statements: "{count} 條語句"
     engine: 引擎
+    engineMissing: 引擎不可用
     template: 模板
     templateFollowing: 模板：跟隨目前引擎
   fileTree:

--- a/src/locales/zh-Hant.yml
+++ b/src/locales/zh-Hant.yml
@@ -540,6 +540,7 @@ edit:
     statements: "{count} 條語句"
     engine: 引擎
     template: 模板
+    templateFollowing: 模板：跟隨目前引擎
   fileTree:
     newFile: 新建檔案
     newFolder: 新建資料夾

--- a/src/services/platform/app-paths.ts
+++ b/src/services/platform/app-paths.ts
@@ -44,11 +44,6 @@ export function engineIconPath(enginePath: string): Promise<string> {
   return join(enginePath, 'icons', 'favicon.ico')
 }
 
-/** 引擎清单: {enginePath}/manifest.json */
-export function engineManifestPath(enginePath: string): Promise<string> {
-  return join(enginePath, 'manifest.json')
-}
-
 /** 模板清单: {templatePath}/template.json */
 export function templateManifestPath(templatePath: string): Promise<string> {
   return join(templatePath, 'template.json')

--- a/src/stores/file.ts
+++ b/src/stores/file.ts
@@ -978,6 +978,7 @@ export const useFileStore = defineStore('file', () => {
       })
     },
     clear,
+    getItemByPath,
     initialize,
     refreshTemplateOverlay,
   })


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [ ] 错误修复
- [x] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [x] 代码重构
- [x] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

本 PR 将编辑器侧资源浏览能力接入 VFS 体系，并同步补齐模板跟随状态在编辑器中的展示与感知。

主要改动包括：

- `AssetView` / `AssetBreadcrumb`
  - 资源路径统一基于 `game/{assetType}` 目录解析，不再依赖旧的资产目录拼接方式
  - 适配 VFS 返回的资源项与路径结构，为后续区分 overlay/base 层资源提供基础
- `FileTree` / `FileTreeContextMenu` / `FileTreeContextMenuContent`
  - 基于 VFS overlay 的真实路径处理文件树与右键菜单行为
  - 为文件来源、脏状态展示及后续文件操作对齐新的路径模型
- `EditorStatusBar`
  - 增加模板跟随当前引擎时的状态文案展示
  - 让文档级模板信息能够在状态栏中被正确感知
- `ScenePanel`
  - 同步接入新的资源根路径与模板感知逻辑
- 测试与多语言文案
  - 更新 `AssetView`、`EditorStatusBar`、`ScenePanel`、`StatementEditorInline`、statement editor panel 相关测试
  - 为状态栏新增多语言文案 `templateFollowing`
- 清理
  - 移除 `services/platform/app-paths.ts` 中已无引用的 `engineManifestPath`

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

前序工作已经完成 VFS 基础设施、项目级 VFS 配置以及站点级预览服务注入，但编辑器侧的资源浏览、文件树展示和模板状态感知仍未完全对齐新的 VFS 模型。

本 PR 的目标是把编辑器中与资源访问直接相关的 UI 与测试迁移到 VFS 语义之上，解决以下问题：

- 编辑器资源面板、文件树与实际 `game/*` 资源路径模型不一致
- 后续 overlay/base 资源来源区分缺少前端承接点
- 文档级模板跟随当前引擎时，编辑器状态反馈不完整

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
