### PR TITLE
🐛 修复主窗口状态恢复前闪现默认大小和位置

### DIFF
--- a/src-tauri/src/window.rs
+++ b/src-tauri/src/window.rs
@@ -10,6 +10,7 @@ pub struct WindowConfig {
     height: Option<f64>,
     resizable: bool,
     center: bool,
+    visible: bool,
     use_custom_title_bar: bool,
 }
 
@@ -25,6 +26,7 @@ impl WindowConfig {
             height: None,
             resizable: true,
             center: false,
+            visible: true,
             use_custom_title_bar: false,
         }
     }
@@ -67,7 +69,13 @@ impl WindowConfig {
             .min_size(620.0, 540.0)
             .size(1280.0, 800.0)
             .center(true)
+            .visible(false)
             .use_custom_title_bar(true)
+    }
+
+    pub fn visible(mut self, visible: bool) -> Self {
+        self.visible = visible;
+        self
     }
 
     fn apply_platform_tweaks<'a, R: Runtime, M: tauri::Manager<R>>(
@@ -112,6 +120,7 @@ impl WindowConfig {
             height,
             resizable,
             center,
+            visible,
             use_custom_title_bar,
         } = self;
 
@@ -119,7 +128,9 @@ impl WindowConfig {
             log::debug!("正在创建窗口 '{}'，URL: '{:?}'", label, url);
         }
 
-        let mut builder = WebviewWindowBuilder::new(handle, &label, url).resizable(resizable);
+        let mut builder = WebviewWindowBuilder::new(handle, &label, url)
+            .resizable(resizable)
+            .visible(visible);
 
         if let (Some(width), Some(height)) = (min_width, min_height) {
             builder = builder.min_inner_size(width, height);
@@ -168,6 +179,7 @@ mod tests {
         assert!(config.height.is_none());
         assert!(config.resizable);
         assert!(!config.center);
+        assert!(config.visible);
         assert!(!config.use_custom_title_bar);
     }
 
@@ -183,6 +195,7 @@ mod tests {
         assert_eq!(config.height, Some(800.0));
         assert!(config.resizable);
         assert!(config.center);
+        assert!(!config.visible);
         assert!(config.use_custom_title_bar);
     }
 }


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [x] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [ ] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

修复主窗口在启动时先以默认大小和居中位置出现，随后才恢复到上次记录状态的问题。

本次修改为 `WindowConfig` 增加了 `visible` 配置：
- 普通窗口默认保持可见
- 主窗口默认以隐藏状态创建
- 等 `tauri-plugin-window-state` 在窗口 ready 后恢复大小和位置后，再由插件按保存状态显示窗口

同时补充了对应的 Rust 单元测试，固定以下行为：
- 普通窗口默认可见
- 主窗口默认隐藏

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

问题根因是 `tauri-plugin-window-state` 的自动恢复发生在窗口 `on_window_ready` 阶段，而不是窗口初始构建阶段。

当前主窗口在创建时带有默认 `1280x800` 和 `center(true)` 配置，并且默认可见，因此用户会先看到默认状态，再看到插件恢复后的状态，形成明显跳变。

这次调整将默认窗口几何配置保留为首启 fallback，同时避免它成为用户可见的首帧。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
