### PR TITLE
🐛 修复资源浏览器在 VFS 模式下新建项重命名浮层无法弹出

### DIFF
--- a/src/components/editor/AssetView.vue
+++ b/src/components/editor/AssetView.vue
@@ -340,11 +340,15 @@ async function resolveRenameAnchor(
     return undefined
   }
 
+  // 项被搜索过滤掉时，没有对应 DOM 行可锚定，仅在此场景退回 viewport，
+  // 避免新建后因搜索条件不匹配而完全无法重命名。
+  // 注意不要把这条 fallback 用于「项可见但 DOM 锚点未及时出现」的情况：
+  // 那会让 Popover 错误地相对整个 viewport 定位，造成位置异常。
   if (!isItemVisibleInCurrentFilter(path)) {
     return getRenameFallbackAnchor()
   }
 
-  return await waitForRenameAnchor(path, directoryPathSnapshot) ?? getRenameFallbackAnchor()
+  return await waitForRenameAnchor(path, directoryPathSnapshot)
 }
 
 function normalizeRenameTarget(item: { path: string, name: string, isDir?: boolean }): FileViewerItem {
@@ -518,7 +522,8 @@ async function handleContextMenuCreateItem(
   const currentDirectorySnapshot = currentDirectoryPath || item.path
 
   try {
-    const createdPath = await options.create(item.path, options.name)
+    const rawCreatedPath = await options.create(item.path, options.name)
+    const createdPath = normalizeFsPath(rawCreatedPath)
     const createdName = getBaseName(createdPath)
 
     scheduleItemsRefresh(true)


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [x] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [ ] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

修复 `c023668` 引入的回归：在资源浏览器（尤其是模板等 VFS 目录）中新建文件 / 文件夹后，重命名浮层不再出现，或在旧版本里出现「相对整个 viewport 错误定位」。

**根因有两层**：

1. **路径形态不一致**：VFS `ensureWritable` 后端返回的是 upper layer **物理路径**（Windows 上保留反斜杠），而 `items` 中条目的 `path` 经 `normalizeFsPath` 已统一为正斜杠。`waitForCreatedItem` / `findRenameAnchor` 都以严格 `===` 对比，永远命中不到新建项。
2. **fallback 误用掩盖了上述差异**：旧 `resolveRenameAnchor` 在找不到锚点时一律退回 viewport，导致「找不到对应行」时浮层挂在滚动容器上，看起来位置异常。

**修复**：

- 在 `handleContextMenuCreateItem` 入口对 `createdPath` 调用 `normalizeFsPath`，让 VFS 与非 VFS 两条路径都得到统一形态。
- 收窄 `getRenameFallbackAnchor` 的使用范围：仅在新建项被当前搜索关键词过滤掉、视图里没有对应 DOM 行时退回 viewport（这是合理边界，因为此场景下不存在更好的锚点）；其他情况（如 DOM 锚点未及时出现）直接返回 `undefined`，由 popover 不打开承担，避免错误定位。
- 在 `resolveRenameAnchor` 上加注释解释为何区别对待这两条路径，防止后续被再次扩成全局兜底。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

`c023668` 编辑器侧接入 VFS 后，新建动作改走 `gameFs` → `ensureWritable` 路径；后端 `to_physical_path_string` 不做分隔符规整，与前端逻辑路径形态背离。在 Windows + VFS 目录（如模板资源）下复现度 100%。非 VFS + Windows 路径上同样存在该差异，本次一并被覆盖。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->

- 修复不变更后端行为：物理路径形态由前端统一规整，避免对其他依赖物理路径的调用面（如 `convertFileSrc`）造成连锁影响。
- 已保留 `getRenameFallbackAnchor`，仅缩小其作用域；删除它会破坏「搜索过滤场景下仍能新建并重命名」的既有用例。

### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [x] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
