### PR TITLE
🐛 修复编辑页返回主页时未保存更改丢失的问题

### DIFF
--- a/src/components/editor/EditHeader.spec.ts
+++ b/src/components/editor/EditHeader.spec.ts
@@ -343,6 +343,7 @@ describe('EditHeader', () => {
     await page.getByRole('button', { name: 'common.back' }).click()
 
     const saveChangesCall = modalOpenMock.mock.calls.find(([name]) => name === 'SaveChangesModal')
+    expect(saveChangesCall).toBeDefined()
     const modalOptions = saveChangesCall?.[1] as { onSave?: () => Promise<void> }
 
     await modalOptions.onSave?.()
@@ -350,6 +351,29 @@ describe('EditHeader', () => {
     expect(saveFileMock).toHaveBeenCalledTimes(2)
     expect(saveFileMock).toHaveBeenNthCalledWith(1, '/games/test/scene/a.txt')
     expect(saveFileMock).toHaveBeenNthCalledWith(2, '/games/test/assets/c.png')
+    expect(routerPushMock).toHaveBeenCalledWith('/')
+  })
+  it('确认不保存时会直接返回主页且不会触发保存', async () => {
+    hasUnsavedDocumentsUnderMock.mockReturnValue(true)
+
+    renderInBrowser(EditHeader, {
+      browser: {
+        i18nMode: 'lite',
+      },
+      global: {
+        stubs: globalStubs,
+      },
+    })
+
+    await page.getByRole('button', { name: 'common.back' }).click()
+
+    const saveChangesCall = modalOpenMock.mock.calls.find(([name]) => name === 'SaveChangesModal')
+    expect(saveChangesCall).toBeDefined()
+    const modalOptions = saveChangesCall?.[1] as { onDontSave?: () => Promise<void> }
+
+    await modalOptions.onDontSave?.()
+
+    expect(saveFileMock).not.toHaveBeenCalled()
     expect(routerPushMock).toHaveBeenCalledWith('/')
   })
 

--- a/src/components/editor/EditHeader.spec.ts
+++ b/src/components/editor/EditHeader.spec.ts
@@ -15,22 +15,32 @@ interface ThumbnailStubValue {
 }
 
 const {
+  collectDocumentPathsUnderMock,
   getConfigMock,
+  getDirtyBufferContentMock,
   getByLabelMock,
+  hasUnsavedDocumentsUnderMock,
   loggerErrorMock,
   modalOpenMock,
   routerPushMock,
+  saveFileMock,
   toastErrorMock,
+  useEditorStoreMock,
   useModalStoreMock,
   usePreviewSessionStoreMock,
   useWorkspaceStoreMock,
 } = vi.hoisted(() => ({
+  collectDocumentPathsUnderMock: vi.fn(),
   getConfigMock: vi.fn(),
+  getDirtyBufferContentMock: vi.fn(),
   getByLabelMock: vi.fn(),
+  hasUnsavedDocumentsUnderMock: vi.fn(),
   loggerErrorMock: vi.fn(),
   modalOpenMock: vi.fn(),
   routerPushMock: vi.fn(),
+  saveFileMock: vi.fn(),
   toastErrorMock: vi.fn(),
+  useEditorStoreMock: vi.fn(),
   useModalStoreMock: vi.fn(),
   usePreviewSessionStoreMock: vi.fn(),
   useWorkspaceStoreMock: vi.fn(),
@@ -67,6 +77,10 @@ vi.mock('~/services/config-manager', () => ({
 
 vi.mock('~/services/platform/app-paths', () => ({
   gameAssetDir: vi.fn(async (gamePath: string, assetType: string) => `${gamePath}/game/${assetType}`),
+}))
+
+vi.mock('~/stores/editor', () => ({
+  useEditorStore: useEditorStoreMock,
 }))
 
 vi.mock('~/stores/modal', () => ({
@@ -141,16 +155,29 @@ const globalStubs = {
 
 describe('EditHeader', () => {
   beforeEach(() => {
+    collectDocumentPathsUnderMock.mockReset()
     getConfigMock.mockReset()
+    getDirtyBufferContentMock.mockReset()
     getByLabelMock.mockReset()
+    hasUnsavedDocumentsUnderMock.mockReset()
     loggerErrorMock.mockReset()
     modalOpenMock.mockReset()
     routerPushMock.mockReset()
+    saveFileMock.mockReset()
     toastErrorMock.mockReset()
+    useEditorStoreMock.mockReset()
     useModalStoreMock.mockReset()
     usePreviewSessionStoreMock.mockReset()
     useWorkspaceStoreMock.mockReset()
 
+    collectDocumentPathsUnderMock.mockReturnValue([])
+    hasUnsavedDocumentsUnderMock.mockReturnValue(false)
+    useEditorStoreMock.mockReturnValue({
+      collectDocumentPathsUnder: collectDocumentPathsUnderMock,
+      getDirtyBufferContent: getDirtyBufferContentMock,
+      hasUnsavedDocumentsUnder: hasUnsavedDocumentsUnderMock,
+      saveFile: saveFileMock,
+    })
     useModalStoreMock.mockReturnValue({
       open: modalOpenMock,
     })
@@ -241,6 +268,89 @@ describe('EditHeader', () => {
     })
 
     await expect.element(page.getByRole('button', { name: 'edit.header.gameSettings' })).not.toBeInTheDocument()
+  })
+
+  it('返回主页前无未保存更改时直接跳转', async () => {
+    renderInBrowser(EditHeader, {
+      browser: {
+        i18nMode: 'lite',
+      },
+      global: {
+        stubs: globalStubs,
+      },
+    })
+
+    await page.getByRole('button', { name: 'common.back' }).click()
+
+    await vi.waitFor(() => {
+      expect(hasUnsavedDocumentsUnderMock).toHaveBeenCalledWith('/games/test')
+      expect(routerPushMock).toHaveBeenCalledWith('/')
+    })
+    expect(modalOpenMock).not.toHaveBeenCalledWith('SaveChangesModal', expect.anything())
+  })
+
+  it('返回主页前有未保存更改时会打开确认弹窗', async () => {
+    hasUnsavedDocumentsUnderMock.mockReturnValue(true)
+
+    renderInBrowser(EditHeader, {
+      browser: {
+        i18nMode: 'lite',
+      },
+      global: {
+        stubs: globalStubs,
+      },
+    })
+
+    await page.getByRole('button', { name: 'common.back' }).click()
+
+    await vi.waitFor(() => {
+      expect(modalOpenMock).toHaveBeenCalledWith('SaveChangesModal', expect.objectContaining({
+        title: 'edit.leaveConfirm.title',
+      }))
+    })
+    expect(routerPushMock).not.toHaveBeenCalled()
+  })
+
+  it('确认保存后会先保存所有脏文档再返回主页', async () => {
+    hasUnsavedDocumentsUnderMock.mockReturnValue(true)
+    collectDocumentPathsUnderMock.mockReturnValue(['/games/test/scene/a.txt', '/games/test/scene/b.txt', '/games/test/assets/c.png'])
+    getDirtyBufferContentMock.mockImplementation((path: string) => {
+      switch (path) {
+        case '/games/test/scene/a.txt': {
+          return 'dirty-a'
+        }
+        case '/games/test/scene/b.txt': {
+          return
+        }
+        case '/games/test/assets/c.png': {
+          return 'dirty-c'
+        }
+        default: {
+          return
+        }
+      }
+    })
+
+    renderInBrowser(EditHeader, {
+      browser: {
+        i18nMode: 'lite',
+      },
+      global: {
+        stubs: globalStubs,
+      },
+    })
+
+    await page.getByRole('button', { name: 'common.back' }).click()
+
+    const saveChangesCall = modalOpenMock.mock.calls.find(([name]) => name === 'SaveChangesModal')
+    const modalOptions = saveChangesCall?.[1] as { onSave?: () => Promise<void> }
+
+    await modalOptions.onSave?.()
+
+    expect(saveFileMock).toHaveBeenCalledTimes(2)
+    expect(saveFileMock).toHaveBeenNthCalledWith(1, '/games/test/scene/a.txt')
+    expect(saveFileMock).toHaveBeenNthCalledWith(2, '/games/test/assets/c.png')
+    expect(routerPushMock).toHaveBeenCalledWith('/')
   })
 
   it('打开游戏配置前会先预取配置，再带着准备好的数据打开模态框', async () => {

--- a/src/components/editor/EditHeader.spec.ts
+++ b/src/components/editor/EditHeader.spec.ts
@@ -360,6 +360,7 @@ describe('EditHeader', () => {
     expect(saveFileMock).toHaveBeenNthCalledWith(2, '/games/test/assets/c.png')
     expect(routerPushMock).toHaveBeenCalledWith('/')
   })
+
   it('确认不保存时会直接返回主页且不会触发保存', async () => {
     hasUnsavedDocumentsUnderMock.mockReturnValue(true)
 
@@ -374,9 +375,16 @@ describe('EditHeader', () => {
 
     await page.getByRole('button', { name: 'common.back' }).click()
 
+    await vi.waitFor(() => {
+      expect(modalOpenMock.mock.calls.some(([name]) => name === 'SaveChangesModal')).toBe(true)
+    })
+
     const saveChangesCall = modalOpenMock.mock.calls.find(([name]) => name === 'SaveChangesModal')
-    expect(saveChangesCall).toBeDefined()
-    const modalOptions = saveChangesCall?.[1] as { onDontSave?: () => Promise<void> }
+    if (!saveChangesCall) {
+      throw new Error('expected SaveChangesModal to be opened')
+    }
+
+    const [, modalOptions] = saveChangesCall as [string, { onDontSave?: () => Promise<void> }]
 
     await modalOptions.onDontSave?.()
 

--- a/src/components/editor/EditHeader.spec.ts
+++ b/src/components/editor/EditHeader.spec.ts
@@ -342,9 +342,16 @@ describe('EditHeader', () => {
 
     await page.getByRole('button', { name: 'common.back' }).click()
 
+    await vi.waitFor(() => {
+      expect(modalOpenMock.mock.calls.some(([name]) => name === 'SaveChangesModal')).toBe(true)
+    })
+
     const saveChangesCall = modalOpenMock.mock.calls.find(([name]) => name === 'SaveChangesModal')
-    expect(saveChangesCall).toBeDefined()
-    const modalOptions = saveChangesCall?.[1] as { onSave?: () => Promise<void> }
+    if (!saveChangesCall) {
+      throw new Error('expected SaveChangesModal to be opened')
+    }
+
+    const [, modalOptions] = saveChangesCall as [string, { onSave?: () => Promise<void> }]
 
     await modalOptions.onSave?.()
 

--- a/src/components/editor/EditHeader.vue
+++ b/src/components/editor/EditHeader.vue
@@ -6,6 +6,7 @@ import { windowCmds } from '~/commands/window'
 import { parseGameConfigFormValues } from '~/features/modals/game-config/game-config-form'
 import { configManager } from '~/services/config-manager'
 import { gameAssetDir } from '~/services/platform/app-paths'
+import { useEditorStore } from '~/stores/editor'
 import { useModalStore } from '~/stores/modal'
 import { usePreviewSessionStore } from '~/stores/preview-session'
 import { useWorkspaceStore } from '~/stores/workspace'
@@ -17,14 +18,39 @@ const router = useRouter()
 
 const { t } = useI18n()
 
-function handleBack() {
-  void closeTestWindow()
-  router.push('/')
-}
-
+const editorStore = useEditorStore()
 const workspaceStore = useWorkspaceStore()
 const previewSessionStore = usePreviewSessionStore()
 const modalStore = useModalStore()
+
+async function navigateHome() {
+  void closeTestWindow()
+  await router.push('/')
+}
+
+async function handleBack() {
+  const currentGamePath = workspaceStore.currentGame?.path
+  const currentGameName = workspaceStore.currentGame?.metadata.name
+  if (!currentGamePath || !editorStore.hasUnsavedDocumentsUnder(currentGamePath)) {
+    await navigateHome()
+    return
+  }
+
+  modalStore.open('SaveChangesModal', {
+    title: t('edit.leaveConfirm.title', { name: currentGameName }),
+    description: t('edit.leaveConfirm.description'),
+    dontSaveLabel: t('edit.leaveConfirm.dontSave'),
+    onDontSave: navigateHome,
+    onSave: async () => {
+      const dirtyPaths = editorStore.collectDocumentPathsUnder(currentGamePath)
+        .filter(path => editorStore.getDirtyBufferContent(path) !== undefined)
+
+      await Promise.all(dirtyPaths.map(path => editorStore.saveFile(path)))
+      await navigateHome()
+    },
+    saveLabel: t('edit.leaveConfirm.save'),
+  })
+}
 
 const HEADER_ICON_THUMBNAIL = {
   width: 64,
@@ -174,7 +200,7 @@ onBeforeUnmount(() => {
 <template>
   <header class="px-4 border-b bg-white flex h-12 items-center justify-between dark:bg-gray-950">
     <div class="flex gap-2 items-center">
-      <Button variant="ghost" size="icon" class="size-8" @click="handleBack">
+      <Button variant="ghost" size="icon" class="size-8" @click="void handleBack()">
         <ArrowLeft class="size-5!" />
         <span class="sr-only">{{ $t('common.back') }}</span>
       </Button>

--- a/src/components/editor/EditHeader.vue
+++ b/src/components/editor/EditHeader.vue
@@ -42,11 +42,15 @@ async function handleBack() {
     dontSaveLabel: t('edit.leaveConfirm.dontSave'),
     onDontSave: navigateHome,
     onSave: async () => {
-      const dirtyPaths = editorStore.collectDocumentPathsUnder(currentGamePath)
-        .filter(path => editorStore.getDirtyBufferContent(path) !== undefined)
+      try {
+        const dirtyPaths = editorStore.collectDocumentPathsUnder(currentGamePath)
+          .filter(path => editorStore.getDirtyBufferContent(path) !== undefined)
 
-      await Promise.all(dirtyPaths.map(path => editorStore.saveFile(path)))
-      await navigateHome()
+        await Promise.all(dirtyPaths.map(path => editorStore.saveFile(path)))
+        await navigateHome()
+      } catch (error) {
+        handleError(error)
+      }
     },
     saveLabel: t('edit.leaveConfirm.save'),
   })

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -574,7 +574,12 @@ edit:
     previewUnavailable: Preview URL is not available. Please start preview first.
     workspaceUnavailable: Workspace is not initialized yet. Please try again shortly.
   unsupported:
-    unsupportedFile: The file is binary or uses an unsupported text encoding, so it cannot be displayed in the editor
+    unsupportedFile: This file is binary or uses an unsupported text encoding and cannot be displayed in the editor
+  leaveConfirm:
+    title: Save changes before returning home?
+    description: If you return to the home page now, your unsaved changes will be lost.
+    save: Save and return
+    dontSave: Return without saving
   textEditor:
     languages:
       webgalscript: WebGAL Script

--- a/src/locales/ja.yml
+++ b/src/locales/ja.yml
@@ -574,7 +574,12 @@ edit:
     previewUnavailable: プレビューURLがありません。先にプレビューを起動してください。
     workspaceUnavailable: ワークスペースがまだ初期化されていません。少し待ってから再試行してください。
   unsupported:
-    unsupportedFile: このファイルはバイナリファイル、またはサポートされていないテキストエンコーディングを使用しているため、エディターに表示できません
+    unsupportedFile: このファイルはバイナリ、または未対応のテキストエンコーディングのため、エディターで表示できません
+  leaveConfirm:
+    title: ホームに戻る前に変更を保存しますか？
+    description: 今ホームに戻ると、未保存の変更は失われます。
+    save: 保存して戻る
+    dontSave: 保存せずに戻る
   textEditor:
     languages:
       webgalscript: WebGAL スクリプト

--- a/src/locales/zh-Hans.yml
+++ b/src/locales/zh-Hans.yml
@@ -575,6 +575,11 @@ edit:
     workspaceUnavailable: 工作区尚未初始化，请稍后重试
   unsupported:
     unsupportedFile: 该文件是二进制文件或使用了不受支持的文本编码，无法在编辑器中显示
+  leaveConfirm:
+    title: 返回主页前保存更改？
+    description: 如果现在返回主页，未保存的更改将会丢失。
+    save: 保存并返回
+    dontSave: 直接返回
   textEditor:
     languages:
       webgalscript: WebGAL 脚本

--- a/src/locales/zh-Hant.yml
+++ b/src/locales/zh-Hant.yml
@@ -574,7 +574,12 @@ edit:
     previewUnavailable: 預覽地址不存在，請先啟動預覽
     workspaceUnavailable: 工作區尚未初始化，請稍後重試
   unsupported:
-    unsupportedFile: 該檔案是二進位檔案或使用了不受支援的文字編碼，無法在編輯器中顯示
+    unsupportedFile: 此檔案是二進位檔案或使用了未支援的文字編碼，無法在編輯器中顯示
+  leaveConfirm:
+    title: 返回主頁前要先儲存變更嗎？
+    description: 如果現在返回主頁，未儲存的變更將會遺失。
+    save: 儲存並返回
+    dontSave: 直接返回
   textEditor:
     languages:
       webgalscript: WebGAL 腳本


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [x] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [ ] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

修复了从编辑页返回主页时，未保存更改会直接丢失的问题。

本次修改在编辑页顶部返回按钮处增加了离开确认逻辑：
- 当前游戏目录下没有未保存文档时，仍然直接返回主页
- 当前游戏目录下存在未保存文档时，弹出确认框
- 用户选择“保存并返回”时，会先保存当前游戏下所有仍为 dirty 的文档，再返回主页
- 用户选择“直接返回”时，不保存并直接离开

同时为该场景补充了专用文案，避免复用通用 `saveChanges` 文案造成语义不准确的问题，并同步更新了 `en / ja / zh-Hans / zh-Hant` 四套语言资源。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

当前编辑页返回主页的行为缺少未保存保护，用户在存在未保存更改时点击返回，会直接丢失修改内容。

这次修改的目标是把“离开编辑器返回主页”纳入与其他编辑确认场景一致的保护范围，同时保持实现边界尽量小，只在返回主页入口增加确认，而不引入额外的全局路由拦截逻辑。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
