### PR TITLE
🐛 修复跨目录移动子树残留与模板切换父目录失效缺失

### DIFF
--- a/src/stores/__tests__/file.test.ts
+++ b/src/stores/__tests__/file.test.ts
@@ -1029,4 +1029,77 @@ describe('文件状态仓库', () => {
       '/workspace/game/foo',
     ])
   })
+
+  it('refreshTemplateOverlay 会同步失效父 game 目录', async () => {
+    existsMock.mockImplementation(async (path: string) => path === '/workspace/project.wgcp')
+    resolvePreviewSiteMock.mockResolvedValue({
+      projectPath: '/workspace',
+      enginePath: '/engines/webgal',
+      templatePath: '/templates/old',
+    })
+    vfsListDirMock.mockResolvedValue([
+      { isDir: true, name: 'template', source: 'upper' },
+    ])
+
+    workspaceStoreState = reactive({
+      CWD: '/workspace',
+      currentGame: { engineId: 'engine-1', path: '/workspace' },
+    })
+    useWorkspaceStoreMock.mockReturnValue(workspaceStoreState)
+
+    const store = useFileStore()
+    await vi.waitFor(() => {
+      expect(watchFsMock).toHaveBeenCalledTimes(1)
+    })
+
+    await store.getFolderContents('/workspace/game')
+    const gameItem = store.getItemByPath('/workspace/game')
+    expect(gameItem).toBeDefined()
+    expect(gameItem?.isDir).toBe(true)
+    expect((gameItem as { isLoaded: boolean }).isLoaded).toBe(true)
+
+    await store.refreshTemplateOverlay('/workspace', { nextTemplatePath: '/templates/new' })
+
+    const refreshedGameItem = store.getItemByPath('/workspace/game')
+    expect((refreshedGameItem as { isLoaded: boolean }).isLoaded).toBe(false)
+  })
+
+  it('refreshTemplateOverlay 在父 game 目录尚未加载时不会抛错', async () => {
+    existsMock.mockImplementation(async (path: string) => path === '/workspace/project.wgcp')
+    resolvePreviewSiteMock.mockResolvedValue({
+      projectPath: '/workspace',
+      enginePath: '/engines/webgal',
+      templatePath: '/templates/old',
+    })
+    vfsListDirMock.mockResolvedValue([])
+
+    workspaceStoreState = reactive({
+      CWD: '/workspace',
+      currentGame: { engineId: 'engine-1', path: '/workspace' },
+    })
+    useWorkspaceStoreMock.mockReturnValue(workspaceStoreState)
+
+    const store = useFileStore()
+    await vi.waitFor(() => {
+      expect(watchFsMock).toHaveBeenCalledTimes(1)
+    })
+
+    // initialize 内部已加载 game/，需要把它从 items 里移除以模拟"未加载"
+    const caches = captureFileStoreCaches()
+    try {
+      const pathToId = caches.pathToId
+      const items = caches.items
+      const gameId = pathToId?.get('/workspace/game')
+      if (gameId) {
+        items?.delete(gameId)
+        pathToId?.delete('/workspace/game')
+      }
+
+      await expect(
+        store.refreshTemplateOverlay('/workspace', { nextTemplatePath: '/templates/new' }),
+      ).resolves.toBeUndefined()
+    } finally {
+      caches.restore()
+    }
+  })
 })

--- a/src/stores/__tests__/file.test.ts
+++ b/src/stores/__tests__/file.test.ts
@@ -967,4 +967,66 @@ describe('文件状态仓库', () => {
     const finalItems = await store.getFolderContents('/workspace/game/template')
     expect(finalItems.map(item => item.path)).toEqual(['/workspace/game/template/new.txt'])
   })
