### PR TITLE
♻️ 统一测试分组标题文案

### DIFF
--- a/src/__tests__/browser.test.ts
+++ b/src/__tests__/browser.test.ts
@@ -17,7 +17,7 @@ interface BrowserTestI18nHandle {
   }
 }
 
-describe('createBrowserConsoleMonitor 浏览器控制台监视器', () => {
+describe('createBrowserConsoleMonitor', () => {
   const monitor = createBrowserConsoleMonitor() as {
     expectNoConsoleMessage(pattern: string | RegExp): void
   }
@@ -47,7 +47,7 @@ describe('createBrowserConsoleMonitor 浏览器控制台监视器', () => {
   })
 })
 
-describe('browser 测试 i18n 辅助函数', () => {
+describe('浏览器测试国际化', () => {
   it('localized helper 默认使用 zh-Hans 作为测试 locale', () => {
     const i18n = createBrowserLocalizedI18n() as BrowserTestI18nHandle
 

--- a/src/__tests__/mocks/monaco.test.ts
+++ b/src/__tests__/mocks/monaco.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { createMonacoMockModule, monacoMockState, resetMonacoMockState } from './monaco'
 
-describe('Monaco mock 模拟器', () => {
+describe('monacoMock', () => {
   beforeEach(() => {
     resetMonacoMockState()
   })

--- a/src/components/editor/__tests__/useAssetViewItemsLoader.test.ts
+++ b/src/components/editor/__tests__/useAssetViewItemsLoader.test.ts
@@ -40,7 +40,7 @@ async function flushLoaderWatchers() {
   await Promise.resolve()
 }
 
-describe('useAssetViewItemsLoader 行为', () => {
+describe('useAssetViewItemsLoader', () => {
   let scope: EffectScope | undefined
 
   beforeEach(() => {

--- a/src/components/editor/animation/__tests__/animation-timeline-layout.test.ts
+++ b/src/components/editor/animation/__tests__/animation-timeline-layout.test.ts
@@ -9,7 +9,7 @@ import {
   resolveZeroDurationSpanLayoutPercents,
 } from '../animation-timeline-layout'
 
-describe('resolveAnimationTimelineContainerWidth 计算逻辑', () => {
+describe('resolveAnimationTimelineContainerWidth', () => {
   it('当最小片段总宽度超过基础容器宽度时扩展时间轴容器', () => {
     const containerWidth = resolveAnimationTimelineContainerWidth(120, 1, [
       { isHold: true },
@@ -31,7 +31,7 @@ describe('resolveAnimationTimelineContainerWidth 计算逻辑', () => {
   })
 })
 
-describe('resolveZeroDurationSpanLayoutPercents 计算逻辑', () => {
+describe('resolveZeroDurationSpanLayoutPercents', () => {
   it('总时长为 0 时仍保证首帧和后续帧的最小像素宽度', () => {
     const containerWidth = 160
     const layout = resolveZeroDurationSpanLayoutPercents(containerWidth, [
@@ -49,7 +49,7 @@ describe('resolveZeroDurationSpanLayoutPercents 计算逻辑', () => {
   })
 })
 
-describe('resolveAnimationTimelineAnchoredScrollLeft 计算逻辑', () => {
+describe('resolveAnimationTimelineAnchoredScrollLeft', () => {
   it('内容宽度被最小宽度钳制时按真实内容宽度保持滚动锚点', () => {
     const nextScrollLeft = resolveAnimationTimelineAnchoredScrollLeft({
       contentPosition: 80,
@@ -85,7 +85,7 @@ describe('resolveAnimationTimelineAnchoredScrollLeft 计算逻辑', () => {
   })
 })
 
-describe('resolveAnimationTimelineResizeMsPerPixel 计算逻辑', () => {
+describe('resolveAnimationTimelineResizeMsPerPixel', () => {
   it('零时长帧使用至少 1ms/px 的拖拽比例，确保可以从 0ms 拉出', () => {
     expect(resolveAnimationTimelineResizeMsPerPixel(0, 64)).toBe(1)
   })

--- a/src/components/file-viewer/FileViewer.spec.ts
+++ b/src/components/file-viewer/FileViewer.spec.ts
@@ -421,7 +421,7 @@ async function leaveHoverImageTrigger(index: number = 0): Promise<void> {
   await nextTick()
 }
 
-describe('FileViewer 组合式逻辑', () => {
+describe('文件查看器布局与虚拟滚动', () => {
   it('useFileViewerLayout 会根据宽度和缩放返回布局派生状态', async () => {
     const contentWidth = ref(780)
     const zoom = ref(100)
@@ -494,7 +494,7 @@ describe('FileViewer 组合式逻辑', () => {
   })
 })
 
-describe('FileViewer 外观契约', () => {
+describe('FileViewer', () => {
   beforeEach(() => {
     getImageDimensionsMock.mockReset()
     loggerDebugMock.mockReset()

--- a/src/composables/__tests__/useControlId.test.ts
+++ b/src/composables/__tests__/useControlId.test.ts
@@ -14,7 +14,7 @@ vi.mock('vue', async () => {
 
 import { useControlId } from '~/composables/useControlId'
 
-describe('useControlId 行为', () => {
+describe('useControlId', () => {
   it('会对 namespace 和 key 做可访问 id 规范化', () => {
     const { buildControlId } = useControlId('Statement Panel')
 

--- a/src/composables/__tests__/usePointerDrag.test.ts
+++ b/src/composables/__tests__/usePointerDrag.test.ts
@@ -76,7 +76,7 @@ afterEach(() => {
   globalThis.removeEventListener = originalRemoveEventListener
 })
 
-describe('usePointerDrag 行为', () => {
+describe('usePointerDrag', () => {
   it('正常收到 pointerup 时会结束拖拽', () => {
     const onEnd = vi.fn()
     const onMove = vi.fn()

--- a/src/composables/__tests__/useSettingsForm.test.ts
+++ b/src/composables/__tests__/useSettingsForm.test.ts
@@ -44,7 +44,7 @@ function createScopedFieldsStore() {
   }
 }
 
-describe('useSettingsForm 行为', () => {
+describe('useSettingsForm', () => {
   beforeEach(() => {
     latestValues = reactive({})
     useFormMock.mockReset()

--- a/src/database/db.spec.ts
+++ b/src/database/db.spec.ts
@@ -11,7 +11,7 @@ async function resetDatabase() {
   await db.open()
 }
 
-describe('数据库 schema', () => {
+describe('db', () => {
   beforeEach(async () => {
     await resetDatabase()
   })

--- a/src/domain/document/__tests__/serializer.test.ts
+++ b/src/domain/document/__tests__/serializer.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest'
 import { createDocumentModel } from '../document-model'
 import { serializeDocument } from '../serializer'
 
-describe('serializer 序列化', () => {
+describe('serializeDocument', () => {
   it('场景文档序列化时保持原始 CRLF', () => {
     const model = createDocumentModel({
       kind: 'scene',

--- a/src/domain/document/__tests__/transaction-engine.test.ts
+++ b/src/domain/document/__tests__/transaction-engine.test.ts
@@ -12,7 +12,7 @@ function makeInverse(id = 0): Transaction {
   return { type: 'statement:update', id, rawText: `old-${id}` } as Transaction
 }
 
-describe('EditHistory 编辑历史', () => {
+describe('EditHistory', () => {
   it('初始状态：sequenceNumber 为 0，不可 undo/redo', () => {
     const engine = new EditHistory()
     expect(engine.sequenceNumber).toBe(0)

--- a/src/domain/script/__tests__/arg-utils.test.ts
+++ b/src/domain/script/__tests__/arg-utils.test.ts
@@ -4,7 +4,7 @@ import { removeArg, setOrRemoveArg, upsertArg } from '~/domain/script/arg-utils'
 
 import type { arg } from 'webgal-parser/src/interface/sceneInterface'
 
-describe('WebGAL 参数工具', () => {
+describe('argUtils', () => {
   it('upsertArg 会在缺失时插入，在已存在时更新', () => {
     const args: arg[] = [{ key: 'duration', value: '300' }]
 

--- a/src/domain/script/__tests__/content.test.ts
+++ b/src/domain/script/__tests__/content.test.ts
@@ -9,7 +9,7 @@ import {
   stringifyStyleRuleContent,
 } from '~/domain/script/content'
 
-describe('WebGAL 内容辅助函数', () => {
+describe('content', () => {
   it('setVar 内容支持解析和序列化', () => {
     expect(parseSetVarContent('score=10')).toEqual({
       name: 'score',

--- a/src/domain/script/__tests__/parse-check.test.ts
+++ b/src/domain/script/__tests__/parse-check.test.ts
@@ -3,7 +3,7 @@ import { commandType } from 'webgal-parser/src/interface/sceneInterface'
 
 import { parseSentence } from '../parser'
 
-describe('say 形式解析检查', () => {
+describe('对话语句解析', () => {
   it('say:xxxxxx; 解析结果', () => {
     const s = parseSentence('say:xxxxxx;')
     expect(s).toBeDefined()

--- a/src/domain/script/__tests__/parser.test.ts
+++ b/src/domain/script/__tests__/parser.test.ts
@@ -23,7 +23,7 @@ afterAll(() => {
   parserLoggerTarget.logger = originalLogger
 })
 
-describe('WebGAL 解析辅助函数', () => {
+describe('parser', () => {
   it('parseScene 会解析多行脚本', () => {
     const scene = parseScene('Alice:Hello -next;\nchangeBg:bg.jpg;')
 

--- a/src/domain/script/__tests__/roundtrip.test.ts
+++ b/src/domain/script/__tests__/roundtrip.test.ts
@@ -67,7 +67,7 @@ afterAll(() => {
   roundtripLoggerTarget.logger = originalLogger
 })
 
-describe('WebGAL 脚本语句往返测试', () => {
+describe('脚本语句往返', () => {
   for (const fixture of SENTENCE_FIXTURES) {
     it(`可以解析 fixture：${fixture.name}`, () => {
       const parsed = parseSentence(fixture.raw)
@@ -88,7 +88,7 @@ describe('WebGAL 脚本语句往返测试', () => {
   }
 })
 
-describe('内容解析器/序列化器', () => {
+describe('content', () => {
   it('setVar 往返测试', () => {
     const content = 'score=10'
     const parsed = parseSetVarContent(content)
@@ -117,7 +117,7 @@ describe('内容解析器/序列化器', () => {
   })
 })
 
-describe('语句列表辅助函数', () => {
+describe('sentence', () => {
   it('split/build/join 保持行边界', () => {
     const raw = 'a\nb\nc'
     expect(splitStatements(raw)).toEqual(['a', 'b', 'c'])

--- a/src/domain/script/__tests__/serialize.test.ts
+++ b/src/domain/script/__tests__/serialize.test.ts
@@ -17,7 +17,7 @@ function createSentence(overrides: Partial<ISentence>): ISentence {
   } as ISentence
 }
 
-describe('serializeSentence 序列化', () => {
+describe('serializeSentence', () => {
   it('comment 语句会序列化为注释格式', () => {
     expect(serializeSentence(createSentence({
       command: commandType.comment,

--- a/src/domain/script/__tests__/utils.test.ts
+++ b/src/domain/script/__tests__/utils.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import { makeParamDef, mustParse } from './utils'
 
-describe('webgal-script 测试工具', () => {
+describe('scriptTestUtils', () => {
   it('mustParse 返回可用的句子对象', () => {
     const sentence = mustParse('bgm: bgm.ogg;')
 

--- a/src/features/editor/animation/__tests__/animation-frame-editor.test.ts
+++ b/src/features/editor/animation/__tests__/animation-frame-editor.test.ts
@@ -11,7 +11,7 @@ import {
 
 import type { AnimationFrame } from '~/domain/stage/types'
 
-describe('动画帧编辑辅助函数', () => {
+describe('animationFrameEditor', () => {
   it('在选中帧后插入新帧并返回新的选中帧 id', () => {
     const frames = reactive<AnimationFrame[]>([
       { duration: 120, alpha: 0.2 },

--- a/src/features/editor/animation/__tests__/useAnimationEditorSession.test.ts
+++ b/src/features/editor/animation/__tests__/useAnimationEditorSession.test.ts
@@ -22,7 +22,7 @@ function createSessionFixture(framesFactory: () => AnimationFrame[] = createFram
   return { frames, scope, session }
 }
 
-describe('useAnimationEditorSession 行为', () => {
+describe('useAnimationEditorSession', () => {
   it('根据帧列表派生关键帧和当前选中帧状态', () => {
     const { scope, session } = createSessionFixture()
 

--- a/src/features/editor/animation/__tests__/useStatementAnimationDialog.test.ts
+++ b/src/features/editor/animation/__tests__/useStatementAnimationDialog.test.ts
@@ -74,7 +74,7 @@ afterEach(() => {
   }
 })
 
-describe('useStatementAnimationDialog 行为', () => {
+describe('useStatementAnimationDialog', () => {
   it('非法动画 JSON 会阻止打开并弹出错误 toast', () => {
     const { dialog, openDialog } = mountDialogHarness()
     const handleApply = vi.fn()

--- a/src/features/editor/animation/__tests__/useStatementAnimationEditorBridge.test.ts
+++ b/src/features/editor/animation/__tests__/useStatementAnimationEditorBridge.test.ts
@@ -82,7 +82,7 @@ afterEach(() => {
   }
 })
 
-describe('applyAnimationEditorResultToSentence 行为', () => {
+describe('applyAnimationEditorResultToSentence', () => {
   it('setTempAnimation 语句使用单行 JSON 回写动画内容并保留其他参数', () => {
     const sentence = createSentence({
       command: commandType.setTempAnimation,
@@ -107,7 +107,7 @@ describe('applyAnimationEditorResultToSentence 行为', () => {
   })
 })
 
-describe('useStatementAnimationEditorBridge 行为', () => {
+describe('useStatementAnimationEditorBridge', () => {
   it('打开编辑器后使用打开当时的语句与目标快照回写结果', () => {
     const {
       bridge,

--- a/src/features/editor/animation/__tests__/useStatementAnimationEditorPanel.test.ts
+++ b/src/features/editor/animation/__tests__/useStatementAnimationEditorPanel.test.ts
@@ -45,7 +45,7 @@ function createFixture(framesFactory: () => AnimationFrame[] = createFrames) {
   }
 }
 
-describe('useStatementAnimationEditorPanel 行为', () => {
+describe('useStatementAnimationEditorPanel', () => {
   it('删除当前帧前会先清空草稿，避免旧草稿挂到重排后的帧上', async () => {
     const { controller, emitFrames, scope } = createFixture()
 

--- a/src/features/editor/animation/__tests__/useVisualEditorAnimation.test.ts
+++ b/src/features/editor/animation/__tests__/useVisualEditorAnimation.test.ts
@@ -62,7 +62,7 @@ function createFixture(options: {
   }
 }
 
-describe('useVisualEditorAnimation 行为', () => {
+describe('useVisualEditorAnimation', () => {
   it('撤销成功时会请求自动保存', () => {
     const { controller, scheduleAutoSaveIfEnabled, scope, undoDocument } = createFixture()
 

--- a/src/features/editor/asset-preview/__tests__/asset-preview.test.ts
+++ b/src/features/editor/asset-preview/__tests__/asset-preview.test.ts
@@ -6,7 +6,7 @@ import {
   shouldSuspendPreviousAssetPreviewMediaSession,
 } from '../asset-preview'
 
-describe('资源预览辅助函数', () => {
+describe('assetPreview', () => {
   it('会为音频和视频资源解析对应的媒体标签', () => {
     expect(resolveAssetPreviewMediaTag('audio/mpeg')).toBe('audio')
     expect(resolveAssetPreviewMediaTag('video/mp4')).toBe('video')

--- a/src/features/editor/command-panel/__tests__/command-panel.test.ts
+++ b/src/features/editor/command-panel/__tests__/command-panel.test.ts
@@ -5,7 +5,7 @@ import {
   resolveCommandPanelVisibleCommands,
 } from '../command-panel'
 
-describe('命令面板辅助函数', () => {
+describe('commandPanel', () => {
   it('会在全部和语句组视图中返回全部命令，在分类视图中过滤命令', () => {
     const allCommands = resolveCommandPanelVisibleCommands('all')
     const groupCommands = resolveCommandPanelVisibleCommands('groups')

--- a/src/features/editor/command-registry/__tests__/registry.test.ts
+++ b/src/features/editor/command-registry/__tests__/registry.test.ts
@@ -4,7 +4,7 @@ import { commandType } from 'webgal-parser/src/interface/sceneInterface'
 import { categoryTheme, commandEntries, commandPanelCategories, getCommandConfig } from '../index'
 import { readArgFields, readEditorFields, resolveI18n } from '../schema'
 
-describe('命令注册表 schema 完整性', () => {
+describe('命令注册表完整性', () => {
   it('源条目的命令类型应唯一', () => {
     const seen = new Set<commandType>()
     for (const entry of commandEntries) {

--- a/src/features/editor/command-registry/__tests__/schema.test.ts
+++ b/src/features/editor/command-registry/__tests__/schema.test.ts
@@ -18,7 +18,7 @@ import {
 
 import type { CommandEntry, NumberField } from '~/features/editor/command-registry/schema'
 
-describe('命令注册表 Schema 辅助函数', () => {
+describe('commandRegistrySchema', () => {
   it('resolveI18n 支持字符串和回调两种输入', () => {
     const t = (key: string) => `t:${key}`
 

--- a/src/features/editor/editor-tabs/__tests__/editor-tabs.test.ts
+++ b/src/features/editor/editor-tabs/__tests__/editor-tabs.test.ts
@@ -14,7 +14,7 @@ const createTab = (overrides: Partial<Tab> = {}): Tab => ({
   ...overrides,
 })
 
-describe('编辑器标签辅助函数', () => {
+describe('editorTabs', () => {
   it('未修改的标签会直接关闭且不会触发模态框', () => {
     const closeTab = vi.fn()
     const decision = getCloseTabDecision({

--- a/src/features/editor/effect-editor/__tests__/effect-draft-form.test.ts
+++ b/src/features/editor/effect-editor/__tests__/effect-draft-form.test.ts
@@ -29,7 +29,7 @@ const baseParam: NumberField & { linkedPairKey: string } = {
   linkedPairKey: 'scale.y',
 }
 
-describe('特效草稿表单辅助函数', () => {
+describe('effectDraftForm', () => {
   it('存在 linkedGroupLabel 时优先使用它', () => {
     const param = {
       ...baseParam,

--- a/src/features/editor/effect-editor/__tests__/useEffectColorControl.test.ts
+++ b/src/features/editor/effect-editor/__tests__/useEffectColorControl.test.ts
@@ -115,7 +115,7 @@ function createColorField(
   }
 }
 
-describe('useEffectColorControl 行为', () => {
+describe('useEffectColorControl', () => {
   beforeEach(() => {
     dragController.active = false
     dragController.param = undefined

--- a/src/features/editor/effect-editor/__tests__/useEffectContinuousControls.test.ts
+++ b/src/features/editor/effect-editor/__tests__/useEffectContinuousControls.test.ts
@@ -78,7 +78,7 @@ function createDialField(overrides: Partial<DialField> = {}): DialField {
   }
 }
 
-describe('useEffectContinuousControls 行为', () => {
+describe('useEffectContinuousControls', () => {
   beforeEach(() => {
     usePreferenceStoreMock.mockReset()
     preferenceStoreState.effectEditorLinkedSliderLocks = {}

--- a/src/features/editor/effect-editor/__tests__/useEffectDurationControl.test.ts
+++ b/src/features/editor/effect-editor/__tests__/useEffectDurationControl.test.ts
@@ -60,7 +60,7 @@ function createPointerEvent(overrides: Partial<PointerEvent> = {}): PointerEvent
   } as PointerEvent
 }
 
-describe('useEffectDurationControl 行为', () => {
+describe('useEffectDurationControl', () => {
   beforeEach(() => {
     dragRuntime.callbacks = undefined
     dragRuntime.state = undefined

--- a/src/features/editor/effect-editor/__tests__/useEffectEditorProvider-preview.test.ts
+++ b/src/features/editor/effect-editor/__tests__/useEffectEditorProvider-preview.test.ts
@@ -9,7 +9,7 @@ import type {
   EffectEditorTransformUpdatePayload,
 } from '~/features/editor/effect-editor/useEffectEditorProvider'
 
-describe('效果预览事件发射器', () => {
+describe('createEffectPreviewEmitter', () => {
   it('emitTransform 会同时触发 transform 与 preview 事件', () => {
     const previewPayloads: EffectEditorPreviewPayload[] = []
     const transformPayloads: EffectEditorTransformUpdatePayload[] = []

--- a/src/features/editor/effect-editor/__tests__/useEffectEditorProvider-queue.test.ts
+++ b/src/features/editor/effect-editor/__tests__/useEffectEditorProvider-queue.test.ts
@@ -156,7 +156,7 @@ beforeEach(() => {
   debugCommanderMock.syncScene.mockImplementation(async () => { /* no-op */ })
 })
 
-describe('useEffectEditorProvider 队列并发', () => {
+describe('useEffectEditorProvider', () => {
   it('将 transform 设置为默认值时仍应视为可应用改动', async () => {
     useEditSettingsStore().autoApplyEffectEditorChanges = false
 

--- a/src/features/editor/effect-editor/__tests__/useStatementEffectEditorBridge.test.ts
+++ b/src/features/editor/effect-editor/__tests__/useStatementEffectEditorBridge.test.ts
@@ -7,7 +7,7 @@ import { createSentence } from '~/features/editor/__tests__/statement-editor-tes
 import { serializeTransform } from '~/features/editor/effect-editor/effect-editor-config'
 import { applyEffectEditorResultToSentence } from '~/features/editor/effect-editor/effect-editor-result'
 
-describe('applyEffectEditorResultToSentence 行为', () => {
+describe('applyEffectEditorResultToSentence', () => {
   it('setTransform 命令写入 content 并同步 duration/ease', () => {
     const sentence = createSentence({
       command: commandType.setTransform,

--- a/src/features/editor/file-tree/__tests__/file-tree.test.ts
+++ b/src/features/editor/file-tree/__tests__/file-tree.test.ts
@@ -42,7 +42,7 @@ function createFlattenedItem(
   }
 }
 
-describe('文件树辅助函数', () => {
+describe('fileTree', () => {
   it('计算重命名时的默认选区结束位置', () => {
     expect(getFileTreeNameSelectionEnd('scene.txt', false)).toBe(5)
     expect(getFileTreeNameSelectionEnd('.gitignore', false)).toBe(10)

--- a/src/features/editor/file-tree/__tests__/useFileClipboard.test.ts
+++ b/src/features/editor/file-tree/__tests__/useFileClipboard.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import { useFileClipboard } from '~/features/editor/file-tree/useFileClipboard'
 
-describe('useFileClipboard 行为', () => {
+describe('useFileClipboard', () => {
   it('同一个 key 会共享剪贴板状态', () => {
     const source = useFileClipboard('shared')
     const mirror = useFileClipboard('shared')

--- a/src/features/editor/file-tree/__tests__/useFileTreeController.test.ts
+++ b/src/features/editor/file-tree/__tests__/useFileTreeController.test.ts
@@ -133,7 +133,7 @@ function createFixture(options: {
   }
 }
 
-describe('useFileTreeController 行为', () => {
+describe('useFileTreeController', () => {
   beforeEach(() => {
     createFileMock.mockReset()
     createFolderMock.mockReset()

--- a/src/features/editor/preview/__tests__/preview-panel.test.ts
+++ b/src/features/editor/preview/__tests__/preview-panel.test.ts
@@ -5,7 +5,7 @@ import {
   resolvePreviewPanelStageSize,
 } from '../preview-panel'
 
-describe('预览面板辅助函数', () => {
+describe('previewPanel', () => {
   it('没有请求路径时会回退到默认舞台尺寸', () => {
     expect(resolvePreviewPanelStageSize({
       currentGamePath: undefined,

--- a/src/features/editor/scene-panel/__tests__/scene-panel.test.ts
+++ b/src/features/editor/scene-panel/__tests__/scene-panel.test.ts
@@ -13,7 +13,7 @@ interface TestFolderItem {
   path: string
 }
 
-describe('场景面板辅助函数', () => {
+describe('scenePanel', () => {
   it('递归读取目录内容并保留目录层级', async () => {
     const entries = new Map<string, TestFolderItem[]>([
       ['/games/demo/game/scene', [

--- a/src/features/editor/shared/__tests__/useTabsWatcher.test.ts
+++ b/src/features/editor/shared/__tests__/useTabsWatcher.test.ts
@@ -20,7 +20,7 @@ vi.mock('~/stores/tabs', () => ({
 
 import { useTabsWatcher } from '~/features/editor/shared/useTabsWatcher'
 
-describe('useTabsWatcher 行为', () => {
+describe('useTabsWatcher', () => {
   beforeEach(() => {
     tabsStoreState.tabs = [
       { path: '/game/a.txt' },

--- a/src/features/editor/shell/__tests__/useEditorPanelShell.test.ts
+++ b/src/features/editor/shell/__tests__/useEditorPanelShell.test.ts
@@ -153,7 +153,7 @@ function createFixture(options: {
   }
 }
 
-describe('useEditorPanelShell 行为', () => {
+describe('useEditorPanelShell', () => {
   beforeEach(() => {
     commandPanelBridgeMock.activeBinding.value = undefined
     sidebarPanelMock.activeBinding.value = undefined

--- a/src/features/editor/shortcut/__tests__/definitions.test.ts
+++ b/src/features/editor/shortcut/__tests__/definitions.test.ts
@@ -10,7 +10,7 @@ vi.mock('~/utils/error-handler', () => ({
 
 import { createEditorShortcutDefinitions } from '../definitions'
 
-describe('createEditorShortcutDefinitions 的全局快捷键定义', () => {
+describe('createEditorShortcutDefinitions', () => {
   beforeEach(() => {
     handleErrorMock.mockReset()
   })

--- a/src/features/editor/shortcut/__tests__/dispatcher.test.ts
+++ b/src/features/editor/shortcut/__tests__/dispatcher.test.ts
@@ -77,7 +77,7 @@ function createBinding(
   }
 }
 
-describe('dispatchShortcut 与快捷键匹配工具函数', () => {
+describe('快捷键分发与匹配', () => {
   it('标准化绑定与按键事件时会统一 Mod 和修饰键顺序', () => {
     expect(normalizeShortcutBindingKeys(['Shift+Mod+S', 'mod+y'], 'windows')).toEqual([
       'Ctrl+Shift+S',

--- a/src/features/editor/shortcut/__tests__/shortcut-context-registry.test.ts
+++ b/src/features/editor/shortcut/__tests__/shortcut-context-registry.test.ts
@@ -4,7 +4,7 @@ import '~/__tests__/setup'
 
 import { useShortcutContextRegistry } from '../shortcut-context-registry'
 
-describe('useShortcutContextRegistry 的上下文注册表', () => {
+describe('useShortcutContextRegistry', () => {
   let store: ReturnType<typeof useShortcutContextRegistry>
 
   beforeEach(() => {

--- a/src/features/editor/shortcut/__tests__/useShortcutDispatcher.browser.test.ts
+++ b/src/features/editor/shortcut/__tests__/useShortcutDispatcher.browser.test.ts
@@ -344,7 +344,7 @@ function createComponentTargetHarnessComponent() {
   })
 }
 
-describe('useShortcutDispatcher 的浏览器分发行为', () => {
+describe('useShortcutDispatcher', () => {
   beforeEach(() => {
     for (const action of Object.values(shortcutActions)) {
       action.mockReset()

--- a/src/features/editor/statement-editor/__tests__/field-utils.test.ts
+++ b/src/features/editor/statement-editor/__tests__/field-utils.test.ts
@@ -6,7 +6,7 @@ import {
   resolvePanelSliderEmitValue,
 } from '~/features/editor/statement-editor/field-utils'
 
-describe('statement-editor field-utils: 事件工具', () => {
+describe('fieldUtils', () => {
   it('normalizeFieldStringValue 统一归一化输入值', () => {
     const jsonNullValue = JSON.parse('null') as unknown
 

--- a/src/features/editor/statement-editor/__tests__/file-missing.test.ts
+++ b/src/features/editor/statement-editor/__tests__/file-missing.test.ts
@@ -42,7 +42,7 @@ function createFileArgField(storageKey: string, fieldKey = storageKey, assetType
   }
 }
 
-describe('语句编辑器缺失文件检查', () => {
+describe('fileMissing', () => {
   it('collectStatementFileChecks 仅收集 content 与 file arg', () => {
     const parsed = {
       command: commandType.changeFigure,

--- a/src/features/editor/statement-editor/__tests__/helpers.test.ts
+++ b/src/features/editor/statement-editor/__tests__/helpers.test.ts
@@ -75,7 +75,7 @@ function createSetAnimationNode(target?: string): CommandNode {
   }
 }
 
-describe('语句编辑器辅助函数: 核心', () => {
+describe('语句编辑器核心工具', () => {
   it('buildSchemaKeySet 包含参数 key 和 flag-choice 选项 key', () => {
     const keys = buildSchemaKeySet([modeField, speedField])
     expect(keys.has('mode')).toBe(true)
@@ -211,7 +211,7 @@ describe('语句编辑器辅助函数: 核心', () => {
   })
 })
 
-describe('语句编辑器辅助函数: 参数', () => {
+describe('语句编辑器参数工具', () => {
   it('resolveParamSelectValue 在非 customizable 时直接返回当前值', () => {
     const choiceField = af({ key: 'k', type: 'choice', options: [] })
     expect(resolveParamSelectValue({

--- a/src/features/editor/statement-editor/__tests__/json-fields.test.ts
+++ b/src/features/editor/statement-editor/__tests__/json-fields.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest'
 import { UNSPECIFIED } from '~/features/editor/command-registry/schema'
 import { readJsonFieldValue, writeJsonFieldValue } from '~/features/editor/statement-editor/json-fields'
 
-describe('JSON 字段辅助函数', () => {
+describe('jsonFields', () => {
   it('readJsonFieldValue 按字段类型做值归一化', () => {
     expect(readJsonFieldValue('{"ratio":"0.25"}', 'ratio', 'number')).toBe(0.25)
     expect(readJsonFieldValue('{"enabled":"true"}', 'enabled', 'switch')).toBe(true)

--- a/src/features/editor/statement-editor/__tests__/panel.test.ts
+++ b/src/features/editor/statement-editor/__tests__/panel.test.ts
@@ -28,7 +28,7 @@ function createFileContentField(assetType: string): EditorField {
   }
 }
 
-describe('语句编辑面板辅助函数', () => {
+describe('panel', () => {
   it('会把多行输入归一化为单行文本', () => {
     expect(normalizeStatementPanelSingleLineValue('line1\nline2\r\nline3')).toBe('line1 line2 line3')
   })

--- a/src/features/editor/statement-editor/__tests__/param-value.test.ts
+++ b/src/features/editor/statement-editor/__tests__/param-value.test.ts
@@ -49,7 +49,7 @@ function createCommandNode(args: GenericCommandNode['args']): CommandNode {
   } satisfies GenericCommandNode
 }
 
-describe('参数取值辅助函数', () => {
+describe('paramValue', () => {
   it('getParamValueFromArgs 在 json 参数为布尔值时回退默认值', () => {
     const focusXField = createJsonArgField({
       argKey: 'focus',

--- a/src/features/editor/statement-editor/__tests__/preview.test.ts
+++ b/src/features/editor/statement-editor/__tests__/preview.test.ts
@@ -58,7 +58,7 @@ function createContentField(
   }
 }
 
-describe('语句编辑器预览', () => {
+describe('buildStatementPreviewParams', () => {
   it('unsupported 语句展示原始文本', () => {
     const result = buildStatementPreviewParams({
       parsed: createSentence({ content: 'hello' }),

--- a/src/features/editor/statement-editor/__tests__/useStatementEditor.test.ts
+++ b/src/features/editor/statement-editor/__tests__/useStatementEditor.test.ts
@@ -41,7 +41,7 @@ function createDirEntry(name: string, isDirectory: boolean) {
   }
 }
 
-describe('useStatementEditor 行为', () => {
+describe('useStatementEditor', () => {
   it('setTempAnimation 语句显示动画编辑器按钮并隐藏原始 content 字段', () => {
     const { editor } = createHarness('setTempAnimation: [{"duration":0}] -target=fig-left;')
 
@@ -295,7 +295,7 @@ describe('useStatementEditor 行为', () => {
 
   // ─── say 命令：标准形式与简写形式 ───
 
-  describe('say 标准形式（say:内容 -speaker=角色）', () => {
+  describe('标准形式（显式 say 命令）', () => {
     it('命令面板默认 say 语句连续编辑 speaker 和内容时应保留 speaker', () => {
       const { editor, updates } = createHarness('say:;')
 
@@ -371,7 +371,7 @@ describe('useStatementEditor 行为', () => {
     })
   })
 
-  describe('say 简写形式（角色:内容 / 无冒号 / :旁白）', () => {
+  describe('简写形式（角色前缀 / 无冒号 / 旁白）', () => {
     it('有 speaker：编辑内容后保留简写形式和 speaker', () => {
       const { editor, updates } = createHarness('角色A:你好，世界！;')
 

--- a/src/features/editor/statement-editor/__tests__/useStatementEditorContent.test.ts
+++ b/src/features/editor/statement-editor/__tests__/useStatementEditorContent.test.ts
@@ -15,7 +15,7 @@ import { useStatementEditorContent } from '~/features/editor/statement-editor/us
 import type { ISentence } from 'webgal-parser/src/interface/sceneInterface'
 import type { ArgField, EditorField } from '~/features/editor/command-registry/schema'
 
-describe('useStatementEditor 内容行为', () => {
+describe('useStatementEditorContent', () => {
   beforeEach(() => {
     resetStatementEditorRuntime()
   })

--- a/src/features/editor/statement-editor/__tests__/useStatementEditorParams.test.ts
+++ b/src/features/editor/statement-editor/__tests__/useStatementEditorParams.test.ts
@@ -21,7 +21,7 @@ import { useStatementEditorParams } from '~/features/editor/statement-editor/use
 import type { ISentence } from 'webgal-parser/src/interface/sceneInterface'
 import type { ArgField } from '~/features/editor/command-registry/schema'
 
-describe('useStatementEditor 参数行为', () => {
+describe('useStatementEditorParams', () => {
   beforeEach(() => {
     resetStatementEditorRuntime()
   })

--- a/src/features/editor/statement-editor/__tests__/useStatementEditorScrub.test.ts
+++ b/src/features/editor/statement-editor/__tests__/useStatementEditorScrub.test.ts
@@ -99,7 +99,7 @@ afterEach(() => {
   globalThis.removeEventListener = originalRemoveEventListener
 })
 
-describe('useStatementEditorScrub 行为', () => {
+describe('useStatementEditorScrub', () => {
   it('canScrubParam 根据 surface 与 param 类型生效', () => {
     const contentField = ref()
 

--- a/src/features/editor/statement-editor/__tests__/visibility.test.ts
+++ b/src/features/editor/statement-editor/__tests__/visibility.test.ts
@@ -14,7 +14,7 @@ function createArgField(field: Record<string, unknown> & { key: string, type: st
   }
 }
 
-describe('可见性辅助函数', () => {
+describe('visibility', () => {
   it('buildSchemaKeySet 为 flag-choice 同时收集存储 key 与选项 key', () => {
     const modeField = createArgField({
       key: 'mode',

--- a/src/features/editor/status-bar/__tests__/editor-status-bar.test.ts
+++ b/src/features/editor/status-bar/__tests__/editor-status-bar.test.ts
@@ -65,7 +65,7 @@ function createPreviewState(overrides: Partial<AssetPreviewState> = {}): AssetPr
   }
 }
 
-describe('编辑器状态栏辅助函数', () => {
+describe('editorStatusBar', () => {
   it('文本模式会计算保存态、相对时间显示和行词统计', () => {
     const editableState = createTextState({
       lastSavedTime: new Date('2026-03-20T10:00:00.000Z'),

--- a/src/features/editor/text-editor/__tests__/scene-text-panel.test.ts
+++ b/src/features/editor/text-editor/__tests__/scene-text-panel.test.ts
@@ -19,7 +19,7 @@ function createLineSource(lines: string[]) {
   }
 }
 
-describe('场景文本面板', () => {
+describe('sceneTextPanel', () => {
   it('空快照保持空 entry 和空 previous speaker', () => {
     expect(createEmptySceneTextPanelSnapshot()).toEqual({
       entry: undefined,

--- a/src/features/editor/text-editor/__tests__/text-editor-history-adapter.test.ts
+++ b/src/features/editor/text-editor/__tests__/text-editor-history-adapter.test.ts
@@ -141,7 +141,7 @@ function createFakeEditor() {
   }
 }
 
-describe('文本编辑器历史适配器', () => {
+describe('textEditorHistoryAdapter', () => {
   it('识别历史快捷键与普通输入捕获条件', () => {
     expect(shouldCaptureBeforeContentChangeKeydown(
       createMonacoKeydownEvent(0, { key: 'a' }),

--- a/src/features/editor/text-editor/__tests__/text-editor-language.test.ts
+++ b/src/features/editor/text-editor/__tests__/text-editor-language.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import { resolveTextEditorLanguage } from '~/features/editor/text-editor/text-editor-language'
 
-describe('resolveTextEditorLanguage 语言解析', () => {
+describe('resolveTextEditorLanguage', () => {
   const registeredLanguages = [
     {
       extensions: ['.md'],

--- a/src/features/editor/text-editor/__tests__/text-editor-model-uri.test.ts
+++ b/src/features/editor/text-editor/__tests__/text-editor-model-uri.test.ts
@@ -11,7 +11,7 @@ const windowsSceneUri = 'X:%5CProject%5CWebGALCraft%5Cgame%5Cscene.txt'
 const unixScenePath = '/project/WebGALCraft/game/scene.txt'
 const unixSceneUri = '/project/WebGALCraft/game/scene.txt'
 
-describe('文本编辑器 model URI 辅助函数', () => {
+describe('textEditorModelUri', () => {
   it('会把 Windows/Unix Monaco model uri 还原为工作区文件路径，并处理边界输入', () => {
     expect(toTextEditorWorkspacePath(windowsSceneUri)).toBe(windowsScenePath)
     expect(toTextEditorWorkspacePath(unixSceneUri)).toBe(unixScenePath)

--- a/src/features/editor/text-editor/__tests__/text-editor-options.test.ts
+++ b/src/features/editor/text-editor/__tests__/text-editor-options.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import { buildTextEditorOptions } from '~/features/editor/text-editor/text-editor-options'
 
-describe('buildTextEditorOptions 配置映射', () => {
+describe('buildTextEditorOptions', () => {
   it('会把编辑器设置映射到 Monaco 选项', () => {
     expect(buildTextEditorOptions({
       automaticLayout: true,

--- a/src/features/editor/text-editor/__tests__/text-editor-play-to-line.test.ts
+++ b/src/features/editor/text-editor/__tests__/text-editor-play-to-line.test.ts
@@ -23,7 +23,7 @@ function createModel(lines: string[]): EditorModelMock {
   }
 }
 
-describe('文本编辑器播放到此句控制器', () => {
+describe('createTextEditorPlayToLineController', () => {
   it('光标进入可播放行时会创建 glyph margin 装饰，并在无效行时清除', () => {
     const deltaDecorations = vi.fn()
       .mockReturnValueOnce(['glyph-1'])

--- a/src/features/editor/text-editor/__tests__/text-editor-scene-sync.test.ts
+++ b/src/features/editor/text-editor/__tests__/text-editor-scene-sync.test.ts
@@ -8,7 +8,7 @@ import {
   resolveSceneReplayAnchorLine,
 } from '~/features/editor/text-editor/text-editor-scene-sync'
 
-describe('文本编辑器场景同步', () => {
+describe('textEditorSceneSync', () => {
   it('只在行号有效时返回场景预览行内容', () => {
     const reader = {
       getLineContent(lineNumber: number) {

--- a/src/features/editor/text-editor/__tests__/text-editor-selection.test.ts
+++ b/src/features/editor/text-editor/__tests__/text-editor-selection.test.ts
@@ -11,7 +11,7 @@ function createNullValue(): null {
   return null
 }
 
-describe('text-editor-selection', () => {
+describe('textEditorSelection', () => {
   it('跨行选区会被识别为多个编辑目标', () => {
     expect(hasMultipleEditTargets({
       selection: {

--- a/src/features/editor/text-editor/__tests__/text-editor-view-state.test.ts
+++ b/src/features/editor/text-editor/__tests__/text-editor-view-state.test.ts
@@ -37,7 +37,7 @@ function createSelection(
   } as monaco.Selection
 }
 
-describe('normalizeEditorViewState 视图状态归一化', () => {
+describe('normalizeEditorViewState', () => {
   it('使用当前编辑器选区作为持久化光标状态', () => {
     const viewState = createViewState()
     const normalized = normalizeEditorViewState(viewState, [

--- a/src/features/editor/text-editor/__tests__/useTextEditorBindings.test.ts
+++ b/src/features/editor/text-editor/__tests__/useTextEditorBindings.test.ts
@@ -100,7 +100,7 @@ async function flushBindingUpdates() {
   await Promise.resolve()
 }
 
-describe('useTextEditorBindings 行为', () => {
+describe('useTextEditorBindings', () => {
   afterEach(() => {
     getSceneSelectionMock.mockReset()
     useEditSettingsStoreMock.mockReset()

--- a/src/features/editor/text-editor/__tests__/useTextEditorHistory.test.ts
+++ b/src/features/editor/text-editor/__tests__/useTextEditorHistory.test.ts
@@ -119,7 +119,7 @@ function createEditor(content: string) {
   }
 }
 
-describe('useTextEditorHistory 行为', () => {
+describe('useTextEditorHistory', () => {
   beforeEach(() => {
     installTextEditorHistoryAdapterMock.mockReset()
     installTextEditorHistoryAdapterMock.mockReturnValue(createAdapterHandle())

--- a/src/features/editor/text-editor/__tests__/useTextEditorPanel.test.ts
+++ b/src/features/editor/text-editor/__tests__/useTextEditorPanel.test.ts
@@ -41,7 +41,7 @@ function createEditor(model: ReturnType<typeof createModel>) {
   } as unknown as monaco.editor.IStandaloneCodeEditor
 }
 
-describe('useTextEditorPanel 行为', () => {
+describe('useTextEditorPanel', () => {
   beforeEach(() => {
     getSceneSelectionMock.mockReset()
     getSceneSelectionMock.mockReturnValue(undefined)

--- a/src/features/editor/text-editor/__tests__/useTextEditorRuntime-preview-sync.test.ts
+++ b/src/features/editor/text-editor/__tests__/useTextEditorRuntime-preview-sync.test.ts
@@ -146,7 +146,7 @@ function flushRuntimeWatchers() {
   return nextTick().then(() => nextTick())
 }
 
-describe('useTextEditorRuntime 预览同步', () => {
+describe('useTextEditorRuntime', () => {
   beforeEach(() => {
     applySceneCursorTargetMock.mockReset()
     didResumeSingleEditTargetMock.mockReset()

--- a/src/features/editor/text-editor/__tests__/useTextEditorRuntime.test.ts
+++ b/src/features/editor/text-editor/__tests__/useTextEditorRuntime.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 
 import { applySceneCursorTarget, prepareSceneCursorTarget } from '~/features/editor/text-editor/text-editor-scene-restore'
 
-describe('applySceneCursorTarget 行为', () => {
+describe('applySceneCursorTarget', () => {
   it('会用仅在视口外才滚动的策略恢复文本光标目标，而不是强制居中', () => {
     const editor = {
       layout: vi.fn(),
@@ -33,7 +33,7 @@ describe('applySceneCursorTarget 行为', () => {
   })
 })
 
-describe('prepareSceneCursorTarget 行为', () => {
+describe('prepareSceneCursorTarget', () => {
   it('可以先同步文本光标位置，而不立刻触发 reveal', () => {
     const editor = {
       layout: vi.fn(),

--- a/src/features/editor/text-editor/__tests__/useTextEditorWorkspace.browser.test.ts
+++ b/src/features/editor/text-editor/__tests__/useTextEditorWorkspace.browser.test.ts
@@ -174,7 +174,7 @@ function renderWorkspaceHarness(options: WorkspaceHarnessOptions): WorkspaceHarn
   }
 }
 
-describe('useTextEditorWorkspace 行为', () => {
+describe('useTextEditorWorkspace', () => {
   beforeEach(() => {
     currentPinia = createPinia()
     setActivePinia(currentPinia)

--- a/src/features/editor/visual-editor/__tests__/useVisualEditorSceneRuntime.test.ts
+++ b/src/features/editor/visual-editor/__tests__/useVisualEditorSceneRuntime.test.ts
@@ -114,7 +114,7 @@ function createState(
   }) as SceneVisualProjectionState
 }
 
-describe('useVisualEditorSceneRuntime 的快捷键、投影同步与预览行为', () => {
+describe('useVisualEditorSceneRuntime', () => {
   afterEach(() => {
     vi.unstubAllGlobals()
   })

--- a/src/features/file-picker/__tests__/file-picker.test.ts
+++ b/src/features/file-picker/__tests__/file-picker.test.ts
@@ -11,7 +11,7 @@ import {
   resolveFilePickerInputFallbackDir,
 } from '../file-picker'
 
-describe('文件选择器辅助函数', () => {
+describe('filePicker', () => {
   it('解析空输入时会回到根目录并触发导航', () => {
     expect(parseFilePickerInput('', 'images/bg')).toEqual({
       directoryPath: '',

--- a/src/features/file-picker/__tests__/useFilePickerController.test.ts
+++ b/src/features/file-picker/__tests__/useFilePickerController.test.ts
@@ -89,7 +89,7 @@ function createFixture(options: ControllerFixtureOptions = {}) {
   }
 }
 
-describe('useFilePickerController 行为', () => {
+describe('useFilePickerController', () => {
   beforeEach(() => {
     vi.useFakeTimers()
     existsMock.mockClear()

--- a/src/features/file-picker/__tests__/useFilePickerHistory.test.ts
+++ b/src/features/file-picker/__tests__/useFilePickerHistory.test.ts
@@ -66,7 +66,7 @@ function createFixture() {
   }
 }
 
-describe('useFilePickerHistory 行为', () => {
+describe('useFilePickerHistory', () => {
   beforeEach(() => {
     existsMock.mockClear()
     useStorageMock.mockClear()

--- a/src/features/home/engines-tab/__tests__/useEnginesTabController.test.ts
+++ b/src/features/home/engines-tab/__tests__/useEnginesTabController.test.ts
@@ -59,7 +59,7 @@ vi.mock('~/database/db', () => ({
   },
 }))
 
-describe('useEnginesTabController 行为', () => {
+describe('useEnginesTabController', () => {
   const openDeleteEngineGroupModalMock = vi.fn()
   const openDeleteEngineModalMock = vi.fn()
   const setDefaultEngineIdMock = vi.fn()

--- a/src/features/home/games-tab/__tests__/useGamesTabController.test.ts
+++ b/src/features/home/games-tab/__tests__/useGamesTabController.test.ts
@@ -55,7 +55,7 @@ vi.mock('~/services/resource-reconcile', () => ({
   },
 }))
 
-describe('useGamesTabController 行为', () => {
+describe('useGamesTabController', () => {
   const openCreateGameModalMock = vi.fn()
   const openDeleteGameModalMock = vi.fn()
   const openNoEngineAlertModalMock = vi.fn()

--- a/src/features/modals/create-game/__tests__/create-game-modal.test.ts
+++ b/src/features/modals/create-game/__tests__/create-game-modal.test.ts
@@ -6,7 +6,7 @@ import {
   sanitizeCreateGameName,
 } from '../create-game-modal'
 
-describe('创建游戏弹窗辅助函数', () => {
+describe('createGameModal', () => {
   it('会把非法游戏名字符清洗为下划线', () => {
     expect(sanitizeCreateGameName('My:Game/2025')).toBe('My_Game_2025')
     expect(sanitizeCreateGameName('')).toBe('')

--- a/src/features/modals/create-game/__tests__/useCreateGameForm.test.ts
+++ b/src/features/modals/create-game/__tests__/useCreateGameForm.test.ts
@@ -99,7 +99,7 @@ function createDeferred<T>() {
   }
 }
 
-describe('useCreateGameForm 行为', () => {
+describe('useCreateGameForm', () => {
   beforeEach(() => {
     formValues = reactive({})
     vi.resetAllMocks()

--- a/src/features/modals/game-config/__tests__/game-config-form.test.ts
+++ b/src/features/modals/game-config/__tests__/game-config-form.test.ts
@@ -42,7 +42,7 @@ function createReadResult(overrides: Partial<GameConfigReadResult> = {}): GameCo
   }
 }
 
-describe('game-config 表单辅助函数', () => {
+describe('gameConfigForm', () => {
   it('parseGameConfigFormValues 会把原始条目解析成表单可编辑值，并保留自定义项', () => {
     expect(parseGameConfigFormValues(createReadResult({
       entries: [

--- a/src/services/__tests__/animation-table-sync.test.ts
+++ b/src/services/__tests__/animation-table-sync.test.ts
@@ -44,7 +44,7 @@ function createDirEntry(name: string, options: Partial<DirEntry> = {}): DirEntry
   }
 }
 
-describe('animationTable 索引同步', () => {
+describe('animationTableSync', () => {
   beforeEach(() => {
     existsMock.mockReset()
     gameAssetDirMock.mockReset()

--- a/src/services/__tests__/config-manager.test.ts
+++ b/src/services/__tests__/config-manager.test.ts
@@ -31,7 +31,7 @@ vi.mock('~/stores/preview-session', () => ({
   }),
 }))
 
-describe('configManager 配置管理', () => {
+describe('configManager', () => {
   beforeEach(() => {
     refreshIfCurrentGameMock.mockReset()
     refreshRegisteredGameSnapshotMock.mockReset()

--- a/src/services/__tests__/game-fs.test.ts
+++ b/src/services/__tests__/game-fs.test.ts
@@ -80,7 +80,7 @@ vi.mock('~/stores/file', () => ({
   useFileStore: useFileStoreMock,
 }))
 
-describe('gameFs 游戏文件系统', () => {
+describe('gameFs', () => {
   beforeEach(() => {
     commitPendingFileWriteMock.mockReset()
     copyEntryMock.mockReset()

--- a/src/services/__tests__/path-lint.test.ts
+++ b/src/services/__tests__/path-lint.test.ts
@@ -12,7 +12,7 @@ async function lintText(code: string) {
   })
 }
 
-describe('路径 lint 规则', () => {
+describe('路径校验规则', () => {
   it('会拒绝在 ~/domain/path 之外使用正则归一化反斜杠', async () => {
     const [result] = await lintText([
       'export function normalizePath(path: string) {',

--- a/src/services/__tests__/template-manager.test.ts
+++ b/src/services/__tests__/template-manager.test.ts
@@ -82,7 +82,7 @@ vi.mock('~/stores/storage-settings', () => ({
   useStorageSettingsStore: useStorageSettingsStoreMock,
 }))
 
-describe('templateManager 模板管理', () => {
+describe('templateManager', () => {
   beforeEach(() => {
     vi.resetAllMocks()
 

--- a/src/services/platform/__tests__/asset-url.test.ts
+++ b/src/services/platform/__tests__/asset-url.test.ts
@@ -25,7 +25,7 @@ vi.mock('~/stores/workspace', () => ({
   useWorkspaceStore: useWorkspaceStoreMock,
 }))
 
-describe('getAssetUrl 资源地址解析', () => {
+describe('assetUrl', () => {
   beforeEach(() => {
     workspaceStoreState.CWD = '/games/demo'
     previewSessionStoreState.currentGameServeUrl = 'http://127.0.0.1:8899/game/demo/'

--- a/src/stores/__tests__/command-panel.test.ts
+++ b/src/stores/__tests__/command-panel.test.ts
@@ -20,7 +20,7 @@ function createParsedSentence(command: number): NonNullable<ReturnType<typeof pa
   return { command } as NonNullable<ReturnType<typeof parseSentence>>
 }
 
-describe('useCommandPanelStore 命令面板状态仓库', () => {
+describe('useCommandPanelStore', () => {
   let store: ReturnType<typeof useCommandPanelStore>
 
   beforeEach(() => {

--- a/src/stores/__tests__/edit-settings.test.ts
+++ b/src/stores/__tests__/edit-settings.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from 'vitest'
 
 import { useEditSettingsStore } from '~/stores/edit-settings'
 
-describe('编辑设置状态仓库', () => {
+describe('useEditSettingsStore', () => {
   it('提供稳定的编辑器默认配置', () => {
     const store = useEditSettingsStore()
 

--- a/src/stores/__tests__/editor-preview-sync.test.ts
+++ b/src/stores/__tests__/editor-preview-sync.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 
 import { createEditorPreviewSync } from '../editor-preview-sync'
 
-describe('编辑器预览同步', () => {
+describe('createEditorPreviewSync', () => {
   it('会规范化输入并在去重窗口内跳过重复同步', () => {
     const dispatch = vi.fn()
     let now = 100

--- a/src/stores/__tests__/editor-ui-state.test.ts
+++ b/src/stores/__tests__/editor-ui-state.test.ts
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it } from 'vitest'
 
 import { useEditorUIStateStore } from '~/stores/editor-ui-state'
 
-describe('编辑器界面状态仓库', () => {
+describe('useEditorUIStateStore', () => {
   let store: ReturnType<typeof useEditorUIStateStore>
 
   beforeEach(() => {

--- a/src/stores/__tests__/editor.test.ts
+++ b/src/stores/__tests__/editor.test.ts
@@ -263,7 +263,7 @@ beforeAll(async () => {
   ({ useEditorStore } = await import('../editor'))
 }, asyncFixtureTimeoutMs * 3)
 
-describe('编辑器状态仓库的文本与文档流程', () => {
+describe('编辑器文本与文档流程', () => {
   beforeEach(() => {
     const tabsStore = useTabsStore()
 

--- a/src/stores/__tests__/file.test.ts
+++ b/src/stores/__tests__/file.test.ts
@@ -199,7 +199,7 @@ function captureFileStoreCaches() {
   }
 }
 
-describe('文件状态仓库', () => {
+describe('useFileStore', () => {
   beforeEach(() => {
     pendingWrites = []
     existsMock.mockReset()

--- a/src/stores/__tests__/general-settings.test.ts
+++ b/src/stores/__tests__/general-settings.test.ts
@@ -33,7 +33,7 @@ vi.mock('~/composables/color-mode', () => ({
   },
 }))
 
-describe('通用设置状态仓库', () => {
+describe('useGeneralSettingsStore', () => {
   beforeEach(() => {
     locale.value = 'en'
     systemLanguage.value = 'ja'

--- a/src/stores/__tests__/preference.test.ts
+++ b/src/stores/__tests__/preference.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from 'vitest'
 
 import { usePreferenceStore } from '~/stores/preference'
 
-describe('偏好设置状态仓库', () => {
+describe('usePreferenceStore', () => {
   it('提供默认视图偏好', () => {
     const store = usePreferenceStore()
 

--- a/src/stores/__tests__/preview-runtime.test.ts
+++ b/src/stores/__tests__/preview-runtime.test.ts
@@ -26,7 +26,7 @@ vi.mock('@tauri-apps/plugin-log', () => ({
   error: loggerErrorMock,
 }))
 
-describe('previewRuntimeStore 预览运行时状态仓库', () => {
+describe('usePreviewRuntimeStore', () => {
   beforeEach(() => {
     vi.resetAllMocks()
   })

--- a/src/stores/__tests__/preview-session.test.ts
+++ b/src/stores/__tests__/preview-session.test.ts
@@ -43,7 +43,7 @@ function createDeferred<T>() {
   }
 }
 
-describe('previewSessionStore 当前工作区预览会话仓库', () => {
+describe('usePreviewSessionStore', () => {
   beforeEach(() => {
     vi.resetAllMocks()
 

--- a/src/stores/__tests__/preview-settings.test.ts
+++ b/src/stores/__tests__/preview-settings.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from 'vitest'
 
 import { usePreviewSettingsStore } from '~/stores/preview-settings'
 
-describe('预览设置状态仓库', () => {
+describe('usePreviewSettingsStore', () => {
   it('初始化时包含预览相关默认值', () => {
     const store = usePreviewSettingsStore()
 

--- a/src/stores/__tests__/resource.test.ts
+++ b/src/stores/__tests__/resource.test.ts
@@ -74,7 +74,7 @@ function createTemplate(id: string, name: string, createdAt: number, webgalVersi
   })
 }
 
-describe('资源状态仓库', () => {
+describe('useResourceStore', () => {
   beforeEach(() => {
     vi.resetAllMocks()
 

--- a/src/stores/__tests__/storage-settings.test.ts
+++ b/src/stores/__tests__/storage-settings.test.ts
@@ -21,7 +21,7 @@ function createMemoryStorage(seed: Record<string, string> = {}) {
   }
 }
 
-describe('存储设置状态仓库', () => {
+describe('useStorageSettingsStore', () => {
   it('默认保存路径为空', () => {
     const store = useStorageSettingsStore()
 

--- a/src/stores/__tests__/tabs.test.ts
+++ b/src/stores/__tests__/tabs.test.ts
@@ -56,7 +56,7 @@ vi.mock('~/composables/useFileSystemEvents', () => ({
   }),
 }))
 
-describe('标签状态仓库', () => {
+describe('useTabsStore', () => {
   beforeEach(() => {
     vi.useRealTimers()
     useWorkspaceStoreMock.mockReset()

--- a/src/stores/__tests__/workspace.test.ts
+++ b/src/stores/__tests__/workspace.test.ts
@@ -65,7 +65,7 @@ async function flushWorkspaceWatchers() {
   await Promise.resolve()
 }
 
-describe('工作区状态仓库', () => {
+describe('useWorkspaceStore', () => {
   beforeEach(() => {
     vi.resetAllMocks()
 

--- a/src/stores/internal/__tests__/editor-document-actions.test.ts
+++ b/src/stores/internal/__tests__/editor-document-actions.test.ts
@@ -165,7 +165,7 @@ function createSceneActionHarness() {
   }
 }
 
-describe('编辑器文档动作的历史回滚', () => {
+describe('编辑器文档动作回滚', () => {
   beforeEach(() => {
     loggerWarnMock.mockReset()
   })

--- a/src/stores/internal/__tests__/editor-document-state.test.ts
+++ b/src/stores/internal/__tests__/editor-document-state.test.ts
@@ -5,7 +5,7 @@ import { serializeDocument } from '~/domain/document/serializer'
 
 import { createDocumentState, getDocumentTextContent, invalidateDocumentTextCache } from '../editor-document-state'
 
-describe('getDocumentTextContent 行为', () => {
+describe('文档文本缓存', () => {
   it('首次调用时序列化并写入缓存', () => {
     const doc = createDocumentState(createDocumentModel({
       kind: 'plaintext',

--- a/src/stores/internal/__tests__/editor-file-lifecycle.test.ts
+++ b/src/stores/internal/__tests__/editor-file-lifecycle.test.ts
@@ -202,7 +202,7 @@ async function waitUntil(
   return waitUntil(description, predicate, stableCycles, remainingCycles - 1, nextMatchedCycles)
 }
 
-describe('handleFileModifiedEvent 行为', () => {
+describe('编辑器文件生命周期', () => {
   beforeEach(() => {
     modalOpenMock.mockReset()
     vi.mocked(fsCmds.isBinaryFile).mockReset()

--- a/src/stores/internal/__tests__/editor-session.test.ts
+++ b/src/stores/internal/__tests__/editor-session.test.ts
@@ -15,7 +15,7 @@ import {
   syncProjectionStateFromDocument,
 } from '../editor-session'
 
-describe('编辑器会话的已加载文档状态', () => {
+describe('编辑器会话与已加载文档状态', () => {
   it('即使偏好可视模式，非法动画草稿仍保留显式文本快照', () => {
     const loadedState = createLoadedDocumentState('animation', '{invalid json')
 

--- a/src/utils/__tests__/artifact-comment.test.ts
+++ b/src/utils/__tests__/artifact-comment.test.ts
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 
 import createArtifactComment from '../../../scripts/formatArtifactComment.js'
 
-describe('createArtifactComment 构建产物注释', () => {
+describe('createArtifactComment', () => {
   const originalRepository = process.env.GITHUB_REPOSITORY
 
   afterEach(() => {

--- a/src/utils/__tests__/async-queue.test.ts
+++ b/src/utils/__tests__/async-queue.test.ts
@@ -12,7 +12,7 @@ function flushMicrotasks(times: number = 4): Promise<void> {
   return Promise.resolve().then(() => flushMicrotasks(times - 1))
 }
 
-describe('createAsyncQueue 异步队列', () => {
+describe('createAsyncQueue', () => {
   it('enqueue 触发 consumer 执行', async () => {
     let called = 0
     const queue = createAsyncQueue(async () => {

--- a/src/utils/__tests__/batch.test.ts
+++ b/src/utils/__tests__/batch.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest'
 import { AppError } from '~/types/errors'
 import { settleBatch } from '~/utils/batch'
 
-describe('settleBatch 批处理收敛', () => {
+describe('settleBatch', () => {
   it('所有任务成功时，succeeded 包含全部结果，failed 为空', async () => {
     const tasks = [
       () => Promise.resolve('a'),

--- a/src/utils/__tests__/color.test.ts
+++ b/src/utils/__tests__/color.test.ts
@@ -7,7 +7,7 @@ function createNullValue(): unknown {
   return null
 }
 
-describe('normalizeColorChannel 颜色通道归一化', () => {
+describe('normalizeColorChannel', () => {
   it('对正常范围内的值进行四舍五入', () => {
     expect(normalizeColorChannel(127.6, 0)).toBe(128)
   })
@@ -29,7 +29,7 @@ describe('normalizeColorChannel 颜色通道归一化', () => {
   })
 })
 
-describe('parseHexColor 十六进制颜色解析', () => {
+describe('parseHexColor', () => {
   it('解析 3 位简写 #fff', () => {
     expect(parseHexColor('#fff')).toEqual([255, 255, 255])
   })
@@ -63,7 +63,7 @@ describe('parseHexColor 十六进制颜色解析', () => {
   })
 })
 
-describe('isRgbColor RGB 颜色校验', () => {
+describe('isRgbColor', () => {
   it('合法 RgbColor 返回 true', () => {
     expect(isRgbColor({ r: 0, g: 128, b: 255 })).toBe(true)
   })
@@ -77,7 +77,7 @@ describe('isRgbColor RGB 颜色校验', () => {
   })
 })
 
-describe('isRgbaPayload RGBA 载荷校验', () => {
+describe('isRgbaPayload', () => {
   it('合法 RgbaPayload 返回 true', () => {
     expect(isRgbaPayload({ rgba: { r: 0, g: 0, b: 0 } })).toBe(true)
   })
@@ -87,7 +87,7 @@ describe('isRgbaPayload RGBA 载荷校验', () => {
   })
 })
 
-describe('extractRgbColor 颜色提取', () => {
+describe('extractRgbColor', () => {
   it('字符串走 parseHexColor 路径', () => {
     expect(extractRgbColor('#ff8000')).toEqual([255, 128, 0])
   })

--- a/src/utils/__tests__/error-handler.test.ts
+++ b/src/utils/__tests__/error-handler.test.ts
@@ -18,7 +18,7 @@ vi.mock('vue-sonner', () => ({
   },
 }))
 
-describe('handleError 错误处理', () => {
+describe('handleError', () => {
   beforeEach(() => {
     loggerErrorMock.mockReset()
     toastErrorMock.mockReset()

--- a/src/utils/__tests__/format.test.ts
+++ b/src/utils/__tests__/format.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import { formatFileSize } from '~/utils/format'
 
-describe('formatFileSize 文件大小格式化', () => {
+describe('formatFileSize', () => {
   it('字节级大小会直接输出整数 B', () => {
     expect(formatFileSize(0)).toBe('0 B')
     expect(formatFileSize(999)).toBe('999 B')

--- a/src/utils/__tests__/math.test.ts
+++ b/src/utils/__tests__/math.test.ts
@@ -17,7 +17,7 @@ function createPointerEvent(clientX: number, clientY: number): PointerEvent {
   return { clientX, clientY } as PointerEvent
 }
 
-describe('clamp 区间钳制', () => {
+describe('clamp', () => {
   it.each([
     ['命中区间内的值', 5, 0, 10, 5],
     ['小于最小值时钳制到下限', -3, 0, 10, 0],
@@ -31,7 +31,7 @@ describe('clamp 区间钳制', () => {
   })
 })
 
-describe('normalizeStepPrecision 步长精度归一化', () => {
+describe('normalizeStepPrecision', () => {
   it.each([
     ['整数步长返回 0', 1, 0],
     ['多位整数步长仍返回 0', 10, 0],
@@ -45,7 +45,7 @@ describe('normalizeStepPrecision 步长精度归一化', () => {
   })
 })
 
-describe('roundByStep 按步长取整', () => {
+describe('roundByStep', () => {
   it.each([
     ['按两位小数步长舍入', 3.456, 0.01, 3.46],
     ['按一位小数步长舍入', 3.456, 0.1, 3.5],
@@ -74,14 +74,14 @@ describe('角度与弧度转换', () => {
   })
 })
 
-describe('roundToPrecision 精度取整', () => {
+describe('roundToPrecision', () => {
   it('按指定位数舍入', () => {
     expect(roundToPrecision(3.1415_9, 2)).toBe(3.14)
     expect(roundToPrecision(3.1415_9, 0)).toBe(3)
   })
 })
 
-describe('normalizeAngleDelta 角度差归一化', () => {
+describe('normalizeAngleDelta', () => {
   it.each([
     ['区间内的值保持不变', 0, 0],
     ['上边界 180 保持不变', 180, 180],
@@ -95,7 +95,7 @@ describe('normalizeAngleDelta 角度差归一化', () => {
   })
 })
 
-describe('normalizeDegree 角度归一化', () => {
+describe('normalizeDegree', () => {
   it.each([
     ['0 度保持不变', 0, 0],
     ['359 度保持不变', 359, 359],
@@ -113,7 +113,7 @@ describe('normalizeDegree 角度归一化', () => {
   })
 })
 
-describe('getPointerAngleDegrees 指针角度计算', () => {
+describe('getPointerAngleDegrees', () => {
   it.each([
     ['指针位于中心右侧时返回 0°', createPointerEvent(200, 100), 0],
     ['指针位于中心下方时返回 90°', createPointerEvent(100, 200), 90],
@@ -123,7 +123,7 @@ describe('getPointerAngleDegrees 指针角度计算', () => {
   })
 })
 
-describe('applyScrubStepModifier 步长修饰符应用', () => {
+describe('applyScrubStepModifier', () => {
   it.each([
     ['未按修饰键时保留基础步长', { altKey: false, shiftKey: false }, 1],
     ['按下 Alt 时使用 0.1 倍步长', { altKey: true, shiftKey: false }, 0.1],

--- a/src/utils/__tests__/sort.test.ts
+++ b/src/utils/__tests__/sort.test.ts
@@ -28,7 +28,7 @@ function sorted(items: TestItem[], sortBy: 'name' | 'modifiedTime' | 'createdTim
 
 // --- normalizeNumber ---
 
-describe('normalizeNumber 数值归一化', () => {
+describe('normalizeNumber', () => {
   it('保留有限数值', () => {
     expect(normalizeNumber(42)).toBe(42)
     expect(normalizeNumber(0)).toBe(0)
@@ -45,7 +45,7 @@ describe('normalizeNumber 数值归一化', () => {
 
 // --- compareOptionalNumber ---
 
-describe('compareOptionalNumber 可选数值比较', () => {
+describe('compareOptionalNumber', () => {
   it('两个 undefined 相等', () => {
     expect(compareOptionalNumber(undefined, undefined, 'asc')).toBe(0)
   })
@@ -71,7 +71,7 @@ describe('compareOptionalNumber 可选数值比较', () => {
 
 // --- isValidPositiveNumber ---
 
-describe('isValidPositiveNumber 正数校验', () => {
+describe('isValidPositiveNumber', () => {
   it('有效非负有限数值返回 true', () => {
     expect(isValidPositiveNumber(0)).toBe(true)
     expect(isValidPositiveNumber(100)).toBe(true)
@@ -87,7 +87,7 @@ describe('isValidPositiveNumber 正数校验', () => {
 
 // --- createItemComparator ---
 
-describe('createItemComparator 条目比较器', () => {
+describe('createItemComparator', () => {
   const dirA: TestItem = { name: 'alpha', isDir: true }
   const dirB: TestItem = { name: 'beta', isDir: true }
   const fileA: TestItem = { name: 'apple.txt', isDir: false, size: 200, modified: 1000, created: 500 }

--- a/src/utils/__tests__/speaker.test.ts
+++ b/src/utils/__tests__/speaker.test.ts
@@ -7,7 +7,7 @@ import {
   getPreviousSpeakerAtLine,
 } from '~/utils/speaker'
 
-describe('extractSpeakerChange 说话人变更提取', () => {
+describe('extractSpeakerChange', () => {
   describe('注释行', () => {
     it('跳过纯注释行', () => {
       expect(extractSpeakerChange(';这是注释')).toBeUndefined()
@@ -40,7 +40,7 @@ describe('extractSpeakerChange 说话人变更提取', () => {
     })
   })
 
-  describe('标准 say 写法', () => {
+  describe('标准对话写法', () => {
     it('say: -speaker=角色A → 说话人 A', () => {
       expect(extractSpeakerChange('say:这是一句话。 -speaker=角色A;')).toBe('角色A')
     })
@@ -85,7 +85,7 @@ describe('extractSpeakerChange 说话人变更提取', () => {
   })
 })
 
-describe('说话人辅助函数', () => {
+describe('speaker', () => {
   const entries = [
     { rawText: 'Alice:你好;' },
     { rawText: '接续上一句;' },

--- a/src/utils/__tests__/wheel.test.ts
+++ b/src/utils/__tests__/wheel.test.ts
@@ -17,7 +17,7 @@ function createWheelEvent(overrides: Partial<WheelEvent> = {}): WheelEvent {
   return event as WheelEvent
 }
 
-describe('handleWheelToHorizontalScroll 横向滚动转换', () => {
+describe('handleWheelToHorizontalScroll', () => {
   it('会把垂直滚动转换成水平滚动并阻止默认事件', () => {
     const event = createWheelEvent()
 


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [ ] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [x] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

统一现有测试中的分组标题文案，收敛命名风格并提升测试输出可读性。

本次调整主要包括：

- 将部分“函数名 + 中文说明”的 `describe` 标题简化为函数名
- 统一同类测试分组的表达方式，减少命名风格混杂
- 调整少量分组文案，使失败输出更容易快速定位

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

当前测试标题的表达方式不够统一，有的偏实现名，有的偏自然语言说明，整套测试输出在扫描和定位失败项时成本较高。

这次改动只整理测试标题和文案，不涉及运行时代码或行为变更，目标是让测试结果更稳定地传达结构和语义，降低后续维护成本。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->

- 当前改动仅涉及测试文件标题/文案调整，无生产逻辑变更

### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [ ] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
