### PR TITLE
🐛 修复仅变更大小写时的文件重命名冲突

### DIFF
--- a/src-tauri/src/commands/fs.rs
+++ b/src-tauri/src/commands/fs.rs
@@ -1,7 +1,7 @@
 use std::{
     fs::{self, OpenOptions},
     io::{self, ErrorKind},
-    path::{Path, PathBuf},
+    path::{Component, Path, PathBuf},
 };
 
 /// 检测文件是否为二进制文件
@@ -293,6 +293,52 @@ pub async fn delete_file(path: String, permanent: Option<bool>) -> AppResult<()>
     Ok(())
 }
 
+fn build_rename_destination(source_path: &Path, new_name: &str) -> AppResult<PathBuf> {
+    let parent = source_path
+        .parent()
+        .ok_or_else(|| AppError::Server("源路径缺少父目录".into()))?;
+    let mut components = Path::new(new_name).components();
+
+    match (components.next(), components.next()) {
+        (Some(Component::Normal(name)), None) => Ok(parent.join(name)),
+        _ => Err(AppError::Server("重命名目标名称无效".into())),
+    }
+}
+
+fn paths_refer_to_same_entry(left: &Path, right: &Path) -> io::Result<bool> {
+    if !left.exists() || !right.exists() {
+        return Ok(false);
+    }
+
+    Ok(left.canonicalize()? == right.canonicalize()?)
+}
+
+#[tauri::command]
+pub fn rename_file(path: String, new_name: String) -> AppResult<String> {
+    let source_path = PathBuf::from(&path);
+    if !source_path.exists() {
+        return Err(AppError::Server(format!(
+            "路径不存在: {}",
+            source_path.display()
+        )));
+    }
+
+    let target_path = build_rename_destination(&source_path, &new_name)?;
+    if source_path == target_path {
+        return Ok(target_path.to_string_lossy().into_owned());
+    }
+
+    if target_path.exists() && !paths_refer_to_same_entry(&source_path, &target_path)? {
+        return Err(AppError::Io(io::Error::new(
+            ErrorKind::AlreadyExists,
+            "目标路径已存在",
+        )));
+    }
+
+    fs::rename(&source_path, &target_path)?;
+    Ok(target_path.to_string_lossy().into_owned())
+}
+
 #[cfg(test)]
 mod tests {
     use std::{
@@ -303,7 +349,7 @@ mod tests {
 
     use super::{
         copy_dir_all, count_files_with_excludes, is_binary_file, read_image_dimensions,
-        validate_directory_structure,
+        rename_file, validate_directory_structure,
     };
 
     const PNG_1X1_BYTES: &[u8] = &[
@@ -504,5 +550,33 @@ mod tests {
 
         fs::remove_dir_all(&src).expect("src temp dir should be removed");
         fs::remove_dir_all(&dst).expect("dst temp dir should be removed");
+    }
+
+    #[test]
+    fn rename_file_allows_case_only_change_for_same_path() {
+        let root = create_temp_dir("webgal-craft-rename-file");
+        let source_path = root.join("scene.txt");
+        fs::write(&source_path, "scene").expect("source file should be created");
+
+        let renamed = rename_file(
+            source_path.to_string_lossy().into_owned(),
+            "Scene.txt".into(),
+        )
+        .expect("case-only rename should succeed");
+
+        let entry_names = fs::read_dir(&root)
+            .expect("root entries should be readable")
+            .map(|entry| {
+                entry
+                    .expect("directory entry should be readable")
+                    .file_name()
+                    .to_string_lossy()
+                    .into_owned()
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(entry_names, vec!["Scene.txt"]);
+        assert_eq!(renamed, root.join("Scene.txt").to_string_lossy());
+
+        fs::remove_dir_all(&root).expect("temp directory should be removed");
     }
 }

--- a/src-tauri/src/commands/fs.rs
+++ b/src-tauri/src/commands/fs.rs
@@ -2,11 +2,13 @@ use std::{
     fs::{self, OpenOptions},
     io::{self, ErrorKind},
     path::{Component, Path, PathBuf},
+    sync::Mutex,
 };
 
 /// 检测文件是否为二进制文件
 /// 读取前 8192 字节，若包含 null byte 则判定为二进制
 const BINARY_CHECK_BUFFER_SIZE: usize = 8192;
+static RENAME_FILE_LOCK: Mutex<()> = Mutex::new(());
 
 use tauri::ipc::Channel;
 
@@ -316,6 +318,11 @@ fn paths_refer_to_same_entry(left: &Path, right: &Path) -> io::Result<bool> {
 #[tauri::command]
 pub fn rename_file(path: String, new_name: String) -> AppResult<String> {
     let source_path = PathBuf::from(&path);
+    let target_path = build_rename_destination(&source_path, &new_name)?;
+    let _rename_guard = RENAME_FILE_LOCK
+        .lock()
+        .map_err(|_| AppError::Io(io::Error::other("文件重命名锁已中毒")))?;
+
     if !source_path.exists() {
         return Err(AppError::Server(format!(
             "路径不存在: {}",
@@ -323,7 +330,6 @@ pub fn rename_file(path: String, new_name: String) -> AppResult<String> {
         )));
     }
 
-    let target_path = build_rename_destination(&source_path, &new_name)?;
     if source_path == target_path {
         return Ok(target_path.to_string_lossy().into_owned());
     }
@@ -343,9 +349,12 @@ pub fn rename_file(path: String, new_name: String) -> AppResult<String> {
 mod tests {
     use std::{
         fs,
+        io::ErrorKind,
         path::{Path, PathBuf},
         time::{SystemTime, UNIX_EPOCH},
     };
+
+    use crate::commands::AppError;
 
     use super::{
         copy_dir_all, count_files_with_excludes, is_binary_file, read_image_dimensions,
@@ -576,6 +585,32 @@ mod tests {
             .collect::<Vec<_>>();
         assert_eq!(entry_names, vec!["Scene.txt"]);
         assert_eq!(renamed, root.join("Scene.txt").to_string_lossy());
+
+        fs::remove_dir_all(&root).expect("temp directory should be removed");
+    }
+
+    #[test]
+    fn rename_file_rejects_existing_distinct_target() {
+        let root = create_temp_dir("webgal-craft-rename-file-conflict");
+        let source_path = root.join("scene.txt");
+        let target_path = root.join("other.txt");
+        fs::write(&source_path, "scene").expect("source file should be created");
+        fs::write(&target_path, "other").expect("target file should be created");
+
+        let error = rename_file(
+            source_path.to_string_lossy().into_owned(),
+            "other.txt".into(),
+        )
+        .expect_err("rename to an existing distinct target should fail");
+
+        assert!(
+            matches!(error, AppError::Io(ref io_error) if io_error.kind() == ErrorKind::AlreadyExists)
+        );
+        assert_eq!(
+            fs::read_to_string(&target_path).expect("target file should remain readable"),
+            "other"
+        );
+        assert!(source_path.exists(), "source file should remain in place");
 
         fs::remove_dir_all(&root).expect("temp directory should be removed");
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -106,6 +106,7 @@ pub fn run() {
             commands::fs::copy_directory_with_progress,
             commands::fs::validate_directory_structure,
             commands::fs::delete_file,
+            commands::fs::rename_file,
             commands::fs::is_binary_file,
             commands::fs::get_image_dimensions,
             // window

--- a/src-tauri/src/vfs.rs
+++ b/src-tauri/src/vfs.rs
@@ -646,7 +646,11 @@ impl OverlayFs {
             .is_some_and(|(lower_path, _)| lower_path.exists()))
     }
 
-    fn logical_paths_share_physical_entry(&self, left: &Path, right: &Path) -> Result<bool, VfsError> {
+    fn logical_paths_share_physical_entry(
+        &self,
+        left: &Path,
+        right: &Path,
+    ) -> Result<bool, VfsError> {
         let left_resolved = match self.resolve_physical_path(left) {
             Ok(path) => path,
             Err(VfsError::NotFound) => return Ok(false),
@@ -1854,7 +1858,10 @@ mod tests {
         .expect("overlay should be created");
 
         overlay
-            .rename_logical_path(Path::new("game/scene/Hero.png"), Path::new("game/scene/hero.png"))
+            .rename_logical_path(
+                Path::new("game/scene/Hero.png"),
+                Path::new("game/scene/hero.png"),
+            )
             .expect("case-only rename should succeed");
 
         let entry_names = fs::read_dir(upper.join("game").join("scene"))

--- a/src-tauri/src/vfs.rs
+++ b/src-tauri/src/vfs.rs
@@ -345,18 +345,21 @@ impl OverlayFs {
             return Ok(());
         }
 
-        if self.logical_path_exists(to)? && !self.logical_paths_share_physical_entry(from, to)? {
-            return Err(already_exists_error());
-        }
-
         let source_upper = self.validate_upper_path(from)?;
         let source_lower = self
             .resolve_lower_path(from)
             .filter(|(lower_path, _)| lower_path.exists());
         let target_upper = self.validate_upper_path(to)?;
+        let source_is_whiteouted = source_category.uses_whiteout() && self.is_whiteouted(from)?;
+        let source_exists =
+            source_upper.exists() || (!source_is_whiteouted && source_lower.is_some());
 
-        if !source_upper.exists() && source_lower.is_none() && !self.is_whiteouted(from)? {
+        if !source_exists {
             return Err(VfsError::NotFound);
+        }
+
+        if self.logical_path_exists(to)? && !self.logical_paths_share_physical_entry(from, to)? {
+            return Err(already_exists_error());
         }
 
         self.ensure_directory_target_is_not_nested(from, to)?;
@@ -1834,6 +1837,40 @@ mod tests {
             .expect_err("rename to existing target should fail");
 
         assert_eq!(error.code(), "ALREADY_EXISTS");
+    }
+
+    #[test]
+    fn rename_logical_path_reports_not_found_before_target_conflict() {
+        let upper_dir = create_temp_dir();
+        let upper = upper_dir.path().to_path_buf();
+        let engine_dir = create_temp_dir();
+        let engine = engine_dir.path().to_path_buf();
+
+        fs::create_dir_all(engine.join("game").join("template"))
+            .expect("template directory should be created");
+        fs::create_dir_all(upper.join("game").join("scene"))
+            .expect("scene directory should be created");
+        fs::write(
+            upper.join("game").join("scene").join("existing.txt"),
+            "target",
+        )
+        .expect("conflict target should already exist");
+
+        let overlay = OverlayFs::new(
+            upper,
+            Some(engine.clone()),
+            Some(engine.join("game").join("template")),
+        )
+        .expect("overlay should be created");
+
+        let error = overlay
+            .rename_logical_path(
+                Path::new("game/scene/missing.txt"),
+                Path::new("game/scene/existing.txt"),
+            )
+            .expect_err("missing source should not be masked by target conflict");
+
+        assert!(matches!(error, VfsError::NotFound));
     }
 
     #[test]

--- a/src-tauri/src/vfs.rs
+++ b/src-tauri/src/vfs.rs
@@ -345,7 +345,7 @@ impl OverlayFs {
             return Ok(());
         }
 
-        if self.logical_path_exists(to)? {
+        if self.logical_path_exists(to)? && !self.logical_paths_share_physical_entry(from, to)? {
             return Err(already_exists_error());
         }
 
@@ -644,6 +644,21 @@ impl OverlayFs {
         Ok(self
             .resolve_lower_path(logical_path)
             .is_some_and(|(lower_path, _)| lower_path.exists()))
+    }
+
+    fn logical_paths_share_physical_entry(&self, left: &Path, right: &Path) -> Result<bool, VfsError> {
+        let left_resolved = match self.resolve_physical_path(left) {
+            Ok(path) => path,
+            Err(VfsError::NotFound) => return Ok(false),
+            Err(error) => return Err(error),
+        };
+        let right_resolved = match self.resolve_physical_path(right) {
+            Ok(path) => path,
+            Err(VfsError::NotFound) => return Ok(false),
+            Err(error) => return Err(error),
+        };
+
+        same_physical_entry(&left_resolved.physical_path, &right_resolved.physical_path)
     }
 
     fn copy_overlay_path(&self, from: &Path, to: &Path) -> Result<(), VfsError> {
@@ -1047,6 +1062,14 @@ fn already_exists_error() -> VfsError {
         ErrorKind::AlreadyExists,
         "目标路径已存在",
     ))
+}
+
+fn same_physical_entry(left: &Path, right: &Path) -> Result<bool, VfsError> {
+    if !left.exists() || !right.exists() {
+        return Ok(false);
+    }
+
+    Ok(left.canonicalize()? == right.canonicalize()?)
 }
 
 fn strip_template_prefix(path: &Path) -> Option<&Path> {
@@ -1807,6 +1830,44 @@ mod tests {
             .expect_err("rename to existing target should fail");
 
         assert_eq!(error.code(), "ALREADY_EXISTS");
+    }
+
+    #[test]
+    fn rename_logical_path_allows_case_only_change_for_same_upper_entry() {
+        let upper_dir = create_temp_dir();
+        let upper = upper_dir.path().to_path_buf();
+        let engine_dir = create_temp_dir();
+        let engine = engine_dir.path().to_path_buf();
+
+        fs::create_dir_all(engine.join("game").join("template"))
+            .expect("template directory should be created");
+        fs::create_dir_all(upper.join("game").join("scene"))
+            .expect("scene directory should be created");
+        fs::write(upper.join("game").join("scene").join("Hero.png"), "hero")
+            .expect("source file should be written");
+
+        let overlay = OverlayFs::new(
+            upper.clone(),
+            Some(engine.clone()),
+            Some(engine.join("game").join("template")),
+        )
+        .expect("overlay should be created");
+
+        overlay
+            .rename_logical_path(Path::new("game/scene/Hero.png"), Path::new("game/scene/hero.png"))
+            .expect("case-only rename should succeed");
+
+        let entry_names = fs::read_dir(upper.join("game").join("scene"))
+            .expect("scene entries should be readable")
+            .map(|entry| {
+                entry
+                    .expect("directory entry should be readable")
+                    .file_name()
+                    .to_string_lossy()
+                    .into_owned()
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(entry_names, vec!["hero.png"]);
     }
 
     #[test]

--- a/src/commands/__tests__/fs.test.ts
+++ b/src/commands/__tests__/fs.test.ts
@@ -1,0 +1,53 @@
+import '~/__tests__/setup'
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const { safeInvokeMock } = vi.hoisted(() => ({
+  safeInvokeMock: vi.fn(),
+}))
+
+vi.mock('@tauri-apps/api/core', () => ({
+  Channel: class {
+    onmessage?: (payload: unknown) => void
+  },
+  invoke: vi.fn(),
+}))
+
+vi.mock('@tauri-apps/api/path', () => ({
+  basename: vi.fn(),
+  join: vi.fn(),
+}))
+
+vi.mock('@tauri-apps/plugin-fs', () => ({
+  copyFile: vi.fn(),
+  exists: vi.fn(),
+  mkdir: vi.fn(),
+  rename: vi.fn(),
+  stat: vi.fn(),
+  writeTextFile: vi.fn(),
+}))
+
+vi.mock('~/utils/invoke', () => ({
+  safeInvoke: safeInvokeMock,
+}))
+
+import { fsCmds } from '../fs'
+
+describe('fsCmds', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renameFile 在仅修改大小写时不会把同一文件误判为目标已存在', async () => {
+    safeInvokeMock.mockResolvedValue('/project/game/Scene.txt')
+
+    await expect(fsCmds.renameFile('/project/game/scene.txt', 'Scene.txt'))
+      .resolves
+      .toBe('/project/game/Scene.txt')
+
+    expect(safeInvokeMock).toHaveBeenCalledWith('rename_file', {
+      path: '/project/game/scene.txt',
+      newName: 'Scene.txt',
+    })
+  })
+})

--- a/src/commands/fs.ts
+++ b/src/commands/fs.ts
@@ -1,5 +1,5 @@
 import { Channel, invoke } from '@tauri-apps/api/core'
-import { basename, dirname, join } from '@tauri-apps/api/path'
+import { basename, join } from '@tauri-apps/api/path'
 import {
   copyFile as copyFileFs,
   exists,
@@ -131,15 +131,7 @@ async function deleteFile(path: string, permanent = false): Promise<void> {
 }
 
 async function renameFile(oldPath: string, newName: string): Promise<string> {
-  const parentDir = await dirname(oldPath)
-  const newPath = await join(parentDir, newName)
-
-  if (await exists(newPath)) {
-    throw new AppError('IO_ERROR', '目标路径已存在')
-  }
-
-  await rename(oldPath, newPath)
-  return newPath
+  return safeInvoke<string>('rename_file', { path: oldPath, newName })
 }
 
 interface DestinationPath {


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [x] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [ ] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

修复文件重命名时“仅修改大小写”会被误判为“目标路径已存在”的问题。

本次修改包含两条链路：

1. 普通文件系统重命名
将前端基于 `exists` 的预检查移除，改为统一调用 Rust 侧 `rename_file` 命令，在执行层判断目标路径是否与源文件指向同一物理条目，避免大小写不敏感文件系统上的误判。

2. VFS 重命名
在 `OverlayFs::rename_logical_path` 的目标存在性检查中，补充“源路径与目标路径是否解析到同一物理条目”的判断，仅在确实是不同条目时才返回 `ALREADY_EXISTS`。

另外补充了普通 fs 与 VFS 两条链路的回归测试，覆盖仅变更大小写的重命名场景。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

在 Windows 等大小写不敏感文件系统上，`scene.txt -> Scene.txt` 这类重命名本质上仍然指向同一物理文件。

此前实现先按字符串路径做“目标是否存在”的预检查，因此会把这种合法重命名误判为冲突，导致用户无法完成仅大小写变更的重命名操作。

这次修改将判断下沉到更接近文件系统语义的执行层，避免继续依赖脆弱的前端路径存在性预判。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