+
+  it('跨目录 moveEntry 会递归清理源子树并按 post-order 发出 removed 事件', async () => {
+    existsMock.mockImplementation(async (path: string) => path === '/workspace/project.wgcp')
+    getGameEnginePathMock.mockResolvedValue('/engines/webgal')
+    statMock.mockImplementation(async (path: string) => createStatResult(path, false))
+    vfsResolvePathMock.mockResolvedValue('/engines/webgal/game/foo')
+    vfsMovePathMock.mockResolvedValue('game/dest/foo')
+    vfsListDirMock.mockImplementation(async ({ relPath }: { relPath: string }) => {
+      if (relPath === '') {
+        return [
+          { isDir: true, name: 'foo', source: 'upper' },
+          { isDir: true, name: 'dest', source: 'upper' },
+        ]
+      }
+      if (relPath === 'game/foo') {
+        return [{ isDir: true, name: 'bar', source: 'upper' }]
+      }
+      if (relPath === 'game/foo/bar') {
+        return [{ isDir: false, name: 'baz.txt', source: 'upper' }]
+      }
+      if (relPath === 'game/dest') {
+        return []
+      }
+      return []
+    })
+
+    workspaceStoreState = reactive({
+      CWD: '/workspace',
+      currentGame: { engineId: 'engine-1', path: '/workspace' },
+    })
+    useWorkspaceStoreMock.mockReturnValue(workspaceStoreState)
+
+    const store = useFileStore()
+    await vi.waitFor(() => {
+      expect(watchFsMock).toHaveBeenCalledTimes(1)
+    })
+
+    // 预热整棵子树
+    await store.getFolderContents('/workspace/game/foo')
+    await store.getFolderContents('/workspace/game/foo/bar')
+    await store.getFolderContents('/workspace/game/dest')
+
+    expect(store.getItemByPath('/workspace/game/foo')).toBeDefined()
+    expect(store.getItemByPath('/workspace/game/foo/bar')).toBeDefined()
+    expect(store.getItemByPath('/workspace/game/foo/bar/baz.txt')).toBeDefined()
+
+    emittedEvents.length = 0
+    await store.moveEntry('/workspace/game/foo', '/workspace/game/dest')
+
+    expect(store.getItemByPath('/workspace/game/foo')).toBeUndefined()
+    expect(store.getItemByPath('/workspace/game/foo/bar')).toBeUndefined()
+    expect(store.getItemByPath('/workspace/game/foo/bar/baz.txt')).toBeUndefined()
+
+    const removedPaths = emittedEvents
+      .filter(event => event.type === 'file:removed' || event.type === 'directory:removed')
+      .map(event => event.path)
+    expect(removedPaths).toEqual([
+      '/workspace/game/foo/bar/baz.txt',
+      '/workspace/game/foo/bar',
+      '/workspace/game/foo',
+    ])
+  })
 })

