### PR TITLE
🐛 统一资源身份键并优化游戏预览资源探测

### DIFF
--- a/src/__tests__/factories.ts
+++ b/src/__tests__/factories.ts
@@ -1,5 +1,6 @@
-import type { Engine, Game, Template } from '~/database/model'
 import { normalizeImportPath } from '~/services/resource-health'
+
+import type { Engine, Game, Template } from '~/database/model'
 
 interface TestGameFactoryOptions extends Partial<Omit<Game, 'metadata' | 'previewAssets'>> {
   metadata?: Partial<Game['metadata']>

--- a/src/__tests__/factories.ts
+++ b/src/__tests__/factories.ts
@@ -1,4 +1,5 @@
 import type { Engine, Game, Template } from '~/database/model'
+import { normalizeImportPath } from '~/services/resource-health'
 
 interface TestGameFactoryOptions extends Partial<Omit<Game, 'metadata' | 'previewAssets'>> {
   metadata?: Partial<Game['metadata']>
@@ -16,7 +17,13 @@ interface TestEngineFactoryOptions extends Partial<Omit<Engine, 'metadata' | 'pr
 }
 
 export function createTestGame(options: TestGameFactoryOptions = {}): Game {
-  const { metadata, path, previewAssets, ...rest } = options
+  const {
+    metadata,
+    path,
+    pathKey,
+    previewAssets,
+    ...rest
+  } = options
   const resolvedGamePath = path ?? '/games/demo'
   const {
     cover: rawCover,
@@ -28,6 +35,7 @@ export function createTestGame(options: TestGameFactoryOptions = {}): Game {
   return {
     id: 'game-1',
     path: resolvedGamePath,
+    pathKey: pathKey ?? normalizeImportPath(resolvedGamePath).comparablePath,
     createdAt: 0,
     lastModified: 0,
     status: 'created',
@@ -52,7 +60,13 @@ export function createTestGame(options: TestGameFactoryOptions = {}): Game {
 }
 
 export function createTestEngine(options: TestEngineFactoryOptions = {}): Engine {
-  const { metadata, path, previewAssets, ...rest } = options
+  const {
+    metadata,
+    path,
+    pathKey,
+    previewAssets,
+    ...rest
+  } = options
   const resolvedEnginePath = path ?? '/engines/default'
   const { icon: rawIcon } = previewAssets ?? {}
   const { path: iconPath, ...icon } = rawIcon ?? {}
@@ -62,6 +76,7 @@ export function createTestEngine(options: TestEngineFactoryOptions = {}): Engine
   return {
     id: 'engine-1',
     path: resolvedEnginePath,
+    pathKey: pathKey ?? normalizeImportPath(resolvedEnginePath).comparablePath,
     engineId: defaultEngineId,
     name: defaultName,
     createdAt: 0,

--- a/src/components/home/templates-tab/TemplatesTab.spec.ts
+++ b/src/components/home/templates-tab/TemplatesTab.spec.ts
@@ -242,6 +242,7 @@ describe('TemplatesTab', () => {
         },
         name: 'WebGAL',
         path: '/engines/WebGAL/4.8.2',
+        pathKey: '/engines/webgal/4.8.2',
         previewAssets: {
           icon: {
             path: 'icons/favicon.ico',

--- a/src/database/db.spec.ts
+++ b/src/database/db.spec.ts
@@ -1,0 +1,49 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { createTestEngine, createTestGame } from '~/__tests__/factories'
+
+import { db } from './db'
+
+async function resetDatabase() {
+  db.close()
+  await db.delete()
+  await db.open()
+}
+
+describe('db schema', () => {
+  beforeEach(async () => {
+    await resetDatabase()
+  })
+
+  afterEach(async () => {
+    await resetDatabase()
+  })
+
+  it('games.pathKey 保持唯一', async () => {
+    await db.games.add(createTestGame({
+      id: 'game-1',
+      path: '/Games/Demo',
+    }))
+
+    await expect(db.games.add(createTestGame({
+      id: 'game-2',
+      path: '/games/demo/',
+    }))).rejects.toBeDefined()
+  })
+
+  it('engines.pathKey 保持唯一', async () => {
+    await db.engines.add(createTestEngine({
+      id: 'engine-1',
+      path: '/Engines/WebGAL/4.5.0',
+      engineId: 'open-webgal.webgal',
+      version: '4.5.0',
+    }))
+
+    await expect(db.engines.add(createTestEngine({
+      id: 'engine-2',
+      path: '/engines/webgal/4.5.0/',
+      engineId: 'open-webgal.webgal-copy',
+      version: '4.5.1',
+    }))).rejects.toBeDefined()
+  })
+})

--- a/src/database/db.ts
+++ b/src/database/db.ts
@@ -11,8 +11,8 @@ class WebGALCraftDatabase extends Dexie {
   constructor() {
     super('WebGALCraft')
     this.version(1).stores({
-      games: 'id, path, engineId, createdAt, lastModified, status, availability',
-      engines: 'id, path, engineId, name, [engineId+version], createdAt, status, availability',
+      games: 'id, &pathKey, path, engineId, createdAt, lastModified, status, availability',
+      engines: 'id, &pathKey, path, engineId, name, [engineId+version], createdAt, status, availability',
       templates: 'id, path, createdAt, status, availability, metadata.name',
     })
   }

--- a/src/database/model.ts
+++ b/src/database/model.ts
@@ -4,6 +4,7 @@ import type { EngineMetadata, EnginePreviewAssets, GameMetadata, GamePreviewAsse
 export interface Game {
   id: string
   path: string
+  pathKey: string
   engineId?: string
   createdAt: number
   lastModified: number
@@ -16,6 +17,7 @@ export interface Game {
 export interface Engine {
   id: string
   path: string
+  pathKey: string
   engineId: string
   name: string
   version?: string

--- a/src/features/home/__tests__/useDiscoverResources.test.ts
+++ b/src/features/home/__tests__/useDiscoverResources.test.ts
@@ -2,6 +2,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const {
   classifyEngineMock,
+  gameIdentityKeyOfMock,
+  engineIdentityKeyOfMock,
   existsMock,
   getEnginePreviewAssetsMock,
   getTemplateMetadataMock,
@@ -18,6 +20,12 @@ const {
   validateTemplateMock,
 } = vi.hoisted(() => ({
   classifyEngineMock: vi.fn(),
+  gameIdentityKeyOfMock: vi.fn((resource: { path: string }) => resource.path.toLowerCase().replace(/\/+$/, '')),
+  engineIdentityKeyOfMock: vi.fn((resource: { path: string, engineId?: string, version?: string }) =>
+    resource.engineId && resource.version
+      ? `${resource.engineId}:${resource.version}`
+      : resource.path.toLowerCase().replace(/\/+$/, ''),
+  ),
   existsMock: vi.fn(),
   getEnginePreviewAssetsMock: vi.fn(),
   getTemplateMetadataMock: vi.fn(),
@@ -76,6 +84,7 @@ vi.mock('~/services/engine-manager', () => ({
   engineManager: {
     classifyEngine: classifyEngineMock,
     getEnginePreviewAssets: getEnginePreviewAssetsMock,
+    identityKeyOf: engineIdentityKeyOfMock,
     importEngine: vi.fn(),
     validateEngine: validateEngineMock,
   },
@@ -84,6 +93,7 @@ vi.mock('~/services/engine-manager', () => ({
 vi.mock('~/services/game-manager', () => ({
   gameManager: {
     getGamePreviewAssets: vi.fn(),
+    identityKeyOf: gameIdentityKeyOfMock,
     importGame: vi.fn(),
     resolvePreviewSite: vi.fn(),
     validateGame: vi.fn(),
@@ -119,6 +129,8 @@ describe('useDiscoverResources', () => {
     vi.resetModules()
 
     classifyEngineMock.mockReset()
+    gameIdentityKeyOfMock.mockClear()
+    engineIdentityKeyOfMock.mockClear()
     existsMock.mockReset()
     getEnginePreviewAssetsMock.mockReset()
     getTemplateMetadataMock.mockReset()
@@ -377,5 +389,63 @@ describe('useDiscoverResources', () => {
     await discoverResources.checkResourcesForActiveTab()
 
     expect(modalOpenMock).not.toHaveBeenCalled()
+    expect(engineIdentityKeyOfMock).toHaveBeenCalled()
+  })
+
+  it('已导入同路径游戏时通过 gameManager.identityKeyOf 去重', async () => {
+    const { gameManager } = await import('~/services/game-manager')
+    vi.mocked(gameManager.validateGame).mockResolvedValue(true)
+    vi.mocked(gameManager.getGamePreviewAssets).mockResolvedValue({
+      icon: { path: 'icons/favicon.ico' },
+      cover: { path: 'game/background/cover.png' },
+    })
+    vi.mocked(gameManager.resolvePreviewSite).mockResolvedValue({
+      projectPath: '/games/demo',
+    })
+    resolveHomeTabDefinitionMock.mockReturnValue({ discoveryType: 'games' })
+    useWorkspaceStoreMock.mockReturnValue({ activeTab: 'games' })
+    useStorageSettingsStoreMock.mockReturnValue({
+      engineSavePath: '/engines',
+      gameSavePath: '/games',
+      templateSavePath: '/templates',
+    })
+    useResourceStoreMock.mockReturnValue({
+      engines: [],
+      games: [
+        {
+          id: 'game-1',
+          path: '/Games/Demo',
+          pathKey: '/games/demo',
+          createdAt: 0,
+          lastModified: 0,
+          status: 'created',
+          availability: 'available',
+          metadata: { name: 'Demo Game' },
+          previewAssets: {
+            icon: { path: 'icons/favicon.ico' },
+            cover: { path: 'game/background/cover.png' },
+          },
+        },
+      ],
+      templates: [],
+    })
+    readDirMock.mockImplementation(async (path: string) => {
+      switch (path) {
+        case '/games': {
+          return [{ isDirectory: true, name: 'demo' }]
+        }
+        default: {
+          return []
+        }
+      }
+    })
+
+    const { useDiscoverResources } = await import('../useDiscoverResources')
+    const discoverResources = useDiscoverResources()
+
+    await discoverResources.checkResourcesForActiveTab()
+
+    expect(modalOpenMock).not.toHaveBeenCalled()
+    expect(gameIdentityKeyOfMock).toHaveBeenCalled()
   })
 })

--- a/src/features/home/__tests__/useDiscoverResources.test.ts
+++ b/src/features/home/__tests__/useDiscoverResources.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { toResourcePathKey } from '~/services/resource-health'
+
 const {
   classifyEngineMock,
   gameIdentityKeyOfMock,
@@ -20,11 +22,11 @@ const {
   validateTemplateMock,
 } = vi.hoisted(() => ({
   classifyEngineMock: vi.fn(),
-  gameIdentityKeyOfMock: vi.fn((resource: { path: string }) => resource.path.toLowerCase().replace(/\/+$/, '')),
+  gameIdentityKeyOfMock: vi.fn((resource: { path: string }) => toResourcePathKey(resource)),
   engineIdentityKeyOfMock: vi.fn((resource: { path: string, engineId?: string, version?: string }) =>
     resource.engineId && resource.version
       ? `${resource.engineId}:${resource.version}`
-      : resource.path.toLowerCase().replace(/\/+$/, ''),
+      : toResourcePathKey(resource),
   ),
   existsMock: vi.fn(),
   getEnginePreviewAssetsMock: vi.fn(),

--- a/src/features/home/useDiscoverResources.ts
+++ b/src/features/home/useDiscoverResources.ts
@@ -10,7 +10,6 @@ import { useModalStore } from '~/stores/modal'
 import { useResourceStore } from '~/stores/resource'
 import { useStorageSettingsStore } from '~/stores/storage-settings'
 import { useWorkspaceStore } from '~/stores/workspace'
-import { toComparablePath } from '~/utils/path'
 
 import type { DiscoveredResource } from './discovered-resource'
 import type { Engine, Game, Template } from '~/database/model'
@@ -192,12 +191,10 @@ function getDiscoveredResourceKey(type: ResourceType, resource: DiscoveredResour
       return resource.name || resource.path
     }
     case 'engines': {
-      return resource.engineId && resource.version
-        ? `${resource.engineId}:${resource.version}`
-        : resource.path
+      return engineManager.identityKeyOf(resource)
     }
     case 'games': {
-      return toComparablePath(resource.path)
+      return gameManager.identityKeyOf(resource)
     }
     default: {
       throw new Error(`未知的资源类型: ${type satisfies never}`)
@@ -216,12 +213,12 @@ function getExistingResourceKey(
         : resource.path
     }
     case 'engines': {
-      return isExistingEngine(resource) && resource.version
-        ? `${resource.engineId}:${resource.version}`
+      return isExistingEngine(resource)
+        ? engineManager.identityKeyOf(resource)
         : resource.path
     }
     case 'games': {
-      return toComparablePath(resource.path)
+      return gameManager.identityKeyOf(resource)
     }
     default: {
       throw new Error(`未知的资源类型: ${type satisfies never}`)

--- a/src/services/__tests__/engine-manager.test.ts
+++ b/src/services/__tests__/engine-manager.test.ts
@@ -246,6 +246,7 @@ describe('engineManager', () => {
 
     expect(addMock).toHaveBeenCalledWith(expect.objectContaining({
       path: '/engines/WebGAL/4.5.0',
+      pathKey: '/engines/webgal/4.5.0',
       name: 'WebGAL',
       version: '4.5.0',
       status: 'creating',
@@ -354,17 +355,30 @@ describe('engineManager', () => {
   })
 
   it('importEngine 在源路径已注册时幂等返回既有 ID', async () => {
-    enginesToArrayMock.mockResolvedValue([
-      createTestEngine({
-        id: 'engine-existing',
-        path: '/downloads/webgal',
-      }),
-    ])
+    engineWhereFirstMock.mockResolvedValue(createTestEngine({
+      id: 'engine-existing',
+      path: '/downloads/webgal',
+    }))
 
     await expect(engineManager.importEngine('/downloads/webgal')).resolves.toEqual({ id: 'engine-existing', alreadyRegistered: true })
 
     expect(addMock).not.toHaveBeenCalled()
     expect(copyDirectoryWithProgressMock).not.toHaveBeenCalled()
+  })
+
+  it('engine 身份键优先使用 engineId + version', () => {
+    expect(engineManager.identityKeyOf({
+      path: '/downloads/webgal',
+      engineId: 'open-webgal.webgal',
+      version: '4.5.0',
+    })).toBe('open-webgal.webgal:4.5.0')
+  })
+
+  it('engine 身份键在缺少版本时回退到路径规范化结果', () => {
+    expect(engineManager.identityKeyOf({
+      path: '/Downloads/WebGAL/',
+      engineId: 'open-webgal.webgal',
+    })).toBe('/downloads/webgal')
   })
 
   it('importEngine 在目标目录已存在但无 DB 记录时抛出 TARGET_CONFLICT', async () => {

--- a/src/services/__tests__/game-manager.test.ts
+++ b/src/services/__tests__/game-manager.test.ts
@@ -268,6 +268,19 @@ describe('gameManager', () => {
     })
   })
 
+  it('getGamePreviewAssets 按既定候选顺序解析图标', async () => {
+    existsMock.mockImplementation(async (path: string) => path === '/games/demo/icons/icon-192.png')
+
+    await expect(gameManager.getGamePreviewAssets('/games/demo')).resolves.toEqual({
+      icon: {
+        path: 'icons/icon-192.png',
+      },
+      cover: {
+        path: 'game/background/cover.png',
+      },
+    })
+  })
+
   it('registerGame 会保留调用方提供的 metadata 并只补齐缺失的 previewAssets', async () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-03-28T10:00:00.000Z'))
@@ -282,6 +295,7 @@ describe('gameManager', () => {
       metadata: {
         name: 'Provided Name',
       },
+      pathKey: '/games/demo',
       previewAssets: {
         icon: {
           path: 'icons/favicon.ico',
@@ -326,12 +340,30 @@ describe('gameManager', () => {
     copyDirectoryWithProgressMock.mockImplementation(async (_from, _to, onProgress: (progress: number) => void) => {
       onProgress(48)
     })
-    existsMock.mockResolvedValueOnce(false).mockResolvedValueOnce(true)
+    existsMock.mockImplementation(async (path: string) => {
+      if (path === '/games/demo') {
+        return false
+      }
+      if (path === '/engines/WebGAL/4.5.0/game') {
+        return true
+      }
+      if (path === '/engines/WebGAL/4.5.0/icons/icon-192.png') {
+        return true
+      }
+      if (path.startsWith('/engines/WebGAL/4.5.0/icons/')) {
+        return false
+      }
+      if (path.startsWith('/games/demo/icons/')) {
+        return false
+      }
+      return false
+    })
 
     await expect(gameManager.createGame('Demo Game', '/games/demo', 'engine-1')).resolves.toBe('game-1')
 
     expect(dbGameAddMock).toHaveBeenCalledWith(expect.objectContaining({
       path: '/games/demo',
+      pathKey: '/games/demo',
       engineId: 'engine-1',
       status: 'creating',
       metadata: {
@@ -339,7 +371,7 @@ describe('gameManager', () => {
       },
       previewAssets: {
         icon: {
-          path: 'icons/favicon.ico',
+          path: 'icons/icon-192.png',
         },
         cover: {
           path: 'game/background/cover.png',
@@ -395,11 +427,27 @@ describe('gameManager', () => {
       version: '4.5.0',
       path: '/engines/WebGAL/4.5.0',
     }))
-    existsMock
-      .mockResolvedValueOnce(false) // gamePath 不存在
-      .mockResolvedValueOnce(true) // engineGameDir 存在
+    let gamePathChecks = 0
+    existsMock.mockImplementation(async (path: string) => {
+      if (path === '/games/demo') {
+        gamePathChecks += 1
+        return gamePathChecks > 1
+      }
+      if (path === '/engines/WebGAL/4.5.0/game') {
+        return true
+      }
+      if (path === '/engines/WebGAL/4.5.0/icons/icon-192.png') {
+        return true
+      }
+      if (path.startsWith('/engines/WebGAL/4.5.0/icons/')) {
+        return false
+      }
+      if (path.startsWith('/games/demo/icons/')) {
+        return false
+      }
+      return false
+    })
     copyDirectoryWithProgressMock.mockRejectedValue(new Error('copy failed'))
-    existsMock.mockResolvedValueOnce(true) // 回滚时 gamePath 存在
 
     await expect(gameManager.createGame('Demo Game', '/games/demo', 'engine-1')).rejects.toThrow('copy failed')
 
@@ -415,11 +463,27 @@ describe('gameManager', () => {
       version: '4.5.0',
       path: '/engines/WebGAL/4.5.0',
     }))
-    existsMock
-      .mockResolvedValueOnce(false) // gamePath 不存在
-      .mockResolvedValueOnce(true) // engineGameDir 存在
+    let gamePathChecks = 0
+    existsMock.mockImplementation(async (path: string) => {
+      if (path === '/games/demo') {
+        gamePathChecks += 1
+        return gamePathChecks > 1
+      }
+      if (path === '/engines/WebGAL/4.5.0/game') {
+        return true
+      }
+      if (path === '/engines/WebGAL/4.5.0/icons/icon-192.png') {
+        return true
+      }
+      if (path.startsWith('/engines/WebGAL/4.5.0/icons/')) {
+        return false
+      }
+      if (path.startsWith('/games/demo/icons/')) {
+        return false
+      }
+      return false
+    })
     gameCmdsSetGameConfigMock.mockRejectedValue(new Error('config failed'))
-    existsMock.mockResolvedValueOnce(true) // 回滚时 gamePath 存在
 
     await expect(gameManager.createGame('Demo Game', '/games/demo', 'engine-1')).rejects.toThrow('config failed')
 
@@ -474,6 +538,7 @@ describe('gameManager', () => {
     expect(dbGameAddMock).toHaveBeenCalledWith(expect.objectContaining({
       engineId: undefined,
       path: '/games/self-contained',
+      pathKey: '/games/self-contained',
     }))
   })
 
@@ -499,6 +564,7 @@ describe('gameManager', () => {
     expect(dbGameAddMock).toHaveBeenCalledWith(expect.objectContaining({
       engineId: 'engine-1',
       path: '/games/vfs',
+      pathKey: '/games/vfs',
     }))
   })
 
@@ -526,6 +592,7 @@ describe('gameManager', () => {
     expect(dbGameAddMock).toHaveBeenCalledWith(expect.objectContaining({
       engineId: 'engine-1',
       path: '/games/vfs',
+      pathKey: '/games/vfs',
     }))
     expect(warnMock).toHaveBeenCalledWith('关联的引擎 WebGAL 当前不可用，项目预览将受限: /games/vfs')
   })
@@ -568,6 +635,7 @@ describe('gameManager', () => {
     expect(dbGameAddMock).toHaveBeenCalledWith(expect.objectContaining({
       engineId: 'engine-2',
       path: '/games/vfs',
+      pathKey: '/games/vfs',
     }))
   })
 
@@ -603,15 +671,19 @@ describe('gameManager', () => {
     })
     expect(dbGameAddMock).toHaveBeenCalledWith(expect.objectContaining({
       engineId: 'engine-2',
+      pathKey: '/games/vfs',
     }))
   })
 
   it('importGame 遇到已注册项目时会幂等返回既有 ID', async () => {
-    existsMock.mockResolvedValue(true)
-    dbGamesToArrayMock.mockResolvedValue([createTestGame({
-      id: 'game-existing',
-      path: '/games/demo',
-    })])
+    dbGameWhereMock.mockReturnValue({
+      equals: () => ({
+        first: async () => createTestGame({
+          id: 'game-existing',
+          path: '/games/demo',
+        }),
+      }),
+    })
 
     await expect(gameManager.importGame('/games/demo')).resolves.toEqual({
       id: 'game-existing',
@@ -621,17 +693,24 @@ describe('gameManager', () => {
   })
 
   it('importGame 对大小写不同但归一化相同的路径也会幂等返回既有 ID', async () => {
-    existsMock.mockResolvedValue(true)
-    dbGamesToArrayMock.mockResolvedValue([createTestGame({
-      id: 'game-existing',
-      path: '/Games/Demo',
-    })])
+    dbGameWhereMock.mockReturnValue({
+      equals: () => ({
+        first: async () => createTestGame({
+          id: 'game-existing',
+          path: '/Games/Demo',
+        }),
+      }),
+    })
 
     await expect(gameManager.importGame('/games/demo')).resolves.toEqual({
       id: 'game-existing',
       alreadyRegistered: true,
     })
     expect(dbGameAddMock).not.toHaveBeenCalled()
+  })
+
+  it('game 身份键与自动发现复用同一套路径规范化规则', () => {
+    expect(gameManager.identityKeyOf({ path: '/Games/Demo/' })).toBe('/games/demo')
   })
 
   it('importGame 在用户取消选择引擎时会返回取消原因', async () => {
@@ -763,7 +842,10 @@ describe('gameManager', () => {
   })
 
   it('inspectGame 在 favicon 缺失时只产 warning', async () => {
-    existsMock.mockImplementation(async (path: string) => path !== '/games/demo/icons/favicon.ico')
+    existsMock.mockImplementation(async (path: string) =>
+      path === '/games/demo'
+      || path === '/games/demo/game/config.txt'
+      || path === '/games/demo/game/background/cover.png')
 
     await expect(gameManager.inspectGame('/games/demo')).resolves.toMatchObject({
       availability: 'available',
@@ -950,6 +1032,7 @@ describe('gameManager', () => {
     expect(workspaceStoreState.currentGame).toEqual({
       id: 'game-1',
       path: '/games/demo',
+      pathKey: '/games/demo',
       createdAt: 0,
       lastModified: new Date('2026-03-28T10:00:00.000Z').getTime(),
       status: 'created',

--- a/src/services/__tests__/game-manager.test.ts
+++ b/src/services/__tests__/game-manager.test.ts
@@ -677,12 +677,15 @@ describe('gameManager', () => {
 
   it('importGame 遇到已注册项目时会幂等返回既有 ID', async () => {
     dbGameWhereMock.mockReturnValue({
-      equals: () => ({
-        first: async () => createTestGame({
-          id: 'game-existing',
-          path: '/games/demo',
-        }),
-      }),
+      equals: (pathKey: string) => {
+        expect(pathKey).toBe('/games/demo')
+        return {
+          first: async () => createTestGame({
+            id: 'game-existing',
+            path: '/games/demo',
+          }),
+        }
+      },
     })
 
     await expect(gameManager.importGame('/games/demo')).resolves.toEqual({

--- a/src/services/__tests__/game-manager.test.ts
+++ b/src/services/__tests__/game-manager.test.ts
@@ -849,7 +849,7 @@ describe('gameManager', () => {
 
     await expect(gameManager.inspectGame('/games/demo')).resolves.toMatchObject({
       availability: 'available',
-      warnings: [{ code: 'missing-favicon' }],
+      warnings: [{ code: 'missing-game-icon' }],
     })
   })
 

--- a/src/services/engine-manager.ts
+++ b/src/services/engine-manager.ts
@@ -14,6 +14,7 @@ import {
   ResourceAvailability,
   ResourceHealthResult,
   ResourceWarning,
+  toResourcePathKey,
 } from '~/services/resource-health'
 import { EngineMetadata, EnginePreviewAssets } from '~/services/types'
 import { useResourceStore } from '~/stores/resource'
@@ -38,10 +39,6 @@ interface DeleteEngineCheckResult {
   associatedGames?: Game[]
   canDelete: boolean
   reason?: 'ENGINE_HAS_ASSOCIATED_GAMES'
-}
-
-function enginePathKeyOf(input: { path: string }): string {
-  return normalizeImportPath(input.path).comparablePath
 }
 
 function sanitizeEnginePathSegment(value: string, fieldName: '引擎名称' | '引擎版本'): string {
@@ -165,7 +162,7 @@ async function registerEngine(
   return db.engines.add({
     id: crypto.randomUUID(),
     path: enginePath,
-    pathKey: enginePathKeyOf({ path: enginePath }),
+    pathKey: toResourcePathKey({ path: enginePath }),
     engineId: options.engineId,
     name: options.name,
     version: options.version,
@@ -294,18 +291,17 @@ async function copyAndFinalizeEngine(
 }
 
 async function findEngineByComparablePath(rawPath: string): Promise<Engine | undefined> {
-  return db.engines.where('pathKey').equals(enginePathKeyOf({ path: rawPath })).first()
+  return db.engines.where('pathKey').equals(toResourcePathKey({ path: rawPath })).first()
 }
 
 function identityKeyOf(
-  input: Pick<Engine, 'path' | 'engineId' | 'version'>
-    | { path: string, engineId?: string, version?: string },
+  input: { path: string, engineId?: string, version?: string },
 ): string {
   if (input.engineId && input.version) {
     return `${input.engineId}:${input.version}`
   }
 
-  return enginePathKeyOf(input)
+  return toResourcePathKey(input)
 }
 
 async function collectEngineWarnings(

--- a/src/services/engine-manager.ts
+++ b/src/services/engine-manager.ts
@@ -21,7 +21,6 @@ import { useStorageSettingsStore } from '~/stores/storage-settings'
 import { EngineManifest, EngineManifestResult } from '~/types/engine'
 import { AppError } from '~/types/errors'
 import { EngineRef } from '~/types/project-config'
-import { toComparablePath } from '~/utils/path'
 
 interface EngineSnapshot {
   engineId: string
@@ -39,6 +38,10 @@ interface DeleteEngineCheckResult {
   associatedGames?: Game[]
   canDelete: boolean
   reason?: 'ENGINE_HAS_ASSOCIATED_GAMES'
+}
+
+function enginePathKeyOf(input: { path: string }): string {
+  return normalizeImportPath(input.path).comparablePath
 }
 
 function sanitizeEnginePathSegment(value: string, fieldName: '引擎名称' | '引擎版本'): string {
@@ -162,6 +165,7 @@ async function registerEngine(
   return db.engines.add({
     id: crypto.randomUUID(),
     path: enginePath,
+    pathKey: enginePathKeyOf({ path: enginePath }),
     engineId: options.engineId,
     name: options.name,
     version: options.version,
@@ -290,9 +294,18 @@ async function copyAndFinalizeEngine(
 }
 
 async function findEngineByComparablePath(rawPath: string): Promise<Engine | undefined> {
-  const { comparablePath } = normalizeImportPath(rawPath)
-  const engines = await db.engines.toArray()
-  return engines.find(engine => toComparablePath(engine.path) === comparablePath)
+  return db.engines.where('pathKey').equals(enginePathKeyOf({ path: rawPath })).first()
+}
+
+function identityKeyOf(
+  input: Pick<Engine, 'path' | 'engineId' | 'version'>
+    | { path: string, engineId?: string, version?: string },
+): string {
+  if (input.engineId && input.version) {
+    return `${input.engineId}:${input.version}`
+  }
+
+  return enginePathKeyOf(input)
 }
 
 async function collectEngineWarnings(
@@ -488,4 +501,5 @@ export const engineManager = {
   importEngine,
   uninstallEngine,
   uninstallEngineGroup,
+  identityKeyOf,
 }

--- a/src/services/game-manager.ts
+++ b/src/services/game-manager.ts
@@ -91,12 +91,13 @@ function mergeGameConfigEntries(
 }
 
 function buildGamePreviewAssets(iconPath: string, titleImage: string | undefined): GamePreviewAssets {
+  const normalizedTitle = titleImage?.replaceAll('\\', '/')
   return {
     icon: {
       path: iconPath,
     },
     cover: {
-      path: titleImage ? `game/background/${titleImage}` : '',
+      path: normalizedTitle ? `game/background/${normalizedTitle}` : '',
     },
   }
 }

--- a/src/services/game-manager.ts
+++ b/src/services/game-manager.ts
@@ -8,7 +8,7 @@ import { vfsCmds } from '~/commands/vfs'
 import { db } from '~/database/db'
 import { Engine, Game } from '~/database/model'
 import { engineManager, isEngineUsable } from '~/services/engine-manager'
-import { gameConfigPath, gameCoverPath, gameIconPath, projectConfigPath } from '~/services/platform/app-paths'
+import { gameConfigPath, gameCoverPath, projectConfigPath } from '~/services/platform/app-paths'
 import {
   classifyAvailability,
   createWarning,
@@ -51,6 +51,7 @@ const GAME_ICON_PREVIEW_CANDIDATES = [
   'icons/apple-touch-icon.png',
   'icons/favicon.ico',
 ] as const
+const DEFAULT_GAME_ICON_PREVIEW_PATH = GAME_ICON_PREVIEW_CANDIDATES.at(-1) ?? 'icons/favicon.ico'
 
 interface GamePreviewLookupResult {
   iconPath: string
@@ -103,17 +104,26 @@ function buildGamePreviewAssets(iconPath: string, titleImage: string | undefined
 }
 
 async function resolveGameIconPreviewPath(gamePath: string): Promise<GamePreviewLookupResult> {
-  for (const relativePath of GAME_ICON_PREVIEW_CANDIDATES) {
-    if (await exists(await join(gamePath, relativePath))) {
+  const candidateChecks = await Promise.all(
+    GAME_ICON_PREVIEW_CANDIDATES.map(async (relativePath) => {
+      const targetPath = await join(gamePath, relativePath)
       return {
-        iconPath: relativePath,
-        iconExists: true,
+        relativePath,
+        iconExists: await exists(targetPath),
       }
+    }),
+  )
+
+  const matchedCandidate = candidateChecks.find(candidate => candidate.iconExists)
+  if (matchedCandidate) {
+    return {
+      iconPath: matchedCandidate.relativePath,
+      iconExists: true,
     }
   }
 
   return {
-    iconPath: GAME_ICON_PREVIEW_CANDIDATES[GAME_ICON_PREVIEW_CANDIDATES.length - 1],
+    iconPath: DEFAULT_GAME_ICON_PREVIEW_PATH,
     iconExists: false,
   }
 }

--- a/src/services/game-manager.ts
+++ b/src/services/game-manager.ts
@@ -22,7 +22,6 @@ import { useResourceStore } from '~/stores/resource'
 import { useWorkspaceStore } from '~/stores/workspace'
 import { AppError } from '~/types/errors'
 import { EngineRef, ProjectConfig, TemplateBinding } from '~/types/project-config'
-import { toComparablePath } from '~/utils/path'
 
 import type { GameConfigEntry } from '~/commands/game'
 import type { StaticSiteConfig } from '~/types/server'
@@ -46,6 +45,17 @@ export interface GameInspectionPayload {
 const GAME_NAME_RAW_KEY = 'Game_name'
 const GAME_KEY_RAW_KEY = 'Game_key'
 const TITLE_IMAGE_RAW_KEY = 'Title_img'
+const GAME_ICON_PREVIEW_CANDIDATES = [
+  'icons/icon-192.png',
+  'icons/icon-512.png',
+  'icons/apple-touch-icon.png',
+  'icons/favicon.ico',
+] as const
+
+interface GamePreviewLookupResult {
+  iconPath: string
+  iconExists: boolean
+}
 
 function mergeGameConfigEntries(
   entries: readonly GameConfigEntry[],
@@ -77,14 +87,34 @@ function mergeGameConfigEntries(
   return mergedEntries
 }
 
-function buildGamePreviewAssets(titleImage: string | undefined): GamePreviewAssets {
+function gamePathKeyOf(input: { path: string }): string {
+  return normalizeImportPath(input.path).comparablePath
+}
+
+function buildGamePreviewAssets(iconPath: string, titleImage: string | undefined): GamePreviewAssets {
   return {
     icon: {
-      path: 'icons/favicon.ico',
+      path: iconPath,
     },
     cover: {
       path: titleImage ? `game/background/${titleImage}` : '',
     },
+  }
+}
+
+async function resolveGameIconPreviewPath(gamePath: string): Promise<GamePreviewLookupResult> {
+  for (const relativePath of GAME_ICON_PREVIEW_CANDIDATES) {
+    if (await exists(await join(gamePath, relativePath))) {
+      return {
+        iconPath: relativePath,
+        iconExists: true,
+      }
+    }
+  }
+
+  return {
+    iconPath: GAME_ICON_PREVIEW_CANDIDATES[GAME_ICON_PREVIEW_CANDIDATES.length - 1],
+    iconExists: false,
   }
 }
 
@@ -119,17 +149,19 @@ function withGamePreviewCacheVersion(
 
 async function getGamePreviewAssets(gamePath: string): Promise<GamePreviewAssets> {
   const metadata = await getGameMetadata(gamePath)
-  return buildGamePreviewAssets(metadata.titleImg)
+  const iconLookup = await resolveGameIconPreviewPath(gamePath)
+  return buildGamePreviewAssets(iconLookup.iconPath, metadata.titleImg)
 }
 
 async function getGameSnapshot(gamePath: string): Promise<Pick<Game, 'metadata' | 'previewAssets'>> {
   const metadata = await getGameMetadata(gamePath)
+  const iconLookup = await resolveGameIconPreviewPath(gamePath)
   const cacheVersion = Date.now()
 
   return {
     metadata,
     previewAssets: withGamePreviewCacheVersion(
-      buildGamePreviewAssets(metadata.titleImg),
+      buildGamePreviewAssets(iconLookup.iconPath, metadata.titleImg),
       cacheVersion,
     ),
   }
@@ -154,7 +186,7 @@ function applyCurrentGamePatch(
 }
 
 async function refreshRegisteredGameSnapshot(gamePath: string): Promise<void> {
-  const game = await db.games.where('path').equals(gamePath).first()
+  const game = await db.games.where('pathKey').equals(gamePathKeyOf({ path: gamePath })).first()
   if (!game) {
     return
   }
@@ -191,6 +223,7 @@ async function registerGame(
   return db.games.add({
     id: crypto.randomUUID(),
     path: gamePath,
+    pathKey: gamePathKeyOf({ path: gamePath }),
     engineId,
     createdAt: Date.now(),
     lastModified: Date.now(),
@@ -393,9 +426,11 @@ async function createGame(gameName: string, gamePath: string, engineId: string, 
     try {
       const engineConfig = await gameCmds.getGameConfig(engine.path)
       const titleImg = findGameConfigEntryValue(engineConfig.entries, TITLE_IMAGE_RAW_KEY) ?? ''
-      initialPreviewAssets = buildGamePreviewAssets(titleImg)
+      const iconLookup = await resolveGameIconPreviewPath(engine.path)
+      initialPreviewAssets = buildGamePreviewAssets(iconLookup.iconPath, titleImg)
     } catch {
-      initialPreviewAssets = buildGamePreviewAssets(undefined)
+      const iconLookup = await resolveGameIconPreviewPath(engine.path)
+      initialPreviewAssets = buildGamePreviewAssets(iconLookup.iconPath, undefined)
     }
 
     gameId = await registerGame(gamePath, {
@@ -492,6 +527,7 @@ async function relinkGame(gameId: string, newPath: string): Promise<Game> {
 
   const patch: Partial<Game> = {
     path: inspection.normalizedPath,
+    pathKey: inspection.comparablePath,
     availability: 'available',
     lastModified: Date.now(),
     ...inspection.payload,
@@ -551,14 +587,17 @@ async function renameGame(id: string, newName: string): Promise<void> {
 }
 
 async function findExistingGameByPath(rawPath: string): Promise<Game | undefined> {
-  const { comparablePath } = normalizeImportPath(rawPath)
-  const games = await db.games.toArray()
-  return games.find(game => toComparablePath(game.path) === comparablePath)
+  return db.games.where('pathKey').equals(gamePathKeyOf({ path: rawPath })).first()
+}
+
+function identityKeyOf(input: Pick<Game, 'path'> | { path: string }): string {
+  return gamePathKeyOf(input)
 }
 
 async function collectGameWarnings(
   gamePath: string,
   metadata: GameMetadata,
+  iconLookup?: GamePreviewLookupResult,
 ): Promise<ResourceWarning[]> {
   const warnings: ResourceWarning[] = []
 
@@ -566,7 +605,8 @@ async function collectGameWarnings(
     warnings.push(createWarning('missing-game-name', '游戏未配置 Game_name'))
   }
 
-  if (!(await exists(await gameIconPath(gamePath)))) {
+  const resolvedIconLookup = iconLookup ?? await resolveGameIconPreviewPath(gamePath)
+  if (!resolvedIconLookup.iconExists) {
     warnings.push(createWarning('missing-favicon', '游戏 favicon 不存在'))
   }
 
@@ -580,11 +620,10 @@ async function collectGameWarnings(
   return warnings
 }
 
-async function inspectGame(
-  rawPath: string,
-): Promise<ResourceHealthResult<GameInspectionPayload>> {
-  const { normalizedPath, comparablePath } = normalizeImportPath(rawPath)
-
+async function inspectGameStructure(
+  normalizedPath: string,
+  comparablePath: string,
+): Promise<ResourceHealthResult<never> | undefined> {
   if (!(await exists(normalizedPath))) {
     return {
       availability: 'missing',
@@ -604,10 +643,51 @@ async function inspectGame(
       comparablePath,
     }
   }
+}
 
-  let metadata: GameMetadata
+async function inspectGameSemantics(
+  normalizedPath: string,
+): Promise<GameInspectionPayload & { warnings: ResourceWarning[] }> {
+  const metadata = await getGameMetadata(normalizedPath)
+  const iconLookup = await resolveGameIconPreviewPath(normalizedPath)
+  const warnings = await collectGameWarnings(normalizedPath, metadata, iconLookup)
+
+  return {
+    metadata,
+    warnings,
+    previewAssets: withGamePreviewCacheVersion(
+      buildGamePreviewAssets(iconLookup.iconPath, metadata.titleImg),
+    ),
+  }
+}
+
+async function inspectGame(
+  rawPath: string,
+): Promise<ResourceHealthResult<GameInspectionPayload>> {
+  const { normalizedPath, comparablePath } = normalizeImportPath(rawPath)
+
+  const structureResult = await inspectGameStructure(normalizedPath, comparablePath)
+  if (structureResult) {
+    return structureResult
+  }
+
   try {
-    metadata = await getGameMetadata(normalizedPath)
+    const payload = await inspectGameSemantics(normalizedPath)
+
+    return {
+      availability: classifyAvailability({
+        pathExists: true,
+        structureValid: true,
+        semanticsValid: true,
+      }),
+      warnings: payload.warnings,
+      payload: {
+        metadata: payload.metadata,
+        previewAssets: payload.previewAssets,
+      },
+      normalizedPath,
+      comparablePath,
+    }
   } catch (error) {
     return {
       availability: 'broken',
@@ -620,22 +700,6 @@ async function inspectGame(
       normalizedPath,
       comparablePath,
     }
-  }
-  const warnings = await collectGameWarnings(normalizedPath, metadata)
-
-  return {
-    availability: classifyAvailability({
-      pathExists: true,
-      structureValid: true,
-      semanticsValid: true,
-    }),
-    warnings,
-    payload: {
-      metadata,
-      previewAssets: withGamePreviewCacheVersion(buildGamePreviewAssets(metadata.titleImg)),
-    },
-    normalizedPath,
-    comparablePath,
   }
 }
 
@@ -747,4 +811,5 @@ export const gameManager = {
   resolvePreviewSite,
   updateGameLastModified,
   updateCurrentGameLastModified,
+  identityKeyOf,
 }

--- a/src/services/game-manager.ts
+++ b/src/services/game-manager.ts
@@ -617,7 +617,7 @@ async function collectGameWarnings(
   }
 
   if (!iconLookup.iconExists) {
-    warnings.push(createWarning('missing-favicon', '游戏 favicon 不存在'))
+    warnings.push(createWarning('missing-game-icon', '游戏图标不存在'))
   }
 
   const titleImg = metadata.titleImg?.trim()

--- a/src/services/game-manager.ts
+++ b/src/services/game-manager.ts
@@ -90,8 +90,12 @@ function mergeGameConfigEntries(
   return mergedEntries
 }
 
+function normalizeLogicalAssetPath(path: string | undefined): string | undefined {
+  return path?.replaceAll('\\', '/')
+}
+
 function buildGamePreviewAssets(iconPath: string, titleImage: string | undefined): GamePreviewAssets {
-  const normalizedTitle = titleImage?.replaceAll('\\', '/')
+  const normalizedTitle = normalizeLogicalAssetPath(titleImage)
   return {
     icon: {
       path: iconPath,
@@ -621,7 +625,7 @@ async function collectGameWarnings(
     warnings.push(createWarning('missing-game-icon', '游戏图标不存在'))
   }
 
-  const titleImg = metadata.titleImg?.trim()
+  const titleImg = normalizeLogicalAssetPath(metadata.titleImg?.trim())
   if (!titleImg) {
     warnings.push(createWarning('missing-title-image', '游戏未配置 Title_img'))
   } else if (!(await exists(await gameCoverPath(gamePath, titleImg)))) {

--- a/src/services/game-manager.ts
+++ b/src/services/game-manager.ts
@@ -15,6 +15,7 @@ import {
   normalizeImportPath,
   ResourceHealthResult,
   ResourceWarning,
+  toResourcePathKey,
 } from '~/services/resource-health'
 import { templateSwitch } from '~/services/template-switch'
 import { GameMetadata, GamePreviewAssets } from '~/services/types'
@@ -51,7 +52,8 @@ const GAME_ICON_PREVIEW_CANDIDATES = [
   'icons/apple-touch-icon.png',
   'icons/favicon.ico',
 ] as const
-const DEFAULT_GAME_ICON_PREVIEW_PATH = GAME_ICON_PREVIEW_CANDIDATES.at(-1) ?? 'icons/favicon.ico'
+const DEFAULT_GAME_ICON_PREVIEW_PATH: string =
+  GAME_ICON_PREVIEW_CANDIDATES.at(-1)!
 
 interface GamePreviewLookupResult {
   iconPath: string
@@ -86,10 +88,6 @@ function mergeGameConfigEntries(
   }
 
   return mergedEntries
-}
-
-function gamePathKeyOf(input: { path: string }): string {
-  return normalizeImportPath(input.path).comparablePath
 }
 
 function buildGamePreviewAssets(iconPath: string, titleImage: string | undefined): GamePreviewAssets {
@@ -158,14 +156,18 @@ function withGamePreviewCacheVersion(
 }
 
 async function getGamePreviewAssets(gamePath: string): Promise<GamePreviewAssets> {
-  const metadata = await getGameMetadata(gamePath)
-  const iconLookup = await resolveGameIconPreviewPath(gamePath)
+  const [metadata, iconLookup] = await Promise.all([
+    getGameMetadata(gamePath),
+    resolveGameIconPreviewPath(gamePath),
+  ])
   return buildGamePreviewAssets(iconLookup.iconPath, metadata.titleImg)
 }
 
 async function getGameSnapshot(gamePath: string): Promise<Pick<Game, 'metadata' | 'previewAssets'>> {
-  const metadata = await getGameMetadata(gamePath)
-  const iconLookup = await resolveGameIconPreviewPath(gamePath)
+  const [metadata, iconLookup] = await Promise.all([
+    getGameMetadata(gamePath),
+    resolveGameIconPreviewPath(gamePath),
+  ])
   const cacheVersion = Date.now()
 
   return {
@@ -196,7 +198,7 @@ function applyCurrentGamePatch(
 }
 
 async function refreshRegisteredGameSnapshot(gamePath: string): Promise<void> {
-  const game = await db.games.where('pathKey').equals(gamePathKeyOf({ path: gamePath })).first()
+  const game = await db.games.where('pathKey').equals(toResourcePathKey({ path: gamePath })).first()
   if (!game) {
     return
   }
@@ -233,7 +235,7 @@ async function registerGame(
   return db.games.add({
     id: crypto.randomUUID(),
     path: gamePath,
-    pathKey: gamePathKeyOf({ path: gamePath }),
+    pathKey: toResourcePathKey({ path: gamePath }),
     engineId,
     createdAt: Date.now(),
     lastModified: Date.now(),
@@ -432,16 +434,15 @@ async function createGame(gameName: string, gamePath: string, engineId: string, 
     })
 
     // 读取引擎默认配置获取初始预览资源路径，使创建中也能通过引擎 serve URL 显示封面和图标
-    let initialPreviewAssets: GamePreviewAssets
+    const iconLookup = await resolveGameIconPreviewPath(engine.path)
+    let titleImg = ''
     try {
       const engineConfig = await gameCmds.getGameConfig(engine.path)
-      const titleImg = findGameConfigEntryValue(engineConfig.entries, TITLE_IMAGE_RAW_KEY) ?? ''
-      const iconLookup = await resolveGameIconPreviewPath(engine.path)
-      initialPreviewAssets = buildGamePreviewAssets(iconLookup.iconPath, titleImg)
+      titleImg = findGameConfigEntryValue(engineConfig.entries, TITLE_IMAGE_RAW_KEY) ?? ''
     } catch {
-      const iconLookup = await resolveGameIconPreviewPath(engine.path)
-      initialPreviewAssets = buildGamePreviewAssets(iconLookup.iconPath, undefined)
+      // 引擎未提供默认 game/config.txt 时按空 titleImg 处理
     }
+    const initialPreviewAssets = buildGamePreviewAssets(iconLookup.iconPath, titleImg)
 
     gameId = await registerGame(gamePath, {
       engineId,
@@ -597,17 +598,17 @@ async function renameGame(id: string, newName: string): Promise<void> {
 }
 
 async function findExistingGameByPath(rawPath: string): Promise<Game | undefined> {
-  return db.games.where('pathKey').equals(gamePathKeyOf({ path: rawPath })).first()
+  return db.games.where('pathKey').equals(toResourcePathKey({ path: rawPath })).first()
 }
 
-function identityKeyOf(input: Pick<Game, 'path'> | { path: string }): string {
-  return gamePathKeyOf(input)
+function identityKeyOf(input: { path: string }): string {
+  return toResourcePathKey(input)
 }
 
 async function collectGameWarnings(
   gamePath: string,
   metadata: GameMetadata,
-  iconLookup?: GamePreviewLookupResult,
+  iconLookup: GamePreviewLookupResult,
 ): Promise<ResourceWarning[]> {
   const warnings: ResourceWarning[] = []
 
@@ -615,8 +616,7 @@ async function collectGameWarnings(
     warnings.push(createWarning('missing-game-name', '游戏未配置 Game_name'))
   }
 
-  const resolvedIconLookup = iconLookup ?? await resolveGameIconPreviewPath(gamePath)
-  if (!resolvedIconLookup.iconExists) {
+  if (!iconLookup.iconExists) {
     warnings.push(createWarning('missing-favicon', '游戏 favicon 不存在'))
   }
 
@@ -658,8 +658,10 @@ async function inspectGameStructure(
 async function inspectGameSemantics(
   normalizedPath: string,
 ): Promise<GameInspectionPayload & { warnings: ResourceWarning[] }> {
-  const metadata = await getGameMetadata(normalizedPath)
-  const iconLookup = await resolveGameIconPreviewPath(normalizedPath)
+  const [metadata, iconLookup] = await Promise.all([
+    getGameMetadata(normalizedPath),
+    resolveGameIconPreviewPath(normalizedPath),
+  ])
   const warnings = await collectGameWarnings(normalizedPath, metadata, iconLookup)
 
   return {

--- a/src/services/resource-health.ts
+++ b/src/services/resource-health.ts
@@ -6,6 +6,7 @@ export type ResourceAvailability = 'available' | 'missing' | 'broken'
 
 export type ResourceWarningCode =
   | 'missing-favicon'
+  | 'missing-game-icon'
   | 'missing-title-image'
   | 'missing-title-image-file'
   | 'missing-game-name'

--- a/src/services/resource-health.ts
+++ b/src/services/resource-health.ts
@@ -51,6 +51,10 @@ export function normalizeImportPath(rawPath: string): NormalizedImportPath {
   }
 }
 
+export function toResourcePathKey(input: { path: string }): string {
+  return normalizeImportPath(input.path).comparablePath
+}
+
 export function classifyAvailability(input: AvailabilityClassificationInput): ResourceAvailability {
   if (!input.pathExists) {
     return 'missing'

--- a/src/stores/__tests__/workspace.test.ts
+++ b/src/stores/__tests__/workspace.test.ts
@@ -87,6 +87,7 @@ describe('工作区状态仓库', () => {
 
     store.currentGame = createTestGame({
       path: '/games/game-1',
+      pathKey: '/games/game-1',
       metadata: {
         name: 'old',
       },
@@ -114,6 +115,7 @@ describe('工作区状态仓库', () => {
     expect(store.currentGame).toEqual({
       id: 'game-1',
       path: '/games/game-1',
+      pathKey: '/games/game-1',
       createdAt: 0,
       lastModified: 0,
       status: 'created',


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [x] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [x] 代码重构
- [x] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

这个 PR 统一了游戏和引擎资源的身份键计算方式，并将数据库层的路径去重从 `path` 改为规范化后的 `pathKey`，避免因为路径大小写、尾部斜杠等差异导致重复导入或重复注册。

主要改动包括：

- 在 `resource-health` 中抽取 `toResourcePathKey`，作为资源路径规范化后的公共身份键工具
- 为 `Game` 和 `Engine` 增加 `pathKey` 字段，并在 Dexie schema 中为 `games.pathKey` 和 `engines.pathKey` 建立唯一索引
- `gameManager` 和 `engineManager` 统一通过 `identityKeyOf` 暴露资源身份键逻辑，自动发现与已注册资源去重复用同一套规则
- 资源查重查询从遍历全表并比较路径，改为直接走 `pathKey` 索引查询
- 游戏预览资源探测改为并行解析元数据和图标候选路径，并按既定候选顺序优先使用更合适的 icon 资源
- 调整相关测试工厂与单元测试，覆盖路径规范化去重、数据库唯一约束、自动发现去重以及预览图标解析行为

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

当前分支修复的问题本质上是“资源身份定义不一致”：

- 自动发现阶段和已注册资源阶段对“同一个资源”的判断规则不完全一致
- 仅依赖原始 `path` 会受到路径大小写和尾部斜杠影响，导致重复导入判断不稳定
- 现有按路径查重部分需要先读取集合再做比较，随着数据量增长可维护性和性能都不理想

这次修改将“路径规范化后的身份键”收敛为共享抽象，并下沉到数据库唯一索引层，确保导入、注册、重连和自动发现使用一致语义。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
