### PR TITLE
♻️ 统一测试文案并规范测试样例数据

### DIFF
--- a/src/__tests__/factories.test.ts
+++ b/src/__tests__/factories.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import { createTestEngine, createTestGame } from '~/__tests__/factories'
 
-describe('test factories', () => {
+describe('测试工厂函数', () => {
   it('createTestGame 默认带 available availability', () => {
     expect(createTestGame()).toMatchObject({
       availability: 'available',

--- a/src/__tests__/mocks/tauri-path.test.ts
+++ b/src/__tests__/mocks/tauri-path.test.ts
@@ -5,8 +5,8 @@ import {
   createTauriPathModuleMock,
 } from './tauri-path'
 
-describe('tauri path mock helper', () => {
-  it('provides the default path helpers used by tests', async () => {
+describe('tauri path mock 辅助器', () => {
+  it('提供测试默认使用的路径辅助函数', async () => {
     const pathMock = createDefaultTauriPathMocks()
 
     await expect(pathMock.basename('/game/scene/start.txt')).resolves.toBe('start.txt')
@@ -17,14 +17,14 @@ describe('tauri path mock helper', () => {
     expect(pathMock.sep()).toBe('/')
   })
 
-  it('preserves actual exports while overriding path helpers', async () => {
+  it('覆盖路径辅助函数时保留模块的真实导出', async () => {
     const pathModule = await createTauriPathModuleMock()
 
     expect(pathModule.BaseDirectory.Document).toBeTypeOf('number')
     await expect(pathModule.join('/game', 'scene')).resolves.toBe('/game/scene')
   })
 
-  it('allows per-test overrides for selected helpers', async () => {
+  it('允许按测试覆盖指定辅助函数', async () => {
     const joinMock = vi.fn(async (...parts: string[]) => parts.join('::'))
 
     const pathModule = await createTauriPathModuleMock({

--- a/src/components/editor/param-renderer/ParamChoiceField.spec.ts
+++ b/src/components/editor/param-renderer/ParamChoiceField.spec.ts
@@ -197,10 +197,10 @@ describe('ParamChoiceField', () => {
       props: {
         comboboxData: {
           browseNodes: [
-            { id: 'group:sakiko', kind: 'group', label: 'sakiko', pathSegments: ['sakiko'], children: [] },
+            { id: 'group:charc', kind: 'group', label: 'charc', pathSegments: ['charc'], children: [] },
           ],
           searchDocuments: [
-            { label: 'sakiko/default', originalIndex: 0, pathText: 'sakiko/default', value: 'sakiko/default' },
+            { label: 'charc/default', originalIndex: 0, pathText: 'charc/default', value: 'charc/default' },
           ],
         },
         customInputId: 'target-custom-input',

--- a/src/components/editor/param-renderer/ParamRenderer.spec.ts
+++ b/src/components/editor/param-renderer/ParamRenderer.spec.ts
@@ -151,8 +151,8 @@ function renderChoiceRenderer(enableComboboxPathDelimiter: boolean) {
       fields: [field],
       fileRootPaths: {},
       getDynamicOptions: () => [
-        { label: 'sakiko/maskon/kime01', value: 'sakiko/maskon/kime01' },
-        { label: 'sakiko/default', value: 'sakiko/default' },
+        { label: 'charc/group01/item01', value: 'charc/group01/item01' },
+        { label: 'charc/default', value: 'charc/default' },
       ],
       getFieldSelectValue: () => '',
       getFieldValue: () => '',

--- a/src/components/editor/param-renderer/__tests__/useParamChoiceFieldViewModel.test.ts
+++ b/src/components/editor/param-renderer/__tests__/useParamChoiceFieldViewModel.test.ts
@@ -114,8 +114,8 @@ describe('useParamChoiceFieldViewModel', () => {
       getComboboxPathDelimiter: () => '/',
       getCustomLabel: () => '',
       getDynamicOptions: () => [
-        { label: 'sakiko/maskon/kime01', value: 'sakiko/maskon/kime01' },
-        { label: 'sakiko/default', value: 'sakiko/default' },
+        { label: 'charc/group01/item01', value: 'charc/group01/item01' },
+        { label: 'charc/default', value: 'charc/default' },
       ],
       getPlaceholder: () => 'Search expression',
       getSelectValue: () => '',
@@ -130,22 +130,22 @@ describe('useParamChoiceFieldViewModel', () => {
       browseNodes: [
         {
           kind: 'group',
-          label: 'sakiko',
+          label: 'charc',
           children: [
             {
               kind: 'group',
-              label: 'maskon',
+              label: 'group01',
               children: [
-                { kind: 'item', label: 'kime01', rawLabel: 'sakiko/maskon/kime01', value: 'sakiko/maskon/kime01' },
+                { kind: 'item', label: 'item01', rawLabel: 'charc/group01/item01', value: 'charc/group01/item01' },
               ],
             },
-            { kind: 'item', label: 'default', rawLabel: 'sakiko/default', value: 'sakiko/default' },
+            { kind: 'item', label: 'default', rawLabel: 'charc/default', value: 'charc/default' },
           ],
         },
       ],
       searchDocuments: [
-        { label: 'sakiko/maskon/kime01', originalIndex: 0, pathText: 'sakiko/maskon/kime01', value: 'sakiko/maskon/kime01' },
-        { label: 'sakiko/default', originalIndex: 1, pathText: 'sakiko/default', value: 'sakiko/default' },
+        { label: 'charc/group01/item01', originalIndex: 0, pathText: 'charc/group01/item01', value: 'charc/group01/item01' },
+        { label: 'charc/default', originalIndex: 1, pathText: 'charc/default', value: 'charc/default' },
       ],
     })
   })
@@ -158,7 +158,7 @@ describe('useParamChoiceFieldViewModel', () => {
       getComboboxPathDelimiter: () => '',
       getCustomLabel: () => '',
       getDynamicOptions: () => [
-        { label: 'sakiko/maskon/kime01', value: 'sakiko/maskon/kime01' },
+        { label: 'charc/group01/item01', value: 'charc/group01/item01' },
       ],
       getPlaceholder: () => 'Search expression',
       getSelectValue: () => '',
@@ -172,7 +172,7 @@ describe('useParamChoiceFieldViewModel', () => {
     expect(viewModel.viewModels.value.get(field.key)).toMatchObject({
       comboboxData: undefined,
       mode: 'combobox',
-      options: [{ label: 'sakiko/maskon/kime01', value: 'sakiko/maskon/kime01' }],
+      options: [{ label: 'charc/group01/item01', value: 'charc/group01/item01' }],
     })
   })
 
@@ -184,8 +184,8 @@ describe('useParamChoiceFieldViewModel', () => {
       getComboboxPathDelimiter: () => ' / ',
       getCustomLabel: () => '',
       getDynamicOptions: () => [
-        { label: 'sakiko/maskon/kime01', value: 'sakiko/maskon/kime01' },
-        { label: 'sakiko/default', value: 'sakiko/default' },
+        { label: 'charc/group01/item01', value: 'charc/group01/item01' },
+        { label: 'charc/default', value: 'charc/default' },
       ],
       getPlaceholder: () => 'Search expression',
       getSelectValue: () => '',
@@ -199,7 +199,7 @@ describe('useParamChoiceFieldViewModel', () => {
     expect(trimmedViewModel.viewModels.value.get(field.key)?.comboboxData?.browseNodes).toMatchObject([
       {
         kind: 'group',
-        label: 'sakiko',
+        label: 'charc',
       },
     ])
 
@@ -208,7 +208,7 @@ describe('useParamChoiceFieldViewModel', () => {
       getComboboxPathDelimiter: () => '   ',
       getCustomLabel: () => '',
       getDynamicOptions: () => [
-        { label: 'sakiko/maskon/kime01', value: 'sakiko/maskon/kime01' },
+        { label: 'charc/group01/item01', value: 'charc/group01/item01' },
       ],
       getPlaceholder: () => 'Search expression',
       getSelectValue: () => '',
@@ -222,7 +222,7 @@ describe('useParamChoiceFieldViewModel', () => {
     expect(whitespaceOnlyViewModel.viewModels.value.get(field.key)).toMatchObject({
       comboboxData: undefined,
       mode: 'combobox',
-      options: [{ label: 'sakiko/maskon/kime01', value: 'sakiko/maskon/kime01' }],
+      options: [{ label: 'charc/group01/item01', value: 'charc/group01/item01' }],
     })
   })
 })

--- a/src/components/primitives/CascadingCombobox.spec.ts
+++ b/src/components/primitives/CascadingCombobox.spec.ts
@@ -21,10 +21,10 @@ interface ActiveAlignmentMetrics {
 }
 
 const groupedData = buildCascadingComboboxData([
-  { label: 'anon/cry01', value: 'anon/cry01' },
-  { label: 'anon/cry02', value: 'anon/cry02' },
-  { label: 'sakiko/maskon/kime01', value: 'sakiko/maskon/kime01' },
-  { label: 'sakiko/default', value: 'sakiko/default' },
+  { label: 'chara/variant01', value: 'chara/variant01' },
+  { label: 'chara/variant02', value: 'chara/variant02' },
+  { label: 'charc/group01/item01', value: 'charc/group01/item01' },
+  { label: 'charc/default', value: 'charc/default' },
 ], {
   grouping: { mode: 'path' },
   resolvedDelimiter: '/',
@@ -103,7 +103,7 @@ const GroupedHarness = defineComponent({
 const NearEdgeHarness = defineComponent({
   components: { CascadingCombobox },
   setup() {
-    const modelValue = ref('sakiko/maskon/kime01')
+    const modelValue = ref('charc/group01/item01')
 
     return {
       groupedData,
@@ -203,12 +203,12 @@ interface CascadingComboboxTestHooks {
 const DynamicSearchDocumentsHarness = defineComponent({
   components: { CascadingCombobox },
   setup() {
-    const modelValue = ref('sakiko/default')
+    const modelValue = ref('charc/default')
     const searchDocuments = ref([...groupedData.searchDocuments])
     const testHooks = globalThis as typeof globalThis & CascadingComboboxTestHooks
 
     function shrinkSearchDocuments() {
-      searchDocuments.value = groupedData.searchDocuments.filter(document => document.value === 'anon/cry01')
+      searchDocuments.value = groupedData.searchDocuments.filter(document => document.value === 'chara/variant01')
     }
 
     onMounted(() => {
@@ -386,13 +386,13 @@ describe('CascadingCombobox', () => {
   it('首次打开已选嵌套值时，根层与级联子层作为独立浮层渲染，并保持向右级联展开', async () => {
     renderInBrowser(GroupedHarness, {
       props: {
-        initialValue: 'sakiko/maskon/kime01',
+        initialValue: 'charc/group01/item01',
       },
     })
 
     await page.getByTestId('grouped-trigger').click()
-    await expect.element(page.getByText('maskon', { exact: true })).toBeInTheDocument()
-    await expect.element(page.getByText('kime01', { exact: true })).toBeInTheDocument()
+    await expect.element(page.getByText('group01', { exact: true })).toBeInTheDocument()
+    await expect.element(page.getByText('item01', { exact: true })).toBeInTheDocument()
 
     const rects = getFloatingRects()
     const rootRect = getElementRect('[data-cascading-root-panel]')
@@ -410,20 +410,20 @@ describe('CascadingCombobox', () => {
   it('搜索态会挂起 submenu，并在清空搜索后恢复之前的 browse path', async () => {
     renderInBrowser(GroupedHarness, {
       props: {
-        initialValue: 'sakiko/maskon/kime01',
+        initialValue: 'charc/group01/item01',
       },
     })
 
     await page.getByTestId('grouped-trigger').click()
-    await expect.element(page.getByText('kime01', { exact: true })).toBeInTheDocument()
+    await expect.element(page.getByText('item01', { exact: true })).toBeInTheDocument()
     expect(getSubpanelRects()).toHaveLength(2)
 
-    await page.getByPlaceholder('Search motion').fill('maskon')
-    await expect.element(page.getByText('kime01', { exact: true })).not.toBeInTheDocument()
+    await page.getByPlaceholder('Search motion').fill('group01')
+    await expect.element(page.getByText('item01', { exact: true })).not.toBeInTheDocument()
     expect(getSubpanelRects()).toHaveLength(0)
 
     await page.getByPlaceholder('Search motion').fill('')
-    await expect.element(page.getByText('kime01', { exact: true })).toBeInTheDocument()
+    await expect.element(page.getByText('item01', { exact: true })).toBeInTheDocument()
     expect(getSubpanelRects()).toHaveLength(2)
   })
 
@@ -431,7 +431,7 @@ describe('CascadingCombobox', () => {
     renderInBrowser(NearEdgeHarness)
 
     await page.getByTestId('edge-trigger').click()
-    await expect.element(page.getByText('kime01', { exact: true })).toBeInTheDocument()
+    await expect.element(page.getByText('item01', { exact: true })).toBeInTheDocument()
 
     const rootRect = getElementRect('[data-cascading-root-panel]')
     const firstSubpanelRect = getElementRect('[data-layer-depth="1"]')
@@ -447,21 +447,21 @@ describe('CascadingCombobox', () => {
     await page.getByTestId('grouped-trigger').click()
     await userEvent.keyboard('{ArrowDown}{ArrowRight}{ArrowLeft}{ArrowRight}{Enter}')
 
-    await expect.element(page.getByTestId('grouped-trigger')).toHaveTextContent('anon/cry01')
+    await expect.element(page.getByTestId('grouped-trigger')).toHaveTextContent('chara/variant01')
   })
 
   it('搜索结果列表暴露 listbox/option 语义，并把当前高亮项关联到搜索框', async () => {
     renderInBrowser(GroupedHarness, {
       props: {
-        initialValue: 'sakiko/default',
+        initialValue: 'charc/default',
       },
     })
 
     await page.getByTestId('grouped-trigger').click()
-    await page.getByPlaceholder('Search motion').fill('sakiko')
+    await page.getByPlaceholder('Search motion').fill('charc')
 
     const listbox = page.getByRole('listbox')
-    const selectedOption = page.getByRole('option', { name: 'sakiko/default' })
+    const selectedOption = page.getByRole('option', { name: 'charc/default' })
 
     await expect.element(listbox).toBeInTheDocument()
     await expect.element(selectedOption).toHaveAttribute('aria-selected', 'true')
@@ -478,37 +478,37 @@ describe('CascadingCombobox', () => {
   it('会把搜索词按空格拆分并要求所有关键词都命中完整路径文本', async () => {
     renderInBrowser(GroupedHarness, {
       props: {
-        initialValue: 'sakiko/default',
+        initialValue: 'charc/default',
       },
     })
 
     await page.getByTestId('grouped-trigger').click()
-    await page.getByPlaceholder('Search motion').fill('sakiko kime01')
+    await page.getByPlaceholder('Search motion').fill('charc item01')
 
-    await expect.element(page.getByRole('option', { name: 'sakiko/maskon/kime01' })).toBeInTheDocument()
-    await expect.element(page.getByRole('option', { name: 'sakiko/default' })).not.toBeInTheDocument()
-    await expect.element(page.getByRole('option', { name: 'anon/cry01' })).not.toBeInTheDocument()
+    await expect.element(page.getByRole('option', { name: 'charc/group01/item01' })).toBeInTheDocument()
+    await expect.element(page.getByRole('option', { name: 'charc/default' })).not.toBeInTheDocument()
+    await expect.element(page.getByRole('option', { name: 'chara/variant01' })).not.toBeInTheDocument()
   })
 
   it('鼠标离开搜索结果列表时，不会回退到已有的键盘高亮项', async () => {
     renderInBrowser(GroupedHarness, {
       props: {
-        initialValue: 'sakiko/default',
+        initialValue: 'charc/default',
       },
     })
 
     await page.getByTestId('grouped-trigger').click()
-    await page.getByPlaceholder('Search motion').fill('sakiko')
+    await page.getByPlaceholder('Search motion').fill('charc')
     await userEvent.keyboard('{ArrowDown}')
 
-    const hoveredOption = findSearchOptionElement('sakiko/default')
+    const hoveredOption = findSearchOptionElement('charc/default')
     const listbox = getSearchListboxElement()
     expect(hoveredOption).toBeDefined()
     expect(listbox).toBeDefined()
-    expect(getActiveSearchOptionElement()?.textContent).toContain('sakiko/maskon/kime01')
+    expect(getActiveSearchOptionElement()?.textContent).toContain('charc/group01/item01')
 
     hoveredOption!.dispatchEvent(new MouseEvent('mouseenter'))
-    await expect.poll(() => getActiveSearchOptionElement()?.textContent?.includes('sakiko/default') ?? false).toBe(true)
+    await expect.poll(() => getActiveSearchOptionElement()?.textContent?.includes('charc/default') ?? false).toBe(true)
 
     listbox!.dispatchEvent(new MouseEvent('mouseleave'))
 
@@ -519,24 +519,24 @@ describe('CascadingCombobox', () => {
     renderInBrowser(DynamicSearchDocumentsHarness)
 
     await page.getByTestId('dynamic-trigger').click()
-    await page.getByPlaceholder('Search motion').fill('cry')
-    await expect.element(page.getByRole('option', { name: 'anon/cry02' })).toBeInTheDocument()
+    await page.getByPlaceholder('Search motion').fill('variant')
+    await expect.element(page.getByRole('option', { name: 'chara/variant02' })).toBeInTheDocument()
 
     await userEvent.keyboard('{ArrowDown}{ArrowDown}')
 
     const testHooks = globalThis as typeof globalThis & CascadingComboboxTestHooks
     testHooks.__shrinkCascadingSearchDocuments?.()
 
-    await expect.element(page.getByRole('option', { name: 'anon/cry02' })).not.toBeInTheDocument()
+    await expect.element(page.getByRole('option', { name: 'chara/variant02' })).not.toBeInTheDocument()
     await userEvent.keyboard('{Enter}')
 
-    await expect.element(page.getByTestId('dynamic-trigger')).toHaveTextContent('sakiko/default')
+    await expect.element(page.getByTestId('dynamic-trigger')).toHaveTextContent('charc/default')
   })
 
   it('点击子菜单叶子项时，会更新选中值并关闭浮层', async () => {
     renderInBrowser(GroupedHarness, {
       props: {
-        initialValue: 'sakiko/maskon/kime01',
+        initialValue: 'charc/group01/item01',
       },
     })
 
@@ -548,38 +548,38 @@ describe('CascadingCombobox', () => {
 
     await userEvent.click(submenuLeafRow!)
 
-    await expect.element(page.getByTestId('grouped-trigger')).toHaveTextContent('sakiko/default')
-    await expect.element(page.getByText('kime01', { exact: true })).not.toBeInTheDocument()
+    await expect.element(page.getByTestId('grouped-trigger')).toHaveTextContent('charc/default')
+    await expect.element(page.getByText('item01', { exact: true })).not.toBeInTheDocument()
   })
 
   it('ArrowLeft 返回上级层时保留当前父层 submenu，ArrowUp/Down 移到其他组项时会自动展开对应 submenu', async () => {
     renderInBrowser(GroupedHarness, {
       props: {
-        initialValue: 'sakiko/maskon/kime01',
+        initialValue: 'charc/group01/item01',
       },
     })
 
     await page.getByTestId('grouped-trigger').click()
-    await expect.element(page.getByText('kime01', { exact: true })).toBeInTheDocument()
+    await expect.element(page.getByText('item01', { exact: true })).toBeInTheDocument()
     expect(getSubpanelRects()).toHaveLength(2)
 
     await userEvent.keyboard('{ArrowLeft}')
 
     expect(getSubpanelRects()).toHaveLength(2)
-    expect(getLayerActiveBrowseText(1)).toContain('maskon')
+    expect(getLayerActiveBrowseText(1)).toContain('group01')
     expect(getLayerActiveBrowseText(2)).toBeUndefined()
 
     await userEvent.keyboard('{ArrowLeft}')
 
     expect(getSubpanelRects()).toHaveLength(1)
-    expect(getLayerActiveBrowseText(0)).toContain('sakiko')
+    expect(getLayerActiveBrowseText(0)).toContain('charc')
     expect(getLayerActiveBrowseText(1)).toBeUndefined()
 
     await userEvent.keyboard('{ArrowUp}')
 
     expect(getSubpanelRects()).toHaveLength(1)
-    expect(getLayerActiveBrowseText(0)).toContain('anon')
-    await expect.element(page.getByText('cry01', { exact: true })).toBeInTheDocument()
+    expect(getLayerActiveBrowseText(0)).toContain('chara')
+    await expect.element(page.getByText('variant01', { exact: true })).toBeInTheDocument()
   })
 
   it('未启用路径分组时浏览态保持扁平列表', async () => {
@@ -636,12 +636,12 @@ describe('CascadingCombobox', () => {
   it('内容未溢出时，根层与子层滚动区域不显示滚动条', async () => {
     renderInBrowser(GroupedHarness, {
       props: {
-        initialValue: 'sakiko/maskon/kime01',
+        initialValue: 'charc/group01/item01',
       },
     })
 
     await page.getByTestId('grouped-trigger').click()
-    await expect.element(page.getByText('maskon', { exact: true })).toBeInTheDocument()
+    await expect.element(page.getByText('group01', { exact: true })).toBeInTheDocument()
 
     const rootViewportMetrics = getLayerViewportMetrics(0)
     const subpanelViewportMetrics = getLayerViewportMetrics(1)
@@ -670,26 +670,26 @@ describe('CascadingCombobox', () => {
   it('点击打开后，从外部 hover 回当前已选组时，不会让已展开的子菜单先收起再重新打开', async () => {
     renderInBrowser(GroupedHarness, {
       props: {
-        initialValue: 'sakiko/maskon/kime01',
+        initialValue: 'charc/group01/item01',
       },
     })
 
     await page.getByTestId('grouped-trigger').click()
-    await expect.element(page.getByText('maskon', { exact: true })).toBeInTheDocument()
+    await expect.element(page.getByText('group01', { exact: true })).toBeInTheDocument()
     expect(getSubpanelRects()).toHaveLength(2)
 
-    const selectedRootGroupRow = findRootGroupRow('sakiko')
+    const selectedRootGroupRow = findRootGroupRow('charc')
     expect(selectedRootGroupRow).toBeDefined()
 
     selectedRootGroupRow!.dispatchEvent(new MouseEvent('mouseenter'))
     await expect.poll(() => getSubpanelRects().length).toBe(2)
-    await expect.poll(() => getLayerActiveBrowseText(1)?.includes('maskon') ?? false).toBe(true)
-    await expect.poll(() => getLayerActiveBrowseText(2)?.includes('kime01') ?? false).toBe(true)
+    await expect.poll(() => getLayerActiveBrowseText(1)?.includes('group01') ?? false).toBe(true)
+    await expect.poll(() => getLayerActiveBrowseText(2)?.includes('item01') ?? false).toBe(true)
 
     expect(getSubpanelRects()).toHaveLength(2)
-    expect(getLayerActiveBrowseText(1)).toContain('maskon')
-    expect(getLayerActiveBrowseText(2)).toContain('kime01')
-    expect(getLayerSelectedBrowseText(2)).toContain('kime01')
+    expect(getLayerActiveBrowseText(1)).toContain('group01')
+    expect(getLayerActiveBrowseText(2)).toContain('item01')
+    expect(getLayerSelectedBrowseText(2)).toContain('item01')
   })
 
   it('hover 组项只展开子菜单，不会自动高亮子层首项', async () => {

--- a/src/components/primitives/combobox/__tests__/cascading-combobox-data.test.ts
+++ b/src/components/primitives/combobox/__tests__/cascading-combobox-data.test.ts
@@ -5,9 +5,9 @@ import { buildCascadingComboboxData } from '../cascading-combobox-data'
 describe('buildCascadingComboboxData', () => {
   it('会把同一路径前缀的候选项聚合成级联树，并保留搜索文档', () => {
     const result = buildCascadingComboboxData([
-      { label: 'anon/cry01', value: 'anon/cry01' },
-      { label: 'anon/cry02', value: 'anon/cry02' },
-      { label: 'saki/cry01', value: 'saki/cry01' },
+      { label: 'chara/variant01', value: 'chara/variant01' },
+      { label: 'chara/variant02', value: 'chara/variant02' },
+      { label: 'charb/variant01', value: 'charb/variant01' },
     ], {
       grouping: { mode: 'path' },
       resolvedDelimiter: '/',
@@ -16,30 +16,30 @@ describe('buildCascadingComboboxData', () => {
     expect(result.browseNodes).toMatchObject([
       {
         kind: 'group',
-        label: 'anon',
+        label: 'chara',
         children: [
-          { kind: 'item', label: 'cry01', rawLabel: 'anon/cry01', value: 'anon/cry01' },
-          { kind: 'item', label: 'cry02', rawLabel: 'anon/cry02', value: 'anon/cry02' },
+          { kind: 'item', label: 'variant01', rawLabel: 'chara/variant01', value: 'chara/variant01' },
+          { kind: 'item', label: 'variant02', rawLabel: 'chara/variant02', value: 'chara/variant02' },
         ],
       },
       {
         kind: 'group',
-        label: 'saki',
+        label: 'charb',
         children: [
-          { kind: 'item', label: 'cry01', rawLabel: 'saki/cry01', value: 'saki/cry01' },
+          { kind: 'item', label: 'variant01', rawLabel: 'charb/variant01', value: 'charb/variant01' },
         ],
       },
     ])
     expect(result.searchDocuments).toEqual([
-      { label: 'anon/cry01', originalIndex: 0, pathText: 'anon/cry01', value: 'anon/cry01' },
-      { label: 'anon/cry02', originalIndex: 1, pathText: 'anon/cry02', value: 'anon/cry02' },
-      { label: 'saki/cry01', originalIndex: 2, pathText: 'saki/cry01', value: 'saki/cry01' },
+      { label: 'chara/variant01', originalIndex: 0, pathText: 'chara/variant01', value: 'chara/variant01' },
+      { label: 'chara/variant02', originalIndex: 1, pathText: 'chara/variant02', value: 'chara/variant02' },
+      { label: 'charb/variant01', originalIndex: 2, pathText: 'charb/variant01', value: 'charb/variant01' },
     ])
   })
 
   it('支持任意深度路径', () => {
     const result = buildCascadingComboboxData([
-      { label: 'sakiko/maskon/kime01', value: 'sakiko/maskon/kime01' },
+      { label: 'charc/group01/item01', value: 'charc/group01/item01' },
     ], {
       grouping: { mode: 'path' },
       resolvedDelimiter: '/',
@@ -48,13 +48,13 @@ describe('buildCascadingComboboxData', () => {
     expect(result.browseNodes).toMatchObject([
       {
         kind: 'group',
-        label: 'sakiko',
+        label: 'charc',
         children: [
           {
             kind: 'group',
-            label: 'maskon',
+            label: 'group01',
             children: [
-              { kind: 'item', label: 'kime01', rawLabel: 'sakiko/maskon/kime01' },
+              { kind: 'item', label: 'item01', rawLabel: 'charc/group01/item01' },
             ],
           },
         ],
@@ -64,9 +64,9 @@ describe('buildCascadingComboboxData', () => {
 
   it('允许根层叶子和组混排，并稳定处理前缀冲突', () => {
     const result = buildCascadingComboboxData([
-      { label: 'sakiko', value: 'sakiko' },
-      { label: 'sakiko/maskon', value: 'sakiko/maskon' },
-      { label: 'sakiko/maskon/kime01', value: 'sakiko/maskon/kime01' },
+      { label: 'charc', value: 'charc' },
+      { label: 'charc/group01', value: 'charc/group01' },
+      { label: 'charc/group01/item01', value: 'charc/group01/item01' },
     ], {
       grouping: { mode: 'path' },
       resolvedDelimiter: '/',
@@ -75,29 +75,29 @@ describe('buildCascadingComboboxData', () => {
     expect(result.browseNodes).toMatchObject([
       {
         kind: 'item',
-        label: 'sakiko',
-        rawLabel: 'sakiko',
-        value: 'sakiko',
+        label: 'charc',
+        rawLabel: 'charc',
+        value: 'charc',
       },
       {
         kind: 'group',
-        label: 'sakiko',
+        label: 'charc',
         children: [
           {
             kind: 'item',
-            label: 'maskon',
-            rawLabel: 'sakiko/maskon',
-            value: 'sakiko/maskon',
+            label: 'group01',
+            rawLabel: 'charc/group01',
+            value: 'charc/group01',
           },
           {
             kind: 'group',
-            label: 'maskon',
+            label: 'group01',
             children: [
               {
                 kind: 'item',
-                label: 'kime01',
-                rawLabel: 'sakiko/maskon/kime01',
-                value: 'sakiko/maskon/kime01',
+                label: 'item01',
+                rawLabel: 'charc/group01/item01',
+                value: 'charc/group01/item01',
               },
             ],
           },
@@ -108,18 +108,18 @@ describe('buildCascadingComboboxData', () => {
 
   it('未启用路径分组时保持扁平浏览节点，但仍生成搜索文档', () => {
     const result = buildCascadingComboboxData([
-      { label: 'sakiko/maskon/kime01', value: 'sakiko/maskon/kime01' },
+      { label: 'charc/group01/item01', value: 'charc/group01/item01' },
       { label: 'plain', value: 'plain' },
     ], {
       resolvedDelimiter: '/',
     })
 
     expect(result.browseNodes).toMatchObject([
-      { kind: 'item', label: 'sakiko/maskon/kime01', rawLabel: 'sakiko/maskon/kime01', value: 'sakiko/maskon/kime01' },
+      { kind: 'item', label: 'charc/group01/item01', rawLabel: 'charc/group01/item01', value: 'charc/group01/item01' },
       { kind: 'item', label: 'plain', rawLabel: 'plain', value: 'plain' },
     ])
     expect(result.searchDocuments).toEqual([
-      { label: 'sakiko/maskon/kime01', originalIndex: 0, pathText: 'sakiko/maskon/kime01', value: 'sakiko/maskon/kime01' },
+      { label: 'charc/group01/item01', originalIndex: 0, pathText: 'charc/group01/item01', value: 'charc/group01/item01' },
       { label: 'plain', originalIndex: 1, pathText: 'plain', value: 'plain' },
     ])
   })

--- a/src/components/primitives/combobox/__tests__/search.test.ts
+++ b/src/components/primitives/combobox/__tests__/search.test.ts
@@ -28,9 +28,9 @@ describe('createSearchOptionDocuments', () => {
 
 describe('filterSearchOptionDocuments', () => {
   const documents = createSearchOptionDocuments([
-    { label: 'sakiko/default', value: 'sakiko/default' },
-    { label: 'sakiko/maskon/kime01', value: 'sakiko/maskon/kime01' },
-    { label: 'anon/cry01', value: 'anon/cry01' },
+    { label: 'charc/default', value: 'charc/default' },
+    { label: 'charc/group01/item01', value: 'charc/group01/item01' },
+    { label: 'chara/variant01', value: 'chara/variant01' },
   ])
 
   it('空查询时返回全部结果', () => {
@@ -38,13 +38,13 @@ describe('filterSearchOptionDocuments', () => {
   })
 
   it('会按空格拆分关键词并要求全部命中', () => {
-    expect(filterSearchOptionDocuments(documents, 'sakiko kime01')).toEqual([
+    expect(filterSearchOptionDocuments(documents, 'charc item01')).toEqual([
       documents[1],
     ])
   })
 
   it('会忽略多余空格并做大小写无关匹配', () => {
-    expect(filterSearchOptionDocuments(documents, '  SAKIKO   DEFAULT  ')).toEqual([
+    expect(filterSearchOptionDocuments(documents, '  CHARC   DEFAULT  ')).toEqual([
       documents[0],
     ])
   })

--- a/src/components/primitives/combobox/__tests__/useCascadingComboboxState.test.ts
+++ b/src/components/primitives/combobox/__tests__/useCascadingComboboxState.test.ts
@@ -6,10 +6,10 @@ import { useCascadingComboboxState } from '../useCascadingComboboxState'
 import type { CascadingComboboxNode } from '../cascading-combobox-data'
 
 const groupedData = buildCascadingComboboxData([
-  { label: 'anon/cry01', value: 'anon/cry01' },
-  { label: 'anon/cry02', value: 'anon/cry02' },
-  { label: 'sakiko/maskon/kime01', value: 'sakiko/maskon/kime01' },
-  { label: 'sakiko/default', value: 'sakiko/default' },
+  { label: 'chara/variant01', value: 'chara/variant01' },
+  { label: 'chara/variant02', value: 'chara/variant02' },
+  { label: 'charc/group01/item01', value: 'charc/group01/item01' },
+  { label: 'charc/default', value: 'charc/default' },
 ], {
   grouping: { mode: 'path' },
   resolvedDelimiter: '/',
@@ -56,8 +56,8 @@ function findItemNodeId(nodes: CascadingComboboxNode[], value: string): string {
 }
 
 describe('useCascadingComboboxState', () => {
-  it('restores expanded and highlighted paths from the selected leaf', () => {
-    const modelValue = ref('sakiko/maskon/kime01')
+  it('会从已选叶子节点恢复展开路径与高亮路径', () => {
+    const modelValue = ref('charc/group01/item01')
     const state = useCascadingComboboxState({
       browseNodes: () => groupedData.browseNodes,
       modelValue: () => modelValue.value,
@@ -66,35 +66,35 @@ describe('useCascadingComboboxState', () => {
     state.restoreSelectionPath(modelValue.value)
 
     expect(state.expandedGroupPath.value).toEqual([
-      findGroupNodeId(groupedData.browseNodes, ['sakiko']),
-      findGroupNodeId(groupedData.browseNodes, ['sakiko', 'maskon']),
+      findGroupNodeId(groupedData.browseNodes, ['charc']),
+      findGroupNodeId(groupedData.browseNodes, ['charc', 'group01']),
     ])
     expect(state.highlightedPath.value).toEqual([
-      findGroupNodeId(groupedData.browseNodes, ['sakiko']),
-      findGroupNodeId(groupedData.browseNodes, ['sakiko', 'maskon']),
-      findItemNodeId(groupedData.browseNodes, 'sakiko/maskon/kime01'),
+      findGroupNodeId(groupedData.browseNodes, ['charc']),
+      findGroupNodeId(groupedData.browseNodes, ['charc', 'group01']),
+      findItemNodeId(groupedData.browseNodes, 'charc/group01/item01'),
     ])
   })
 
-  it('moves right into the first child of a highlighted group', () => {
+  it('向右移动时会进入当前高亮分组的第一个子项', () => {
     const state = useCascadingComboboxState({
       browseNodes: () => groupedData.browseNodes,
       modelValue: () => undefined,
     })
-    const anonGroupId = findGroupNodeId(groupedData.browseNodes, ['anon'])
+    const charaGroupId = findGroupNodeId(groupedData.browseNodes, ['chara'])
 
-    state.setHighlightedNode(anonGroupId)
+    state.setHighlightedNode(charaGroupId)
     state.moveRight()
 
-    expect(state.expandedGroupPath.value).toEqual([anonGroupId])
+    expect(state.expandedGroupPath.value).toEqual([charaGroupId])
     expect(state.highlightedPath.value).toEqual([
-      anonGroupId,
-      findItemNodeId(groupedData.browseNodes, 'anon/cry01'),
+      charaGroupId,
+      findItemNodeId(groupedData.browseNodes, 'chara/variant01'),
     ])
   })
 
-  it('clears submenu state while search is active and restores the last browse path when search clears', () => {
-    const modelValue = ref('sakiko/maskon/kime01')
+  it('搜索激活时会清空子菜单状态，并在清空搜索后恢复上次浏览路径', () => {
+    const modelValue = ref('charc/group01/item01')
     const state = useCascadingComboboxState({
       browseNodes: () => groupedData.browseNodes,
       modelValue: () => modelValue.value,

--- a/src/database/db.spec.ts
+++ b/src/database/db.spec.ts
@@ -10,7 +10,7 @@ async function resetDatabase() {
   await db.open()
 }
 
-describe('db schema', () => {
+describe('数据库 schema', () => {
   beforeEach(async () => {
     await resetDatabase()
   })

--- a/src/domain/engine/__tests__/version.test.ts
+++ b/src/domain/engine/__tests__/version.test.ts
@@ -3,21 +3,21 @@ import { describe, expect, it } from 'vitest'
 import { compareEngineVersions } from '../version'
 
 describe('compareEngineVersions', () => {
-  it('prefers stable release over prerelease', () => {
+  it('稳定版本优先于预发布版本', () => {
     expect(compareEngineVersions('1.0.0', '1.0.0-rc.1')).toBeLessThan(0)
     expect(compareEngineVersions('1.0.0-rc.1', '1.0.0')).toBeGreaterThan(0)
   })
 
-  it('keeps invalid versions behind valid ones', () => {
+  it('无效版本排在有效版本之后', () => {
     expect(compareEngineVersions('4.8.1', 'invalid-build')).toBeLessThan(0)
     expect(compareEngineVersions('invalid-build', '4.8.1')).toBeGreaterThan(0)
   })
 
-  it('falls back to numeric-aware locale order when both versions are invalid', () => {
+  it('两个版本都无效时回退到带数字感知的本地排序', () => {
     expect(compareEngineVersions('build-2', 'build-10')).toBeGreaterThan(0)
   })
 
-  it('treats undefined and empty strings as smaller than any value', () => {
+  it('将 undefined 和空字符串视为比任何有效值都更小', () => {
     expect(compareEngineVersions('1.0.0', undefined)).toBeLessThan(0)
     expect(compareEngineVersions(undefined, '1.0.0')).toBeGreaterThan(0)
     expect(compareEngineVersions(undefined, undefined)).toBe(0)

--- a/src/features/editor/effect-editor/__tests__/useEffectClearControls.test.ts
+++ b/src/features/editor/effect-editor/__tests__/useEffectClearControls.test.ts
@@ -21,7 +21,7 @@ function createDeps(initialFields: Record<string, string>) {
 }
 
 describe('useEffectClearControls', () => {
-  it('clears grouped paths and emits a single immediate flush update', () => {
+  it('会清除成组路径，并只触发一次立即 flush 更新', () => {
     const { deps, fields, emitTransform } = createDeps({
       'scale.x': '1',
       'scale.y': '1',
@@ -46,7 +46,7 @@ describe('useEffectClearControls', () => {
     })
   })
 
-  it('does not emit when every target path is already absent', () => {
+  it('当所有目标路径本来就不存在时不会触发更新', () => {
     const { deps, emitTransform } = createDeps({})
     const controls = useEffectClearControls(deps)
 

--- a/src/features/file-picker/__tests__/useFilePickerHistory.test.ts
+++ b/src/features/file-picker/__tests__/useFilePickerHistory.test.ts
@@ -80,7 +80,7 @@ describe('useFilePickerHistory 行为', () => {
     useStorageMock.mockImplementation((_key: string, initial: Record<string, string[]>) => ref(initial))
   })
 
-  it('刷新 recent history 期间被移除的项不会回写到 invalid map', async () => {
+  it('刷新最近历史记录期间，被移除的项不会回写到无效映射', async () => {
     const { history, scope } = createFixture()
     const pendingExists = createDeferred<boolean>()
 

--- a/src/features/home/__tests__/home-tabs.test.ts
+++ b/src/features/home/__tests__/home-tabs.test.ts
@@ -6,18 +6,18 @@ import {
 } from '~/features/home/home-tabs'
 import { resolveI18nLike } from '~/utils/i18n-like'
 
-describe('首页 tab 定义', () => {
-  it('按固定顺序暴露所有首页 tab', () => {
+describe('首页标签页定义', () => {
+  it('按固定顺序暴露所有首页标签页', () => {
     expect(HOME_TABS.map(tab => tab.id)).toEqual(['recent', 'engines', 'templates'])
   })
 
-  it('只为支持资源发现的 tab 返回 discovery 类型', () => {
+  it('只为支持资源发现的标签页返回 discovery 类型', () => {
     expect(resolveHomeTabDefinition('recent').discoveryType).toBe('games')
     expect(resolveHomeTabDefinition('engines').discoveryType).toBe('engines')
     expect(resolveHomeTabDefinition('templates').discoveryType).toBe('templates')
   })
 
-  it('通过静态分支解析 tab 标题', () => {
+  it('通过静态分支解析标签页标题', () => {
     const t = vi.fn((key: string) => `translated:${key}`)
 
     expect(resolveI18nLike(resolveHomeTabDefinition('recent').label, t)).toBe('translated:home.tabs.recent')

--- a/src/features/home/engines-tab/__tests__/engine-group-view-model.test.ts
+++ b/src/features/home/engines-tab/__tests__/engine-group-view-model.test.ts
@@ -5,7 +5,7 @@ import { createTestEngine } from '~/__tests__/factories'
 import { buildEngineGroupCollectionItems } from '../engine-group-view-model'
 
 describe('buildEngineGroupCollectionItems', () => {
-  it('uses the latest available version as representative item', () => {
+  it('使用最新的可用版本作为代表项', () => {
     const items = buildEngineGroupCollectionItems({
       defaultEngineId: 'open-webgal.webgal',
       engines: [
@@ -57,7 +57,7 @@ describe('buildEngineGroupCollectionItems', () => {
     expect(items[0]?.engines.map(item => item.engine.id)).toEqual(['broken-latest', 'stable', 'legacy'])
   })
 
-  it('keeps groups with no available version but marks them unavailable', () => {
+  it('保留没有可用版本的分组，并将其标记为不可用', () => {
     const items = buildEngineGroupCollectionItems({
       engines: [
         createTestEngine({

--- a/src/features/modals/game-config/__tests__/game-config-form.test.ts
+++ b/src/features/modals/game-config/__tests__/game-config-form.test.ts
@@ -42,8 +42,8 @@ function createReadResult(overrides: Partial<GameConfigReadResult> = {}): GameCo
   }
 }
 
-describe('game-config form helpers', () => {
-  it('parseGameConfigFormValues 会把 raw entries 解析成表单可编辑值，并保留自定义项', () => {
+describe('game-config 表单辅助函数', () => {
+  it('parseGameConfigFormValues 会把原始条目解析成表单可编辑值，并保留自定义项', () => {
     expect(parseGameConfigFormValues(createReadResult({
       entries: [
         {


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [ ] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [x] 代码重构
- [x] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

- 统一多个测试文件中的 `describe` / `it` 文案，收敛为简体中文表述，与仓库约定保持一致。
- 调整 `ParamRenderer`、`CascadingCombobox` 及相关测试中的样例路径和分组名称，将带具体角色语义的测试数据替换为更中性的占位值，例如 `chara` / `charb` / `charc`、`variant01` / `group01` / `item01`。
- 不涉及生产逻辑修改，主要目的是提升测试可读性、降低样例数据噪音，并让失败输出更聚焦于行为本身。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

当前测试中存在两类可维护性问题：

1. 测试文案存在中英混用，阅读和排查失败用例时不够统一。
2. 部分断言依赖带具体语义的示例值，容易把注意力带到业务命名上，而不是测试真正验证的路径分组、搜索匹配和状态恢复行为。

这次整理的目标，是让测试表达更一致，也让样例数据更抽象、更利于后续维护。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [ ] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