--- a/src/stores/file.ts
+++ b/src/stores/file.ts
@@ -634,6 +634,53 @@ export const useFileStore = defineStore('file', () => {
     return id ? items.get(id) : undefined
   }
 
+  /**
+   * 递归清理一整棵子树的内存状态。
+   *
+   * 与 `handleRemoveEvent` 不同：watcher 推送的 remove 事件在 OS 层只对应叶子级
+   * 删除，所以那条路径不能假设要枚举子项。本函数仅在我们自己已经知道"整棵子树
+   * 一次性消失"（如 `moveEntry` 跨目录分支）的场合调用，避免源目录下的后代
+   * `FileSystemItem` 与 `pathToId` key 残留为孤儿。
+   *
+   * 子树枚举走 `childIds` 而非按 path prefix 扫全量 `items`：精确且 O(子树)，且
+   * 避免误清同前缀但不同根的项（如 `/a/foo` 与 `/a/foo-bar`）。
+   *
+   * 事件按 post-order（叶子先于目录）发出，与 `handleRemoveEvent` 单 item 语义对齐。
+   */
+  async function removeSubtree(rootPath: string): Promise<void> {
+    const rootItem = getItemByPath(rootPath)
+    if (!rootItem) {
+      await invalidateParentDirectoryCache(rootPath)
+      await invalidateDirectoryCacheSafe(rootPath, true)
+      return
+    }
+
+    const collected: FileSystemItem[] = []
+    function walk(item: FileSystemItem): void {
+      if (item.isDir) {
+        for (const childId of item.childIds) {
+          const child = items.get(childId)
+          if (child) {
+            walk(child)
+          }
+        }
+      }
+      collected.push(item)
+    }
+    walk(rootItem)
+
+    removeChildFromParent(rootItem.id, rootItem.parentId)
+
+    for (const item of collected) {
+      items.delete(item.id)
+      pathToId.delete(normalizeFsPath(item.path))
+      emitFileSystemEvent(item, { eventType: 'removed', path: item.path })
+    }
+
+    await invalidateParentDirectoryCache(rootPath)
+    await invalidateDirectoryCacheSafe(rootPath, true)
+  }
+
   async function handleRemoveEvent(path: string, removedKind?: RemovedEntryKind): Promise<void> {
     const item = getItemByPath(path)
     if (!item) {
@@ -928,7 +975,7 @@ export const useFileStore = defineStore('file', () => {
       if (sourceParentPath === normalizeFsPath(targetPath)) {
         await handleRenameEvent(nextPath, sourcePath)
       } else {
-        await handleRemoveEvent(sourcePath)
+        await removeSubtree(sourcePath)
         await handleCreateEvent(nextPath, targetParentId)
       }
       return nextPath

--- a/src/stores/file.ts
+++ b/src/stores/file.ts
@@ -167,6 +167,18 @@ export const useFileStore = defineStore('file', () => {
 
     await invalidateDirectoryCacheSafe(templateRoot, true)
 
+    // 失效父 game 目录：`game/template` 的 source/existence 字段是在加载父目录时
+    // 写入的，只刷新模板子树自身无法让父目录下次重渲染时看到新 lower 配置。
+    const parentGameDir = joinPath(currentProjectPath, 'game')
+    const parentItem = getItemByPath(parentGameDir)
+    if (parentItem?.isDir) {
+      parentItem.loadRevision += 1
+      parentItem.isLoaded = false
+      parentItem.loadingRevision = undefined
+      parentItem.loadingPromise = undefined
+    }
+    await invalidateDirectoryCacheSafe(parentGameDir, true)
+
     fileSystemEvents.emit({
       type: 'directory:modified',
       path: templateRoot,


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [x] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [x] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

修复 `src/stores/file.ts` 中两个内存状态管理缺陷：

**1. 跨目录 `moveEntry` 子树残留（孤儿状态）**

`moveEntry` 跨目录分支原先建模为 "删除源根 + 创建目标根"，调用 `handleRemoveEvent(sourcePath)`。但 `handleRemoveEvent` 只清理被点名的 root：从 `items` 删除 root item、从 `pathToId` 删除 root key、invalidate root 目录缓存——**不会**枚举该 root 已加载的后代。

后果：
- `items` 残留：源目录下已加载的所有后代 `FileSystemItem` 仍留在 map 里，`parentId` 指向已被删除的 root id；
- `pathToId` 残留：所有后代 key 仍指向旧 id，后续通过旧路径调 `getItemByPath` 仍会"命中"返回失效项；
- 子节点事件丢失：未发出后代的 `file:removed` / `directory:removed`，订阅这些事件的下游（如打开的 tab/编辑器）感知不到自身路径已失效；
- 缓存不一致：被加载的后代各自的 `loadingPromise` / `loadRevision` / `isLoaded` 未被重置。

**修复**：新增内部 `removeSubtree(rootPath)` 辅助函数，沿 `childIds` 走 O(子树) 递归，post-order（叶子先于目录）清理 `items` / `pathToId` 并发出 `removed` 事件。`moveEntry` 跨目录分支改用 `removeSubtree`。`handleRemoveEvent` 不动——它仍是 watcher 路径上的入口（OS 层 remove 已是叶子级，递归清理会破坏增量快照）。

**2. `refreshTemplateOverlay` 未失效父 `game/` 目录**

`refreshTemplateOverlay` 原先只重置 `templateRoot` 子树的 `isLoaded` 与目录缓存。但 `game/template` 这个 `DirItem` 的 `source` / `existence` 字段是在加载父 `game/` 目录时写入的，父项的 `isLoaded` 不失效就会让下次重渲染按旧 lower 配置显示，直到用户手动 reload。

**修复**：在现有 invalidate 之后追加：若 `game/` 已加载则重置其 `isLoaded` / `loadRevision` / `loadingPromise`，并失效目录缓存；未加载时跳过。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

跨目录文件移动后，源路径下原本打开的 tab 不会自动关闭、`getItemByPath` 仍能拿到已失效项，以及引擎/模板切换后资源浏览器中模板目录的标签仍显示旧 lower 来源——这两类问题来自同一类内存清理不彻底。本 PR 一次性修复并补齐三个不变量：
- `pathToId` 中不存在指向已不存在路径的 key；
- `items` 中不存在祖先 chain 已断开的孤儿 item；
- 跨目录移动后源目录下的所有项都能收到对应 `removed` 事件。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->

- 子树枚举走 `childIds` 而非按 path prefix 扫全量 `items`：精确且 O(子树)，避免误清同前缀但不同根的项（如 `/a/foo` 与 `/a/foo-bar`）；
- 事件按 post-order 发出，与 `handleRemoveEvent` 单 item 语义对齐；
- 不引入"真正的 move"（复用源/目标同 id 与子树）——move 在用户视角只是"原位置消失 + 新位置出现"，复用 id 没有界面收益；本 PR 只做 subtree 清理；

### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [x] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
