### PR TITLE
🐛 修复 ScenePanel 手动刷新与文件系统事件无法触发场景树重算

### DIFF
--- a/src/components/editor/ScenePanel.spec.ts
+++ b/src/components/editor/ScenePanel.spec.ts
@@ -275,4 +275,65 @@ describe('ScenePanel', () => {
     await expect.element(page.getByText('start.txt')).toBeVisible()
     expect(fileSystemEventHandlers.get('directory:modified')).toBeTypeOf('function')
   })
+
+  it('点击刷新按钮会触发场景树重新读取', async () => {
+    const fileStore = createFileStore()
+    useFileStoreMock.mockReturnValue(fileStore)
+
+    renderInBrowser(ScenePanel, {
+      browser: {
+        i18nMode: 'localized',
+        messages: {
+          'zh-Hans': {
+            edit: {},
+          },
+        },
+      },
+      global: {
+        stubs: globalStubs,
+      },
+    })
+
+    await expect.element(page.getByText('start.txt')).toBeVisible()
+    const initialCalls = fileStore.getFolderContents.mock.calls.length
+
+    // 工具栏按钮顺序：FilePlus / FolderPlus / RotateCw / CopyMinus
+    const refreshButton = document.querySelectorAll('button')[2] as HTMLButtonElement
+    refreshButton.click()
+
+    await vi.waitFor(() => {
+      expect(fileStore.getFolderContents.mock.calls.length).toBeGreaterThan(initialCalls)
+    })
+  })
+
+  it('文件系统目录创建事件会触发场景树重新读取', async () => {
+    const fileStore = createFileStore()
+    useFileStoreMock.mockReturnValue(fileStore)
+
+    renderInBrowser(ScenePanel, {
+      browser: {
+        i18nMode: 'localized',
+        messages: {
+          'zh-Hans': {
+            edit: {},
+          },
+        },
+      },
+      global: {
+        stubs: globalStubs,
+      },
+    })
+
+    await expect.element(page.getByText('start.txt')).toBeVisible()
+    const initialCalls = fileStore.getFolderContents.mock.calls.length
+
+    fileSystemEventHandlers.get('directory:created')?.({
+      type: 'directory:created',
+      path: '/games/demo/game/scene/chapter-2',
+    })
+
+    await vi.waitFor(() => {
+      expect(fileStore.getFolderContents.mock.calls.length).toBeGreaterThan(initialCalls)
+    })
+  })
 })

