### PR TITLE
♻️ 重构数据库路径字段为 AbsPath brand 类型

### DIFF
--- a/src/__tests__/factories.test.ts
+++ b/src/__tests__/factories.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import { createTestEngine, createTestGame } from '~/__tests__/factories'
+import { AbsPath } from '~/domain/path'
 
 describe('测试工厂函数', () => {
   it('createTestGame 默认带 available availability', () => {
@@ -17,7 +18,7 @@ describe('测试工厂函数', () => {
 
   it('createTestGame 会基于解析后的 game path 生成默认预览资源路径', () => {
     expect(createTestGame({
-      path: '/games/custom-demo',
+      path: AbsPath.from('/games/custom-demo'),
     })).toMatchObject({
       path: '/games/custom-demo',
       metadata: {
@@ -60,7 +61,7 @@ describe('测试工厂函数', () => {
 
   it('createTestGame 会保留调用方显式提供的预览资源路径', () => {
     expect(createTestGame({
-      path: '/games/custom-demo',
+      path: AbsPath.from('/games/custom-demo'),
       previewAssets: {
         cover: {
           path: '/covers/custom-cover.png',
@@ -83,7 +84,7 @@ describe('测试工厂函数', () => {
 
   it('createTestEngine 会基于解析后的 engine path 生成默认图标路径', () => {
     expect(createTestEngine({
-      path: '/engines/custom-engine',
+      path: AbsPath.from('/engines/custom-engine'),
     })).toMatchObject({
       path: '/engines/custom-engine',
       previewAssets: {
@@ -114,7 +115,7 @@ describe('测试工厂函数', () => {
 
   it('createTestEngine 会保留调用方显式提供的图标路径', () => {
     expect(createTestEngine({
-      path: '/engines/custom-engine',
+      path: AbsPath.from('/engines/custom-engine'),
       previewAssets: {
         icon: {
           path: '/icons/custom-engine-icon.png',

--- a/src/__tests__/factories.ts
+++ b/src/__tests__/factories.ts
@@ -1,3 +1,4 @@
+import { AbsPath } from '~/domain/path'
 import { normalizeImportPath } from '~/services/resource-health'
 
 import type { Engine, Game, Template } from '~/database/model'
@@ -25,7 +26,7 @@ export function createTestGame(options: TestGameFactoryOptions = {}): Game {
     previewAssets,
     ...rest
   } = options
-  const resolvedGamePath = path ?? '/games/demo'
+  const resolvedGamePath = path ?? AbsPath.from('/games/demo')
   const {
     cover: rawCover,
     icon: rawIcon,
@@ -68,7 +69,7 @@ export function createTestEngine(options: TestEngineFactoryOptions = {}): Engine
     previewAssets,
     ...rest
   } = options
-  const resolvedEnginePath = path ?? '/engines/default'
+  const resolvedEnginePath = path ?? AbsPath.from('/engines/default')
   const { icon: rawIcon } = previewAssets ?? {}
   const { path: iconPath, ...icon } = rawIcon ?? {}
   const defaultName = options.name ?? 'Default Engine'
@@ -102,7 +103,7 @@ export function createTestEngine(options: TestEngineFactoryOptions = {}): Engine
 export function createTestTemplate(options: Partial<Template> = {}): Template {
   return {
     id: 'template-1',
-    path: '/templates/default',
+    path: AbsPath.from('/templates/default'),
     createdAt: 0,
     status: 'created',
     availability: 'available',

--- a/src/components/editor/AssetView.vue
+++ b/src/components/editor/AssetView.vue
@@ -137,7 +137,7 @@ const assetBasePath = $computed(() => {
     return ''
   }
 
-  return AbsPath.join(AbsPath.from(workspaceStore.currentGame.path), RelPath.from(`game/${assetType}`))
+  return AbsPath.join(workspaceStore.currentGame.path, RelPath.from(`game/${assetType}`))
 })
 
 const currentDirectoryPath = $computed(() => {

--- a/src/components/editor/EditHeader.vue
+++ b/src/components/editor/EditHeader.vue
@@ -3,7 +3,6 @@ import { ArrowLeft, Download, Loader2, MonitorPlay, Pencil, Play, Settings } fro
 import { WebviewWindow } from '@tauri-apps/api/webviewWindow'
 
 import { windowCmds } from '~/commands/window'
-import { AbsPath } from '~/domain/path'
 import { parseGameConfigFormValues } from '~/features/modals/game-config/game-config-form'
 import { configManager } from '~/services/config-manager'
 import { gameAssetDir } from '~/services/platform/app-paths'
@@ -87,8 +86,8 @@ async function handleOpenGameConfig() {
   try {
     const [config, backgroundRootPath, bgmRootPath] = await Promise.all([
       configManager.getConfig(gamePath),
-      gameAssetDir(AbsPath.from(gamePath), 'background'),
-      gameAssetDir(AbsPath.from(gamePath), 'bgm'),
+      gameAssetDir(gamePath, 'background'),
+      gameAssetDir(gamePath, 'bgm'),
     ])
 
     if (workspaceStore.currentGame?.path !== gamePath) {

--- a/src/components/home/WelcomeSection.vue
+++ b/src/components/home/WelcomeSection.vue
@@ -2,6 +2,7 @@
 import { FolderOpen, Plus } from '@lucide/vue'
 import { open } from '@tauri-apps/plugin-dialog'
 
+import { AbsPath } from '~/domain/path'
 import { resolveHomeResourceImportNotification } from '~/features/home/shared/home-resource-import'
 import {
   HomeResourceImportMessages,
@@ -74,7 +75,7 @@ async function selectGameFolder() {
   }
 
   try {
-    const gameId = await gameManager.importGame(path, { selectEngine: requestEngineSelection })
+    const gameId = await gameManager.importGame(AbsPath.from(path), { selectEngine: requestEngineSelection })
     router.push(`/edit/${gameId}`)
   } catch (error: unknown) {
     logger.error(`导入游戏时发生错误: ${error}`)

--- a/src/components/home/engines-tab/EngineGroupCard.spec.ts
+++ b/src/components/home/engines-tab/EngineGroupCard.spec.ts
@@ -7,6 +7,7 @@ import {
   renderInBrowser,
 } from '~/__tests__/browser-render'
 import { createTestEngine } from '~/__tests__/factories'
+import { AbsPath } from '~/domain/path'
 
 import EngineGroupCard from './EngineGroupCard.vue'
 
@@ -33,7 +34,7 @@ function createGroup(): EngineGroupCollectionItem {
   const stable = createTestEngine({
     id: 'stable',
     name: 'WebGAL',
-    path: '/engines/WebGAL/4.5.0',
+    path: AbsPath.from('/engines/WebGAL/4.5.0'),
     version: '4.5.0',
     metadata: {
       description: 'Stable release',
@@ -42,7 +43,7 @@ function createGroup(): EngineGroupCollectionItem {
   const unavailable = createTestEngine({
     id: 'unavailable',
     name: 'WebGAL',
-    path: '/engines/WebGAL/4.6.0',
+    path: AbsPath.from('/engines/WebGAL/4.6.0'),
     availability: 'broken',
     version: '4.6.0',
   })

--- a/src/components/home/engines-tab/EnginesTab.spec.ts
+++ b/src/components/home/engines-tab/EnginesTab.spec.ts
@@ -3,6 +3,7 @@ import { page } from 'vitest/browser'
 
 import { createBrowserClickStub, createBrowserContainerStub, renderInBrowser } from '~/__tests__/browser-render'
 import { createTestEngine } from '~/__tests__/factories'
+import { AbsPath } from '~/domain/path'
 import { AppError } from '~/types/errors'
 
 import EnginesTab from './EnginesTab.vue'
@@ -214,7 +215,7 @@ describe('EnginesTab', () => {
     const engine = createTestEngine({
       engineId: 'open-webgal.webgal',
       name: 'WebGAL',
-      path: '/engines/WebGAL/4.5.0',
+      path: AbsPath.from('/engines/WebGAL/4.5.0'),
       version: '4.5.0',
     })
 
@@ -266,7 +267,7 @@ describe('EnginesTab', () => {
     const engine = createTestEngine({
       engineId: 'open-webgal.webgal',
       name: 'WebGAL',
-      path: '/engines/WebGAL/4.5.0',
+      path: AbsPath.from('/engines/WebGAL/4.5.0'),
       version: '4.5.0',
     })
     const preferenceStore = reactive({
@@ -305,7 +306,7 @@ describe('EnginesTab', () => {
     const engine = createTestEngine({
       engineId: 'open-webgal.webgal',
       name: 'WebGAL',
-      path: '/engines/WebGAL/4.5.0',
+      path: AbsPath.from('/engines/WebGAL/4.5.0'),
       version: '4.5.0',
     })
     const preferenceStore = reactive({

--- a/src/components/home/engines-tab/EnginesTabCollectionSection.spec.ts
+++ b/src/components/home/engines-tab/EnginesTabCollectionSection.spec.ts
@@ -7,6 +7,7 @@ import {
   renderInBrowser,
 } from '~/__tests__/browser-render'
 import { createTestEngine } from '~/__tests__/factories'
+import { AbsPath } from '~/domain/path'
 
 import EnginesTabCollectionSection from './EnginesTabCollectionSection.vue'
 
@@ -46,7 +47,7 @@ function createGroups(): EngineGroupCollectionItem[] {
   const stable = createTestEngine({
     id: 'engine-2',
     name: 'WebGAL',
-    path: '/engines/WebGAL/4.5.0',
+    path: AbsPath.from('/engines/WebGAL/4.5.0'),
     version: '4.5.0',
   })
 
@@ -63,7 +64,7 @@ function createGroups(): EngineGroupCollectionItem[] {
           engine: createTestEngine({
             id: 'engine-1',
             name: 'WebGAL',
-            path: '/engines/WebGAL/4.4.0',
+            path: AbsPath.from('/engines/WebGAL/4.4.0'),
             availability: 'broken',
             version: '4.4.0',
           }),

--- a/src/components/home/templates-tab/TemplatesTab.spec.ts
+++ b/src/components/home/templates-tab/TemplatesTab.spec.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { page } from 'vitest/browser'
 
 import { createBrowserClickStub, renderInBrowser } from '~/__tests__/browser-render'
+import { AbsPath } from '~/domain/path'
 
 import TemplatesTab from './TemplatesTab.vue'
 
@@ -142,7 +143,7 @@ function createResourceStore() {
             kind: 'standalone',
             templateId: 'template-1',
             name: 'Modern Template',
-            path: '/templates/modern',
+            path: AbsPath.from('/templates/modern'),
             createdAt: 1,
           },
         ],
@@ -151,7 +152,7 @@ function createResourceStore() {
     templates: [
       {
         id: 'template-1',
-        path: '/templates/modern',
+        path: AbsPath.from('/templates/modern'),
         createdAt: 1,
         status: 'created',
         metadata: {
@@ -241,7 +242,7 @@ describe('TemplatesTab', () => {
           icon: 'icons/favicon.ico',
         },
         name: 'WebGAL',
-        path: '/engines/WebGAL/4.8.2',
+        path: AbsPath.from('/engines/WebGAL/4.8.2'),
         pathLookupKey: '/engines/webgal/4.8.2',
         previewAssets: {
           icon: {
@@ -265,9 +266,9 @@ describe('TemplatesTab', () => {
             kind: 'engineBuiltin',
             engineId: 'engine-1',
             engineName: 'WebGAL',
-            enginePath: '/engines/WebGAL/4.8.2',
+            enginePath: AbsPath.from('/engines/WebGAL/4.8.2'),
             engineVersion: '4.8.2',
-            templatePath: '/engines/WebGAL/4.8.2/game/template',
+            templatePath: AbsPath.from('/engines/WebGAL/4.8.2/game/template'),
             createdAt: 2,
           },
         ],

--- a/src/components/home/templates-tab/TemplatesTabCollectionSection.spec.ts
+++ b/src/components/home/templates-tab/TemplatesTabCollectionSection.spec.ts
@@ -3,6 +3,7 @@ import { page } from 'vitest/browser'
 
 import { createBrowserClickStub, createBrowserContainerStub, renderInBrowser } from '~/__tests__/browser-render'
 import { createTestEngine } from '~/__tests__/factories'
+import { AbsPath } from '~/domain/path'
 
 import TemplatesTabCollectionSection from './TemplatesTabCollectionSection.vue'
 
@@ -89,7 +90,7 @@ function createItems(): TemplateCollectionItem[] {
   const builtinNovaEngine = createTestEngine({
     id: 'engine-3',
     name: 'WebGAL Nova',
-    path: '/engines/WebGAL Nova/5.0.0',
+    path: AbsPath.from('/engines/WebGAL Nova/5.0.0'),
     previewAssets: {
       icon: {
         cacheVersion: 13,
@@ -101,7 +102,7 @@ function createItems(): TemplateCollectionItem[] {
   const builtinStableEngine = createTestEngine({
     id: 'engine-2',
     name: 'WebGAL',
-    path: '/engines/WebGAL/4.8.2',
+    path: AbsPath.from('/engines/WebGAL/4.8.2'),
     previewAssets: {
       icon: {
         cacheVersion: 21,
@@ -122,7 +123,7 @@ function createItems(): TemplateCollectionItem[] {
             kind: 'standalone',
             templateId: 'template-1',
             name: 'Modern Template',
-            path: '/templates/modern',
+            path: AbsPath.from('/templates/modern'),
             createdAt: 1,
             webgalVersion: '4.8.1',
             availability: 'available',
@@ -145,8 +146,8 @@ function createItems(): TemplateCollectionItem[] {
             engineId: 'engine-3',
             engineName: 'WebGAL Nova',
             engineVersion: '5.0.0',
-            enginePath: '/engines/WebGAL Nova/5.0.0',
-            templatePath: '/engines/WebGAL Nova/5.0.0/game/template',
+            enginePath: AbsPath.from('/engines/WebGAL Nova/5.0.0'),
+            templatePath: AbsPath.from('/engines/WebGAL Nova/5.0.0/game/template'),
             createdAt: 3,
           },
         ],
@@ -167,8 +168,8 @@ function createItems(): TemplateCollectionItem[] {
             engineId: 'engine-2',
             engineName: 'WebGAL',
             engineVersion: '4.8.2',
-            enginePath: '/engines/WebGAL/4.8.2',
-            templatePath: '/engines/WebGAL/4.8.2/game/template',
+            enginePath: AbsPath.from('/engines/WebGAL/4.8.2'),
+            templatePath: AbsPath.from('/engines/WebGAL/4.8.2/game/template'),
             createdAt: 2,
           },
           {
@@ -176,8 +177,8 @@ function createItems(): TemplateCollectionItem[] {
             engineId: 'engine-1',
             engineName: 'WebGAL',
             engineVersion: '4.8.1',
-            enginePath: '/engines/WebGAL/4.8.1',
-            templatePath: '/engines/WebGAL/4.8.1/game/template',
+            enginePath: AbsPath.from('/engines/WebGAL/4.8.1'),
+            templatePath: AbsPath.from('/engines/WebGAL/4.8.1/game/template'),
             createdAt: 1,
           },
         ],

--- a/src/components/modals/DiscoveredResourcesModal.spec.ts
+++ b/src/components/modals/DiscoveredResourcesModal.spec.ts
@@ -6,6 +6,7 @@ import {
   createBrowserContainerStub,
   renderInBrowser,
 } from '~/__tests__/browser-render'
+import { AbsPath } from '~/domain/path'
 
 import DiscoveredResourcesModal from './DiscoveredResourcesModal.vue'
 
@@ -94,7 +95,7 @@ describe('DiscoveredResourcesModal', () => {
         open: true,
         resources: [
           {
-            path: '/games/demo',
+            path: AbsPath.from('/games/demo'),
             name: 'Demo Game',
             icon: '/games/demo/icons/favicon.ico',
           },
@@ -123,7 +124,7 @@ describe('DiscoveredResourcesModal', () => {
         open: true,
         resources: [
           {
-            path: '/games/demo',
+            path: AbsPath.from('/games/demo'),
             name: 'Demo Game',
             icon: '/games/demo/icons/favicon.ico',
           },
@@ -148,12 +149,12 @@ describe('DiscoveredResourcesModal', () => {
         open: true,
         resources: [
           {
-            path: '/games/demo',
+            path: AbsPath.from('/games/demo'),
             name: 'Demo Game',
             icon: 'icons/favicon.ico',
             previewSite: {
-              projectPath: '/games/demo',
-              enginePath: '/engines/webgal',
+              projectPath: AbsPath.from('/games/demo'),
+              enginePath: AbsPath.from('/engines/webgal'),
             },
           },
         ],
@@ -178,12 +179,12 @@ describe('DiscoveredResourcesModal', () => {
       setup() {
         const resources = ref([
           {
-            path: '/games/alpha',
+            path: AbsPath.from('/games/alpha'),
             name: 'Alpha Game',
             icon: '/games/alpha/icons/favicon.ico',
           },
           {
-            path: '/games/beta',
+            path: AbsPath.from('/games/beta'),
             name: 'Beta Game',
             icon: '/games/beta/icons/favicon.ico',
           },
@@ -192,12 +193,12 @@ describe('DiscoveredResourcesModal', () => {
         function replaceResources() {
           resources.value = [
             {
-              path: '/games/beta',
+              path: AbsPath.from('/games/beta'),
               name: 'Beta Game',
               icon: '/games/beta/icons/favicon.ico',
             },
             {
-              path: '/games/charlie',
+              path: AbsPath.from('/games/charlie'),
               name: 'Charlie Game',
               icon: '/games/charlie/icons/favicon.ico',
             },
@@ -252,7 +253,7 @@ describe('DiscoveredResourcesModal', () => {
         open: true,
         resources: [
           {
-            path: '/templates/modern',
+            path: AbsPath.from('/templates/modern'),
             name: 'Modern Template',
           },
         ],

--- a/src/components/modals/DiscoveredResourcesModal.vue
+++ b/src/components/modals/DiscoveredResourcesModal.vue
@@ -4,6 +4,7 @@ import { Box, Scroll } from '@lucide/vue'
 import { compareEngineVersions } from '~/domain/engine/version'
 import { usePreviewRuntimeStore } from '~/stores/preview-runtime'
 
+import type { AbsPath } from '~/domain/path'
 import type { DiscoveredResource } from '~/features/home/discovered-resource'
 import type { AssetThumbnailOptions } from '~/services/platform/asset-url'
 
@@ -22,7 +23,7 @@ let open = $(defineModel<boolean>('open'))
 const props = defineProps<{
   type: ResourceType
   resources: DiscoveredResource[]
-  onImport?: (paths: string[]) => void
+  onImport?: (paths: AbsPath[]) => void
 }>()
 
 const { t } = useI18n()
@@ -71,7 +72,7 @@ const engineGroups = $computed<EngineGroup[]>(() => {
   return [...groupsMap.values()]
 })
 
-function toggleSelection(path: string) {
+function toggleSelection(path: AbsPath) {
   const next = new Set(selectedPaths)
   if (next.has(path)) {
     next.delete(path)

--- a/src/components/modals/GameConfigModal.vue
+++ b/src/components/modals/GameConfigModal.vue
@@ -14,12 +14,13 @@ import { useModalStore } from '~/stores/modal'
 import { handleError } from '~/utils/error-handler'
 
 import type { Game } from '~/database/model'
+import type { AbsPath } from '~/domain/path'
 import type { GameConfigFormValues } from '~/features/modals/game-config/game-config-form'
 
 interface Props {
-  backgroundRootPath: string
-  bgmRootPath: string
-  gamePath: string
+  backgroundRootPath: AbsPath
+  bgmRootPath: AbsPath
+  gamePath: AbsPath
   initialValues: GameConfigFormValues
   serveUrl?: string
   unmanagedLineCount: number

--- a/src/components/modals/RecoverGameModal.vue
+++ b/src/components/modals/RecoverGameModal.vue
@@ -3,6 +3,7 @@ import { TriangleAlert } from '@lucide/vue'
 import { open as openDialog } from '@tauri-apps/plugin-dialog'
 import { openPath } from '@tauri-apps/plugin-opener'
 
+import { AbsPath } from '~/domain/path'
 import { gameManager } from '~/services/game-manager'
 import { resourceReconcile } from '~/services/resource-reconcile'
 import { useEditorViewStateStore } from '~/stores/editor-view-state'
@@ -62,7 +63,7 @@ async function handleRelink() {
 
   isRelinking = true
   try {
-    const updated = await gameManager.relinkGame(props.game.id, selected)
+    const updated = await gameManager.relinkGame(props.game.id, AbsPath.from(selected))
     // 重链接后旧路径绑定的标签页与编辑器视图状态需要清掉，避免污染新工作区
     tabsStore.clearProjectState(updated.id)
     editorViewStateStore.clearProjectStates(updated.id)

--- a/src/components/modals/SwitchEngineModal.spec.ts
+++ b/src/components/modals/SwitchEngineModal.spec.ts
@@ -7,6 +7,7 @@ import {
   renderInBrowser,
 } from '~/__tests__/browser-render'
 import { createTestEngine, createTestGame } from '~/__tests__/factories'
+import { AbsPath } from '~/domain/path'
 
 import SwitchEngineModal from './SwitchEngineModal.vue'
 
@@ -192,7 +193,7 @@ function renderSwitchEngineModal() {
   const game = createTestGame({
     id: 'game-1',
     engineId: 'engine-current',
-    path: '/games/demo',
+    path: AbsPath.from('/games/demo'),
   })
 
   renderInBrowser(SwitchEngineModal, {
@@ -218,7 +219,7 @@ describe('SwitchEngineModal', () => {
     const currentGame = createTestGame({
       id: 'game-1',
       engineId: 'engine-current',
-      path: '/games/demo',
+      path: AbsPath.from('/games/demo'),
     })
 
     const currentEngine = createTestEngine({

--- a/src/components/modals/game-config/GameConfigFieldsSection.vue
+++ b/src/components/modals/game-config/GameConfigFieldsSection.vue
@@ -6,12 +6,13 @@ import { FormField } from '~/components/ui/form'
 import { AUDIO_EXTENSIONS } from '~/features/editor/command-registry/common-params'
 import { createGameConfigKey } from '~/features/modals/game-config/game-config-form'
 
+import type { AbsPath } from '~/domain/path'
 import type { GameConfigFormValues } from '~/features/modals/game-config/game-config-form'
 
 interface Props {
-  backgroundRootPath: string
-  bgmRootPath: string
-  gamePath: string
+  backgroundRootPath: AbsPath
+  bgmRootPath: AbsPath
+  gamePath: AbsPath
   serveUrl?: string
 }
 

--- a/src/components/modals/game-config/GameLogoPicker.spec.ts
+++ b/src/components/modals/game-config/GameLogoPicker.spec.ts
@@ -3,6 +3,7 @@ import { page } from 'vitest/browser'
 import { defineComponent, h, ref } from 'vue'
 
 import { createBrowserContainerStub, renderInBrowser } from '~/__tests__/browser-render'
+import { AbsPath } from '~/domain/path'
 
 import GameLogoPicker from './GameLogoPicker.vue'
 
@@ -117,8 +118,8 @@ const GameLogoPickerHarness = defineComponent({
     return () => h('div', [
       h(GameLogoPicker, {
         'modelValue': value.value,
-        'gamePath': '/games/demo',
-        'backgroundRootPath': '/games/demo/game/background',
+        'gamePath': AbsPath.from('/games/demo'),
+        'backgroundRootPath': AbsPath.from('/games/demo/game/background'),
         'serveUrl': 'http://127.0.0.1:8899/game/demo/',
         'onUpdate:modelValue': (nextValue: string[]) => {
           value.value = nextValue

--- a/src/components/modals/game-config/GameLogoPicker.vue
+++ b/src/components/modals/game-config/GameLogoPicker.vue
@@ -3,9 +3,11 @@ import { Plus, X } from '@lucide/vue'
 
 import { GAME_CONFIG_IMAGE_EXTENSIONS } from '~/features/modals/game-config/game-config-images'
 
+import type { AbsPath } from '~/domain/path'
+
 interface GameLogoPickerProps {
-  backgroundRootPath: string
-  gamePath: string
+  backgroundRootPath: AbsPath
+  gamePath: AbsPath
   serveUrl?: string
 }
 

--- a/src/components/modals/game-config/TitleImgPicker.spec.ts
+++ b/src/components/modals/game-config/TitleImgPicker.spec.ts
@@ -3,6 +3,7 @@ import { page } from 'vitest/browser'
 import { defineComponent, h, ref } from 'vue'
 
 import { renderInBrowser } from '~/__tests__/browser-render'
+import { AbsPath } from '~/domain/path'
 
 import TitleImgPicker from './TitleImgPicker.vue'
 
@@ -111,8 +112,8 @@ const TitleImgPickerHarness = defineComponent({
     return () => h('div', [
       h(TitleImgPicker, {
         'modelValue': value.value,
-        'gamePath': '/games/demo',
-        'backgroundRootPath': '/games/demo/game/background',
+        'gamePath': AbsPath.from('/games/demo'),
+        'backgroundRootPath': AbsPath.from('/games/demo/game/background'),
         'serveUrl': 'http://127.0.0.1:8899/game/demo/',
         'onUpdate:modelValue': (nextValue: string) => {
           value.value = nextValue

--- a/src/components/modals/game-config/TitleImgPicker.vue
+++ b/src/components/modals/game-config/TitleImgPicker.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
 import { GAME_CONFIG_IMAGE_EXTENSIONS } from '~/features/modals/game-config/game-config-images'
 
+import type { AbsPath } from '~/domain/path'
+
 interface TitleImgPickerProps {
-  backgroundRootPath: string
-  gamePath: string
+  backgroundRootPath: AbsPath
+  gamePath: AbsPath
   serveUrl?: string
 }
 

--- a/src/database/db.spec.ts
+++ b/src/database/db.spec.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import { createTestEngine, createTestGame } from '~/__tests__/factories'
+import { AbsPath } from '~/domain/path'
 
 import { db } from './db'
 
@@ -22,26 +23,26 @@ describe('数据库 schema', () => {
   it('games.pathLookupKey 保持唯一', async () => {
     await db.games.add(createTestGame({
       id: 'game-1',
-      path: '/Games/Demo',
+      path: AbsPath.from('/Games/Demo'),
     }))
 
     await expect(db.games.add(createTestGame({
       id: 'game-2',
-      path: '/games/demo/',
+      path: AbsPath.from('/games/demo/'),
     }))).rejects.toBeDefined()
   })
 
   it('engines.pathLookupKey 保持唯一', async () => {
     await db.engines.add(createTestEngine({
       id: 'engine-1',
-      path: '/Engines/WebGAL/4.5.0',
+      path: AbsPath.from('/Engines/WebGAL/4.5.0'),
       engineId: 'open-webgal.webgal',
       version: '4.5.0',
     }))
 
     await expect(db.engines.add(createTestEngine({
       id: 'engine-2',
-      path: '/engines/webgal/4.5.0/',
+      path: AbsPath.from('/engines/webgal/4.5.0/'),
       engineId: 'open-webgal.webgal-copy',
       version: '4.5.1',
     }))).rejects.toBeDefined()

--- a/src/database/model.ts
+++ b/src/database/model.ts
@@ -1,9 +1,10 @@
+import type { AbsPath } from '~/domain/path'
 import type { ResourceAvailability } from '~/services/resource-health'
 import type { EngineMetadata, EnginePreviewAssets, GameMetadata, GamePreviewAssets, TemplateMetadata } from '~/services/types'
 
 export interface Game {
   id: string
-  path: string
+  path: AbsPath
   pathLookupKey: string
   engineId?: string
   createdAt: number
@@ -16,7 +17,7 @@ export interface Game {
 
 export interface Engine {
   id: string
-  path: string
+  path: AbsPath
   pathLookupKey: string
   engineId: string
   name: string
@@ -30,7 +31,7 @@ export interface Engine {
 
 export interface Template {
   id: string
-  path: string
+  path: AbsPath
   createdAt: number
   status: TemplateStatus
   availability: ResourceAvailability

--- a/src/features/home/__tests__/useDiscoverResources.test.ts
+++ b/src/features/home/__tests__/useDiscoverResources.test.ts
@@ -22,11 +22,11 @@ const {
   validateTemplateMock,
 } = vi.hoisted(() => ({
   classifyEngineMock: vi.fn(),
-  gameIdentityKeyOfMock: vi.fn((resource: { path: string }) => toLookupPathKey(AbsPath.from(resource.path))),
-  engineIdentityKeyOfMock: vi.fn((resource: { path: string, engineId?: string, version?: string }) =>
+  gameIdentityKeyOfMock: vi.fn((resource: { path: AbsPath }) => toLookupPathKey(resource.path)),
+  engineIdentityKeyOfMock: vi.fn((resource: { path: AbsPath, engineId?: string, version?: string }) =>
     resource.engineId && resource.version
       ? `${resource.engineId}:${resource.version}`
-      : toLookupPathKey(AbsPath.from(resource.path)),
+      : toLookupPathKey(resource.path),
   ),
   existsMock: vi.fn(),
   getEnginePreviewAssetsMock: vi.fn(),

--- a/src/features/home/__tests__/useDiscoverResources.test.ts
+++ b/src/features/home/__tests__/useDiscoverResources.test.ts
@@ -428,7 +428,7 @@ describe('useDiscoverResources', () => {
       cover: { path: 'game/background/cover.png' },
     })
     vi.mocked(gameManager.resolvePreviewSite).mockResolvedValue({
-      projectPath: '/games/demo',
+      projectPath: AbsPath.from('/games/demo'),
     })
     resolveHomeTabDefinitionMock.mockReturnValue({ discoveryType: 'games' })
     useWorkspaceStoreMock.mockReturnValue({ activeTab: 'games' })

--- a/src/features/home/discovered-resource.ts
+++ b/src/features/home/discovered-resource.ts
@@ -1,7 +1,8 @@
+import type { AbsPath } from '~/domain/path'
 import type { StaticSiteConfig } from '~/types/server'
 
 export interface DiscoveredResource {
-  path: string
+  path: AbsPath
   name: string
   icon?: string
   previewSite?: StaticSiteConfig

--- a/src/features/home/engines-tab/__tests__/engine-group-view-model.test.ts
+++ b/src/features/home/engines-tab/__tests__/engine-group-view-model.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import { createTestEngine } from '~/__tests__/factories'
+import { AbsPath } from '~/domain/path'
 
 import { buildEngineGroupCollectionItems } from '../engine-group-view-model'
 
@@ -13,7 +14,7 @@ describe('buildEngineGroupCollectionItems', () => {
           id: 'legacy',
           engineId: 'open-webgal.webgal',
           name: 'WebGAL',
-          path: '/engines/WebGAL/4.4.0',
+          path: AbsPath.from('/engines/WebGAL/4.4.0'),
           version: '4.4.0',
           metadata: {
             description: 'legacy build',
@@ -23,7 +24,7 @@ describe('buildEngineGroupCollectionItems', () => {
           id: 'broken-latest',
           engineId: 'open-webgal.webgal',
           name: 'WebGAL',
-          path: '/engines/WebGAL/4.6.0',
+          path: AbsPath.from('/engines/WebGAL/4.6.0'),
           version: '4.6.0',
           availability: 'broken',
           metadata: {
@@ -34,7 +35,7 @@ describe('buildEngineGroupCollectionItems', () => {
           id: 'stable',
           engineId: 'open-webgal.webgal',
           name: 'WebGAL',
-          path: '/engines/WebGAL/4.5.0',
+          path: AbsPath.from('/engines/WebGAL/4.5.0'),
           version: '4.5.0',
           metadata: {
             description: 'stable build',
@@ -63,7 +64,7 @@ describe('buildEngineGroupCollectionItems', () => {
         createTestEngine({
           id: 'unavailable',
           name: 'Legacy',
-          path: '/engines/Legacy/1.0.0',
+          path: AbsPath.from('/engines/Legacy/1.0.0'),
           version: '1.0.0',
           availability: 'broken',
           metadata: {

--- a/src/features/home/engines-tab/__tests__/useEnginesTabController.test.ts
+++ b/src/features/home/engines-tab/__tests__/useEnginesTabController.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { createTestEngine } from '~/__tests__/factories'
+import { AbsPath } from '~/domain/path'
 import { AppError } from '~/types/errors'
 
 import { useEnginesTabController } from '../useEnginesTabController'
@@ -122,7 +123,7 @@ describe('useEnginesTabController 行为', () => {
       engines: [
         {
           engine: createTestEngine({
-            path: '/engines/WebGAL/4.5.0',
+            path: AbsPath.from('/engines/WebGAL/4.5.0'),
             version: '4.5.0',
           }),
         },

--- a/src/features/home/engines-tab/engine-group-view-model.ts
+++ b/src/features/home/engines-tab/engine-group-view-model.ts
@@ -3,12 +3,13 @@ import { toEngineCollectionItem } from '~/features/home/home-collection-items'
 import { isEngineUsable } from '~/services/engine-manager'
 
 import type { Engine } from '~/database/model'
+import type { AbsPath } from '~/domain/path'
 import type { EngineGroupCollectionItem } from '~/features/home/home-collection-items'
 
 export interface BuildEngineGroupCollectionItemsOptions {
   defaultEngineId?: string
   engines: readonly Engine[]
-  resolveServeUrl: (path: string) => string | undefined
+  resolveServeUrl: (path: AbsPath) => string | undefined
 }
 
 export function buildEngineGroupCollectionItems(

--- a/src/features/home/home-collection-items.ts
+++ b/src/features/home/home-collection-items.ts
@@ -1,4 +1,5 @@
 import type { Engine, Game } from '~/database/model'
+import type { AbsPath } from '~/domain/path'
 import type { TemplateGroupViewModel } from '~/features/home/templates-tab/template-groups'
 
 export interface GameCollectionItem {
@@ -14,7 +15,7 @@ export interface EngineCollectionItem {
 
 export function toEngineCollectionItem(
   engine: Engine,
-  resolveServeUrl: (path: string) => string | undefined,
+  resolveServeUrl: (path: AbsPath) => string | undefined,
 ): EngineCollectionItem {
   return {
     engine,

--- a/src/features/home/shared/useHomeResourceImportActions.ts
+++ b/src/features/home/shared/useHomeResourceImportActions.ts
@@ -1,6 +1,7 @@
 import { open } from '@tauri-apps/plugin-dialog'
 import { openPath } from '@tauri-apps/plugin-opener'
 
+import { AbsPath } from '~/domain/path'
 import { resolveI18nLike } from '~/utils/i18n-like'
 
 import {
@@ -33,7 +34,7 @@ export interface HomeResourceImportMessages {
 
 interface UseHomeResourceImportActionsOptions {
   activeProgress: ReadonlyMap<string, number>
-  importResource: (path: string) => Promise<HomeResourceImportOutcome | unknown>
+  importResource: (path: AbsPath) => Promise<HomeResourceImportOutcome | unknown>
   messages: HomeResourceImportMessages
   t: I18nT
 }
@@ -72,7 +73,7 @@ function isImportOutcome(value: unknown): value is HomeResourceImportOutcome {
 export function useHomeResourceImportActions<TResource extends { id: string, path: string }>(
   options: UseHomeResourceImportActionsOptions,
 ) {
-  async function importWithNotify(path: string) {
+  async function importWithNotify(path: AbsPath) {
     let importError: unknown
     let outcome: HomeResourceImportOutcome | undefined
 
@@ -127,7 +128,7 @@ export function useHomeResourceImportActions<TResource extends { id: string, pat
       return
     }
 
-    await importWithNotify(path)
+    await importWithNotify(AbsPath.from(path))
   }
 
   async function handleDrop(paths: string[]) {
@@ -139,10 +140,10 @@ export function useHomeResourceImportActions<TResource extends { id: string, pat
       return
     }
 
-    await importWithNotify(decision.path)
+    await importWithNotify(AbsPath.from(decision.path))
   }
 
-  async function handleOpenFolder(resource: Pick<TResource, 'path'>) {
+  async function handleOpenFolder(resource: { path: string }) {
     await openPath(resource.path)
   }
 

--- a/src/features/home/templates-tab/__tests__/template-collection-items.test.ts
+++ b/src/features/home/templates-tab/__tests__/template-collection-items.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import { createTestEngine } from '~/__tests__/factories'
+import { AbsPath } from '~/domain/path'
 
 import { buildTemplateCollectionItems } from '../template-collection-items'
 
@@ -9,13 +10,13 @@ describe('buildTemplateCollectionItems', () => {
     const stableEngine = createTestEngine({
       id: 'webgal-stable',
       name: 'WebGAL',
-      path: '/engines/WebGAL/4.8.2',
+      path: AbsPath.from('/engines/WebGAL/4.8.2'),
       version: '4.8.2',
     })
     const legacyEngine = createTestEngine({
       id: 'webgal-legacy',
       name: 'WebGAL',
-      path: '/engines/WebGAL/4.8.1',
+      path: AbsPath.from('/engines/WebGAL/4.8.1'),
       version: '4.8.1',
     })
 
@@ -32,7 +33,7 @@ describe('buildTemplateCollectionItems', () => {
               kind: 'standalone',
               templateId: 'template-1',
               name: 'Modern Template',
-              path: '/templates/modern',
+              path: AbsPath.from('/templates/modern'),
               createdAt: 1,
               availability: 'available',
             },
@@ -48,8 +49,8 @@ describe('buildTemplateCollectionItems', () => {
               engineId: 'webgal-stable',
               engineName: 'WebGAL',
               engineVersion: '4.8.2',
-              enginePath: '/engines/WebGAL/4.8.2',
-              templatePath: '/engines/WebGAL/4.8.2/game/template',
+              enginePath: AbsPath.from('/engines/WebGAL/4.8.2'),
+              templatePath: AbsPath.from('/engines/WebGAL/4.8.2/game/template'),
               createdAt: 2,
             },
             {
@@ -57,8 +58,8 @@ describe('buildTemplateCollectionItems', () => {
               engineId: 'webgal-legacy',
               engineName: 'WebGAL',
               engineVersion: '4.8.1',
-              enginePath: '/engines/WebGAL/4.8.1',
-              templatePath: '/engines/WebGAL/4.8.1/game/template',
+              enginePath: AbsPath.from('/engines/WebGAL/4.8.1'),
+              templatePath: AbsPath.from('/engines/WebGAL/4.8.1/game/template'),
               createdAt: 1,
             },
           ],
@@ -101,8 +102,8 @@ describe('buildTemplateCollectionItems', () => {
               engineId: 'missing-engine',
               engineName: 'WebGAL',
               engineVersion: '4.8.2',
-              enginePath: '/engines/WebGAL/4.8.2',
-              templatePath: '/engines/WebGAL/4.8.2/game/template',
+              enginePath: AbsPath.from('/engines/WebGAL/4.8.2'),
+              templatePath: AbsPath.from('/engines/WebGAL/4.8.2/game/template'),
               createdAt: 2,
             },
           ],

--- a/src/features/home/templates-tab/template-collection-items.ts
+++ b/src/features/home/templates-tab/template-collection-items.ts
@@ -1,6 +1,7 @@
 import { toEngineCollectionItem } from '~/features/home/home-collection-items'
 
 import type { Engine } from '~/database/model'
+import type { AbsPath } from '~/domain/path'
 import type {
   EngineCollectionItem,
   TemplateCollectionItem,
@@ -12,7 +13,7 @@ import type {
 
 interface BuildTemplateCollectionItemsOptions {
   engines: readonly Engine[]
-  resolveServeUrl: (path: string) => string | undefined
+  resolveServeUrl: (path: AbsPath) => string | undefined
   templateGroups: readonly TemplateGroupViewModel[]
 }
 
@@ -31,7 +32,7 @@ function resolveRepresentativeEngineSource(
 function resolveRepresentativeEngineItem(
   templateGroup: TemplateGroupViewModel,
   enginesById: ReadonlyMap<string, Engine>,
-  resolveServeUrl: (path: string) => string | undefined,
+  resolveServeUrl: (path: AbsPath) => string | undefined,
 ): EngineCollectionItem | undefined {
   const source = resolveRepresentativeEngineSource(templateGroup)
   if (!source) {

--- a/src/features/home/templates-tab/template-groups.ts
+++ b/src/features/home/templates-tab/template-groups.ts
@@ -9,7 +9,7 @@ export interface StandaloneTemplateSourceItem {
   kind: 'standalone'
   templateId: string
   name: string
-  path: string
+  path: AbsPath
   createdAt: number
   webgalVersion?: string
   availability: ResourceAvailability
@@ -20,8 +20,8 @@ export interface EngineBuiltinTemplateSourceItem {
   engineId: string
   engineName: string
   engineVersion?: string
-  enginePath: string
-  templatePath: string
+  enginePath: AbsPath
+  templatePath: AbsPath
   createdAt: number
 }
 
@@ -62,7 +62,7 @@ function createEngineBuiltinTemplateSource(engine: Engine): EngineBuiltinTemplat
     engineName: engine.name,
     engineVersion: engine.version,
     enginePath: engine.path,
-    templatePath: AbsPath.join(AbsPath.from(engine.path), RelPath.from('game/template')),
+    templatePath: AbsPath.join(engine.path, RelPath.from('game/template')),
     createdAt: engine.createdAt,
   }
 }

--- a/src/features/home/templates-tab/useTemplatesTabController.ts
+++ b/src/features/home/templates-tab/useTemplatesTabController.ts
@@ -63,7 +63,7 @@ export function useTemplatesTabController(options: UseTemplatesTabControllerOpti
 
   function handleOpenSourceFolder(source: TemplateGroupSourceItem) {
     return importActions.handleOpenFolder({
-      path: source.kind === 'standalone' ? source.path : source.templatePath,
+      path: source.kind === 'standalone' ? source.path : source.enginePath,
     })
   }
 

--- a/src/features/home/useDiscoverResources.ts
+++ b/src/features/home/useDiscoverResources.ts
@@ -19,7 +19,7 @@ export type { DiscoveredResource } from './discovered-resource'
 
 async function discoverResourcesInDirectory(
   directory: string,
-  validateFn: (path: string) => Promise<boolean>,
+  validateFn: (path: AbsPath) => Promise<boolean>,
 ): Promise<DiscoveredResource[]> {
   try {
     if (!directory || !(await exists(directory))) {
@@ -51,7 +51,7 @@ async function discoverResourcesInDirectory(
 
 async function enrichWithIcons(
   resources: DiscoveredResource[],
-  resolveIconPath: (path: string) => Promise<string>,
+  resolveIconPath: (path: AbsPath) => Promise<string>,
 ): Promise<DiscoveredResource[]> {
   return Promise.all(
     resources.map(async (resource) => {
@@ -129,18 +129,19 @@ async function discoverTemplates(): Promise<DiscoveredResource[]> {
 }
 
 async function discoverEngineVersion(versionPath: string, fallbackVersion: string): Promise<DiscoveredResource | undefined> {
-  const isValid = await engineManager.validateEngine(versionPath).catch(() => false)
+  const normalizedVersionPath = AbsPath.from(versionPath)
+  const isValid = await engineManager.validateEngine(normalizedVersionPath).catch(() => false)
   if (!isValid) {
     return
   }
 
-  const classification = await engineManager.classifyEngine(versionPath).catch(() => undefined)
+  const classification = await engineManager.classifyEngine(normalizedVersionPath).catch(() => undefined)
   if (classification?.status !== 'ok') {
     return
   }
 
   return {
-    path: versionPath,
+    path: normalizedVersionPath,
     name: classification.manifest.name,
     engineId: classification.manifest.id,
     version: classification.manifest.version ?? fallbackVersion,
@@ -281,11 +282,11 @@ function resolveImportMessages(type: ResourceType, t: (key: string) => string): 
   }
 }
 
-function resolveImportFn(type: ResourceType): (path: string) => Promise<unknown> {
+function resolveImportFn(type: ResourceType): (path: AbsPath) => Promise<unknown> {
   switch (type) {
     case 'games': { return path => gameManager.importGame(path, { selectEngine: requestEngineSelection }) }
-    case 'engines': { return engineManager.importEngine }
-    case 'templates': { return templateManager.importTemplate }
+    case 'engines': { return path => engineManager.importEngine(path) }
+    case 'templates': { return path => templateManager.importTemplate(path) }
     default: { throw new Error(`未知的资源类型: ${type satisfies never}`) }
   }
 }
@@ -331,8 +332,8 @@ export function useDiscoverResources() {
   }
 
   async function handleImport(
-    paths: string[],
-    importFn: (path: string) => Promise<unknown>,
+    paths: AbsPath[],
+    importFn: (path: AbsPath) => Promise<unknown>,
     successMsg: string,
     errorMsg: string,
   ) {
@@ -381,7 +382,7 @@ export function useDiscoverResources() {
     modalStore.open('DiscoveredResourcesModal', {
       type,
       resources: newResources,
-      onImport: (paths: string[]) => handleImport(paths, importFn, messages.success, messages.error),
+      onImport: paths => handleImport(paths, importFn, messages.success, messages.error),
     })
   }
 

--- a/src/features/modals/create-game/useCreateGameForm.ts
+++ b/src/features/modals/create-game/useCreateGameForm.ts
@@ -4,6 +4,7 @@ import { useForm } from 'vee-validate'
 import * as z from 'zod'
 
 import { db } from '~/database/db'
+import { AbsPath } from '~/domain/path'
 import {
   resolveCreateGamePathSuggestion,
 } from '~/features/modals/create-game/create-game-modal'
@@ -138,7 +139,7 @@ export function useCreateGameForm(options: UseCreateGameFormOptions) {
     options.open.value = false
 
     try {
-      const gameId = await gameManager.createGame(gameName, gamePath, gameEngine, {
+      const gameId = await gameManager.createGame(gameName, AbsPath.from(gamePath), gameEngine, {
         templateBinding: gameTemplate,
       })
       options.onSuccess?.(gameId)

--- a/src/services/__tests__/config-manager.test.ts
+++ b/src/services/__tests__/config-manager.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { AbsPath } from '~/domain/path'
 import { configManager } from '~/services/config-manager'
 
 const {
@@ -38,7 +39,7 @@ describe('configManager 配置管理', () => {
   })
 
   it('setConfig 会写入配置、刷新已注册游戏快照并触发当前预览重载', async () => {
-    await configManager.setConfig('/game', {
+    await configManager.setConfig(AbsPath.from('/game'), {
       entries: [
         {
           key: 'Game_name',

--- a/src/services/__tests__/engine-manager.test.ts
+++ b/src/services/__tests__/engine-manager.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { createTestEngine, createTestGame } from '~/__tests__/factories'
+import { AbsPath } from '~/domain/path'
 import { engineManager } from '~/services/engine-manager'
 import { AppError } from '~/types/errors'
 
@@ -165,7 +166,7 @@ describe('engineManager', () => {
   it('validateEngine 在目录结构有效时返回 true', async () => {
     validateDirectoryStructureMock.mockResolvedValue(true)
 
-    await expect(engineManager.validateEngine('/engines/WebGAL')).resolves.toBe(true)
+    await expect(engineManager.validateEngine(AbsPath.from('/engines/WebGAL'))).resolves.toBe(true)
 
     expect(validateDirectoryStructureMock).toHaveBeenCalledWith(
       '/engines/WebGAL',
@@ -178,7 +179,7 @@ describe('engineManager', () => {
   it('validateEngine 在目录结构无效时返回 false', async () => {
     validateDirectoryStructureMock.mockResolvedValue(false)
 
-    await expect(engineManager.validateEngine('/engines/WebGAL')).resolves.toBe(false)
+    await expect(engineManager.validateEngine(AbsPath.from('/engines/WebGAL'))).resolves.toBe(false)
 
     expect(readEngineManifestMock).not.toHaveBeenCalled()
   })
@@ -231,7 +232,7 @@ describe('engineManager', () => {
       onProgress(100)
     })
 
-    await expect(engineManager.importEngine('/downloads/webgal')).resolves.toEqual({ id: 'engine-1', alreadyRegistered: false })
+    await expect(engineManager.importEngine(AbsPath.from('/downloads/webgal'))).resolves.toEqual({ id: 'engine-1', alreadyRegistered: false })
 
     expect(addMock).toHaveBeenCalledWith(expect.objectContaining({
       path: '/engines/WebGAL/4.5.0',
@@ -280,7 +281,7 @@ describe('engineManager', () => {
     validateDirectoryStructureMock.mockResolvedValue(true)
     addMock.mockResolvedValue('engine-1')
 
-    await expect(engineManager.importEngine(String.raw`C:\downloads\webgal`)).resolves.toEqual({
+    await expect(engineManager.importEngine(AbsPath.from(String.raw`C:\downloads\webgal`))).resolves.toEqual({
       id: 'engine-1',
       alreadyRegistered: false,
     })
@@ -300,7 +301,7 @@ describe('engineManager', () => {
     readEngineManifestMock.mockResolvedValue({ status: 'missing' })
     validateDirectoryStructureMock.mockResolvedValue(true)
 
-    await expect(engineManager.importEngine('/downloads/LegacyEngine')).rejects.toEqual(
+    await expect(engineManager.importEngine(AbsPath.from('/downloads/LegacyEngine'))).rejects.toEqual(
       new AppError('INVALID_MANIFEST', '不支持导入旧版引擎，请导入包含该引擎的项目或使用受支持的引擎版本', {
         details: { reason: 'LEGACY_ENGINE' },
       }),
@@ -318,7 +319,7 @@ describe('engineManager', () => {
     })
     validateDirectoryStructureMock.mockResolvedValue(true)
 
-    await expect(engineManager.importEngine('/downloads/futureEngine')).rejects.toMatchObject({
+    await expect(engineManager.importEngine(AbsPath.from('/downloads/futureEngine'))).rejects.toMatchObject({
       code: 'INVALID_MANIFEST',
       details: {
         reason: 'UNSUPPORTED_SCHEMA',
@@ -338,7 +339,7 @@ describe('engineManager', () => {
     })
     validateDirectoryStructureMock.mockResolvedValue(true)
 
-    await expect(engineManager.importEngine('/downloads/brokenEngine')).rejects.toEqual(
+    await expect(engineManager.importEngine(AbsPath.from('/downloads/brokenEngine'))).rejects.toEqual(
       new AppError('INVALID_MANIFEST', '缺少必填字段', {
         details: {
           reason: 'PARSE_FAILED',
@@ -367,7 +368,7 @@ describe('engineManager', () => {
       version: '4.5.0',
     }))
 
-    await expect(engineManager.importEngine('/downloads/webgal')).resolves.toEqual({
+    await expect(engineManager.importEngine(AbsPath.from('/downloads/webgal'))).resolves.toEqual({
       id: 'engine-existing-by-ref',
       alreadyRegistered: true,
     })
@@ -379,10 +380,10 @@ describe('engineManager', () => {
   it('importEngine 在源路径已注册时幂等返回既有 ID', async () => {
     engineWhereFirstMock.mockResolvedValue(createTestEngine({
       id: 'engine-existing',
-      path: '/downloads/webgal',
+      path: AbsPath.from('/downloads/webgal'),
     }))
 
-    await expect(engineManager.importEngine('/downloads/webgal')).resolves.toEqual({ id: 'engine-existing', alreadyRegistered: true })
+    await expect(engineManager.importEngine(AbsPath.from('/downloads/webgal'))).resolves.toEqual({ id: 'engine-existing', alreadyRegistered: true })
 
     expect(addMock).not.toHaveBeenCalled()
     expect(copyDirectoryWithProgressMock).not.toHaveBeenCalled()
@@ -390,7 +391,7 @@ describe('engineManager', () => {
 
   it('engine 身份键优先使用 engineId + version', () => {
     expect(engineManager.identityKeyOf({
-      path: '/downloads/webgal',
+      path: AbsPath.from('/downloads/webgal'),
       engineId: 'open-webgal.webgal',
       version: '4.5.0',
     })).toBe('open-webgal.webgal:4.5.0')
@@ -398,7 +399,7 @@ describe('engineManager', () => {
 
   it('engine 身份键在缺少版本时回退到路径规范化结果', () => {
     expect(engineManager.identityKeyOf({
-      path: '/Downloads/WebGAL/',
+      path: AbsPath.from('/Downloads/WebGAL/'),
       engineId: 'open-webgal.webgal',
     })).toBe('/downloads/webgal')
   })
@@ -418,7 +419,7 @@ describe('engineManager', () => {
     validateDirectoryStructureMock.mockResolvedValue(true)
     existsMock.mockImplementation(async (path: string) => path === '/engines/WebGAL/4.5.0')
 
-    await expect(engineManager.importEngine('/downloads/webgal')).rejects.toEqual(
+    await expect(engineManager.importEngine(AbsPath.from('/downloads/webgal'))).rejects.toEqual(
       new AppError('TARGET_CONFLICT', '目标引擎目录已存在，请先清理后重试'),
     )
   })
@@ -438,7 +439,7 @@ describe('engineManager', () => {
     validateDirectoryStructureMock.mockResolvedValue(true)
     existsMock.mockImplementation(async (path: string) => path !== '/source/icons/favicon.ico')
 
-    await expect(engineManager.inspectEngine('/source')).resolves.toMatchObject({
+    await expect(engineManager.inspectEngine(AbsPath.from('/source'))).resolves.toMatchObject({
       availability: 'available',
       warnings: [{ code: 'missing-favicon' }],
     })
@@ -461,7 +462,7 @@ describe('engineManager', () => {
     // 默认 favicon 路径存在但自定义 icon 不存在，应仍然产生 warning
     existsMock.mockImplementation(async (path: string) => path !== '/source/assets/custom.png')
 
-    await expect(engineManager.inspectEngine('/source')).resolves.toMatchObject({
+    await expect(engineManager.inspectEngine(AbsPath.from('/source'))).resolves.toMatchObject({
       availability: 'available',
       warnings: [{ code: 'missing-favicon' }],
     })
@@ -471,7 +472,7 @@ describe('engineManager', () => {
     enginesToArrayMock.mockResolvedValue([
       createTestEngine({
         id: 'engine-1',
-        path: '/engines/webgal',
+        path: AbsPath.from('/engines/webgal'),
         status: 'created',
       }),
     ])
@@ -487,7 +488,7 @@ describe('engineManager', () => {
     enginesToArrayMock.mockResolvedValue([
       createTestEngine({
         id: 'engine-1',
-        path: '/engines/WebGAL/4.5.0',
+        path: AbsPath.from('/engines/WebGAL/4.5.0'),
         status: 'created',
       }),
     ])
@@ -504,7 +505,7 @@ describe('engineManager', () => {
     enginesToArrayMock.mockResolvedValue([
       createTestEngine({
         id: 'engine-1',
-        path: '/engines/WebGAL/4.5.0',
+        path: AbsPath.from('/engines/WebGAL/4.5.0'),
         status: 'created',
       }),
     ])
@@ -531,7 +532,7 @@ describe('engineManager', () => {
     enginesToArrayMock.mockResolvedValue([
       createTestEngine({
         id: 'engine-1',
-        path: '/engines/WebGAL/4.5.0',
+        path: AbsPath.from('/engines/WebGAL/4.5.0'),
         status: 'created',
       }),
     ])
@@ -587,14 +588,14 @@ describe('engineManager', () => {
       id: 'engine-1',
       engineId: 'open-webgal.webgal',
       name: 'WebGAL',
-      path: '/engines/WebGAL/4.5.0',
+      path: AbsPath.from('/engines/WebGAL/4.5.0'),
       version: '4.5.0',
     })
     const legacy = createTestEngine({
       id: 'engine-2',
       engineId: 'open-webgal.webgal',
       name: 'WebGAL',
-      path: '/engines/WebGAL/4.4.0',
+      path: AbsPath.from('/engines/WebGAL/4.4.0'),
       version: '4.4.0',
     })
     const associatedGame = createTestGame({
@@ -642,13 +643,13 @@ describe('engineManager', () => {
       createTestEngine({
         id: 'engine-1',
         name: 'WebGAL',
-        path: '/engines/WebGAL/4.5.0',
+        path: AbsPath.from('/engines/WebGAL/4.5.0'),
         version: '4.5.0',
       }),
       createTestEngine({
         id: 'engine-2',
         name: 'WebGAL',
-        path: '/engines/WebGAL/4.4.0',
+        path: AbsPath.from('/engines/WebGAL/4.4.0'),
         version: '4.4.0',
       }),
     ])

--- a/src/services/__tests__/engine-manager.test.ts
+++ b/src/services/__tests__/engine-manager.test.ts
@@ -297,6 +297,40 @@ describe('engineManager', () => {
     )
   })
 
+  it('importEngine 在缺少版本时会回退到基于 engineId 的稳定托管目录', async () => {
+    readEngineManifestMock.mockResolvedValue({
+      status: 'ok',
+      manifest: {
+        schemaVersion: '1.0.0',
+        id: 'open-webgal.webgal',
+        name: 'WebGAL',
+        engineType: 'official',
+        webgalVersion: '4.5.0',
+        icon: 'branding/icon.png',
+      },
+    })
+    validateDirectoryStructureMock.mockResolvedValue(true)
+    addMock.mockResolvedValue('engine-legacy')
+
+    await expect(engineManager.importEngine(AbsPath.from('/downloads/webgal-legacy'))).resolves.toEqual({
+      id: 'engine-legacy',
+      alreadyRegistered: false,
+    })
+
+    expect(addMock).toHaveBeenCalledWith(expect.objectContaining({
+      path: '/engines/WebGAL/open-webgal.webgal',
+      pathLookupKey: '/engines/webgal/open-webgal.webgal',
+      name: 'WebGAL',
+      version: undefined,
+      status: 'creating',
+    }))
+    expect(copyDirectoryWithProgressMock).toHaveBeenCalledWith(
+      '/downloads/webgal-legacy',
+      '/engines/WebGAL/open-webgal.webgal',
+      expect.any(Function),
+    )
+  })
+
   it('importEngine 会拒绝导入旧版引擎目录', async () => {
     readEngineManifestMock.mockResolvedValue({ status: 'missing' })
     validateDirectoryStructureMock.mockResolvedValue(true)

--- a/src/services/__tests__/engine-switch.test.ts
+++ b/src/services/__tests__/engine-switch.test.ts
@@ -3,6 +3,7 @@ import '~/__tests__/setup'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { createTestEngine, createTestGame } from '~/__tests__/factories'
+import { AbsPath } from '~/domain/path'
 import { engineSwitch } from '~/services/engine-switch'
 import { AppError } from '~/types/errors'
 
@@ -129,7 +130,7 @@ describe('engineSwitch.switchEngine', () => {
 
   it('在自带引擎项目上拒绝切换', async () => {
     const game = createTestGame({ engineId: undefined })
-    const newEngine = createTestEngine({ id: 'engine-new', path: '/engines/new' })
+    const newEngine = createTestEngine({ id: 'engine-new', path: AbsPath.from('/engines/new') })
 
     await expect(engineSwitch.switchEngine(game, newEngine)).rejects.toBeInstanceOf(AppError)
     expect(writeProjectConfigMock).not.toHaveBeenCalled()
@@ -137,8 +138,8 @@ describe('engineSwitch.switchEngine', () => {
 
   it('在旧引擎记录缺失时直接拒绝，不产生任何副作用', async () => {
     dbEngineGetMock.mockResolvedValue(undefined)
-    const game = createTestGame({ id: 'game-1', engineId: 'engine-old', path: '/games/demo' })
-    const newEngine = createTestEngine({ id: 'engine-new', path: '/engines/new' })
+    const game = createTestGame({ id: 'game-1', engineId: 'engine-old', path: AbsPath.from('/games/demo') })
+    const newEngine = createTestEngine({ id: 'engine-new', path: AbsPath.from('/engines/new') })
 
     await expect(engineSwitch.switchEngine(game, newEngine)).rejects.toThrowError(/当前引擎记录缺失/)
     expect(readProjectConfigMock).not.toHaveBeenCalled()
@@ -148,10 +149,10 @@ describe('engineSwitch.switchEngine', () => {
   })
 
   it('clean 模板时按顺序更新 config / DB / site，并刷新预览', async () => {
-    const oldEngine = createTestEngine({ id: 'engine-old', path: '/engines/old' })
+    const oldEngine = createTestEngine({ id: 'engine-old', path: AbsPath.from('/engines/old') })
     const newEngine = createTestEngine({
       id: 'engine-new',
-      path: '/engines/new',
+      path: AbsPath.from('/engines/new'),
       engineId: 'open-webgal.webgal',
       version: '4.6.0',
     })
@@ -160,7 +161,7 @@ describe('engineSwitch.switchEngine', () => {
       .mockResolvedValueOnce('/engines/old/game/template')
       .mockResolvedValueOnce('/engines/new/game/template')
 
-    const game = createTestGame({ id: 'game-1', engineId: 'engine-old', path: '/games/demo' })
+    const game = createTestGame({ id: 'game-1', engineId: 'engine-old', path: AbsPath.from('/games/demo') })
 
     await engineSwitch.switchEngine(game, newEngine)
 
@@ -179,11 +180,11 @@ describe('engineSwitch.switchEngine', () => {
   })
 
   it('dirty 模板缺少决策时拒绝，不产生副作用', async () => {
-    const oldEngine = createTestEngine({ id: 'engine-old', path: '/engines/old' })
+    const oldEngine = createTestEngine({ id: 'engine-old', path: AbsPath.from('/engines/old') })
     dbEngineGetMock.mockResolvedValue(oldEngine)
     evaluateTemplateStrategyMock.mockResolvedValue('dirty')
-    const game = createTestGame({ id: 'game-1', engineId: 'engine-old', path: '/games/demo' })
-    const newEngine = createTestEngine({ id: 'engine-new', path: '/engines/new' })
+    const game = createTestGame({ id: 'game-1', engineId: 'engine-old', path: AbsPath.from('/games/demo') })
+    const newEngine = createTestEngine({ id: 'engine-new', path: AbsPath.from('/engines/new') })
 
     await expect(engineSwitch.switchEngine(game, newEngine)).rejects.toMatchObject({
       details: { reason: 'TEMPLATE_DIRTY_NEEDS_DECISION' },
@@ -193,15 +194,15 @@ describe('engineSwitch.switchEngine', () => {
   })
 
   it('discard 决策会清理模板 upper 并切换到新引擎模板', async () => {
-    const oldEngine = createTestEngine({ id: 'engine-old', path: '/engines/old' })
-    const newEngine = createTestEngine({ id: 'engine-new', path: '/engines/new' })
+    const oldEngine = createTestEngine({ id: 'engine-old', path: AbsPath.from('/engines/old') })
+    const newEngine = createTestEngine({ id: 'engine-new', path: AbsPath.from('/engines/new') })
     dbEngineGetMock.mockResolvedValue(oldEngine)
     evaluateTemplateStrategyMock.mockResolvedValue('dirty')
     resolveTemplatePathMock
       .mockResolvedValueOnce('/engines/old/game/template')
       .mockResolvedValueOnce('/engines/new/game/template')
 
-    const game = createTestGame({ id: 'game-1', engineId: 'engine-old', path: '/games/demo' })
+    const game = createTestGame({ id: 'game-1', engineId: 'engine-old', path: AbsPath.from('/games/demo') })
 
     await engineSwitch.switchEngine(game, newEngine, { templateDecision: 'discard' })
 
@@ -211,10 +212,10 @@ describe('engineSwitch.switchEngine', () => {
 
   describe('回滚', () => {
     function setupBaseSwitch() {
-      const oldEngine = createTestEngine({ id: 'engine-old', path: '/engines/old' })
+      const oldEngine = createTestEngine({ id: 'engine-old', path: AbsPath.from('/engines/old') })
       const newEngine = createTestEngine({
         id: 'engine-new',
-        path: '/engines/new',
+        path: AbsPath.from('/engines/new'),
         engineId: 'open-webgal.webgal',
         version: '4.6.0',
       })
@@ -222,7 +223,7 @@ describe('engineSwitch.switchEngine', () => {
       resolveTemplatePathMock
         .mockResolvedValueOnce('/engines/old/game/template')
         .mockResolvedValueOnce('/engines/new/game/template')
-      const game = createTestGame({ id: 'game-1', engineId: 'engine-old', path: '/games/demo' })
+      const game = createTestGame({ id: 'game-1', engineId: 'engine-old', path: AbsPath.from('/games/demo') })
 
       return { game, newEngine }
     }

--- a/src/services/__tests__/game-manager.test.ts
+++ b/src/services/__tests__/game-manager.test.ts
@@ -1019,7 +1019,7 @@ describe('gameManager', () => {
       path: AbsPath.from('/games/demo'),
     }), true)
 
-    expect(deleteFileMock).toHaveBeenCalledWith('/games/demo')
+    expect(deleteFileMock).toHaveBeenCalledWith('/games/demo', true)
     expect(dbGameDeleteMock).toHaveBeenCalledWith('game-1')
     expect(deleteFileMock.mock.invocationCallOrder[0]).toBeLessThan(
       dbGameDeleteMock.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,

--- a/src/services/__tests__/game-manager.test.ts
+++ b/src/services/__tests__/game-manager.test.ts
@@ -3,6 +3,7 @@ import '~/__tests__/setup'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { createTestEngine, createTestGame } from '~/__tests__/factories'
+import { AbsPath } from '~/domain/path'
 import { gameManager } from '~/services/game-manager'
 import { AppError } from '~/types/errors'
 
@@ -239,19 +240,19 @@ describe('gameManager', () => {
   it('validateGame 仅检查 game/config.txt 是否存在', async () => {
     existsMock.mockResolvedValue(true)
 
-    await expect(gameManager.validateGame('/games/demo')).resolves.toBe(true)
+    await expect(gameManager.validateGame(AbsPath.from('/games/demo'))).resolves.toBe(true)
     expect(gameConfigPathMock).toHaveBeenCalledWith('/games/demo')
   })
 
   it('getGameMetadata 只返回语义元数据', async () => {
-    await expect(gameManager.getGameMetadata('/games/demo')).resolves.toEqual({
+    await expect(gameManager.getGameMetadata(AbsPath.from('/games/demo'))).resolves.toEqual({
       name: 'Demo Game',
       titleImg: 'cover.png',
     })
   })
 
   it('getGamePreviewAssets 返回相对预览路径', async () => {
-    await expect(gameManager.getGamePreviewAssets('/games/demo')).resolves.toEqual({
+    await expect(gameManager.getGamePreviewAssets(AbsPath.from('/games/demo'))).resolves.toEqual({
       icon: {
         path: 'icons/favicon.ico',
       },
@@ -264,7 +265,7 @@ describe('gameManager', () => {
   it('getGamePreviewAssets 按既定候选顺序解析图标', async () => {
     existsMock.mockImplementation(async (path: string) => path === '/games/demo/icons/icon-192.png')
 
-    await expect(gameManager.getGamePreviewAssets('/games/demo')).resolves.toEqual({
+    await expect(gameManager.getGamePreviewAssets(AbsPath.from('/games/demo'))).resolves.toEqual({
       icon: {
         path: 'icons/icon-192.png',
       },
@@ -278,7 +279,7 @@ describe('gameManager', () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-03-28T10:00:00.000Z'))
 
-    await gameManager.registerGame('/games/demo', {
+    await gameManager.registerGame(AbsPath.from('/games/demo'), {
       metadata: {
         name: 'Provided Name',
       },
@@ -305,7 +306,7 @@ describe('gameManager', () => {
   })
 
   it('getGameSnapshot 只持久化语义元数据，并返回相对预览路径', async () => {
-    await expect(gameManager.getGameSnapshot('/games/demo')).resolves.toEqual({
+    await expect(gameManager.getGameSnapshot(AbsPath.from('/games/demo'))).resolves.toEqual({
       metadata: {
         name: 'Demo Game',
         titleImg: 'cover.png',
@@ -328,7 +329,7 @@ describe('gameManager', () => {
       id: 'engine-1',
       name: 'WebGAL',
       version: '4.5.0',
-      path: '/engines/WebGAL/4.5.0',
+      path: AbsPath.from('/engines/WebGAL/4.5.0'),
     }))
     copyDirectoryWithProgressMock.mockImplementation(async (_from, _to, onProgress: (progress: number) => void) => {
       onProgress(48)
@@ -352,7 +353,7 @@ describe('gameManager', () => {
       return false
     })
 
-    await expect(gameManager.createGame('Demo Game', '/games/demo', 'engine-1')).resolves.toBe('game-1')
+    await expect(gameManager.createGame('Demo Game', AbsPath.from('/games/demo'), 'engine-1')).resolves.toBe('game-1')
 
     expect(dbGameAddMock).toHaveBeenCalledWith(expect.objectContaining({
       path: '/games/demo',
@@ -418,7 +419,7 @@ describe('gameManager', () => {
       id: 'engine-1',
       name: 'WebGAL',
       version: '4.5.0',
-      path: String.raw`C:\Engines\WebGAL\4.5.0`,
+      path: AbsPath.from(String.raw`C:\Engines\WebGAL\4.5.0`),
     }))
     existsMock.mockImplementation(async (path: string) => {
       if (path === 'C:/Engines/WebGAL/4.5.0/game') {
@@ -430,7 +431,7 @@ describe('gameManager', () => {
       return false
     })
 
-    await gameManager.createGame('Demo Game', String.raw`C:\Games\Demo`, 'engine-1')
+    await gameManager.createGame('Demo Game', AbsPath.from(String.raw`C:\Games\Demo`), 'engine-1')
 
     expect(mkdirMock).toHaveBeenCalledWith('C:/Games/Demo/game', { recursive: true })
     expect(copyDirectoryWithProgressMock).toHaveBeenCalledWith(
@@ -446,7 +447,7 @@ describe('gameManager', () => {
       id: 'engine-1',
       name: 'WebGAL',
       version: '4.5.0',
-      path: '/engines/WebGAL/4.5.0',
+      path: AbsPath.from('/engines/WebGAL/4.5.0'),
     }))
     let gamePathChecks = 0
     existsMock.mockImplementation(async (path: string) => {
@@ -470,7 +471,7 @@ describe('gameManager', () => {
     })
     copyDirectoryWithProgressMock.mockRejectedValue(new Error('copy failed'))
 
-    await expect(gameManager.createGame('Demo Game', '/games/demo', 'engine-1')).rejects.toThrow('copy failed')
+    await expect(gameManager.createGame('Demo Game', AbsPath.from('/games/demo'), 'engine-1')).rejects.toThrow('copy failed')
 
     expect(dbGameDeleteMock).toHaveBeenCalledWith('game-1')
     expect(deleteFileMock).toHaveBeenCalledWith('/games/demo', true)
@@ -482,7 +483,7 @@ describe('gameManager', () => {
       id: 'engine-1',
       name: 'WebGAL',
       version: '4.5.0',
-      path: '/engines/WebGAL/4.5.0',
+      path: AbsPath.from('/engines/WebGAL/4.5.0'),
     }))
     let gamePathChecks = 0
     existsMock.mockImplementation(async (path: string) => {
@@ -506,7 +507,7 @@ describe('gameManager', () => {
     })
     gameCmdsSetGameConfigMock.mockRejectedValue(new Error('config failed'))
 
-    await expect(gameManager.createGame('Demo Game', '/games/demo', 'engine-1')).rejects.toThrow('config failed')
+    await expect(gameManager.createGame('Demo Game', AbsPath.from('/games/demo'), 'engine-1')).rejects.toThrow('config failed')
 
     expect(dbGameDeleteMock).toHaveBeenCalledWith('game-1')
     expect(deleteFileMock).toHaveBeenCalledWith('/games/demo', true)
@@ -517,11 +518,11 @@ describe('gameManager', () => {
     dbGameGetMock.mockResolvedValue(createTestGame({
       id: 'game-1',
       engineId: 'engine-1',
-      path: '/games/demo',
+      path: AbsPath.from('/games/demo'),
     }))
     dbEngineGetMock.mockResolvedValue(createTestEngine({
       id: 'engine-1',
-      path: '/engines/WebGAL/4.5.0',
+      path: AbsPath.from('/engines/WebGAL/4.5.0'),
       name: 'WebGAL',
       version: '4.5.0',
     }))
@@ -554,7 +555,7 @@ describe('gameManager', () => {
       || path === '/games/self-contained/index.html'
       || path === '/games/self-contained/game/background/cover.png')
 
-    await expect(gameManager.importGame('/games/self-contained')).resolves.toEqual({ id: 'game-1', alreadyRegistered: false })
+    await expect(gameManager.importGame(AbsPath.from('/games/self-contained'))).resolves.toEqual({ id: 'game-1', alreadyRegistered: false })
 
     expect(writeProjectConfigMock).toHaveBeenCalledWith('/games/self-contained', { version: 1 })
     expect(dbGameAddMock).toHaveBeenCalledWith(expect.objectContaining({
@@ -583,7 +584,7 @@ describe('gameManager', () => {
       version: '4.5.0',
     }))
 
-    await expect(gameManager.importGame('/games/vfs')).resolves.toEqual({ id: 'game-1', alreadyRegistered: false })
+    await expect(gameManager.importGame(AbsPath.from('/games/vfs'))).resolves.toEqual({ id: 'game-1', alreadyRegistered: false })
 
     expect(dbGameAddMock).toHaveBeenCalledWith(expect.objectContaining({
       engineId: 'engine-1',
@@ -612,7 +613,7 @@ describe('gameManager', () => {
       availability: 'broken',
     }))
 
-    await expect(gameManager.importGame('/games/vfs')).resolves.toEqual({ id: 'game-1', alreadyRegistered: false })
+    await expect(gameManager.importGame(AbsPath.from('/games/vfs'))).resolves.toEqual({ id: 'game-1', alreadyRegistered: false })
 
     expect(writeProjectConfigMock).not.toHaveBeenCalled()
     expect(dbGameAddMock).toHaveBeenCalledWith(expect.objectContaining({
@@ -649,7 +650,7 @@ describe('gameManager', () => {
       status: 'created',
     }))
 
-    await expect(gameManager.importGame('/games/vfs', {
+    await expect(gameManager.importGame(AbsPath.from('/games/vfs'), {
       selectEngine: vi.fn().mockResolvedValue('engine-2'),
     })).resolves.toEqual({ id: 'game-1', alreadyRegistered: false })
 
@@ -688,7 +689,7 @@ describe('gameManager', () => {
       status: 'created',
     }))
 
-    await expect(gameManager.importGame('/games/vfs', {
+    await expect(gameManager.importGame(AbsPath.from('/games/vfs'), {
       selectEngine: vi.fn().mockResolvedValue('engine-2'),
     })).resolves.toEqual({ id: 'game-1', alreadyRegistered: false })
 
@@ -712,13 +713,13 @@ describe('gameManager', () => {
         return {
           first: async () => createTestGame({
             id: 'game-existing',
-            path: '/games/demo',
+            path: AbsPath.from('/games/demo'),
           }),
         }
       },
     })
 
-    await expect(gameManager.importGame('/games/demo')).resolves.toEqual({
+    await expect(gameManager.importGame(AbsPath.from('/games/demo'))).resolves.toEqual({
       id: 'game-existing',
       alreadyRegistered: true,
     })
@@ -730,12 +731,12 @@ describe('gameManager', () => {
       equals: () => ({
         first: async () => createTestGame({
           id: 'game-existing',
-          path: '/Games/Demo',
+          path: AbsPath.from('/Games/Demo'),
         }),
       }),
     })
 
-    await expect(gameManager.importGame('/games/demo')).resolves.toEqual({
+    await expect(gameManager.importGame(AbsPath.from('/games/demo'))).resolves.toEqual({
       id: 'game-existing',
       alreadyRegistered: true,
     })
@@ -743,7 +744,7 @@ describe('gameManager', () => {
   })
 
   it('game 身份键与自动发现复用同一套路径规范化规则', () => {
-    expect(gameManager.identityKeyOf({ path: '/Games/Demo/' })).toBe('/games/demo')
+    expect(gameManager.identityKeyOf({ path: AbsPath.from('/Games/Demo/') })).toBe('/games/demo')
   })
 
   it('importGame 在用户取消选择引擎时会返回取消原因', async () => {
@@ -752,7 +753,7 @@ describe('gameManager', () => {
       || path === '/games/no-engine/game/config.txt'
       || path === '/games/no-engine/game/background/cover.png')
 
-    await expect(gameManager.importGame('/games/no-engine', {
+    await expect(gameManager.importGame(AbsPath.from('/games/no-engine'), {
       selectEngine: vi.fn().mockResolvedValue(undefined),
     })).rejects.toEqual(
       new AppError('IO_ERROR', '导入已取消', {
@@ -769,7 +770,7 @@ describe('gameManager', () => {
       || path === '/games/broken-config/game/background/cover.png')
     readProjectConfigMock.mockRejectedValue(new AppError('INVALID_PROJECT_CONFIG', 'project.wgcp 损坏'))
 
-    await expect(gameManager.importGame('/games/broken-config')).rejects.toEqual(
+    await expect(gameManager.importGame(AbsPath.from('/games/broken-config'))).rejects.toEqual(
       new AppError('INVALID_PROJECT_CONFIG', '项目配置文件损坏', {
         details: { reason: 'CONFIG_CORRUPTED' },
       }),
@@ -784,7 +785,7 @@ describe('gameManager', () => {
       || path === '/games/io-error/game/background/cover.png')
     readProjectConfigMock.mockRejectedValue(new AppError('IO_ERROR', '权限不足'))
 
-    await expect(gameManager.importGame('/games/io-error')).rejects.toEqual(
+    await expect(gameManager.importGame(AbsPath.from('/games/io-error'))).rejects.toEqual(
       new AppError('IO_ERROR', '权限不足'),
     )
   })
@@ -792,11 +793,11 @@ describe('gameManager', () => {
   it('resolvePreviewSite 会返回游戏路径与已解析的引擎路径', async () => {
     dbEngineGetMock.mockResolvedValue(createTestEngine({
       id: 'engine-1',
-      path: '/engines/WebGAL/4.5.0',
+      path: AbsPath.from('/engines/WebGAL/4.5.0'),
     }))
 
     await expect(gameManager.resolvePreviewSite({
-      path: '/games/demo',
+      path: AbsPath.from('/games/demo'),
       engineId: 'engine-1',
     })).resolves.toEqual({
       projectPath: '/games/demo',
@@ -807,12 +808,12 @@ describe('gameManager', () => {
   it('getGameEnginePath 会忽略 broken availability 引擎，允许回退为仅编辑本地 game 目录', async () => {
     dbEngineGetMock.mockResolvedValue(createTestEngine({
       id: 'engine-1',
-      path: '/engines/WebGAL/4.5.0',
+      path: AbsPath.from('/engines/WebGAL/4.5.0'),
       availability: 'broken',
     }))
 
     await expect(gameManager.getGameEnginePath({
-      path: '/games/demo',
+      path: AbsPath.from('/games/demo'),
       engineId: 'engine-1',
     })).resolves.toBeUndefined()
   })
@@ -820,7 +821,7 @@ describe('gameManager', () => {
   it('resolvePreviewSite 会在引擎绑定项目的引擎不可用时直接拒绝预览', async () => {
     dbEngineGetMock.mockResolvedValue(createTestEngine({
       id: 'engine-1',
-      path: '/engines/WebGAL/4.5.0',
+      path: AbsPath.from('/engines/WebGAL/4.5.0'),
       availability: 'broken',
     }))
     readProjectConfigMock.mockResolvedValue({
@@ -832,7 +833,7 @@ describe('gameManager', () => {
     })
 
     await expect(gameManager.resolvePreviewSite({
-      path: '/games/demo',
+      path: AbsPath.from('/games/demo'),
       engineId: 'engine-1',
     })).rejects.toEqual(new AppError('IO_ERROR', '引擎不可用'))
   })
@@ -840,7 +841,7 @@ describe('gameManager', () => {
   it('importGame 遇到不存在的目录时抛出 DIR_NOT_FOUND', async () => {
     existsMock.mockResolvedValue(false)
 
-    await expect(gameManager.importGame('/games/missing')).rejects.toEqual(
+    await expect(gameManager.importGame(AbsPath.from('/games/missing'))).rejects.toEqual(
       new AppError('DIR_NOT_FOUND', '游戏目录不存在'),
     )
   })
@@ -848,7 +849,7 @@ describe('gameManager', () => {
   it('importGame 遇到缺失 game/config.txt 的目录时抛出 INVALID_STRUCTURE', async () => {
     existsMock.mockImplementation(async (path: string) => path === '/games/invalid')
 
-    await expect(gameManager.importGame('/games/invalid')).rejects.toEqual(
+    await expect(gameManager.importGame(AbsPath.from('/games/invalid'))).rejects.toEqual(
       new AppError('INVALID_STRUCTURE', '无效的游戏文件夹'),
     )
   })
@@ -857,7 +858,7 @@ describe('gameManager', () => {
     existsMock.mockResolvedValue(true)
     gameCmdsGetGameConfigMock.mockRejectedValue(new Error('parse failed'))
 
-    await expect(gameManager.importGame('/games/bad-config')).rejects.toMatchObject({
+    await expect(gameManager.importGame(AbsPath.from('/games/bad-config'))).rejects.toMatchObject({
       code: 'INVALID_CONFIG',
     })
   })
@@ -865,7 +866,7 @@ describe('gameManager', () => {
   it('inspectGame 在路径不存在时返回 missing + DIR_NOT_FOUND', async () => {
     existsMock.mockResolvedValue(false)
 
-    await expect(gameManager.inspectGame('/games/missing')).resolves.toMatchObject({
+    await expect(gameManager.inspectGame(AbsPath.from('/games/missing'))).resolves.toMatchObject({
       availability: 'missing',
       warnings: [],
       blockingIssue: { code: 'DIR_NOT_FOUND' },
@@ -875,7 +876,7 @@ describe('gameManager', () => {
   it('inspectGame 在缺失 game/config.txt 时返回 broken + INVALID_STRUCTURE', async () => {
     existsMock.mockImplementation(async (path: string) => path === '/games/demo')
 
-    await expect(gameManager.inspectGame('/games/demo')).resolves.toMatchObject({
+    await expect(gameManager.inspectGame(AbsPath.from('/games/demo'))).resolves.toMatchObject({
       availability: 'broken',
       blockingIssue: { code: 'INVALID_STRUCTURE' },
     })
@@ -888,7 +889,7 @@ describe('gameManager', () => {
       { key: 'Title_img', value: 'cover.png' },
     ]))
 
-    await expect(gameManager.inspectGame('/games/demo')).resolves.toMatchObject({
+    await expect(gameManager.inspectGame(AbsPath.from('/games/demo'))).resolves.toMatchObject({
       availability: 'available',
       warnings: [{ code: 'missing-game-name' }],
     })
@@ -900,7 +901,7 @@ describe('gameManager', () => {
       || path === '/games/demo/game/config.txt'
       || path === '/games/demo/game/background/cover.png')
 
-    await expect(gameManager.inspectGame('/games/demo')).resolves.toMatchObject({
+    await expect(gameManager.inspectGame(AbsPath.from('/games/demo'))).resolves.toMatchObject({
       availability: 'available',
       warnings: [{ code: 'missing-game-icon' }],
     })
@@ -913,7 +914,7 @@ describe('gameManager', () => {
       { key: 'Title_img', value: '' },
     ]))
 
-    await expect(gameManager.inspectGame('/games/demo')).resolves.toMatchObject({
+    await expect(gameManager.inspectGame(AbsPath.from('/games/demo'))).resolves.toMatchObject({
       availability: 'available',
       warnings: [{ code: 'missing-title-image' }],
     })
@@ -922,7 +923,7 @@ describe('gameManager', () => {
   it('inspectGame 在 titleImg 文件不存在时产 missing-title-image-file warning', async () => {
     existsMock.mockImplementation(async (path: string) => path !== '/games/demo/game/background/cover.png')
 
-    await expect(gameManager.inspectGame('/games/demo')).resolves.toMatchObject({
+    await expect(gameManager.inspectGame(AbsPath.from('/games/demo'))).resolves.toMatchObject({
       availability: 'available',
       warnings: [{ code: 'missing-title-image-file' }],
     })
@@ -933,7 +934,7 @@ describe('gameManager', () => {
     vi.setSystemTime(new Date('2026-03-28T10:00:00.000Z'))
     dbGameWhereFirstMock.mockResolvedValue(createTestGame({
       id: 'game-1',
-      path: '/games/demo',
+      path: AbsPath.from('/games/demo'),
       metadata: {
         name: 'Old Name',
       },
@@ -954,7 +955,7 @@ describe('gameManager', () => {
     ]))
     workspaceStoreState.currentGame = createTestGame({
       id: 'game-1',
-      path: '/games/demo',
+      path: AbsPath.from('/games/demo'),
       metadata: {
         name: 'Old Name',
       },
@@ -970,7 +971,7 @@ describe('gameManager', () => {
       },
     })
 
-    await gameManager.refreshRegisteredGameSnapshot('/games/demo')
+    await gameManager.refreshRegisteredGameSnapshot(AbsPath.from('/games/demo'))
 
     expect(dbGameUpdateMock).toHaveBeenCalledWith('game-1', {
       lastModified: new Date('2026-03-28T10:00:00.000Z').getTime(),
@@ -1015,7 +1016,7 @@ describe('gameManager', () => {
   it('deleteGame 在 removeFiles=true 时会通过 fs 命令删除游戏目录后再删除记录', async () => {
     await gameManager.deleteGame(createTestGame({
       id: 'game-1',
-      path: '/games/demo',
+      path: AbsPath.from('/games/demo'),
     }), true)
 
     expect(deleteFileMock).toHaveBeenCalledWith('/games/demo')
@@ -1030,7 +1031,7 @@ describe('gameManager', () => {
     vi.setSystemTime(new Date('2026-03-28T10:00:00.000Z'))
     workspaceStoreState.currentGame = createTestGame({
       id: 'game-1',
-      path: '/games/demo',
+      path: AbsPath.from('/games/demo'),
       metadata: {
         name: 'Demo',
       },
@@ -1047,7 +1048,7 @@ describe('gameManager', () => {
     })
     dbGameGetMock.mockResolvedValue(createTestGame({
       id: 'game-1',
-      path: '/games/demo',
+      path: AbsPath.from('/games/demo'),
       metadata: {
         name: 'Demo',
       },
@@ -1123,7 +1124,7 @@ describe('gameManager', () => {
     vi.setSystemTime(new Date('2026-03-28T10:00:00.000Z'))
     dbGameGetMock.mockResolvedValue(createTestGame({
       id: 'game-1',
-      path: '/games/demo',
+      path: AbsPath.from('/games/demo'),
       previewAssets: {
         icon: {
           path: 'icons/current.ico',
@@ -1137,7 +1138,7 @@ describe('gameManager', () => {
     }))
     workspaceStoreState.currentGame = createTestGame({
       id: 'game-1',
-      path: '/games/demo',
+      path: AbsPath.from('/games/demo'),
       previewAssets: {
         icon: {
           path: 'icons/current.ico',
@@ -1175,11 +1176,11 @@ describe('gameManager', () => {
     vi.useFakeTimers()
     workspaceStoreState.currentGame = createTestGame({
       id: 'game-1',
-      path: '/games/demo',
+      path: AbsPath.from('/games/demo'),
     })
     dbGameGetMock.mockResolvedValue(createTestGame({
       id: 'game-1',
-      path: '/games/demo',
+      path: AbsPath.from('/games/demo'),
     }))
 
     gameManager.updateCurrentGameLastModified()

--- a/src/services/__tests__/path-brand-types.test.ts
+++ b/src/services/__tests__/path-brand-types.test.ts
@@ -1,0 +1,75 @@
+import { describe, expectTypeOf, it } from 'vitest'
+
+import { createTestEngine, createTestGame, createTestTemplate } from '~/__tests__/factories'
+import { configManager } from '~/services/config-manager'
+import { engineManager } from '~/services/engine-manager'
+import { gameManager } from '~/services/game-manager'
+import { templateManager } from '~/services/template-manager'
+import { templateSwitch } from '~/services/template-switch'
+
+import type { Engine, Game, Template } from '~/database/model'
+import type { AbsPath } from '~/domain/path'
+import type { DiscoveredResource } from '~/features/home/discovered-resource'
+import type {
+  EngineBuiltinTemplateSourceItem,
+  StandaloneTemplateSourceItem,
+} from '~/features/home/templates-tab/template-groups'
+
+describe('path brands', () => {
+  it('requires AbsPath for database resource paths', () => {
+    expectTypeOf<Game['path']>().toEqualTypeOf<AbsPath>()
+    expectTypeOf<Engine['path']>().toEqualTypeOf<AbsPath>()
+    expectTypeOf<Template['path']>().toEqualTypeOf<AbsPath>()
+    expectTypeOf<DiscoveredResource['path']>().toEqualTypeOf<AbsPath>()
+  })
+
+  it('requires AbsPath for path-bearing service public APIs', () => {
+    expectTypeOf<Parameters<typeof gameManager.validateGame>[0]>().toEqualTypeOf<AbsPath>()
+    expectTypeOf<Parameters<typeof gameManager.getGameMetadata>[0]>().toEqualTypeOf<AbsPath>()
+    expectTypeOf<Parameters<typeof gameManager.getGamePreviewAssets>[0]>().toEqualTypeOf<AbsPath>()
+    expectTypeOf<Parameters<typeof gameManager.getGameSnapshot>[0]>().toEqualTypeOf<AbsPath>()
+    expectTypeOf<Parameters<typeof gameManager.refreshRegisteredGameSnapshot>[0]>().toEqualTypeOf<AbsPath>()
+    expectTypeOf<Parameters<typeof gameManager.registerGame>[0]>().toEqualTypeOf<AbsPath>()
+    expectTypeOf<Parameters<typeof gameManager.createGame>[1]>().toEqualTypeOf<AbsPath>()
+    expectTypeOf<Parameters<typeof gameManager.relinkGame>[1]>().toEqualTypeOf<AbsPath>()
+    expectTypeOf<Parameters<typeof gameManager.importGame>[0]>().toEqualTypeOf<AbsPath>()
+    expectTypeOf<Parameters<typeof gameManager.inspectGame>[0]>().toEqualTypeOf<AbsPath>()
+    expectTypeOf<Parameters<typeof gameManager.resolvePreviewSite>[0]['path']>().toEqualTypeOf<AbsPath>()
+
+    expectTypeOf<Parameters<typeof engineManager.validateEngine>[0]>().toEqualTypeOf<AbsPath>()
+    expectTypeOf<Parameters<typeof engineManager.classifyEngine>[0]>().toEqualTypeOf<AbsPath>()
+    expectTypeOf<Parameters<typeof engineManager.inspectEngine>[0]>().toEqualTypeOf<AbsPath>()
+    expectTypeOf<Parameters<typeof engineManager.getEnginePreviewAssets>[0]>().toEqualTypeOf<AbsPath>()
+    expectTypeOf<Parameters<typeof engineManager.importEngine>[0]>().toEqualTypeOf<AbsPath>()
+    expectTypeOf<Parameters<typeof engineManager.identityKeyOf>[0]['path']>().toEqualTypeOf<AbsPath>()
+
+    expectTypeOf<Parameters<typeof templateManager.validateTemplate>[0]>().toEqualTypeOf<AbsPath>()
+    expectTypeOf<Parameters<typeof templateManager.inspectTemplateAvailability>[0]>().toEqualTypeOf<AbsPath>()
+    expectTypeOf<Parameters<typeof templateManager.getTemplateMetadata>[0]>().toEqualTypeOf<AbsPath>()
+    expectTypeOf<Parameters<typeof templateManager.importTemplate>[0]>().toEqualTypeOf<AbsPath>()
+
+    expectTypeOf<Parameters<typeof configManager.getConfig>[0]>().toEqualTypeOf<AbsPath>()
+    expectTypeOf<Parameters<typeof configManager.setConfig>[0]>().toEqualTypeOf<AbsPath>()
+
+    expectTypeOf<Parameters<typeof templateSwitch.resolveTemplatePath>[0]>().not.toBeAny()
+    expectTypeOf<Awaited<ReturnType<typeof templateSwitch.resolveTemplatePath>>>().toEqualTypeOf<AbsPath | undefined>()
+    expectTypeOf<Parameters<typeof templateSwitch.evaluateTemplateStrategy>[0]>().toEqualTypeOf<AbsPath>()
+    expectTypeOf<Parameters<typeof templateSwitch.isTemplateDirty>[0]>().toEqualTypeOf<AbsPath>()
+    expectTypeOf<Parameters<typeof templateSwitch.notifyTemplateChanged>[0]>().toEqualTypeOf<AbsPath>()
+  })
+
+  it('uses AbsPath in shared test factories', () => {
+    expectTypeOf<ReturnType<typeof createTestGame>['path']>().toEqualTypeOf<AbsPath>()
+    expectTypeOf<ReturnType<typeof createTestEngine>['path']>().toEqualTypeOf<AbsPath>()
+    expectTypeOf<ReturnType<typeof createTestTemplate>['path']>().toEqualTypeOf<AbsPath>()
+    expectTypeOf<NonNullable<Parameters<typeof createTestGame>[0]>['path']>().toEqualTypeOf<AbsPath | undefined>()
+    expectTypeOf<NonNullable<Parameters<typeof createTestEngine>[0]>['path']>().toEqualTypeOf<AbsPath | undefined>()
+    expectTypeOf<NonNullable<Parameters<typeof createTestTemplate>[0]>['path']>().toEqualTypeOf<AbsPath | undefined>()
+  })
+
+  it('requires AbsPath for template group and preview session boundaries', () => {
+    expectTypeOf<StandaloneTemplateSourceItem['path']>().toEqualTypeOf<AbsPath>()
+    expectTypeOf<EngineBuiltinTemplateSourceItem['enginePath']>().toEqualTypeOf<AbsPath>()
+    expectTypeOf<EngineBuiltinTemplateSourceItem['templatePath']>().toEqualTypeOf<AbsPath>()
+  })
+})

--- a/src/services/__tests__/template-manager.test.ts
+++ b/src/services/__tests__/template-manager.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { AbsPath } from '~/domain/path'
 import { templateManager } from '~/services/template-manager'
 import { AppError } from '~/types/errors'
 
@@ -104,7 +105,7 @@ describe('templateManager 模板管理', () => {
       'webgal-version': '4.8.1',
     }))
 
-    await expect(templateManager.getTemplateMetadata('/source/template')).resolves.toEqual({
+    await expect(templateManager.getTemplateMetadata(AbsPath.from('/source/template'))).resolves.toEqual({
       name: 'Modern Template',
       webgalVersion: '4.8.1',
     })
@@ -113,7 +114,7 @@ describe('templateManager 模板管理', () => {
   it('importTemplate 会要求模板目录存在 template.json', async () => {
     validateDirectoryStructureMock.mockResolvedValue(false)
 
-    await expect(templateManager.importTemplate('/source/template')).rejects.toEqual(
+    await expect(templateManager.importTemplate(AbsPath.from('/source/template'))).rejects.toEqual(
       new AppError('INVALID_STRUCTURE', '无效的模板文件夹'),
     )
 
@@ -139,7 +140,7 @@ describe('templateManager 模板管理', () => {
       onProgress(100)
     })
 
-    await templateManager.importTemplate('/source/template')
+    await templateManager.importTemplate(AbsPath.from('/source/template'))
 
     expect(dbTemplatesAddMock).toHaveBeenCalledWith(expect.objectContaining({
       path: '/templates/Modern Template',
@@ -164,15 +165,16 @@ describe('templateManager 模板管理', () => {
     }))
     dbTemplatesFirstMock.mockResolvedValue({
       id: 'existing-template',
-      path: '/templates/Modern Template',
+      path: AbsPath.from('/templates/Modern Template'),
       createdAt: 0,
       status: 'created',
+      availability: 'available',
       metadata: {
         name: 'Modern Template',
       },
     })
 
-    await expect(templateManager.importTemplate('/source/template')).rejects.toEqual(
+    await expect(templateManager.importTemplate(AbsPath.from('/source/template'))).rejects.toEqual(
       new AppError('DUPLICATE_RESOURCE', '同名模板已存在'),
     )
   })
@@ -184,7 +186,7 @@ describe('templateManager 模板管理', () => {
     }))
     existsMock.mockImplementation(async (path: string) => path === '/templates/Modern Template')
 
-    await expect(templateManager.importTemplate('/source/template')).rejects.toEqual(
+    await expect(templateManager.importTemplate(AbsPath.from('/source/template'))).rejects.toEqual(
       new AppError('IO_ERROR', '目标模板目录已存在，请先清理后重试'),
     )
     expect(copyDirectoryWithProgressMock).not.toHaveBeenCalled()
@@ -200,10 +202,10 @@ describe('templateManager 模板管理', () => {
       templateSavePath: 'C:/Templates',
     })
 
-    await templateManager.importTemplate('C:\\Templates\\Modern Template\\')
+    await templateManager.importTemplate(AbsPath.from('C:\\Templates\\Modern Template\\'))
 
     expect(dbTemplatesAddMock).toHaveBeenCalledWith(expect.objectContaining({
-      path: 'C:\\Templates\\Modern Template\\',
+      path: 'C:/Templates/Modern Template',
       status: 'created',
     }))
     expect(copyDirectoryWithProgressMock).not.toHaveBeenCalled()
@@ -330,7 +332,7 @@ describe('templateManager 模板管理', () => {
   it('deleteTemplate 会递归删除模板目录并清理数据库记录', async () => {
     await templateManager.deleteTemplate({
       id: 'template-created',
-      path: '/templates/Modern Template',
+      path: AbsPath.from('/templates/Modern Template'),
       createdAt: 0,
       status: 'created',
       availability: 'available',
@@ -348,7 +350,7 @@ describe('templateManager 模板管理', () => {
 
     await expect(templateManager.deleteTemplate({
       id: 'template-created',
-      path: '/templates/Modern Template',
+      path: AbsPath.from('/templates/Modern Template'),
       createdAt: 0,
       status: 'created',
       availability: 'available',

--- a/src/services/config-manager.ts
+++ b/src/services/config-manager.ts
@@ -3,13 +3,14 @@ import { gameManager } from '~/services/game-manager'
 import { usePreviewSessionStore } from '~/stores/preview-session'
 
 import type { GameConfigReadResult, GameConfigWritePayload } from '~/commands/game'
+import type { AbsPath } from '~/domain/path'
 
 /**
  * 获取游戏配置
  * @param gamePath 游戏路径
  * @returns 游戏配置对象
  */
-async function getConfig(gamePath: string): Promise<GameConfigReadResult> {
+async function getConfig(gamePath: AbsPath): Promise<GameConfigReadResult> {
   return await gameCmds.getGameConfig(gamePath)
 }
 
@@ -18,7 +19,7 @@ async function getConfig(gamePath: string): Promise<GameConfigReadResult> {
  * @param gamePath 游戏路径
  * @param config 配置对象
  */
-async function setConfig(gamePath: string, config: GameConfigWritePayload) {
+async function setConfig(gamePath: AbsPath, config: GameConfigWritePayload) {
   await gameCmds.setGameConfig(gamePath, config)
   await gameManager.refreshRegisteredGameSnapshot(gamePath)
   usePreviewSessionStore().refreshIfCurrentGame(gamePath)

--- a/src/services/engine-manager.ts
+++ b/src/services/engine-manager.ts
@@ -117,10 +117,10 @@ function withEnginePreviewCacheVersion(
   }
 }
 
-async function resolveManagedEnginePath(engine: Pick<EngineSnapshot, 'name' | 'version'>): Promise<AbsPath> {
+async function resolveManagedEnginePath(engine: Pick<EngineSnapshot, 'engineId' | 'name' | 'version'>): Promise<AbsPath> {
   const storageSettingsStore = useStorageSettingsStore()
   const nameSegment = sanitizeEnginePathSegment(engine.name, '引擎名称')
-  const versionSegment = sanitizeEnginePathSegment(engine.version ?? '', '引擎版本')
+  const versionSegment = sanitizeEnginePathSegment(engine.version ?? engine.engineId, '引擎版本')
   return AbsPath.append(
     AbsPath.append(AbsPath.from(storageSettingsStore.engineSavePath), nameSegment),
     versionSegment,

--- a/src/services/engine-manager.ts
+++ b/src/services/engine-manager.ts
@@ -66,21 +66,21 @@ function buildEngineMetadata(manifest: EngineManifest): EngineMetadata {
 }
 
 async function resolveEngineIconPreviewPath(
-  enginePath: string,
+  enginePath: AbsPath,
   metadata: EngineMetadata,
 ): Promise<string> {
   if (!metadata.icon || metadata.icon === 'icons/favicon.ico') {
-    return engineIconPath(AbsPath.from(enginePath))
+    return engineIconPath(enginePath)
   }
 
-  return AbsPath.join(AbsPath.from(enginePath), RelPath.from(metadata.icon))
+  return AbsPath.join(enginePath, RelPath.from(metadata.icon))
 }
 
-async function classifyEngine(enginePath: string): Promise<EngineManifestResult> {
+async function classifyEngine(enginePath: AbsPath): Promise<EngineManifestResult> {
   return engineCmds.readEngineManifest(enginePath)
 }
 
-async function buildEngineSnapshot(enginePath: string, manifest: EngineManifest): Promise<EngineSnapshot> {
+async function buildEngineSnapshot(enginePath: AbsPath, manifest: EngineManifest): Promise<EngineSnapshot> {
   const metadata = buildEngineMetadata(manifest)
 
   return {
@@ -96,7 +96,7 @@ async function buildEngineSnapshot(enginePath: string, manifest: EngineManifest)
   }
 }
 
-async function resolveEngineSnapshot(enginePath: string): Promise<EngineSnapshot> {
+async function resolveEngineSnapshot(enginePath: AbsPath): Promise<EngineSnapshot> {
   const result = await classifyEngine(enginePath)
   if (result.status !== 'ok') {
     throw new AppError('IO_ERROR', '引擎缺少有效的 webgal-engine.json')
@@ -117,7 +117,7 @@ function withEnginePreviewCacheVersion(
   }
 }
 
-async function resolveManagedEnginePath(engine: Pick<EngineSnapshot, 'name' | 'version'>): Promise<string> {
+async function resolveManagedEnginePath(engine: Pick<EngineSnapshot, 'name' | 'version'>): Promise<AbsPath> {
   const storageSettingsStore = useStorageSettingsStore()
   const nameSegment = sanitizeEnginePathSegment(engine.name, '引擎名称')
   const versionSegment = sanitizeEnginePathSegment(engine.version ?? '', '引擎版本')
@@ -131,20 +131,20 @@ export function isEngineUsable(engine: Pick<Engine, 'status' | 'availability'>):
   return engine.status === 'created' && engine.availability === 'available'
 }
 
-async function validateEngine(enginePath: string): Promise<boolean> {
+async function validateEngine(enginePath: AbsPath): Promise<boolean> {
   return fsCmds.validateDirectoryStructure(
-    AbsPath.from(enginePath),
+    enginePath,
     ['game/template'],
     ['index.html', 'game/config.txt'],
   )
 }
 
-async function getEnginePreviewAssets(enginePath: string): Promise<EnginePreviewAssets> {
+async function getEnginePreviewAssets(enginePath: AbsPath): Promise<EnginePreviewAssets> {
   const snapshot = await resolveEngineSnapshot(enginePath)
   return snapshot.previewAssets
 }
 
-async function getEngineSnapshot(enginePath: string): Promise<Pick<Engine, 'engineId' | 'name' | 'version' | 'metadata' | 'previewAssets'>> {
+async function getEngineSnapshot(enginePath: AbsPath): Promise<Pick<Engine, 'engineId' | 'name' | 'version' | 'metadata' | 'previewAssets'>> {
   const snapshot = await resolveEngineSnapshot(enginePath)
 
   return {
@@ -157,7 +157,7 @@ async function getEngineSnapshot(enginePath: string): Promise<Pick<Engine, 'engi
 }
 
 async function registerEngine(
-  enginePath: string,
+  enginePath: AbsPath,
   options: RegisterEngineOptions,
 ): Promise<string> {
   const previewAssets = withEnginePreviewCacheVersion(options.previewAssets)
@@ -165,7 +165,7 @@ async function registerEngine(
   return db.engines.add({
     id: crypto.randomUUID(),
     path: enginePath,
-    pathLookupKey: toLookupPathKey(AbsPath.from(enginePath)),
+    pathLookupKey: toLookupPathKey(enginePath),
     engineId: options.engineId,
     name: options.name,
     version: options.version,
@@ -238,7 +238,7 @@ async function validateAllEngines(): Promise<void> {
     }))
 }
 
-async function assertEngineImportable(enginePath: string): Promise<EngineSnapshot> {
+async function assertEngineImportable(enginePath: AbsPath): Promise<EngineSnapshot> {
   if (!(await validateEngine(enginePath))) {
     logger.error(`[引擎导入] 无效的引擎文件夹: ${enginePath}`)
     throw new AppError('INVALID_STRUCTURE', '无效的引擎文件夹')
@@ -277,12 +277,12 @@ async function assertEngineImportable(enginePath: string): Promise<EngineSnapsho
 
 async function copyAndFinalizeEngine(
   engineId: string,
-  sourcePath: string,
-  targetPath: string,
+  sourcePath: AbsPath,
+  targetPath: AbsPath,
 ): Promise<void> {
   const resourceStore = useResourceStore()
 
-  await fsCmds.copyDirectoryWithProgress(AbsPath.from(sourcePath), AbsPath.from(targetPath), (progress) => {
+  await fsCmds.copyDirectoryWithProgress(sourcePath, targetPath, (progress) => {
     resourceStore.updateProgress(engineId, progress)
   })
 
@@ -298,17 +298,17 @@ async function findEngineByLookupPath(path: AbsPath): Promise<Engine | undefined
 }
 
 function identityKeyOf(
-  input: { path: string, engineId?: string, version?: string },
+  input: { path: AbsPath, engineId?: string, version?: string },
 ): string {
   if (input.engineId && input.version) {
     return `${input.engineId}:${input.version}`
   }
 
-  return toLookupPathKey(AbsPath.from(input.path))
+  return toLookupPathKey(input.path)
 }
 
 async function collectEngineWarnings(
-  enginePath: string,
+  enginePath: AbsPath,
   metadata: EngineMetadata,
 ): Promise<ResourceWarning[]> {
   const warnings: ResourceWarning[] = []
@@ -320,7 +320,7 @@ async function collectEngineWarnings(
 }
 
 async function inspectEngine(
-  rawPath: string,
+  rawPath: AbsPath,
 ): Promise<ResourceHealthResult<EngineSnapshot>> {
   const { normalizedPath, lookupKey } = normalizeImportPath(rawPath)
 
@@ -401,7 +401,7 @@ export interface ImportEngineResult {
   alreadyRegistered: boolean
 }
 
-async function importEngine(enginePath: string): Promise<ImportEngineResult> {
+async function importEngine(enginePath: AbsPath): Promise<ImportEngineResult> {
   const { normalizedPath, lookupKey: sourceLookupKey } = normalizeImportPath(enginePath)
 
   // 幂等：源路径已注册直接返回既有 ID
@@ -452,7 +452,7 @@ async function importEngine(enginePath: string): Promise<ImportEngineResult> {
       logger.warn(`[引擎导入] 清理异常 - 更新状态失败: ${error_}`)
     })
     if (await exists(targetPath)) {
-      await fsCmds.deleteFile(AbsPath.from(targetPath), true).catch((error_) => {
+      await fsCmds.deleteFile(targetPath, true).catch((error_) => {
         logger.warn(`[引擎导入] 清理异常 - 删除目录失败: ${error_}`)
       })
     }
@@ -472,7 +472,7 @@ async function uninstallEngine(engine: Engine): Promise<void> {
   logger.info(`[引擎卸载] ${engine.name}@${engine.version ?? 'unknown'}: ${engine.path}`)
   if (engine.availability === 'available') {
     try {
-      await fsCmds.deleteFile(AbsPath.from(engine.path), true)
+      await fsCmds.deleteFile(engine.path, true)
     } catch (error) {
       logger.warn(`[引擎卸载] 删除托管目录失败，继续清理数据库记录: ${engine.path} - ${error}`)
     }

--- a/src/services/engine-switch.ts
+++ b/src/services/engine-switch.ts
@@ -2,7 +2,6 @@ import { projectConfigCmds } from '~/commands/project-config'
 import { serverCmds } from '~/commands/server'
 import { vfsCmds } from '~/commands/vfs'
 import { db } from '~/database/db'
-import { AbsPath } from '~/domain/path'
 import { gameManager } from '~/services/game-manager'
 import { templateSwitch } from '~/services/template-switch'
 import { usePreviewSessionStore } from '~/stores/preview-session'
@@ -131,9 +130,8 @@ async function switchEngine(
     // 步骤 5：模板清理（仅 discard 分支）。
     // 该步骤不可逆，必须排在所有可回滚步骤之后；前面任何步骤失败都不应触及用户的模板上层。
     if (templateDecision === 'discard') {
-      const gameAbsPath = AbsPath.from(game.path)
       noRollbackAfterDiscard = true
-      await vfsCmds.cleanTemplateUpper(gameAbsPath)
+      await vfsCmds.cleanTemplateUpper(game.path)
     }
     step = 5
 

--- a/src/services/game-manager.ts
+++ b/src/services/game-manager.ts
@@ -107,11 +107,10 @@ function buildGamePreviewAssets(iconPath: string, titleImage: string | undefined
   }
 }
 
-async function resolveGameIconPreviewPath(gamePath: string): Promise<GamePreviewLookupResult> {
-  const absoluteGamePath = AbsPath.from(gamePath)
+async function resolveGameIconPreviewPath(gamePath: AbsPath): Promise<GamePreviewLookupResult> {
   const candidateChecks = await Promise.all(
     GAME_ICON_PREVIEW_CANDIDATES.map(async (relativePath) => {
-      const targetPath = AbsPath.join(absoluteGamePath, RelPath.from(relativePath))
+      const targetPath = AbsPath.join(gamePath, RelPath.from(relativePath))
       return {
         relativePath,
         iconExists: await exists(targetPath),
@@ -133,11 +132,11 @@ async function resolveGameIconPreviewPath(gamePath: string): Promise<GamePreview
   }
 }
 
-async function validateGame(gamePath: string): Promise<boolean> {
-  return exists(gameConfigPath(AbsPath.from(gamePath)))
+async function validateGame(gamePath: AbsPath): Promise<boolean> {
+  return exists(gameConfigPath(gamePath))
 }
 
-async function getGameMetadata(gamePath: string): Promise<GameMetadata> {
+async function getGameMetadata(gamePath: AbsPath): Promise<GameMetadata> {
   const gameConfig = await gameCmds.getGameConfig(gamePath)
 
   return {
@@ -162,7 +161,7 @@ function withGamePreviewCacheVersion(
   }
 }
 
-async function getGamePreviewAssets(gamePath: string): Promise<GamePreviewAssets> {
+async function getGamePreviewAssets(gamePath: AbsPath): Promise<GamePreviewAssets> {
   const [metadata, iconLookup] = await Promise.all([
     getGameMetadata(gamePath),
     resolveGameIconPreviewPath(gamePath),
@@ -170,7 +169,7 @@ async function getGamePreviewAssets(gamePath: string): Promise<GamePreviewAssets
   return buildGamePreviewAssets(iconLookup.iconPath, metadata.titleImg)
 }
 
-async function getGameSnapshot(gamePath: string): Promise<Pick<Game, 'metadata' | 'previewAssets'>> {
+async function getGameSnapshot(gamePath: AbsPath): Promise<Pick<Game, 'metadata' | 'previewAssets'>> {
   const [metadata, iconLookup] = await Promise.all([
     getGameMetadata(gamePath),
     resolveGameIconPreviewPath(gamePath),
@@ -204,8 +203,8 @@ function applyCurrentGamePatch(
   }
 }
 
-async function refreshRegisteredGameSnapshot(gamePath: string): Promise<void> {
-  const game = await db.games.where('pathLookupKey').equals(toLookupPathKey(AbsPath.from(gamePath))).first()
+async function refreshRegisteredGameSnapshot(gamePath: AbsPath): Promise<void> {
+  const game = await db.games.where('pathLookupKey').equals(toLookupPathKey(gamePath)).first()
   if (!game) {
     return
   }
@@ -224,7 +223,7 @@ async function refreshRegisteredGameSnapshot(gamePath: string): Promise<void> {
 }
 
 async function registerGame(
-  gamePath: string,
+  gamePath: AbsPath,
   options: RegisterGameOptions = {},
 ): Promise<string> {
   const { engineId, status = 'created' } = options
@@ -242,7 +241,7 @@ async function registerGame(
   return db.games.add({
     id: crypto.randomUUID(),
     path: gamePath,
-    pathLookupKey: toLookupPathKey(AbsPath.from(gamePath)),
+    pathLookupKey: toLookupPathKey(gamePath),
     engineId,
     createdAt: Date.now(),
     lastModified: Date.now(),
@@ -264,11 +263,11 @@ function canAutoBindMatchedEngine(engine: Engine): boolean {
   return engine.status === 'created'
 }
 
-async function writeSelfContainedProjectConfig(gamePath: string): Promise<void> {
+async function writeSelfContainedProjectConfig(gamePath: AbsPath): Promise<void> {
   await projectConfigCmds.writeProjectConfig(gamePath, { version: 1 })
 }
 
-async function readProjectConfigSafe(gamePath: string): Promise<ProjectConfig | undefined> {
+async function readProjectConfigSafe(gamePath: AbsPath): Promise<ProjectConfig | undefined> {
   try {
     return await projectConfigCmds.readProjectConfig(gamePath)
   } catch (error) {
@@ -329,11 +328,11 @@ async function resolveSelectableEngine(
 }
 
 async function importLegacyGame(
-  gamePath: string,
+  gamePath: AbsPath,
   options: ImportGameOptions,
   inspection: GameInspectionPayload,
 ): Promise<string> {
-  const hasIndexHtml = await exists(AbsPath.join(AbsPath.from(gamePath), RelPath.from('index.html')))
+  const hasIndexHtml = await exists(AbsPath.join(gamePath, RelPath.from('index.html')))
 
   if (hasIndexHtml) {
     await writeSelfContainedProjectConfig(gamePath)
@@ -350,7 +349,7 @@ async function importLegacyGame(
 }
 
 async function importConfiguredGame(
-  gamePath: string,
+  gamePath: AbsPath,
   options: ImportGameOptions,
   inspection: GameInspectionPayload,
 ): Promise<string> {
@@ -364,7 +363,7 @@ async function importConfiguredGame(
       throw error
     }
 
-    if (await exists(AbsPath.join(AbsPath.from(gamePath), RelPath.from('index.html')))) {
+    if (await exists(AbsPath.join(gamePath, RelPath.from('index.html')))) {
       logger.warn(`project.wgcp 解析失败，但检测到自带引擎，按自带引擎项目导入: ${gamePath}`)
       await writeSelfContainedProjectConfig(gamePath)
       return await registerGame(gamePath, { ...inspection })
@@ -377,7 +376,7 @@ async function importConfiguredGame(
 
   // 无引擎配置：自带引擎项目 或 让用户选择引擎
   if (!config.engine) {
-    if (await exists(AbsPath.join(AbsPath.from(gamePath), RelPath.from('index.html')))) {
+    if (await exists(AbsPath.join(gamePath, RelPath.from('index.html')))) {
       return registerGame(gamePath, { ...inspection })
     }
 
@@ -399,7 +398,7 @@ async function importConfiguredGame(
 
 /** 让用户选择引擎，写入配置并注册游戏 */
 async function bindSelectedEngine(
-  gamePath: string,
+  gamePath: AbsPath,
   config: ProjectConfig,
   options: ImportGameOptions,
   inspection: GameInspectionPayload,
@@ -418,7 +417,7 @@ interface CreateGameOptions {
   templateBinding?: TemplateBinding
 }
 
-async function createGame(gameName: string, gamePath: string, engineId: string, options: CreateGameOptions = {}): Promise<string> {
+async function createGame(gameName: string, gamePath: AbsPath, engineId: string, options: CreateGameOptions = {}): Promise<string> {
   const resourceStore = useResourceStore()
   const engine = await db.engines.get(engineId)
   if (!engine) {
@@ -436,7 +435,7 @@ async function createGame(gameName: string, gamePath: string, engineId: string, 
 
   try {
     // 先创建目录和项目配置，确保 preview primer 触发时路径已存在且 VFS 可解析引擎层资源
-    await mkdir(AbsPath.join(AbsPath.from(gamePath), RelPath.from('game')), { recursive: true })
+    await mkdir(AbsPath.join(gamePath, RelPath.from('game')), { recursive: true })
     await projectConfigCmds.writeProjectConfig(gamePath, {
       version: 1,
       engine: buildProjectEngineRef(engine),
@@ -465,9 +464,9 @@ async function createGame(gameName: string, gamePath: string, engineId: string, 
 
     // 复制引擎 game/ 到项目（含 config.txt 等），但排除 template/：
     // 模板按 phase-4b/01 设计走 template lower，不再下沉到项目目录
-    const engineGameDir = AbsPath.join(AbsPath.from(engine.path), RelPath.from('game'))
+    const engineGameDir = AbsPath.join(engine.path, RelPath.from('game'))
     if (await exists(engineGameDir)) {
-      const projectGameDir = AbsPath.join(AbsPath.from(gamePath), RelPath.from('game'))
+      const projectGameDir = AbsPath.join(gamePath, RelPath.from('game'))
       await fsCmds.copyDirectoryWithProgress(
         engineGameDir,
         projectGameDir,
@@ -511,7 +510,7 @@ async function createGame(gameName: string, gamePath: string, engineId: string, 
       })
     }
     if (!targetExisted && await exists(gamePath)) {
-      await fsCmds.deleteFile(AbsPath.from(gamePath), true).catch((error_) => {
+      await fsCmds.deleteFile(gamePath, true).catch((error_) => {
         logger.warn(`[游戏创建] 清理异常 - 删除目录失败: ${error_}`)
       })
     }
@@ -521,7 +520,7 @@ async function createGame(gameName: string, gamePath: string, engineId: string, 
 
 async function deleteGame(game: Game, removeFiles: boolean = false): Promise<void> {
   if (removeFiles) {
-    await fsCmds.deleteFile(AbsPath.from(game.path))
+    await fsCmds.deleteFile(game.path)
   }
   await db.games.delete(game.id)
 }
@@ -530,7 +529,7 @@ async function deleteGame(game: Game, removeFiles: boolean = false): Promise<voi
  * 把游戏记录指向新的目录路径。第一版不做 gameKey 身份校验，只要新路径是合法游戏目录即可，
  * 对应的会话状态由调用方负责清理。
  */
-async function relinkGame(gameId: string, newPath: string): Promise<Game> {
+async function relinkGame(gameId: string, newPath: AbsPath): Promise<Game> {
   const game = await db.games.get(gameId)
   if (!game) {
     throw new AppError('IO_ERROR', '游戏不存在')
@@ -541,7 +540,7 @@ async function relinkGame(gameId: string, newPath: string): Promise<Game> {
     throw new AppError('INVALID_STRUCTURE', '所选目录不是合法的游戏文件夹')
   }
 
-  const conflicting = await findExistingGameByPath(inspection.normalizedPath)
+  const conflicting = await findRegisteredGameByPath(inspection.normalizedPath)
   if (conflicting && conflicting.id !== gameId) {
     throw new AppError('DUPLICATE_RESOURCE', '该目录已绑定到其他游戏记录')
   }
@@ -558,7 +557,7 @@ async function relinkGame(gameId: string, newPath: string): Promise<Game> {
   return { ...game, ...patch }
 }
 
-async function getGameEnginePath(game: Pick<Game, 'engineId' | 'path'>): Promise<string | undefined> {
+async function getGameEnginePath(game: Pick<Game, 'engineId' | 'path'>): Promise<AbsPath | undefined> {
   const { engine } = await resolveBoundEngine(game)
   if (!engine || !isEngineUsable(engine)) {
     return undefined
@@ -574,8 +573,8 @@ async function ensureConfigWritable(game: Pick<Game, 'engineId' | 'path'>): Prom
   }
 
   await vfsCmds.ensureWritable({
-    projectPath: AbsPath.from(game.path),
-    enginePath: AbsPath.from(enginePath),
+    projectPath: game.path,
+    enginePath,
     relPath: RelPath.from('game/config.txt'),
   })
 }
@@ -607,16 +606,16 @@ async function renameGame(id: string, newName: string): Promise<void> {
   applyCurrentGamePatch(id, patch)
 }
 
-async function findExistingGameByPath(rawPath: string): Promise<Game | undefined> {
-  return db.games.where('pathLookupKey').equals(toLookupPathKey(AbsPath.from(rawPath))).first()
+async function findRegisteredGameByPath(path: AbsPath): Promise<Game | undefined> {
+  return db.games.where('pathLookupKey').equals(toLookupPathKey(path)).first()
 }
 
-function identityKeyOf(input: { path: string }): string {
-  return toLookupPathKey(AbsPath.from(input.path))
+function identityKeyOf(input: { path: AbsPath }): string {
+  return toLookupPathKey(input.path)
 }
 
 async function collectGameWarnings(
-  gamePath: string,
+  gamePath: AbsPath,
   metadata: GameMetadata,
   iconLookup: GamePreviewLookupResult,
 ): Promise<ResourceWarning[]> {
@@ -633,7 +632,7 @@ async function collectGameWarnings(
   const titleImg = normalizeLogicalAssetPath(metadata.titleImg?.trim())
   if (!titleImg) {
     warnings.push(createWarning('missing-title-image', '游戏未配置 Title_img'))
-  } else if (!(await exists(gameCoverPath(AbsPath.from(gamePath), titleImg)))) {
+  } else if (!(await exists(gameCoverPath(gamePath, titleImg)))) {
     warnings.push(createWarning('missing-title-image-file', `Title_img 指向的文件不存在: ${titleImg}`))
   }
 
@@ -684,7 +683,7 @@ async function inspectGameSemantics(
 }
 
 async function inspectGame(
-  rawPath: string,
+  rawPath: AbsPath,
 ): Promise<ResourceHealthResult<GameInspectionPayload>> {
   const { normalizedPath, lookupKey } = normalizeImportPath(rawPath)
 
@@ -730,12 +729,12 @@ export interface ImportGameResult {
   alreadyRegistered: boolean
 }
 
-async function importGame(gamePath: string, options: ImportGameOptions = {}): Promise<ImportGameResult> {
+async function importGame(gamePath: AbsPath, options: ImportGameOptions = {}): Promise<ImportGameResult> {
   const { normalizedPath } = normalizeImportPath(gamePath)
 
   // 幂等：已注册路径直接返回既有 ID（按归一化后路径比较）
   // 即使目录已损坏也允许命中既有记录，由后续 reconcile 流程处理 availability
-  const existing = await findExistingGameByPath(normalizedPath)
+  const existing = await findRegisteredGameByPath(normalizedPath)
   if (existing) {
     return { id: existing.id, alreadyRegistered: true }
   }

--- a/src/services/game-manager.ts
+++ b/src/services/game-manager.ts
@@ -520,7 +520,7 @@ async function createGame(gameName: string, gamePath: AbsPath, engineId: string,
 
 async function deleteGame(game: Game, removeFiles: boolean = false): Promise<void> {
   if (removeFiles) {
-    await fsCmds.deleteFile(game.path)
+    await fsCmds.deleteFile(game.path, true)
   }
   await db.games.delete(game.id)
 }

--- a/src/services/template-manager.ts
+++ b/src/services/template-manager.ts
@@ -18,9 +18,9 @@ interface RegisterTemplateOptions {
   status?: Template['status']
 }
 
-async function validateTemplate(templatePath: string): Promise<boolean> {
+async function validateTemplate(templatePath: AbsPath): Promise<boolean> {
   return fsCmds.validateDirectoryStructure(
-    AbsPath.from(templatePath),
+    templatePath,
     [],
     ['template.json'],
   )
@@ -49,8 +49,8 @@ function normalizeTemplateMetadata(raw: unknown): TemplateMetadata {
   }
 }
 
-async function getTemplateMetadata(templatePath: string): Promise<TemplateMetadata> {
-  const manifestPath = templateManifestPath(AbsPath.from(templatePath))
+async function getTemplateMetadata(templatePath: AbsPath): Promise<TemplateMetadata> {
+  const manifestPath = templateManifestPath(templatePath)
   const metaContent = await readTextFile(manifestPath)
 
   try {
@@ -65,7 +65,7 @@ async function getTemplateMetadata(templatePath: string): Promise<TemplateMetada
 }
 
 async function registerTemplate(
-  templatePath: string,
+  templatePath: AbsPath,
   options: RegisterTemplateOptions = {},
 ): Promise<string> {
   const { status = 'created' } = options
@@ -90,7 +90,7 @@ function sanitizeTemplateDirectoryName(templateName: string): string {
   return sanitizedName
 }
 
-async function resolveInstalledTemplatePath(templateSavePath: string, templateName: string): Promise<string> {
+async function resolveInstalledTemplatePath(templateSavePath: string, templateName: string): Promise<AbsPath> {
   return AbsPath.append(AbsPath.from(templateSavePath), sanitizeTemplateDirectoryName(templateName))
 }
 
@@ -101,23 +101,22 @@ async function findTemplateByName(templateName: string): Promise<Template | unde
     .first()
 }
 
-async function findTemplateByPath(templatePath: string): Promise<Template | undefined> {
-  const normalizedPath = AbsPath.from(templatePath)
+async function findTemplateByPath(templatePath: AbsPath): Promise<Template | undefined> {
   const templates = await db.templates.toArray()
-  return templates.find(template => caseFoldedEquals(AbsPath.from(template.path), normalizedPath))
+  return templates.find(template => caseFoldedEquals(template.path, templatePath))
 }
 
-async function deleteTemplateDirectoryIfExists(path: string): Promise<void> {
+async function deleteTemplateDirectoryIfExists(path: AbsPath): Promise<void> {
   try {
     if (await exists(path)) {
-      await fsCmds.deleteFile(AbsPath.from(path), true)
+      await fsCmds.deleteFile(path, true)
     }
   } catch (error) {
     logger.warn(`[模板清理] 删除目录失败 (${path}): ${error}`)
   }
 }
 
-async function assertTemplateImportable(templatePath: string): Promise<TemplateMetadata> {
+async function assertTemplateImportable(templatePath: AbsPath): Promise<TemplateMetadata> {
   if (!(await validateTemplate(templatePath))) {
     logger.error(`[模板导入] 无效的模板文件夹: ${templatePath}`)
     throw new AppError('INVALID_STRUCTURE', '无效的模板文件夹')
@@ -132,7 +131,7 @@ async function assertTemplateImportable(templatePath: string): Promise<TemplateM
   return metadata
 }
 
-async function installTemplate(templatePath: string, metadata: TemplateMetadata): Promise<void> {
+async function installTemplate(templatePath: AbsPath, metadata: TemplateMetadata): Promise<void> {
   const resourceStore = useResourceStore()
   const storageSettingsStore = useStorageSettingsStore()
 
@@ -152,7 +151,7 @@ async function installTemplate(templatePath: string, metadata: TemplateMetadata)
   })
 
   try {
-    await fsCmds.copyDirectoryWithProgress(AbsPath.from(templatePath), AbsPath.from(targetPath), (progress) => {
+    await fsCmds.copyDirectoryWithProgress(templatePath, targetPath, (progress) => {
       resourceStore.updateProgress(id, progress)
     })
 
@@ -169,7 +168,7 @@ async function installTemplate(templatePath: string, metadata: TemplateMetadata)
   }
 }
 
-async function importTemplate(templatePath: string): Promise<void> {
+async function importTemplate(templatePath: AbsPath): Promise<void> {
   const storageSettingsStore = useStorageSettingsStore()
   const metadata = await assertTemplateImportable(templatePath)
 
@@ -178,7 +177,7 @@ async function importTemplate(templatePath: string): Promise<void> {
   }
 
   const targetPath = await resolveInstalledTemplatePath(storageSettingsStore.templateSavePath, metadata.name)
-  if (caseFoldedEquals(AbsPath.from(templatePath), AbsPath.from(targetPath))) {
+  if (caseFoldedEquals(templatePath, targetPath)) {
     const existingByPath = await findTemplateByPath(templatePath)
     if (existingByPath) {
       throw new AppError('DUPLICATE_RESOURCE', '同名模板已存在')
@@ -195,7 +194,7 @@ async function importTemplate(templatePath: string): Promise<void> {
 async function deleteTemplate(template: Template): Promise<void> {
   if (template.availability === 'available') {
     try {
-      await fsCmds.deleteFile(AbsPath.from(template.path), true)
+      await fsCmds.deleteFile(template.path, true)
     } catch (error) {
       logger.warn(`[模板删除] 删除模板目录失败，继续清理数据库记录: ${template.path} - ${error}`)
     }
@@ -203,7 +202,7 @@ async function deleteTemplate(template: Template): Promise<void> {
   await db.templates.delete(template.id)
 }
 
-async function inspectTemplateAvailability(templatePath: string): Promise<{
+async function inspectTemplateAvailability(templatePath: AbsPath): Promise<{
   availability: ResourceAvailability
   metadata?: TemplateMetadata
 }> {

--- a/src/services/template-switch.ts
+++ b/src/services/template-switch.ts
@@ -15,12 +15,12 @@ import type { ProjectConfig, TemplateBinding } from '~/types/project-config'
 
 type TemplateStrategy = 'explicit' | 'clean' | 'dirty'
 
-function templateUpperPath(gamePath: string): AbsPath {
-  return AbsPath.join(AbsPath.from(gamePath), RelPath.from('game/template'))
+function templateUpperPath(gamePath: AbsPath): AbsPath {
+  return AbsPath.join(gamePath, RelPath.from('game/template'))
 }
 
-async function isTemplateDirty(gamePath: string): Promise<boolean> {
-  if (await vfsCmds.isTemplateDirty(AbsPath.from(gamePath))) {
+async function isTemplateDirty(gamePath: AbsPath): Promise<boolean> {
+  if (await vfsCmds.isTemplateDirty(gamePath)) {
     return true
   }
 
@@ -33,7 +33,7 @@ async function isTemplateDirty(gamePath: string): Promise<boolean> {
   }
 }
 
-async function closeOpenedTemplateDocuments(gamePath: string): Promise<void> {
+async function closeOpenedTemplateDocuments(gamePath: AbsPath): Promise<void> {
   try {
     const templateRoot = templateUpperPath(gamePath)
     const editorStore = useEditorStore()
@@ -62,8 +62,8 @@ async function closeOpenedTemplateDocuments(gamePath: string): Promise<void> {
  *   "跟随当前引擎默认"（缺省 binding）。
  */
 async function notifyTemplateChanged(
-  gamePath: string,
-  options: { nextEnginePath?: string, nextTemplatePath?: string | null } = {},
+  gamePath: AbsPath,
+  options: { nextEnginePath?: AbsPath, nextTemplatePath?: AbsPath | null } = {},
 ): Promise<void> {
   await closeOpenedTemplateDocuments(gamePath)
 
@@ -72,13 +72,9 @@ async function notifyTemplateChanged(
   // 引擎/模板切换不会改动磁盘文件本身（只是 lower 路径变了），
   // OS watcher 不会触发；必须主动失效，否则 listDir 仍会用旧 lower 配置返回。
   try {
-    const nextTemplatePath = typeof options.nextTemplatePath === 'string'
-      ? AbsPath.from(options.nextTemplatePath)
-      : options.nextTemplatePath
-
-    await useFileStore().refreshTemplateOverlay(AbsPath.from(gamePath), {
-      nextEnginePath: options.nextEnginePath ? AbsPath.from(options.nextEnginePath) : undefined,
-      nextTemplatePath,
+    await useFileStore().refreshTemplateOverlay(gamePath, {
+      nextEnginePath: options.nextEnginePath,
+      nextTemplatePath: options.nextTemplatePath,
     })
   } catch (error) {
     logger.warn(`[模板切换] 失效模板 overlay 缓存失败: ${error}`)
@@ -108,10 +104,10 @@ async function applySiteUpdate(updater: () => Promise<void>, label: string): Pro
 async function resolveTemplatePath(
   binding: TemplateBinding | undefined,
   currentEngine?: Pick<Engine, 'path'>,
-): Promise<string | undefined> {
+): Promise<AbsPath | undefined> {
   if (!binding) {
     return currentEngine
-      ? AbsPath.join(AbsPath.from(currentEngine.path), RelPath.from('game/template'))
+      ? AbsPath.join(currentEngine.path, RelPath.from('game/template'))
       : undefined
   }
 
@@ -125,7 +121,7 @@ async function resolveTemplatePath(
     case 'engineBuiltin': {
       const engine = await engineManager.findEngineByRef(binding.engine)
       return engine && isEngineUsable(engine)
-        ? AbsPath.join(AbsPath.from(engine.path), RelPath.from('game/template'))
+        ? AbsPath.join(engine.path, RelPath.from('game/template'))
         : undefined
     }
     default: {
@@ -135,7 +131,7 @@ async function resolveTemplatePath(
 }
 
 async function evaluateTemplateStrategy(
-  gamePath: string,
+  gamePath: AbsPath,
   config: ProjectConfig,
 ): Promise<TemplateStrategy> {
   if (config.template) {
@@ -184,7 +180,7 @@ async function switchTemplate(
   await closeOpenedTemplateDocuments(game.path)
 
   await projectConfigCmds.writeProjectConfig(game.path, newConfig)
-  await vfsCmds.cleanTemplateUpper(AbsPath.from(game.path))
+  await vfsCmds.cleanTemplateUpper(game.path)
 
   const newTemplatePath = await resolveTemplatePath(newBinding, engine)
   await applySiteUpdate(

--- a/src/stores/__tests__/preview-runtime.test.ts
+++ b/src/stores/__tests__/preview-runtime.test.ts
@@ -2,6 +2,7 @@ import '~/__tests__/setup'
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { AbsPath } from '~/domain/path'
 import { usePreviewRuntimeStore } from '~/stores/preview-runtime'
 
 const {
@@ -37,12 +38,12 @@ describe('previewRuntimeStore 预览运行时状态仓库', () => {
 
     expect('ensureServer' in store).toBe(false)
     expect('serverUrl' in store).toBe(false)
-    expect(store.getServeUrl('/games/alpha')).toBeUndefined()
+    expect(store.getServeUrl(AbsPath.from('/games/alpha'))).toBeUndefined()
 
-    await expect(store.ensureServeUrl({ projectPath: '/games/alpha' })).resolves.toBe(
+    await expect(store.ensureServeUrl({ projectPath: AbsPath.from('/games/alpha') })).resolves.toBe(
       'http://127.0.0.1:8899/game/game-alpha/',
     )
-    await expect(store.ensureServeUrl({ projectPath: '/games/alpha' })).resolves.toBe(
+    await expect(store.ensureServeUrl({ projectPath: AbsPath.from('/games/alpha') })).resolves.toBe(
       'http://127.0.0.1:8899/game/game-alpha/',
     )
 
@@ -50,7 +51,7 @@ describe('previewRuntimeStore 预览运行时状态仓库', () => {
     expect(startServerMock).toHaveBeenCalledWith('127.0.0.1', 8899)
     expect(addStaticSiteMock).toHaveBeenCalledTimes(1)
     expect(addStaticSiteMock).toHaveBeenCalledWith({ projectPath: '/games/alpha' })
-    expect(store.getServeUrl('/games/alpha')).toBe('http://127.0.0.1:8899/game/game-alpha/')
+    expect(store.getServeUrl(AbsPath.from('/games/alpha'))).toBe('http://127.0.0.1:8899/game/game-alpha/')
   })
 
   it('ensureServeUrl 并发调用同一路径时只会启动一次服务器并注册一次站点', async () => {
@@ -59,22 +60,22 @@ describe('previewRuntimeStore 预览运行时状态仓库', () => {
     const store = usePreviewRuntimeStore()
 
     const [firstUrl, secondUrl] = await Promise.all([
-      store.ensureServeUrl({ projectPath: '/games/alpha' }),
-      store.ensureServeUrl({ projectPath: '/games/alpha' }),
+      store.ensureServeUrl({ projectPath: AbsPath.from('/games/alpha') }),
+      store.ensureServeUrl({ projectPath: AbsPath.from('/games/alpha') }),
     ])
 
     expect(firstUrl).toBe('http://127.0.0.1:8899/game/game-alpha/')
     expect(secondUrl).toBe('http://127.0.0.1:8899/game/game-alpha/')
     expect(startServerMock).toHaveBeenCalledTimes(1)
     expect(addStaticSiteMock).toHaveBeenCalledTimes(1)
-    expect(store.getServeUrl('/games/alpha')).toBe('http://127.0.0.1:8899/game/game-alpha/')
+    expect(store.getServeUrl(AbsPath.from('/games/alpha'))).toBe('http://127.0.0.1:8899/game/game-alpha/')
   })
 
   it('ensureServeUrl 在服务器启动失败时会记录日志并返回 undefined', async () => {
     startServerMock.mockRejectedValue(new Error('occupied'))
     const store = usePreviewRuntimeStore()
 
-    await expect(store.ensureServeUrl({ projectPath: '/games/alpha' })).resolves.toBeUndefined()
+    await expect(store.ensureServeUrl({ projectPath: AbsPath.from('/games/alpha') })).resolves.toBeUndefined()
 
     expect(loggerErrorMock).toHaveBeenCalledWith('服务器启动失败: Error: occupied')
   })
@@ -84,7 +85,7 @@ describe('previewRuntimeStore 预览运行时状态仓库', () => {
     addStaticSiteMock.mockRejectedValue(new Error('register failed'))
     const store = usePreviewRuntimeStore()
 
-    await expect(store.ensureServeUrl({ projectPath: '/games/alpha' })).resolves.toBeUndefined()
+    await expect(store.ensureServeUrl({ projectPath: AbsPath.from('/games/alpha') })).resolves.toBeUndefined()
 
     expect(loggerErrorMock).toHaveBeenCalledWith(
       '注册静态站点失败: /games/alpha - Error: register failed',
@@ -99,8 +100,8 @@ describe('previewRuntimeStore 预览运行时状态仓库', () => {
     const store = usePreviewRuntimeStore()
 
     await store.ensureServeUrls([
-      { projectPath: '/games/alpha' },
-      { projectPath: '/engines/beta' },
+      { projectPath: AbsPath.from('/games/alpha') },
+      { projectPath: AbsPath.from('/engines/beta') },
     ])
 
     expect(loggerErrorMock).toHaveBeenCalledWith(
@@ -108,16 +109,15 @@ describe('previewRuntimeStore 预览运行时状态仓库', () => {
     )
   })
 
-  it('ensureServeUrls 会过滤空路径，并按原始路径字符串去重', async () => {
+  it('ensureServeUrls 会按原始路径字符串去重', async () => {
     startServerMock.mockResolvedValue('http://127.0.0.1:8899/')
     addStaticSiteMock.mockResolvedValue('game-alpha')
     const store = usePreviewRuntimeStore()
 
     await store.ensureServeUrls([
-      { projectPath: '' },
-      { projectPath: '/games/alpha ' },
-      { projectPath: '/games/alpha ' },
-      { projectPath: '/games/alpha' },
+      { projectPath: AbsPath.from('/games/alpha ') },
+      { projectPath: AbsPath.from('/games/alpha ') },
+      { projectPath: AbsPath.from('/games/alpha') },
     ])
 
     expect(startServerMock).toHaveBeenCalledTimes(1)
@@ -130,11 +130,11 @@ describe('previewRuntimeStore 预览运行时状态仓库', () => {
     startServerMock.mockResolvedValue('http://127.0.0.1:8899/')
     addStaticSiteMock.mockResolvedValue('game-alpha')
     const store = usePreviewRuntimeStore()
-    const serveUrl = computed(() => store.getServeUrl('/games/alpha'))
+    const serveUrl = computed(() => store.getServeUrl(AbsPath.from('/games/alpha')))
 
     expect(serveUrl.value).toBeUndefined()
 
-    await store.ensureServeUrls([{ projectPath: '/games/alpha' }])
+    await store.ensureServeUrls([{ projectPath: AbsPath.from('/games/alpha') }])
 
     expect(serveUrl.value).toBe('http://127.0.0.1:8899/game/game-alpha/')
   })

--- a/src/stores/__tests__/preview-session.test.ts
+++ b/src/stores/__tests__/preview-session.test.ts
@@ -3,6 +3,7 @@ import '~/__tests__/setup'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { createTestGame } from '~/__tests__/factories'
+import { AbsPath } from '~/domain/path'
 import { usePreviewSessionStore } from '~/stores/preview-session'
 
 const {
@@ -57,7 +58,7 @@ describe('previewSessionStore 当前工作区预览会话仓库', () => {
 
     ensureServeUrlMock.mockResolvedValueOnce('http://preview/game-1/')
     await store.syncCurrentGame(createTestGame({
-      path: '/games/game-1',
+      path: AbsPath.from('/games/game-1'),
       engineId: 'engine-1',
     }))
 
@@ -89,13 +90,13 @@ describe('previewSessionStore 当前工作区预览会话仓库', () => {
 
     ensureServeUrlMock.mockResolvedValue('http://preview/game-1/')
     await store.syncCurrentGame(createTestGame({
-      path: '/games/game-1',
+      path: AbsPath.from('/games/game-1'),
     }))
 
-    store.refreshIfCurrentGame('/games/other')
+    store.refreshIfCurrentGame(AbsPath.from('/games/other'))
     expect(store.reloadVersion).toBe(0)
 
-    store.refreshIfCurrentGame('/games/game-1')
+    store.refreshIfCurrentGame(AbsPath.from('/games/game-1'))
     expect(store.reloadVersion).toBe(1)
   })
 
@@ -104,13 +105,13 @@ describe('previewSessionStore 当前工作区预览会话仓库', () => {
 
     ensureServeUrlMock.mockResolvedValue(undefined)
     await store.syncCurrentGame(createTestGame({
-      path: '/games/game-1',
+      path: AbsPath.from('/games/game-1'),
     }))
 
     expect(store.currentGameServeUrl).toBeUndefined()
     expect(loggerErrorMock).toHaveBeenCalledWith('获取预览链接失败: 预览链接不存在')
 
-    store.refreshIfCurrentGame('/games/game-1')
+    store.refreshIfCurrentGame(AbsPath.from('/games/game-1'))
     expect(store.reloadVersion).toBe(1)
   })
 
@@ -122,10 +123,10 @@ describe('previewSessionStore 当前工作区预览会话仓库', () => {
     ensureServeUrlMock.mockResolvedValueOnce('http://preview/game-2/')
 
     const firstSyncTask = store.syncCurrentGame(createTestGame({
-      path: '/games/game-1',
+      path: AbsPath.from('/games/game-1'),
     }))
     const secondSyncTask = store.syncCurrentGame(createTestGame({
-      path: '/games/game-2',
+      path: AbsPath.from('/games/game-2'),
     }))
 
     await secondSyncTask
@@ -142,7 +143,7 @@ describe('previewSessionStore 当前工作区预览会话仓库', () => {
 
     resolvePreviewSiteMock.mockRejectedValue(new Error('engine unavailable'))
     await store.syncCurrentGame(createTestGame({
-      path: '/games/game-1',
+      path: AbsPath.from('/games/game-1'),
     }))
 
     expect(ensureServeUrlMock).not.toHaveBeenCalled()

--- a/src/stores/__tests__/resource.test.ts
+++ b/src/stores/__tests__/resource.test.ts
@@ -3,6 +3,7 @@ import '~/__tests__/setup'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { createTestEngine, createTestGame, createTestTemplate } from '~/__tests__/factories'
+import { AbsPath } from '~/domain/path'
 import { useResourceStore } from '~/stores/resource'
 
 import type { Engine, Game, Template } from '~/database/model'
@@ -40,7 +41,7 @@ vi.mock('~/stores/workspace', () => ({
 function createGame(id: string, name: string, lastModified: number): Game {
   return createTestGame({
     id,
-    path: `/games/${id}`,
+    path: AbsPath.from(`/games/${id}`),
     lastModified,
     metadata: {
       name,
@@ -51,7 +52,7 @@ function createGame(id: string, name: string, lastModified: number): Game {
 function createEngine(id: string, name: string, createdAt: number): Engine {
   return createTestEngine({
     id,
-    path: `/engines/${id}`,
+    path: AbsPath.from(`/engines/${id}`),
     createdAt,
     name,
     metadata: {
@@ -64,7 +65,7 @@ function createEngine(id: string, name: string, createdAt: number): Engine {
 function createTemplate(id: string, name: string, createdAt: number, webgalVersion?: string): Template {
   return createTestTemplate({
     id,
-    path: `/templates/${id}`,
+    path: AbsPath.from(`/templates/${id}`),
     createdAt,
     metadata: {
       name,
@@ -138,7 +139,7 @@ describe('资源状态仓库', () => {
         id: 'webgal-481',
         engineId: 'open-webgal.webgal',
         name: 'WebGAL',
-        path: '/engines/WebGAL/4.8.1',
+        path: AbsPath.from('/engines/WebGAL/4.8.1'),
         version: '4.8.1',
         metadata: {
           description: '',
@@ -149,7 +150,7 @@ describe('资源状态仓库', () => {
         id: 'webgal-482',
         engineId: 'open-webgal.webgal',
         name: 'WebGAL',
-        path: '/engines/WebGAL/4.8.2',
+        path: AbsPath.from('/engines/WebGAL/4.8.2'),
         version: '4.8.2',
         status: 'created',
         metadata: {
@@ -161,7 +162,7 @@ describe('资源状态仓库', () => {
         id: 'webgal-unavailable',
         engineId: 'broken-publisher.broken',
         name: 'Broken',
-        path: '/engines/Broken/1.0.0',
+        path: AbsPath.from('/engines/Broken/1.0.0'),
         version: '1.0.0',
         availability: 'broken',
         metadata: {
@@ -209,7 +210,7 @@ describe('资源状态仓库', () => {
         id: 'webgal-created',
         engineId: 'open-webgal.webgal',
         name: 'WebGAL',
-        path: '/engines/WebGAL/4.8.2',
+        path: AbsPath.from('/engines/WebGAL/4.8.2'),
         version: '4.8.2',
         status: 'created',
         metadata: {
@@ -221,7 +222,7 @@ describe('资源状态仓库', () => {
         id: 'webgal-creating',
         engineId: 'open-webgal.webgal',
         name: 'WebGAL',
-        path: '/engines/WebGAL/4.8.3',
+        path: AbsPath.from('/engines/WebGAL/4.8.3'),
         version: '4.8.3',
         status: 'creating',
         metadata: {
@@ -233,7 +234,7 @@ describe('资源状态仓库', () => {
         id: 'webgal-unavailable',
         engineId: 'open-webgal.webgal',
         name: 'WebGAL',
-        path: '/engines/WebGAL/4.8.1',
+        path: AbsPath.from('/engines/WebGAL/4.8.1'),
         version: '4.8.1',
         availability: 'broken',
         metadata: {

--- a/src/stores/__tests__/workspace.test.ts
+++ b/src/stores/__tests__/workspace.test.ts
@@ -3,6 +3,7 @@ import '~/__tests__/setup'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { createTestGame } from '~/__tests__/factories'
+import { AbsPath } from '~/domain/path'
 import { useWorkspaceStore } from '~/stores/workspace'
 
 const {
@@ -86,7 +87,7 @@ describe('工作区状态仓库', () => {
     const store = useWorkspaceStore()
 
     store.currentGame = createTestGame({
-      path: '/games/game-1',
+      path: AbsPath.from('/games/game-1'),
       pathLookupKey: '/games/game-1',
       metadata: {
         name: 'old',
@@ -142,7 +143,7 @@ describe('工作区状态仓库', () => {
 
     dbGetMock.mockResolvedValue(createTestGame({
       id: 'game-1',
-      path: '/games/game-1',
+      path: AbsPath.from('/games/game-1'),
       metadata: {
         name: 'Game One',
       },
@@ -175,7 +176,7 @@ describe('工作区状态仓库', () => {
 
   it('ensureCurrentGameAvailable 在 currentGame 可达时返回 true', async () => {
     const store = useWorkspaceStore()
-    store.currentGame = createTestGame({ id: 'game-1', path: '/games/game-1' })
+    store.currentGame = createTestGame({ id: 'game-1', path: AbsPath.from('/games/game-1') })
 
     reconcileGameRecordMock.mockResolvedValueOnce('available')
 
@@ -184,7 +185,7 @@ describe('工作区状态仓库', () => {
 
   it('ensureCurrentGameAvailable 在 currentGame 不可达时返回 false', async () => {
     const store = useWorkspaceStore()
-    store.currentGame = createTestGame({ id: 'game-stale', path: '/games/game-stale' })
+    store.currentGame = createTestGame({ id: 'game-stale', path: AbsPath.from('/games/game-stale') })
 
     reconcileGameRecordMock.mockResolvedValueOnce('missing')
 
@@ -197,7 +198,7 @@ describe('工作区状态仓库', () => {
 
     dbGetMock.mockResolvedValue(createTestGame({
       id: 'game-2',
-      path: '/games/game-2',
+      path: AbsPath.from('/games/game-2'),
       metadata: {
         name: 'Game Two',
       },

--- a/src/stores/file.ts
+++ b/src/stores/file.ts
@@ -144,7 +144,7 @@ export const useFileStore = defineStore('file', () => {
   }
 
   function getCurrentProjectPath(): AbsPath | undefined {
-    return workspaceStore.currentGame?.path ? AbsPath.from(workspaceStore.currentGame.path) : projectPath
+    return workspaceStore.currentGame?.path ?? projectPath
   }
 
   function getCurrentTemplatePath(): AbsPath | undefined {
@@ -947,19 +947,19 @@ export const useFileStore = defineStore('file', () => {
     }
 
     try {
-      projectPath = workspaceStore.currentGame?.path ? AbsPath.from(workspaceStore.currentGame.path) : undefined
+      projectPath = workspaceStore.currentGame?.path
       const configPath = projectPath ? projectConfigPath(projectPath) : undefined
       const hasProjectConfig = configPath ? await exists(configPath) : false
       if (hasProjectConfig && workspaceStore.currentGame) {
         try {
           const site = await gameManager.resolvePreviewSite(workspaceStore.currentGame)
-          enginePath = site.enginePath ? AbsPath.from(site.enginePath) : undefined
-          templatePath = site.templatePath ? AbsPath.from(site.templatePath) : undefined
+          enginePath = site.enginePath
+          templatePath = site.templatePath
         } catch (error) {
           const msg = error instanceof Error ? error.message : String(error)
           void logger.warn(`[FileStore] 解析项目站点失败，回退仅引擎路径: ${msg}`)
           const fallbackEnginePath = await gameManager.getGameEnginePath(workspaceStore.currentGame)
-          enginePath = fallbackEnginePath ? AbsPath.from(fallbackEnginePath) : undefined
+          enginePath = fallbackEnginePath
           templatePath = undefined
         }
       } else {

--- a/src/stores/file.ts
+++ b/src/stores/file.ts
@@ -192,7 +192,7 @@ export const useFileStore = defineStore('file', () => {
     } else if (workspaceStore.currentGame) {
       try {
         const nextEnginePath = await gameManager.getGameEnginePath(workspaceStore.currentGame)
-        enginePath = nextEnginePath ? AbsPath.from(nextEnginePath) : undefined
+        enginePath = nextEnginePath
       } catch (error) {
         const msg = error instanceof Error ? error.message : String(error)
         void logger.warn(`[FileStore] 刷新 enginePath 失败: ${msg}`)

--- a/src/stores/preview-runtime.ts
+++ b/src/stores/preview-runtime.ts
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia'
 
 import { serverCmds } from '~/commands/server'
 
+import type { AbsPath } from '~/domain/path'
 import type { StaticSiteConfig } from '~/types/server'
 
 interface RegisteredSite {
@@ -59,7 +60,7 @@ export const usePreviewRuntimeStore = defineStore('previewRuntime', () => {
     }
   }
 
-  function getServeUrl(path: string): string | undefined {
+  function getServeUrl(path: AbsPath): string | undefined {
     if (!path) {
       return undefined
     }

--- a/src/stores/preview-session.ts
+++ b/src/stores/preview-session.ts
@@ -4,11 +4,12 @@ import { gameManager } from '~/services/game-manager'
 import { usePreviewRuntimeStore } from '~/stores/preview-runtime'
 
 import type { Game } from '~/database/model'
+import type { AbsPath } from '~/domain/path'
 
 type PreviewGameTarget = Pick<Game, 'engineId' | 'path'>
 
 export const usePreviewSessionStore = defineStore('previewSession', () => {
-  let currentGamePath = $ref<string>()
+  let currentGamePath = $ref<AbsPath>()
   let currentGameServeUrl = $ref<string>()
   let reloadVersion = $ref(0)
   let syncToken = 0
@@ -62,7 +63,7 @@ export const usePreviewSessionStore = defineStore('previewSession', () => {
     reloadVersion++
   }
 
-  function refreshIfCurrentGame(gamePath: string): void {
+  function refreshIfCurrentGame(gamePath: AbsPath): void {
     if (!gamePath || currentGamePath !== gamePath) {
       return
     }

--- a/src/types/server.ts
+++ b/src/types/server.ts
@@ -1,5 +1,7 @@
+import type { AbsPath } from '~/domain/path'
+
 export interface StaticSiteConfig {
-  projectPath: string
-  enginePath?: string
-  templatePath?: string
+  projectPath: AbsPath
+  enginePath?: AbsPath
+  templatePath?: AbsPath
 }


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [ ] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [x] 代码重构
- [x] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

将 `Game` / `Engine` / `Template` 的 `path` 字段收紧为 `AbsPath`，同步收紧相关 service public API、DB 写入入口和调用方，移除服务内部重复的 `AbsPath.from(...)` 包装，并更新相关测试与工厂。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

对齐路径 brand 化设计，建立“读出即 `AbsPath`”的编译期不变量，减少重复归一化与误用。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->

- 不引入 Dexie reading hook
- 不修改 `pathLookupKey` 的 string 语义
- `RelPath` 语义的资源字段保持不变

### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
