### PR TITLE
🐛 固化场景文件树中键打开的预览标签

### DIFF
--- a/src/stores/__tests__/tabs.test.ts
+++ b/src/stores/__tests__/tabs.test.ts
@@ -107,6 +107,22 @@ describe('标签状态仓库', () => {
     })
   })
 
+  it('强制以普通标签重新打开已存在的预览标签时会将其固化', () => {
+    const store = useTabsStore()
+
+    store.openTab('preview.txt', '/game/preview.txt')
+    expect(store.tabs[0]?.isPreview).toBe(true)
+
+    store.openTab('preview.txt', '/game/preview.txt', { forceNormal: true })
+
+    expect(store.tabs).toHaveLength(1)
+    expect(store.tabs[0]).toMatchObject({
+      path: '/game/preview.txt',
+      isPreview: false,
+    })
+    expect(store.shouldFocusEditor).toBe(true)
+  })
+
   it('关闭当前标签页后会回退到最近一次激活的剩余标签', () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-03-18T00:00:00.000Z'))

--- a/src/stores/tabs.ts
+++ b/src/stores/tabs.ts
@@ -205,6 +205,9 @@ export const useTabsStore = defineStore(
       if (existIndex === -1) {
         createAndInsertTab(name, path, false)
       } else {
+        if (forceNormal && currentProjectTabs.tabs[existIndex].isPreview) {
+          fixPreviewTab(existIndex)
+        }
         activateTab(existIndex)
       }
 


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [x] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [ ] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

修复场景文件树中的文件在中键点击时，如果目标文件已经以预览标签形式打开，只会激活已有标签、不会将其固化为普通标签的问题。

这次修改将逻辑收敛到 `tabs` store：
当通过 `openTab(..., { forceNormal: true })` 打开一个已存在的标签页时，如果该标签当前是预览标签，则先调用 `fixPreviewTab` 将其固化，再激活该标签。

这样可以保证：
- 场景文件树中键点击已打开的预览标签时，会正确转为普通标签
- `forceNormal` 的语义统一由 store 保证，而不是分散在调用方补丁式处理

同时补充了回归测试，覆盖“强制以普通标签重新打开已存在的预览标签时会将其固化”的场景。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

当前场景文件树中键点击文件会走 `openTab(..., { forceNormal: true })`，语义上应当以普通标签打开文件。

但当目标文件已经以预览标签形式存在时，原实现只会激活已有标签，不会将其从预览标签固化为普通标签，导致 `forceNormal` 在“新开标签”和“复用已有预览标签”这两种路径下语义不一致。

这个 PR 将该语义统一收敛到 `tabs` store`：当 `forceNormal` 命中已有预览标签时，先固化，再激活，并补充回归测试防止再次退化。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
