### PR TITLE
💄 统一关于弹窗版本按钮样式

### DIFF
--- a/src/components/modals/AboutModal.vue
+++ b/src/components/modals/AboutModal.vue
@@ -32,10 +32,8 @@ function handleVersionClick() {
         </div>
         <button
           :class="[
-            'inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md font-mono text-sm font-semibold transition-all',
-            version.link
-              ? 'text-primary bg-primary/10 hover:bg-primary/20 hover:scale-105'
-              : 'text-muted-foreground bg-muted/50 cursor-default',
+            'text-sm font-mono font-semibold px-3 py-1.5 rounded-md bg-muted inline-flex gap-1.5 transition-all items-center',
+            version.link ? 'text-primary' : 'text-muted-foreground cursor-default',
           ]"
           @click="handleVersionClick"
         >


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [ ] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [ ] 测试用例
- [ ] 性能优化
- [x] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

统一 About 弹窗中版本按钮的视觉样式，收敛有链接和无链接两种状态的基础外观：

- 将按钮背景统一为 `bg-muted`
- 保留可跳转版本的主色文本提示
- 移除链接状态下额外的 hover 背景和缩放效果，降低该元信息按钮的视觉噪音

本次调整不涉及版本跳转逻辑，仅修改展示样式。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

当前版本按钮在有链接时使用更强的背景和 hover 动效，使其在 About 弹窗中的视觉权重偏高，也让有链接和无链接两种状态的外观差异过大。

这次修改的目标是让版本信息更接近“元信息标签”的语义，同时保留可点击状态的必要提示，使整体样式更稳定、统一。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [ ] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