--- a/src/components/editor/ScenePanel.spec.ts
+++ b/src/components/editor/ScenePanel.spec.ts
@@ -297,8 +297,7 @@ describe('ScenePanel', () => {
     await expect.element(page.getByText('start.txt')).toBeVisible()
     const initialCalls = fileStore.getFolderContents.mock.calls.length
 
-    // 工具栏按钮顺序：FilePlus / FolderPlus / RotateCw / CopyMinus
-    const refreshButton = document.querySelectorAll('button')[2] as HTMLButtonElement
+    const refreshButton = document.querySelector<HTMLButtonElement>('[data-testid="scene-panel-refresh"]')!
     refreshButton.click()
 
     await vi.waitFor(() => {

--- a/src/components/editor/ScenePanel.vue
+++ b/src/components/editor/ScenePanel.vue
@@ -26,23 +26,20 @@ const scenePath = computedAsync(async () => {
   return gamePath ? await gameSceneDir(gamePath) : ''
 })
 
-let itemsKey = $ref(0)
 let isLoading = $ref(false)
-// 刷新模式队列：true 表示静默刷新，false 或 undefined 表示普通刷新
-let refreshModes = $ref<boolean[]>([])
+// 将刷新计数与模式合并到同一个响应式对象，确保 computedAsync 重算时拿到的
+// 是当前触发的语义，而不是历史队列中错位的模式
+let refreshTrigger = $ref({ count: 0, silent: false })
 
 const items = computedAsync(async () => {
-  // 按触发顺序消费一次刷新模式；默认视为普通刷新，避免并发覆盖刷新语义
-  const mode = refreshModes.shift()
-  const isSilent = mode === true
+  const { silent: isSilent } = refreshTrigger
 
   if (!isSilent) {
     isLoading = true
   }
-  // computedAsync 仅在首个 await 之前同步收集依赖，所以 itemsKey、scenePath、initialized
+  // computedAsync 仅在首个 await 之前同步收集依赖，所以 refreshTrigger、scenePath、initialized
   // 这三处响应式访问必须放在任何 await 之前，否则手动刷新与文件系统事件无法触发重算
   const path = scenePath.value
-  void itemsKey
   const initialized = fileStore.initialized
   try {
     if (!path) {
@@ -159,8 +156,7 @@ async function handleCreateFolder() {
 }
 
 function handleRefresh() {
-  refreshModes.push(false)
-  itemsKey++
+  refreshTrigger = { count: refreshTrigger.count + 1, silent: false }
 }
 
 function handleCollapseAll() {
@@ -169,8 +165,7 @@ function handleCollapseAll() {
 
 // 监听文件系统事件，自动刷新数据（静默刷新，不显示加载状态）
 const debouncedRefresh = useDebounceFn(() => {
-  refreshModes.push(true)
-  itemsKey++
+  refreshTrigger = { count: refreshTrigger.count + 1, silent: true }
 }, 100)
 
 const fsRefreshEvents = [
@@ -200,7 +195,7 @@ onScopeDispose(() => {
         <Button variant="ghost" size="icon" class="rounded h-6 w-6" @click="handleCreateFolder">
           <FolderPlus class="h-4 w-4" :stroke-width="1.5" />
         </Button>
-        <Button variant="ghost" size="icon" class="rounded h-6 w-6" :disabled="isLoading" @click="handleRefresh">
+        <Button variant="ghost" size="icon" class="rounded h-6 w-6" :disabled="isLoading" data-testid="scene-panel-refresh" @click="handleRefresh">
           <RotateCw class="h-4 w-4" :stroke-width="1.5" />
         </Button>
         <Button variant="ghost" size="icon" class="rounded h-6 w-6" @click="handleCollapseAll">

--- a/src/components/editor/ScenePanel.vue
+++ b/src/components/editor/ScenePanel.vue
@@ -39,15 +39,17 @@ const items = computedAsync(async () => {
   if (!isSilent) {
     isLoading = true
   }
+  // computedAsync 仅在首个 await 之前同步收集依赖，所以 itemsKey、scenePath、initialized
+  // 这三处响应式访问必须放在任何 await 之前，否则手动刷新与文件系统事件无法触发重算
+  const path = scenePath.value
+  void itemsKey
+  const initialized = fileStore.initialized
   try {
-    const path = scenePath.value
     if (!path) {
       return []
     }
     // 等待 FileStore 初始化完成，避免在 enginePath 未就绪时加载
-    await fileStore.initialized
-    // 使用 itemsKey 作为无意义依赖，强制触发 computedAsync 重新计算
-    void itemsKey
+    await initialized
     return await loadScenePanelTreeNodes(path, currentPath => fileStore.getFolderContents(currentPath))
   } catch (error) {
     logger.error(`[ScenePanel] 获取场景文件夹内容失败: ${error instanceof Error ? error.message : error}`)

--- a/src/components/editor/ScenePanel.vue
+++ b/src/components/editor/ScenePanel.vue
@@ -27,8 +27,6 @@ const scenePath = computedAsync(async () => {
 })
 
 let isLoading = $ref(false)
-// 将刷新计数与模式合并到同一个响应式对象，确保 computedAsync 重算时拿到的
-// 是当前触发的语义，而不是历史队列中错位的模式
 let refreshTrigger = $ref({ count: 0, silent: false })
 
 const items = computedAsync(async () => {


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [x] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [x] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

修复 `c023668` 引入的回归：在场景浏览器中新建文件 / 文件夹后场景树不刷新，点击手动刷新按钮也无反应，必须返回主页再进入编辑器才能恢复。

**根因**：`computedAsync` 仅在首个 `await` 之前同步收集响应式依赖。`c023668` 把 `await fileStore.initialized` 放到了 `void itemsKey` 与 `scenePath.value` 之前，导致 `itemsKey` 与 `scenePath` 都不再被追踪：

- 手动刷新按钮触发的 `itemsKey++` → 不再触发重算；
- 文件系统事件触发的 `itemsKey++` → 同样无效；
- 离开编辑器再回来组件重新挂载 → `setup()` 重跑，假象「恢复正常」。

**修复**：把 `scenePath.value`、`itemsKey`、`fileStore.initialized` 三处响应式读取全部前移到任何 `await` 之前，让 `computedAsync` 能正常追踪它们；后续再 `await initialized` 不影响依赖收集。

**新增测试**：

1. 「点击刷新按钮会触发场景树重新读取」—— 直接验证 `itemsKey` 依赖追踪。
2. 「文件系统目录创建事件会触发场景树重新读取」—— 验证事件路径同样可重算。

任意把响应式读取放回首个 `await` 之后即会触发上述任一测试失败。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

`c023668` 编辑器侧接入 VFS 后，为了避免在 enginePath 未就绪时加载，引入了 `await fileStore.initialized`。但该 `await` 被放在响应式读取之前，意外切断了 `computedAsync` 的依赖追踪窗口。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [x] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
