### PR TITLE
✨ 为资源索引补齐引用跟踪、缺失引用查询与增量更新

### DIFF
--- a/src/__tests__/mocks/tauri-fs.ts
+++ b/src/__tests__/mocks/tauri-fs.ts
@@ -4,6 +4,7 @@ vi.mock('@tauri-apps/plugin-fs', () => ({
   copyFile: vi.fn(),
   exists: vi.fn(),
   mkdir: vi.fn(),
+  readFile: vi.fn(),
   readTextFile: vi.fn(),
   readDir: vi.fn(),
   remove: vi.fn(),

--- a/src/components/editor/StatementEditorPanel.spec.ts
+++ b/src/components/editor/StatementEditorPanel.spec.ts
@@ -105,7 +105,8 @@ vi.mock('~/stores/workspace', () => ({
   useWorkspaceStore: useWorkspaceStoreMock,
 }))
 
-vi.mock('~/services/platform/app-paths', () => ({
+vi.mock('~/services/platform/app-paths', async importOriginal => ({
+  ...(await importOriginal<typeof import('~/services/platform/app-paths')>()),
   gameAssetDir: gameAssetDirMock,
   gameSceneDir: gameSceneDirMock,
 }))

--- a/src/components/editor/VisualEditorStatementCard.vue
+++ b/src/components/editor/VisualEditorStatementCard.vue
@@ -6,7 +6,7 @@ import { buildStatementPreviewParams, StatementCardPreviewParam } from '~/featur
 import { createStatementIdTarget, StatementUpdatePayload } from '~/features/editor/statement-editor/useStatementEditor'
 import { useStatementFileMissing } from '~/features/editor/statement-editor/useStatementFileMissing'
 import { provideStatementMeta } from '~/features/editor/statement-editor/useStatementMeta'
-import { useResourceCatalogBootstrap } from '~/services/resource-index/service'
+import { useResourceIndexBootstrap } from '~/services/resource-index/service'
 
 const props = defineProps<{
   entry: StatementEntry
@@ -53,7 +53,7 @@ const { parsed, config, contentField, argFields, theme, statementType, commandLa
 
 const { t } = useI18n()
 
-useResourceCatalogBootstrap()
+useResourceIndexBootstrap()
 
 const { fileMissingKeys } = useStatementFileMissing({
   parsed: () => parsed.value,

--- a/src/features/editor/statement-editor/__tests__/file-missing.test.ts
+++ b/src/features/editor/statement-editor/__tests__/file-missing.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { commandType } from 'webgal-parser/src/interface/sceneInterface'
 
-import { RelPath } from '~/domain/path'
 import {
   collectStatementFileChecks,
   resolveMissingFileKeysFromCatalog,
@@ -108,7 +107,7 @@ describe('fileMissing', () => {
         { key: 'sprite', assetType: 'figure', value: 'hero.png' },
         { key: 'scene', assetType: 'scene', value: 's1.txt' },
       ],
-      (_assetType, relativePath) => relativePath !== RelPath.from('hero.png'),
+      key => key.relativePath !== 'hero.png',
     )
 
     expect(missing).toEqual(new Set(['sprite']))
@@ -121,13 +120,31 @@ describe('fileMissing', () => {
         { key: 'a', assetType: 'scene', value: 'myLabel' },
         { key: 'b', assetType: 'scene', value: 'other.txt' },
       ],
-      (_assetType, relativePath) => {
-        checkedPaths.push(String(relativePath))
+      (key) => {
+        checkedPaths.push(String(key.relativePath))
         return true
       },
     )
 
     expect(checkedPaths).toEqual(['other.txt'])
+    expect(missing).toEqual(new Set())
+  })
+
+  it('resolveMissingFileKeysFromCatalog 跳过无法规范化为项目相对路径的值', () => {
+    const checkedKeys: string[] = []
+    const missing = resolveMissingFileKeysFromCatalog(
+      [
+        { key: 'absolute', assetType: 'background', value: '/outside/bg.png' },
+        { key: 'escape', assetType: 'figure', value: '../hero.png' },
+        { key: 'valid', assetType: 'background', value: 'bg.png' },
+      ],
+      (key) => {
+        checkedKeys.push(`${key.assetType}:${key.relativePath}`)
+        return key.assetType === 'background' && key.relativePath === 'bg.png'
+      },
+    )
+
+    expect(checkedKeys).toEqual(['background:bg.png'])
     expect(missing).toEqual(new Set())
   })
 })

--- a/src/features/editor/statement-editor/file-missing.ts
+++ b/src/features/editor/statement-editor/file-missing.ts
@@ -1,28 +1,13 @@
-import { RelPath } from '~/domain/path'
 import { ArgField, EditorField, readArgFieldStorageKey } from '~/features/editor/command-registry/schema'
+import { createReferencedAssetKey, shouldIndexAssetReferenceValue } from '~/services/resource-index/values'
 
 import type { arg, ISentence } from 'webgal-parser/src/interface/sceneInterface'
+import type { AssetKey } from '~/services/resource-index/keys'
 
 export interface StatementFileCheckItem {
   key: string
   assetType: string
   value: string
-}
-
-// WebGAL 支持 {varName} 语法引用变量作为文件路径，
-// 变量占位符无法在编辑时检查文件是否存在，跳过检查避免误报
-function isVariablePlaceholder(value: string): boolean {
-  const trimmed = value.trim()
-  return /^\{[^{}]+\}$/.test(trimmed)
-}
-
-function shouldCheckStatementFileValue(assetType: string, value: string): boolean {
-  // scene 中不带 .txt 的值可能是 label，而不是文件路径
-  if (assetType === 'scene' && !value.endsWith('.txt')) {
-    return false
-  }
-
-  return true
 }
 
 export function collectStatementFileChecks(
@@ -35,7 +20,7 @@ export function collectStatementFileChecks(
   const contentFileConfig = contentField?.field.type === 'file'
     ? contentField.field.fileConfig
     : undefined
-  if (parsed.content && contentFileConfig && !isVariablePlaceholder(parsed.content)) {
+  if (contentFileConfig && shouldIndexAssetReferenceValue(contentFileConfig.assetType, parsed.content)) {
     checks.push({
       key: '__content__',
       assetType: contentFileConfig.assetType,
@@ -49,7 +34,11 @@ export function collectStatementFileChecks(
     }
     const argKey = readArgFieldStorageKey(argField)
     const item = parsed.args.find((argItem: arg) => argItem.key === argKey)
-    if (item && typeof item.value === 'string' && item.value && !isVariablePlaceholder(item.value)) {
+    if (
+      item
+      && typeof item.value === 'string'
+      && shouldIndexAssetReferenceValue(argField.field.fileConfig.assetType, item.value)
+    ) {
       checks.push({
         key: argKey,
         assetType: argField.field.fileConfig.assetType,
@@ -63,7 +52,7 @@ export function collectStatementFileChecks(
 
 export function resolveMissingFileKeysFromCatalog(
   checks: StatementFileCheckItem[],
-  hasAsset: (assetType: string, relativePath: RelPath) => boolean,
+  hasAssetKey: (key: AssetKey) => boolean,
 ): Set<string> {
   if (checks.length === 0) {
     return new Set()
@@ -72,11 +61,12 @@ export function resolveMissingFileKeysFromCatalog(
   const missingKeys = new Set<string>()
 
   for (const { key, assetType, value } of checks) {
-    if (!shouldCheckStatementFileValue(assetType, value)) {
+    const assetKey = createReferencedAssetKey(assetType, value)
+    if (!assetKey) {
       continue
     }
 
-    if (!hasAsset(assetType, RelPath.from(value))) {
+    if (!hasAssetKey(assetKey)) {
       missingKeys.add(key)
     }
   }

--- a/src/features/editor/statement-editor/useStatementEditor.ts
+++ b/src/features/editor/statement-editor/useStatementEditor.ts
@@ -16,7 +16,7 @@ import { useStatementEditorScrub } from '~/features/editor/statement-editor/useS
 import { useStatementFileMissing } from '~/features/editor/statement-editor/useStatementFileMissing'
 import { useStatementFileRoots } from '~/features/editor/statement-editor/useStatementFileRoots'
 import { statementMetaKey, useStatementMeta } from '~/features/editor/statement-editor/useStatementMeta'
-import { useResourceCatalogBootstrap } from '~/services/resource-index/service'
+import { useResourceIndexBootstrap } from '~/services/resource-index/service'
 
 import type { arg, ISentence } from 'webgal-parser/src/interface/sceneInterface'
 import type { TransactionSource } from '~/domain/document/transaction'
@@ -71,7 +71,7 @@ export function isStatementInteractiveTarget(target: EventTarget | null): boolea
 
 export function useStatementEditor(options: UseStatementEditorOptions) {
   useEditorDynamicOptionsBootstrap()
-  useResourceCatalogBootstrap()
+  useResourceIndexBootstrap()
 
   const entry = computed(() => toValue(options.entry))
   const updateTarget = computed(() => toValue(options.updateTarget) ?? createStatementIdTarget(entry.value.id))

--- a/src/features/editor/statement-editor/useStatementFileMissing.ts
+++ b/src/features/editor/statement-editor/useStatementFileMissing.ts
@@ -1,6 +1,6 @@
 import { ArgField, EditorField } from '~/features/editor/command-registry/schema'
 import { collectStatementFileChecks, resolveMissingFileKeysFromCatalog } from '~/features/editor/statement-editor/file-missing'
-import { useResourceCatalog } from '~/services/resource-index/service'
+import { useResourceIndex } from '~/services/resource-index/service'
 
 import type { ISentence } from 'webgal-parser/src/interface/sceneInterface'
 
@@ -11,14 +11,14 @@ export interface UseStatementFileMissingOptions {
 }
 
 export function useStatementFileMissing(options: UseStatementFileMissingOptions) {
-  const resourceCatalog = useResourceCatalog()
+  const resourceIndex = useResourceIndex()
 
   const fileMissingKeys = computed(() => {
     const currentParsed = toValue(options.parsed)
     const currentContentField = toValue(options.contentField)
     const currentArgFields = toValue(options.argFields)
 
-    if (!currentParsed || resourceCatalog.status.value !== 'ready') {
+    if (!currentParsed || resourceIndex.status.value !== 'ready') {
       return new Set<string>()
     }
 
@@ -30,7 +30,7 @@ export function useStatementFileMissing(options: UseStatementFileMissingOptions)
 
     return resolveMissingFileKeysFromCatalog(
       checks,
-      (assetType, relativePath) => resourceCatalog.hasAsset(assetType, relativePath),
+      key => resourceIndex.hasAssetKey(key),
     )
   })
 

--- a/src/services/resource-index/__tests__/service.test.ts
+++ b/src/services/resource-index/__tests__/service.test.ts
@@ -921,6 +921,101 @@ describe('useResourceIndex', () => {
     }
   })
 
+  it('文件移除时会清理对应的引用更新取消占位', async () => {
+    readDirMock.mockImplementation(async (path: string | URL) => {
+      switch (String(path)) {
+        case '/project/game': {
+          return [
+            createDirEntry('background', true),
+          ]
+        }
+        case '/project/game/background': {
+          return [
+            createDirEntry('bg.jpg', false),
+          ]
+        }
+        default: {
+          throw new TypeError(`unexpected readDir path: ${String(path)}`)
+        }
+      }
+    })
+
+    const deleteSpy = vi.spyOn(Map.prototype, 'delete')
+
+    const { useResourceIndex, useResourceIndexBootstrap } = await import('../service')
+
+    const scope = effectScope()
+    let resourceIndex!: ReturnType<typeof useResourceIndex>
+    scope.run(() => {
+      useResourceIndexBootstrap()
+      resourceIndex = useResourceIndex()
+    })
+
+    try {
+      await waitFor(() => resourceIndex.status.value === 'ready')
+      deleteSpy.mockClear()
+
+      emitFileSystemEvent('file:removed', {
+        type: 'file:removed',
+        path: '/project/game/background/bg.jpg',
+      })
+      await flushMicrotasks()
+
+      expect(resourceIndex.hasAssetKey(createAssetKey('asset', 'background', RelPath.from('bg.jpg')))).toBe(false)
+      expect(deleteSpy.mock.calls.some(([key]) => key === '/project/game/background/bg.jpg')).toBe(true)
+    } finally {
+      deleteSpy.mockRestore()
+      scope.stop()
+    }
+  })
+
+  it('非 scene 与配置文件的修改不会写入引用更新版本', async () => {
+    readDirMock.mockImplementation(async (path: string | URL) => {
+      switch (String(path)) {
+        case '/project/game': {
+          return [
+            createDirEntry('background', true),
+          ]
+        }
+        case '/project/game/background': {
+          return [
+            createDirEntry('bg.jpg', false),
+          ]
+        }
+        default: {
+          throw new TypeError(`unexpected readDir path: ${String(path)}`)
+        }
+      }
+    })
+
+    const setSpy = vi.spyOn(Map.prototype, 'set')
+
+    const { useResourceIndex, useResourceIndexBootstrap } = await import('../service')
+
+    const scope = effectScope()
+    let resourceIndex!: ReturnType<typeof useResourceIndex>
+    scope.run(() => {
+      useResourceIndexBootstrap()
+      resourceIndex = useResourceIndex()
+    })
+
+    try {
+      await waitFor(() => resourceIndex.status.value === 'ready')
+      setSpy.mockClear()
+
+      emitFileSystemEvent('file:modified', {
+        type: 'file:modified',
+        path: '/project/game/background/bg.jpg',
+      })
+      await flushMicrotasks()
+
+      expect(setSpy.mock.calls.some(([key]) => key === '/project/game/background/bg.jpg')).toBe(false)
+    } finally {
+      setSpy.mockRestore()
+      scope.stop()
+    }
+  })
+
   it('构建期间收到文件事件后会在完成后补一次重建', async () => {
     const slowFigureRead = createDeferred<ReturnType<typeof createDirEntry>[]>()
     let backgroundReadCount = 0

--- a/src/services/resource-index/__tests__/service.test.ts
+++ b/src/services/resource-index/__tests__/service.test.ts
@@ -1,15 +1,18 @@
 import '~/__tests__/mocks/tauri-fs'
 
-import { readDir } from '@tauri-apps/plugin-fs'
+import { readDir, readTextFile } from '@tauri-apps/plugin-fs'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { effectScope, reactive } from 'vue'
 
-import { RelPath } from '~/domain/path'
+import { AbsPath, RelPath } from '~/domain/path'
+import { createAssetKey } from '~/services/resource-index/keys'
 
 const {
+  getConfigMock,
   onMock,
   useWorkspaceStoreMock,
 } = vi.hoisted(() => ({
+  getConfigMock: vi.fn(),
   onMock: vi.fn(),
   useWorkspaceStoreMock: vi.fn(),
 }))
@@ -24,7 +27,18 @@ vi.mock('~/composables/useFileSystemEvents', () => ({
   }),
 }))
 
+vi.mock('@tauri-apps/plugin-log', () => ({
+  warn: vi.fn(),
+}))
+
+vi.mock('~/services/config-manager', () => ({
+  configManager: {
+    getConfig: getConfigMock,
+  },
+}))
+
 const readDirMock = vi.mocked(readDir)
+const readTextFileMock = vi.mocked(readTextFile)
 
 function createDirEntry(name: string, isDirectory: boolean) {
   return {
@@ -64,7 +78,7 @@ async function waitFor(predicate: () => boolean, maxTries = 20): Promise<void> {
   await waitFor(predicate, maxTries - 1)
 }
 
-describe('ResourceIndexService', () => {
+describe('useResourceIndex', () => {
   let workspaceStoreState = reactive<{ CWD?: string }>({
     CWD: '/project',
   })
@@ -100,6 +114,14 @@ describe('ResourceIndexService', () => {
     })
 
     readDirMock.mockReset()
+    readTextFileMock.mockReset()
+    readTextFileMock.mockResolvedValue('')
+
+    getConfigMock.mockReset()
+    getConfigMock.mockResolvedValue({
+      entries: [],
+      unmanagedLineCount: 0,
+    })
   })
 
   it('启动后会建立资源清单，并支持按 assetType 和相对路径查询', async () => {
@@ -139,24 +161,701 @@ describe('ResourceIndexService', () => {
       }
     })
 
-    const { useResourceCatalog, useResourceCatalogBootstrap } = await import('../service')
+    const { useResourceIndex, useResourceIndexBootstrap } = await import('../service')
 
     const scope = effectScope()
-    let catalog!: ReturnType<typeof useResourceCatalog>
+    let resourceIndex!: ReturnType<typeof useResourceIndex>
     scope.run(() => {
-      useResourceCatalogBootstrap()
-      catalog = useResourceCatalog()
+      useResourceIndexBootstrap()
+      resourceIndex = useResourceIndex()
     })
 
     try {
-      await waitFor(() => catalog.status.value === 'ready')
+      await waitFor(() => resourceIndex.status.value === 'ready')
 
-      expect(catalog.status.value).toBe('ready')
-      expect(catalog.hasAsset('background', RelPath.from('bg.jpg'))).toBe(true)
-      expect(catalog.hasAsset('background', RelPath.from('chapter1/night.png'))).toBe(true)
-      expect(catalog.hasAsset('figure', RelPath.from('hero.png'))).toBe(true)
-      expect(catalog.hasAsset('scene', RelPath.from('intro.txt'))).toBe(true)
-      expect(catalog.hasAsset('background', RelPath.from('missing.png'))).toBe(false)
+      expect(resourceIndex.status.value).toBe('ready')
+      expect(resourceIndex.hasAssetKey(createAssetKey('asset', 'background', RelPath.from('bg.jpg')))).toBe(true)
+      expect(resourceIndex.hasAssetKey(createAssetKey('asset', 'background', RelPath.from('chapter1/night.png')))).toBe(true)
+      expect(resourceIndex.hasAssetKey(createAssetKey('asset', 'figure', RelPath.from('hero.png')))).toBe(true)
+      expect(resourceIndex.hasAssetKey(createAssetKey('scene', 'scene', RelPath.from('intro.txt')))).toBe(true)
+      expect(resourceIndex.hasAssetKey(createAssetKey('asset', 'background', RelPath.from('missing.png')))).toBe(false)
+      expect(resourceIndex.resolveByAbsolutePath(AbsPath.from('/project/game/background/bg.jpg')))
+        .toEqual({
+          key: createAssetKey('asset', 'background', RelPath.from('bg.jpg')),
+          absolutePath: AbsPath.from('/project/game/background/bg.jpg'),
+          fileName: 'bg.jpg',
+          extension: '.jpg',
+        })
+      expect(resourceIndex.listByAssetType('background').map(entry => entry.key.relativePath))
+        .toEqual([
+          RelPath.from('bg.jpg'),
+          RelPath.from('chapter1/night.png'),
+        ])
+    } finally {
+      scope.stop()
+    }
+  })
+
+  it('启动后会建立 scene 与 game config 的资源引用索引', async () => {
+    readDirMock.mockImplementation(async (path: string | URL) => {
+      switch (String(path)) {
+        case '/project/game': {
+          return [
+            createDirEntry('background', true),
+            createDirEntry('figure', true),
+            createDirEntry('bgm', true),
+            createDirEntry('scene', true),
+            createDirEntry('vocal', true),
+          ]
+        }
+        case '/project/game/background': {
+          return [
+            createDirEntry('bg.jpg', false),
+            createDirEntry('cover.png', false),
+            createDirEntry('opening.webp', false),
+            createDirEntry('enter.webp', false),
+          ]
+        }
+        case '/project/game/figure': {
+          return [
+            createDirEntry('hero.png', false),
+          ]
+        }
+        case '/project/game/bgm': {
+          return [
+            createDirEntry('title.ogg', false),
+          ]
+        }
+        case '/project/game/scene': {
+          return [
+            createDirEntry('intro.txt', false),
+            createDirEntry('chapter1', true),
+          ]
+        }
+        case '/project/game/scene/chapter1': {
+          return [
+            createDirEntry('branch.txt', false),
+          ]
+        }
+        case '/project/game/vocal': {
+          return [
+            createDirEntry('voice.ogg', false),
+          ]
+        }
+        default: {
+          throw new TypeError(`unexpected readDir path: ${String(path)}`)
+        }
+      }
+    })
+
+    readTextFileMock.mockImplementation(async (path: string | URL) => {
+      switch (String(path)) {
+        case '/project/game/scene/intro.txt': {
+          return [
+            'changeBg:bg.jpg;',
+            'Alice:Hello -vocal=voice.ogg;',
+            'choose:A:chapter1/branch.txt|B:missing.txt;',
+          ].join('\n')
+        }
+        case '/project/game/scene/chapter1/branch.txt': {
+          return 'changeFigure:hero.png;'
+        }
+        default: {
+          throw new TypeError(`unexpected readTextFile path: ${String(path)}`)
+        }
+      }
+    })
+
+    getConfigMock.mockResolvedValue({
+      entries: [
+        { key: 'Title_img', value: 'cover.png' },
+        { key: 'Title_bgm', value: 'title.ogg' },
+        { key: 'Game_Logo', value: 'opening.webp|enter.webp|' },
+      ],
+      unmanagedLineCount: 0,
+    })
+
+    const { useResourceIndex, useResourceIndexBootstrap } = await import('../service')
+
+    const scope = effectScope()
+    let resourceIndex!: ReturnType<typeof useResourceIndex>
+    scope.run(() => {
+      useResourceIndexBootstrap()
+      resourceIndex = useResourceIndex()
+    })
+
+    try {
+      await waitFor(() => resourceIndex.status.value === 'ready')
+
+      const backgroundKey = createAssetKey('asset', 'background', RelPath.from('bg.jpg'))
+      const coverKey = createAssetKey('asset', 'background', RelPath.from('cover.png'))
+      const titleBgmKey = createAssetKey('asset', 'bgm', RelPath.from('title.ogg'))
+      const openingLogoKey = createAssetKey('asset', 'background', RelPath.from('opening.webp'))
+      const enterLogoKey = createAssetKey('asset', 'background', RelPath.from('enter.webp'))
+      const branchSceneKey = createAssetKey('scene', 'scene', RelPath.from('chapter1/branch.txt'))
+      const missingSceneKey = createAssetKey('scene', 'scene', RelPath.from('missing.txt'))
+
+      expect(resourceIndex.hasAssetKey(backgroundKey)).toBe(true)
+      expect(resourceIndex.getReferencesTo(backgroundKey)).toMatchObject([
+        {
+          sourcePath: '/project/game/scene/intro.txt',
+          sourceKind: 'scene',
+          fieldKey: '__content__',
+          statementId: 1,
+        },
+      ])
+      expect(resourceIndex.getReferencesTo(coverKey)).toMatchObject([
+        {
+          sourcePath: '/project/game/config.txt',
+          sourceKind: 'game-config',
+          fieldKey: 'Title_img',
+        },
+      ])
+      expect(resourceIndex.getReferencesTo(titleBgmKey)).toMatchObject([
+        {
+          sourcePath: '/project/game/config.txt',
+          sourceKind: 'game-config',
+          fieldKey: 'Title_bgm',
+        },
+      ])
+      expect(resourceIndex.getReferencesTo(openingLogoKey)).toMatchObject([
+        {
+          sourcePath: '/project/game/config.txt',
+          sourceKind: 'game-config',
+          fieldKey: 'Game_Logo',
+        },
+      ])
+      expect(resourceIndex.getReferencesTo(enterLogoKey)).toMatchObject([
+        {
+          sourcePath: '/project/game/config.txt',
+          sourceKind: 'game-config',
+          fieldKey: 'Game_Logo',
+        },
+      ])
+      expect(resourceIndex.getReferencesFrom(AbsPath.from('/project/game/scene/intro.txt'))).toHaveLength(4)
+      expect(resourceIndex.getReferencesFrom(AbsPath.from('/project/game/config.txt'))).toHaveLength(4)
+      expect(resourceIndex.getReferencesTo(branchSceneKey)).toMatchObject([
+        {
+          sourcePath: '/project/game/scene/intro.txt',
+          sourceKind: 'scene',
+          fieldKey: 'choose[0].file',
+          statementId: 3,
+        },
+      ])
+      expect(resourceIndex.findMissingReferences()).toEqual([
+        {
+          kind: 'missing-reference',
+          assetKey: missingSceneKey,
+          references: [
+            expect.objectContaining({
+              sourcePath: '/project/game/scene/intro.txt',
+              fieldKey: 'choose[1].file',
+              statementId: 3,
+            }),
+          ],
+        },
+      ])
+    } finally {
+      scope.stop()
+    }
+  })
+
+  it('scene 文件修改时只重建该文件的引用记录', async () => {
+    readDirMock.mockImplementation(async (path: string | URL) => {
+      switch (String(path)) {
+        case '/project/game': {
+          return [
+            createDirEntry('background', true),
+            createDirEntry('scene', true),
+          ]
+        }
+        case '/project/game/background': {
+          return [
+            createDirEntry('bg.jpg', false),
+            createDirEntry('new-bg.jpg', false),
+          ]
+        }
+        case '/project/game/scene': {
+          return [
+            createDirEntry('intro.txt', false),
+          ]
+        }
+        default: {
+          throw new TypeError(`unexpected readDir path: ${String(path)}`)
+        }
+      }
+    })
+
+    readTextFileMock.mockResolvedValueOnce('changeBg:bg.jpg;')
+    readTextFileMock.mockResolvedValue('changeBg:new-bg.jpg;')
+
+    const { useResourceIndex, useResourceIndexBootstrap } = await import('../service')
+
+    const scope = effectScope()
+    let resourceIndex!: ReturnType<typeof useResourceIndex>
+    scope.run(() => {
+      useResourceIndexBootstrap()
+      resourceIndex = useResourceIndex()
+    })
+
+    try {
+      await waitFor(() => resourceIndex.status.value === 'ready')
+      readDirMock.mockClear()
+
+      const oldKey = createAssetKey('asset', 'background', RelPath.from('bg.jpg'))
+      const nextKey = createAssetKey('asset', 'background', RelPath.from('new-bg.jpg'))
+
+      expect(resourceIndex.getReferencesTo(oldKey)).toHaveLength(1)
+      expect(resourceIndex.getReferencesTo(nextKey)).toHaveLength(0)
+
+      emitFileSystemEvent('file:modified', {
+        type: 'file:modified',
+        path: '/project/game/scene/intro.txt',
+      })
+      await waitFor(() => resourceIndex.getReferencesTo(nextKey).length === 1)
+
+      expect(resourceIndex.getReferencesTo(oldKey)).toHaveLength(0)
+      expect(readDirMock).not.toHaveBeenCalled()
+    } finally {
+      scope.stop()
+    }
+  })
+
+  it('game config 修改时只重建配置文件引用记录', async () => {
+    readDirMock.mockImplementation(async (path: string | URL) => {
+      switch (String(path)) {
+        case '/project/game': {
+          return [
+            createDirEntry('background', true),
+            createDirEntry('bgm', true),
+            createDirEntry('scene', true),
+          ]
+        }
+        case '/project/game/background': {
+          return [
+            createDirEntry('cover.png', false),
+            createDirEntry('cover-next.png', false),
+            createDirEntry('opening.webp', false),
+            createDirEntry('opening-next.webp', false),
+          ]
+        }
+        case '/project/game/bgm': {
+          return [
+            createDirEntry('title.ogg', false),
+            createDirEntry('title-next.ogg', false),
+          ]
+        }
+        case '/project/game/scene': {
+          return []
+        }
+        default: {
+          throw new TypeError(`unexpected readDir path: ${String(path)}`)
+        }
+      }
+    })
+
+    getConfigMock
+      .mockResolvedValueOnce({
+        entries: [
+          { key: 'Title_img', value: 'cover.png' },
+          { key: 'Title_bgm', value: 'title.ogg' },
+          { key: 'Game_Logo', value: 'opening.webp|' },
+        ],
+        unmanagedLineCount: 0,
+      })
+      .mockResolvedValue({
+        entries: [
+          { key: 'Title_img', value: 'cover-next.png' },
+          { key: 'Title_bgm', value: 'title-next.ogg' },
+          { key: 'Game_Logo', value: 'opening-next.webp|' },
+        ],
+        unmanagedLineCount: 0,
+      })
+
+    const { useResourceIndex, useResourceIndexBootstrap } = await import('../service')
+
+    const scope = effectScope()
+    let resourceIndex!: ReturnType<typeof useResourceIndex>
+    scope.run(() => {
+      useResourceIndexBootstrap()
+      resourceIndex = useResourceIndex()
+    })
+
+    try {
+      await waitFor(() => resourceIndex.status.value === 'ready')
+      readDirMock.mockClear()
+
+      const oldCoverKey = createAssetKey('asset', 'background', RelPath.from('cover.png'))
+      const nextCoverKey = createAssetKey('asset', 'background', RelPath.from('cover-next.png'))
+      const oldTitleBgmKey = createAssetKey('asset', 'bgm', RelPath.from('title.ogg'))
+      const nextTitleBgmKey = createAssetKey('asset', 'bgm', RelPath.from('title-next.ogg'))
+      const oldLogoKey = createAssetKey('asset', 'background', RelPath.from('opening.webp'))
+      const nextLogoKey = createAssetKey('asset', 'background', RelPath.from('opening-next.webp'))
+
+      expect(resourceIndex.getReferencesTo(oldCoverKey)).toHaveLength(1)
+      expect(resourceIndex.getReferencesTo(nextCoverKey)).toHaveLength(0)
+      expect(resourceIndex.getReferencesTo(oldTitleBgmKey)).toHaveLength(1)
+      expect(resourceIndex.getReferencesTo(nextTitleBgmKey)).toHaveLength(0)
+      expect(resourceIndex.getReferencesTo(oldLogoKey)).toHaveLength(1)
+      expect(resourceIndex.getReferencesTo(nextLogoKey)).toHaveLength(0)
+
+      emitFileSystemEvent('file:modified', {
+        type: 'file:modified',
+        path: '/project/game/config.txt',
+      })
+      await waitFor(() =>
+        resourceIndex.getReferencesTo(nextCoverKey).length === 1
+        && resourceIndex.getReferencesTo(nextTitleBgmKey).length === 1
+        && resourceIndex.getReferencesTo(nextLogoKey).length === 1,
+      )
+
+      expect(resourceIndex.getReferencesTo(oldCoverKey)).toHaveLength(0)
+      expect(resourceIndex.getReferencesTo(oldTitleBgmKey)).toHaveLength(0)
+      expect(resourceIndex.getReferencesTo(oldLogoKey)).toHaveLength(0)
+      expect(readDirMock).not.toHaveBeenCalled()
+    } finally {
+      scope.stop()
+    }
+  })
+
+  it('并发 scene 修改会合并到最新引用索引，不丢弃较晚完成的切片', async () => {
+    readDirMock.mockImplementation(async (path: string | URL) => {
+      switch (String(path)) {
+        case '/project/game': {
+          return [
+            createDirEntry('background', true),
+            createDirEntry('scene', true),
+          ]
+        }
+        case '/project/game/background': {
+          return [
+            createDirEntry('old-a.jpg', false),
+            createDirEntry('old-b.jpg', false),
+            createDirEntry('new-a.jpg', false),
+            createDirEntry('new-b.jpg', false),
+          ]
+        }
+        case '/project/game/scene': {
+          return [
+            createDirEntry('a.txt', false),
+            createDirEntry('b.txt', false),
+          ]
+        }
+        default: {
+          throw new TypeError(`unexpected readDir path: ${String(path)}`)
+        }
+      }
+    })
+
+    const pendingReads = new Map<string, ReturnType<typeof createDeferred<string>>>()
+    readTextFileMock.mockImplementation(async (path: string | URL) => {
+      const pathText = String(path)
+      const pendingRead = pendingReads.get(pathText)
+      if (pendingRead) {
+        return pendingRead.promise
+      }
+
+      switch (pathText) {
+        case '/project/game/scene/a.txt': {
+          return 'changeBg:old-a.jpg;'
+        }
+        case '/project/game/scene/b.txt': {
+          return 'changeBg:old-b.jpg;'
+        }
+        default: {
+          throw new TypeError(`unexpected readTextFile path: ${pathText}`)
+        }
+      }
+    })
+
+    const { useResourceIndex, useResourceIndexBootstrap } = await import('../service')
+
+    const scope = effectScope()
+    let resourceIndex!: ReturnType<typeof useResourceIndex>
+    scope.run(() => {
+      useResourceIndexBootstrap()
+      resourceIndex = useResourceIndex()
+    })
+
+    try {
+      await waitFor(() => resourceIndex.status.value === 'ready')
+
+      const oldAKey = createAssetKey('asset', 'background', RelPath.from('old-a.jpg'))
+      const oldBKey = createAssetKey('asset', 'background', RelPath.from('old-b.jpg'))
+      const newAKey = createAssetKey('asset', 'background', RelPath.from('new-a.jpg'))
+      const newBKey = createAssetKey('asset', 'background', RelPath.from('new-b.jpg'))
+
+      expect(resourceIndex.getReferencesTo(oldAKey)).toHaveLength(1)
+      expect(resourceIndex.getReferencesTo(oldBKey)).toHaveLength(1)
+
+      const aRead = createDeferred<string>()
+      const bRead = createDeferred<string>()
+      pendingReads.set('/project/game/scene/a.txt', aRead)
+      pendingReads.set('/project/game/scene/b.txt', bRead)
+
+      emitFileSystemEvent('file:modified', {
+        type: 'file:modified',
+        path: '/project/game/scene/a.txt',
+      })
+      emitFileSystemEvent('file:modified', {
+        type: 'file:modified',
+        path: '/project/game/scene/b.txt',
+      })
+      await flushMicrotasks()
+
+      aRead.resolve('changeBg:new-a.jpg;')
+      await waitFor(() => resourceIndex.getReferencesTo(newAKey).length === 1)
+
+      bRead.resolve('changeBg:new-b.jpg;')
+      await waitFor(() => resourceIndex.getReferencesTo(newBKey).length === 1)
+
+      expect(resourceIndex.getReferencesTo(oldAKey)).toHaveLength(0)
+      expect(resourceIndex.getReferencesTo(oldBKey)).toHaveLength(0)
+      expect(resourceIndex.getReferencesTo(newAKey)).toHaveLength(1)
+      expect(resourceIndex.getReferencesTo(newBKey)).toHaveLength(1)
+    } finally {
+      scope.stop()
+    }
+  })
+
+  it('同一 scene 连续修改时会忽略较早完成的旧切片', async () => {
+    readDirMock.mockImplementation(async (path: string | URL) => {
+      switch (String(path)) {
+        case '/project/game': {
+          return [
+            createDirEntry('background', true),
+            createDirEntry('scene', true),
+          ]
+        }
+        case '/project/game/background': {
+          return [
+            createDirEntry('old.jpg', false),
+            createDirEntry('stale.jpg', false),
+            createDirEntry('fresh.jpg', false),
+          ]
+        }
+        case '/project/game/scene': {
+          return [
+            createDirEntry('intro.txt', false),
+          ]
+        }
+        default: {
+          throw new TypeError(`unexpected readDir path: ${String(path)}`)
+        }
+      }
+    })
+
+    const pendingReads: ReturnType<typeof createDeferred<string>>[] = []
+    readTextFileMock.mockImplementation(async (path: string | URL) => {
+      if (String(path) !== '/project/game/scene/intro.txt') {
+        throw new TypeError(`unexpected readTextFile path: ${String(path)}`)
+      }
+      const pendingRead = pendingReads.shift()
+      return pendingRead ? pendingRead.promise : 'changeBg:old.jpg;'
+    })
+
+    const { useResourceIndex, useResourceIndexBootstrap } = await import('../service')
+
+    const scope = effectScope()
+    let resourceIndex!: ReturnType<typeof useResourceIndex>
+    scope.run(() => {
+      useResourceIndexBootstrap()
+      resourceIndex = useResourceIndex()
+    })
+
+    try {
+      await waitFor(() => resourceIndex.status.value === 'ready')
+
+      const oldKey = createAssetKey('asset', 'background', RelPath.from('old.jpg'))
+      const staleKey = createAssetKey('asset', 'background', RelPath.from('stale.jpg'))
+      const freshKey = createAssetKey('asset', 'background', RelPath.from('fresh.jpg'))
+
+      expect(resourceIndex.getReferencesTo(oldKey)).toHaveLength(1)
+
+      const staleRead = createDeferred<string>()
+      const freshRead = createDeferred<string>()
+      pendingReads.push(staleRead, freshRead)
+
+      emitFileSystemEvent('file:modified', {
+        type: 'file:modified',
+        path: '/project/game/scene/intro.txt',
+      })
+      emitFileSystemEvent('file:modified', {
+        type: 'file:modified',
+        path: '/project/game/scene/intro.txt',
+      })
+      await flushMicrotasks()
+
+      freshRead.resolve('changeBg:fresh.jpg;')
+      await waitFor(() => resourceIndex.getReferencesTo(freshKey).length === 1)
+
+      staleRead.resolve('changeBg:stale.jpg;')
+      await flushMicrotasks()
+
+      expect(resourceIndex.getReferencesTo(oldKey)).toHaveLength(0)
+      expect(resourceIndex.getReferencesTo(staleKey)).toHaveLength(0)
+      expect(resourceIndex.getReferencesTo(freshKey)).toHaveLength(1)
+    } finally {
+      scope.stop()
+    }
+  })
+
+  it('资源文件重命名会更新清单，并让旧引用进入缺失查询', async () => {
+    readDirMock.mockImplementation(async (path: string | URL) => {
+      switch (String(path)) {
+        case '/project/game': {
+          return [
+            createDirEntry('background', true),
+            createDirEntry('scene', true),
+          ]
+        }
+        case '/project/game/background': {
+          return [
+            createDirEntry('bg.jpg', false),
+          ]
+        }
+        case '/project/game/scene': {
+          return [
+            createDirEntry('intro.txt', false),
+          ]
+        }
+        default: {
+          throw new TypeError(`unexpected readDir path: ${String(path)}`)
+        }
+      }
+    })
+
+    readTextFileMock.mockResolvedValue('changeBg:bg.jpg;')
+
+    const { useResourceIndex, useResourceIndexBootstrap } = await import('../service')
+
+    const scope = effectScope()
+    let resourceIndex!: ReturnType<typeof useResourceIndex>
+    scope.run(() => {
+      useResourceIndexBootstrap()
+      resourceIndex = useResourceIndex()
+    })
+
+    try {
+      await waitFor(() => resourceIndex.status.value === 'ready')
+
+      const oldKey = createAssetKey('asset', 'background', RelPath.from('bg.jpg'))
+      const nextKey = createAssetKey('asset', 'background', RelPath.from('renamed.jpg'))
+
+      expect(resourceIndex.hasAssetKey(oldKey)).toBe(true)
+      expect(resourceIndex.findMissingReferences()).toEqual([])
+
+      emitFileSystemEvent('file:renamed', {
+        type: 'file:renamed',
+        oldPath: '/project/game/background/bg.jpg',
+        newPath: '/project/game/background/renamed.jpg',
+      })
+      await flushMicrotasks()
+
+      expect(resourceIndex.hasAssetKey(oldKey)).toBe(false)
+      expect(resourceIndex.hasAssetKey(nextKey)).toBe(true)
+      expect(resourceIndex.getReferencesTo(oldKey)).toHaveLength(1)
+      expect(resourceIndex.findMissingReferences()).toMatchObject([
+        {
+          kind: 'missing-reference',
+          assetKey: oldKey,
+        },
+      ])
+    } finally {
+      scope.stop()
+    }
+  })
+
+  it('scene 重命名会忽略旧路径上较晚完成的修改切片', async () => {
+    readDirMock.mockImplementation(async (path: string | URL) => {
+      switch (String(path)) {
+        case '/project/game': {
+          return [
+            createDirEntry('background', true),
+            createDirEntry('scene', true),
+          ]
+        }
+        case '/project/game/background': {
+          return [
+            createDirEntry('old.jpg', false),
+            createDirEntry('stale.jpg', false),
+            createDirEntry('renamed.jpg', false),
+          ]
+        }
+        case '/project/game/scene': {
+          return [
+            createDirEntry('intro.txt', false),
+          ]
+        }
+        default: {
+          throw new TypeError(`unexpected readDir path: ${String(path)}`)
+        }
+      }
+    })
+
+    const pendingReads = new Map<string, ReturnType<typeof createDeferred<string>>>()
+    readTextFileMock.mockImplementation(async (path: string | URL) => {
+      const pathText = String(path)
+      const pendingRead = pendingReads.get(pathText)
+      if (pendingRead) {
+        return pendingRead.promise
+      }
+
+      switch (pathText) {
+        case '/project/game/scene/intro.txt': {
+          return 'changeBg:old.jpg;'
+        }
+        case '/project/game/scene/renamed.txt': {
+          return 'changeBg:renamed.jpg;'
+        }
+        default: {
+          throw new TypeError(`unexpected readTextFile path: ${pathText}`)
+        }
+      }
+    })
+
+    const { useResourceIndex, useResourceIndexBootstrap } = await import('../service')
+
+    const scope = effectScope()
+    let resourceIndex!: ReturnType<typeof useResourceIndex>
+    scope.run(() => {
+      useResourceIndexBootstrap()
+      resourceIndex = useResourceIndex()
+    })
+
+    try {
+      await waitFor(() => resourceIndex.status.value === 'ready')
+
+      const oldKey = createAssetKey('asset', 'background', RelPath.from('old.jpg'))
+      const staleKey = createAssetKey('asset', 'background', RelPath.from('stale.jpg'))
+      const renamedKey = createAssetKey('asset', 'background', RelPath.from('renamed.jpg'))
+
+      expect(resourceIndex.getReferencesTo(oldKey)).toHaveLength(1)
+
+      const staleRead = createDeferred<string>()
+      pendingReads.set('/project/game/scene/intro.txt', staleRead)
+
+      emitFileSystemEvent('file:modified', {
+        type: 'file:modified',
+        path: '/project/game/scene/intro.txt',
+      })
+      await flushMicrotasks()
+
+      pendingReads.delete('/project/game/scene/intro.txt')
+      emitFileSystemEvent('file:renamed', {
+        type: 'file:renamed',
+        oldPath: '/project/game/scene/intro.txt',
+        newPath: '/project/game/scene/renamed.txt',
+      })
+      await waitFor(() => resourceIndex.getReferencesTo(renamedKey).length === 1)
+
+      staleRead.resolve('changeBg:stale.jpg;')
+      await flushMicrotasks()
+
+      expect(resourceIndex.getReferencesTo(oldKey)).toHaveLength(0)
+      expect(resourceIndex.getReferencesTo(staleKey)).toHaveLength(0)
+      expect(resourceIndex.getReferencesTo(renamedKey)).toHaveLength(1)
+      expect(resourceIndex.getReferencesFrom(AbsPath.from('/project/game/scene/intro.txt'))).toEqual([])
     } finally {
       scope.stop()
     }
@@ -181,23 +880,23 @@ describe('ResourceIndexService', () => {
       }
     })
 
-    const { useResourceCatalog, useResourceCatalogBootstrap } = await import('../service')
+    const { useResourceIndex, useResourceIndexBootstrap } = await import('../service')
 
     const scope = effectScope()
-    let catalog!: ReturnType<typeof useResourceCatalog>
+    let resourceIndex!: ReturnType<typeof useResourceIndex>
     scope.run(() => {
-      useResourceCatalogBootstrap()
-      catalog = useResourceCatalog()
+      useResourceIndexBootstrap()
+      resourceIndex = useResourceIndex()
     })
 
     try {
       slowRootRead.resolve([
         createDirEntry('background', true),
       ])
-      await waitFor(() => catalog.status.value === 'ready')
+      await waitFor(() => resourceIndex.status.value === 'ready')
 
-      expect(catalog.status.value).toBe('ready')
-      expect(catalog.hasAsset('background', RelPath.from('bg.jpg'))).toBe(true)
+      expect(resourceIndex.status.value).toBe('ready')
+      expect(resourceIndex.hasAssetKey(createAssetKey('asset', 'background', RelPath.from('bg.jpg')))).toBe(true)
       expect(readDirMock).toHaveBeenCalledTimes(2)
 
       emitFileSystemEvent('file:removed', {
@@ -206,7 +905,7 @@ describe('ResourceIndexService', () => {
       })
       await flushMicrotasks()
 
-      expect(catalog.hasAsset('background', RelPath.from('bg.jpg'))).toBe(false)
+      expect(resourceIndex.hasAssetKey(createAssetKey('asset', 'background', RelPath.from('bg.jpg')))).toBe(false)
       expect(readDirMock).toHaveBeenCalledTimes(2)
 
       emitFileSystemEvent('file:created', {
@@ -215,7 +914,7 @@ describe('ResourceIndexService', () => {
       })
       await flushMicrotasks()
 
-      expect(catalog.hasAsset('background', RelPath.from('new-bg.jpg'))).toBe(true)
+      expect(resourceIndex.hasAssetKey(createAssetKey('asset', 'background', RelPath.from('new-bg.jpg')))).toBe(true)
       expect(readDirMock).toHaveBeenCalledTimes(2)
     } finally {
       scope.stop()
@@ -258,13 +957,13 @@ describe('ResourceIndexService', () => {
       }
     })
 
-    const { useResourceCatalog, useResourceCatalogBootstrap } = await import('../service')
+    const { useResourceIndex, useResourceIndexBootstrap } = await import('../service')
 
     const scope = effectScope()
-    let catalog!: ReturnType<typeof useResourceCatalog>
+    let resourceIndex!: ReturnType<typeof useResourceIndex>
     scope.run(() => {
-      useResourceCatalogBootstrap()
-      catalog = useResourceCatalog()
+      useResourceIndexBootstrap()
+      resourceIndex = useResourceIndex()
     })
 
     try {
@@ -276,11 +975,14 @@ describe('ResourceIndexService', () => {
       })
       await flushMicrotasks()
 
-      expect(catalog.status.value).toBe('building')
+      expect(resourceIndex.status.value).toBe('building')
 
       slowFigureRead.resolve([])
 
-      await waitFor(() => catalog.status.value === 'ready' && catalog.hasAsset('background', RelPath.from('new-bg.jpg')))
+      await waitFor(() =>
+        resourceIndex.status.value === 'ready'
+        && resourceIndex.hasAssetKey(createAssetKey('asset', 'background', RelPath.from('new-bg.jpg'))),
+      )
       expect(backgroundReadCount).toBe(2)
     } finally {
       scope.stop()
@@ -309,17 +1011,17 @@ describe('ResourceIndexService', () => {
         }
       })
 
-      const { useResourceCatalog, useResourceCatalogBootstrap } = await import('../service')
+      const { useResourceIndex, useResourceIndexBootstrap } = await import('../service')
 
       const scope = effectScope()
-      let catalog!: ReturnType<typeof useResourceCatalog>
+      let resourceIndex!: ReturnType<typeof useResourceIndex>
       scope.run(() => {
-        useResourceCatalogBootstrap()
-        catalog = useResourceCatalog()
+        useResourceIndexBootstrap()
+        resourceIndex = useResourceIndex()
       })
 
       try {
-        await waitFor(() => catalog.status.value === 'ready')
+        await waitFor(() => resourceIndex.status.value === 'ready')
         readDirMock.mockClear()
 
         emitFileSystemEvent('directory:created', {
@@ -343,7 +1045,7 @@ describe('ResourceIndexService', () => {
 
         await vi.advanceTimersByTimeAsync(1)
         await waitFor(() => readDirMock.mock.calls.length === 2)
-        await waitFor(() => catalog.status.value === 'ready')
+        await waitFor(() => resourceIndex.status.value === 'ready')
 
         expect(readDirMock).toHaveBeenCalledTimes(2)
       } finally {

--- a/src/services/resource-index/__tests__/values.test.ts
+++ b/src/services/resource-index/__tests__/values.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+
+import { RelPath } from '~/domain/path'
+
+import { createAssetKeyForType } from '../keys'
+import { createReferencedAssetKey, shouldIndexAssetReferenceValue } from '../values'
+
+describe('resource-index values', () => {
+  it('会先去除空白再判断是否索引资源引用值', () => {
+    expect(shouldIndexAssetReferenceValue('background', '   ')).toBe(false)
+    expect(shouldIndexAssetReferenceValue('scene', '  intro.txt  ')).toBe(true)
+    expect(shouldIndexAssetReferenceValue('scene', '  intro  ')).toBe(false)
+  })
+
+  it('会先去除空白再生成引用资源键', () => {
+    expect(createReferencedAssetKey('background', '  bg.jpg  ')).toEqual(
+      createAssetKeyForType('background', RelPath.from('bg.jpg')),
+    )
+  })
+})

--- a/src/services/resource-index/catalog.ts
+++ b/src/services/resource-index/catalog.ts
@@ -1,50 +1,82 @@
 import { readDir } from '@tauri-apps/plugin-fs'
 
 import { AbsPath, RelPath } from '~/domain/path'
+import { gameAssetDir, gameRootDir } from '~/services/platform/app-paths'
+
+import { createAssetKeyForType, stringifyAssetKey } from './keys'
+
+import type { AssetKey } from './keys'
+
+export interface AssetCatalogEntry {
+  key: AssetKey
+  absolutePath: AbsPath
+  fileName: string
+  extension: string
+}
 
 export interface AssetCatalogSnapshot {
-  assetFiles: Map<string, Set<RelPath>>
+  entries: Map<string, AssetCatalogEntry>
 }
 
 export function createEmptyAssetCatalogSnapshot(): AssetCatalogSnapshot {
   return {
-    assetFiles: new Map<string, Set<RelPath>>(),
+    entries: new Map<string, AssetCatalogEntry>(),
   }
 }
 
-export function cloneAssetCatalogSnapshot(snapshot: AssetCatalogSnapshot): AssetCatalogSnapshot {
+function cloneAssetCatalogSnapshot(snapshot: AssetCatalogSnapshot): AssetCatalogSnapshot {
   return {
-    assetFiles: new Map(
-      Array.from(snapshot.assetFiles.entries(), ([assetType, files]) => [assetType, new Set(files)]),
-    ),
+    entries: new Map(snapshot.entries),
   }
 }
 
 export function hasAssetInCatalog(
   snapshot: AssetCatalogSnapshot,
-  assetType: string,
-  relativePath: RelPath,
+  key: AssetKey,
 ): boolean {
-  const files = snapshot.assetFiles.get(assetType)
-  if (!files) {
-    return false
+  return snapshot.entries.has(stringifyAssetKey(key))
+}
+
+export function getAssetFromCatalog(
+  snapshot: AssetCatalogSnapshot,
+  key: AssetKey,
+): AssetCatalogEntry | undefined {
+  return snapshot.entries.get(stringifyAssetKey(key))
+}
+
+export function resolveAssetByAbsolutePath(
+  snapshot: AssetCatalogSnapshot,
+  absolutePath: AbsPath,
+): AssetCatalogEntry | undefined {
+  for (const entry of snapshot.entries.values()) {
+    if (entry.absolutePath === absolutePath) {
+      return entry
+    }
   }
-  return files.has(relativePath)
+}
+
+export function listAssetsByAssetType(
+  snapshot: AssetCatalogSnapshot,
+  assetType: string,
+): AssetCatalogEntry[] {
+  return [...snapshot.entries.values()]
+    .filter(entry => entry.key.assetType === assetType)
 }
 
 export async function buildAssetCatalog(gamePath: AbsPath): Promise<AssetCatalogSnapshot> {
-  const gameRootPath = AbsPath.append(gamePath, 'game')
+  const gameRootPath = gameRootDir(gamePath)
   const rootEntries = await readDir(gameRootPath)
   const assetDirectories = rootEntries.filter(entry => entry.isDirectory && !!entry.name)
-  const assetFiles = await Promise.all(assetDirectories.map(async (entry) => {
+  const assetEntries = await Promise.all(assetDirectories.map(async (entry) => {
     const assetType = entry.name!
-    const rootPath = AbsPath.append(gameRootPath, assetType)
+    const rootPath = gameAssetDir(gamePath, assetType)
     const files = await collectAssetFiles(rootPath, RelPath.empty())
-    return [assetType, files] as const
+    return [...files].map(relativePath => createCatalogEntry(assetType, rootPath, relativePath))
   }))
 
+  const entries = assetEntries.flat()
   return {
-    assetFiles: new Map(assetFiles),
+    entries: new Map(entries.map(entry => [stringifyAssetKey(entry.key), entry])),
   }
 }
 
@@ -53,15 +85,13 @@ export function addAssetPathToCatalog(
   gamePath: AbsPath,
   absolutePath: AbsPath,
 ): AssetCatalogSnapshot {
-  const resolved = resolveCatalogPath(gamePath, absolutePath)
-  if (!resolved) {
+  const entry = resolveCatalogEntry(gamePath, absolutePath)
+  if (!entry) {
     return snapshot
   }
 
   const nextSnapshot = cloneAssetCatalogSnapshot(snapshot)
-  const files = nextSnapshot.assetFiles.get(resolved.assetType) ?? new Set<RelPath>()
-  files.add(resolved.relativePath)
-  nextSnapshot.assetFiles.set(resolved.assetType, files)
+  nextSnapshot.entries.set(stringifyAssetKey(entry.key), entry)
   return nextSnapshot
 }
 
@@ -70,18 +100,17 @@ export function removeAssetPathFromCatalog(
   gamePath: AbsPath,
   absolutePath: AbsPath,
 ): AssetCatalogSnapshot {
-  const resolved = resolveCatalogPath(gamePath, absolutePath)
-  if (!resolved) {
+  const entry = resolveCatalogEntry(gamePath, absolutePath)
+  if (!entry) {
     return snapshot
   }
 
-  const files = snapshot.assetFiles.get(resolved.assetType)
-  if (!files?.has(resolved.relativePath)) {
+  if (!snapshot.entries.has(stringifyAssetKey(entry.key))) {
     return snapshot
   }
 
   const nextSnapshot = cloneAssetCatalogSnapshot(snapshot)
-  nextSnapshot.assetFiles.get(resolved.assetType)?.delete(resolved.relativePath)
+  nextSnapshot.entries.delete(stringifyAssetKey(entry.key))
   return nextSnapshot
 }
 
@@ -96,7 +125,7 @@ export function renameAssetPathInCatalog(
 }
 
 export function isPathWithinGameRoot(gamePath: AbsPath, path: AbsPath): boolean {
-  const gameRootPath = AbsPath.append(gamePath, 'game')
+  const gameRootPath = gameRootDir(gamePath)
   return path === gameRootPath || path.startsWith(`${gameRootPath}/`)
 }
 
@@ -126,7 +155,7 @@ function resolveCatalogPath(gamePath: AbsPath, absolutePath: AbsPath): {
   assetType: string
   relativePath: RelPath
 } | undefined {
-  const gameRootPath = AbsPath.append(gamePath, 'game')
+  const gameRootPath = gameRootDir(gamePath)
   if (!absolutePath.startsWith(`${gameRootPath}/`)) {
     return
   }
@@ -144,4 +173,32 @@ function resolveCatalogPath(gamePath: AbsPath, absolutePath: AbsPath): {
     assetType: segments[0],
     relativePath: RelPath.from(segments.slice(1).join('/')),
   }
+}
+
+function resolveCatalogEntry(gamePath: AbsPath, absolutePath: AbsPath): AssetCatalogEntry | undefined {
+  const resolved = resolveCatalogPath(gamePath, absolutePath)
+  if (!resolved) {
+    return
+  }
+  const assetRootPath = gameAssetDir(gamePath, resolved.assetType)
+  return createCatalogEntry(resolved.assetType, assetRootPath, resolved.relativePath)
+}
+
+function createCatalogEntry(
+  assetType: string,
+  assetRootPath: AbsPath,
+  relativePath: RelPath,
+): AssetCatalogEntry {
+  const fileName = RelPath.basename(relativePath)
+  return {
+    key: createAssetKeyForType(assetType, relativePath),
+    absolutePath: AbsPath.join(assetRootPath, relativePath),
+    fileName,
+    extension: readExtension(fileName),
+  }
+}
+
+function readExtension(fileName: string): string {
+  const extensionStart = fileName.lastIndexOf('.')
+  return extensionStart === -1 ? '' : fileName.slice(extensionStart)
 }

--- a/src/services/resource-index/keys.ts
+++ b/src/services/resource-index/keys.ts
@@ -1,0 +1,29 @@
+import { RelPath } from '~/domain/path'
+
+export type AssetRoot = 'asset' | 'scene'
+
+export interface AssetKey {
+  root: AssetRoot
+  assetType: string
+  relativePath: RelPath
+}
+
+export function createAssetKey(
+  root: AssetRoot,
+  assetType: string,
+  relativePath: RelPath,
+): AssetKey {
+  return {
+    root,
+    assetType,
+    relativePath,
+  }
+}
+
+export function createAssetKeyForType(assetType: string, relativePath: RelPath): AssetKey {
+  return createAssetKey(assetType === 'scene' ? 'scene' : 'asset', assetType, relativePath)
+}
+
+export function stringifyAssetKey(key: AssetKey): string {
+  return `${key.root}\0${key.assetType}\0${key.relativePath}`
+}

--- a/src/services/resource-index/references.ts
+++ b/src/services/resource-index/references.ts
@@ -1,0 +1,314 @@
+import { readTextFile } from '@tauri-apps/plugin-fs'
+import { commandType } from 'webgal-parser/src/interface/sceneInterface'
+
+import { findGameConfigEntryValue } from '~/commands/game'
+import { AbsPath } from '~/domain/path'
+import { parseChooseContent } from '~/domain/script/content'
+import { parseScene } from '~/domain/script/parser'
+import { readCommandConfig } from '~/features/editor/command-registry'
+import {
+  deriveArgFieldsFromEditorFields,
+  readArgFieldStorageKey,
+  readEditorFields,
+} from '~/features/editor/command-registry/schema'
+import { configManager } from '~/services/config-manager'
+import { gameConfigPath, gameSceneDir } from '~/services/platform/app-paths'
+
+import {
+  getAssetFromCatalog,
+  listAssetsByAssetType,
+} from './catalog'
+import { stringifyAssetKey } from './keys'
+import { createReferencedAssetKey, shouldIndexAssetReferenceValue } from './values'
+
+import type { AssetCatalogSnapshot } from './catalog'
+import type { AssetKey } from './keys'
+import type { arg, ISentence } from 'webgal-parser/src/interface/sceneInterface'
+
+export type AssetReferenceSourceKind = 'scene' | 'game-config'
+
+export interface AssetReferenceRecord {
+  sourcePath: AbsPath
+  sourceKind: AssetReferenceSourceKind
+  assetKey: AssetKey
+  fieldKey: string
+  statementId?: number
+}
+
+export interface AssetReferenceDiagnostic {
+  kind: 'missing-reference'
+  assetKey: AssetKey
+  references: AssetReferenceRecord[]
+}
+
+export interface AssetReferenceIndexSnapshot {
+  records: AssetReferenceRecord[]
+}
+
+export function createEmptyAssetReferenceIndexSnapshot(): AssetReferenceIndexSnapshot {
+  return {
+    records: [],
+  }
+}
+
+export async function buildAssetReferenceIndex(
+  gamePath: AbsPath,
+  catalog: AssetCatalogSnapshot,
+): Promise<AssetReferenceIndexSnapshot> {
+  const sourceSlices = await Promise.all([
+    ...listAssetsByAssetType(catalog, 'scene').map(entry => buildSceneReferenceSlice(entry.absolutePath)),
+    buildGameConfigReferenceSlice(gamePath),
+  ])
+
+  return {
+    records: sourceSlices.flatMap(slice => slice.records),
+  }
+}
+
+export async function rebuildReferenceSource(
+  snapshot: AssetReferenceIndexSnapshot,
+  gamePath: AbsPath,
+  sourcePath: AbsPath,
+): Promise<AssetReferenceIndexSnapshot> {
+  if (isGameConfigPath(gamePath, sourcePath)) {
+    return replaceReferenceSource(snapshot, sourcePath, await buildGameConfigReferenceSlice(gamePath))
+  }
+
+  if (isScenePath(gamePath, sourcePath)) {
+    return replaceReferenceSource(snapshot, sourcePath, await buildSceneReferenceSlice(sourcePath))
+  }
+
+  return snapshot
+}
+
+export function removeReferenceSource(
+  snapshot: AssetReferenceIndexSnapshot,
+  sourcePath: AbsPath,
+): AssetReferenceIndexSnapshot {
+  return {
+    records: snapshot.records.filter(record => record.sourcePath !== sourcePath),
+  }
+}
+
+export async function renameReferenceSource(
+  snapshot: AssetReferenceIndexSnapshot,
+  gamePath: AbsPath,
+  oldPath: AbsPath,
+  newPath: AbsPath,
+): Promise<AssetReferenceIndexSnapshot> {
+  if (!isGameConfigPath(gamePath, newPath) && !isScenePath(gamePath, newPath)) {
+    return removeReferenceSource(snapshot, oldPath)
+  }
+
+  return rebuildReferenceSource(removeReferenceSource(snapshot, oldPath), gamePath, newPath)
+}
+
+export function getReferencesToAsset(
+  snapshot: AssetReferenceIndexSnapshot,
+  key: AssetKey,
+): AssetReferenceRecord[] {
+  const lookupKey = stringifyAssetKey(key)
+  return snapshot.records.filter(record => stringifyAssetKey(record.assetKey) === lookupKey)
+}
+
+export function getReferencesFromSource(
+  snapshot: AssetReferenceIndexSnapshot,
+  sourcePath: AbsPath,
+): AssetReferenceRecord[] {
+  return snapshot.records.filter(record => record.sourcePath === sourcePath)
+}
+
+export function findMissingAssetReferences(
+  snapshot: AssetReferenceIndexSnapshot,
+  catalog: AssetCatalogSnapshot,
+): AssetReferenceDiagnostic[] {
+  const missingReferences = new Map<string, AssetReferenceRecord[]>()
+
+  for (const record of snapshot.records) {
+    if (getAssetFromCatalog(catalog, record.assetKey)) {
+      continue
+    }
+
+    const lookupKey = stringifyAssetKey(record.assetKey)
+    const records = missingReferences.get(lookupKey) ?? []
+    records.push(record)
+    missingReferences.set(lookupKey, records)
+  }
+
+  return Array.from(missingReferences.values(), references => ({
+    kind: 'missing-reference',
+    assetKey: references[0]!.assetKey,
+    references,
+  }))
+}
+
+function replaceReferenceSource(
+  snapshot: AssetReferenceIndexSnapshot,
+  sourcePath: AbsPath,
+  slice: AssetReferenceIndexSnapshot,
+): AssetReferenceIndexSnapshot {
+  return {
+    records: [
+      ...snapshot.records.filter(record => record.sourcePath !== sourcePath),
+      ...slice.records,
+    ],
+  }
+}
+
+async function buildSceneReferenceSlice(sourcePath: AbsPath): Promise<AssetReferenceIndexSnapshot> {
+  try {
+    const text = await readTextFile(sourcePath)
+    const scene = parseScene(text, AbsPath.basename(sourcePath), sourcePath)
+    const sentences = scene?.sentenceList ?? []
+    return {
+      records: sentences.flatMap((sentence, index) =>
+        extractSentenceReferences(sourcePath, sentence, index + 1),
+      ),
+    }
+  } catch (error) {
+    logger.warn(`资源索引跳过解析失败的场景文件 (${sourcePath}): ${error}`)
+    return createEmptyAssetReferenceIndexSnapshot()
+  }
+}
+
+async function buildGameConfigReferenceSlice(gamePath: AbsPath): Promise<AssetReferenceIndexSnapshot> {
+  const sourcePath = gameConfigPath(gamePath)
+
+  try {
+    const config = await configManager.getConfig(gamePath)
+    const titleImage = findGameConfigEntryValue(config.entries, 'Title_img')
+    const titleBgm = findGameConfigEntryValue(config.entries, 'Title_bgm')
+    const gameLogo = findGameConfigEntryValue(config.entries, 'Game_Logo')
+
+    return {
+      records: [
+        ...createGameConfigReferenceRecords(sourcePath, 'Title_img', 'background', titleImage),
+        ...createGameConfigReferenceRecords(sourcePath, 'Title_bgm', 'bgm', titleBgm),
+        ...createGameConfigReferenceRecords(sourcePath, 'Game_Logo', 'background', gameLogo, { splitValues: true }),
+      ],
+    }
+  } catch (error) {
+    logger.warn(`资源索引跳过解析失败的游戏配置 (${sourcePath}): ${error}`)
+    return createEmptyAssetReferenceIndexSnapshot()
+  }
+}
+
+function extractSentenceReferences(
+  sourcePath: AbsPath,
+  sentence: ISentence,
+  statementId: number,
+): AssetReferenceRecord[] {
+  const entry = readCommandConfig(sentence.command)
+  const editorFields = readEditorFields(entry)
+  const contentField = editorFields.find(field => field.storage === 'content')
+  const argFields = deriveArgFieldsFromEditorFields(editorFields)
+
+  return [
+    ...extractContentReferences(sourcePath, sentence, statementId, contentField?.field),
+    ...extractArgReferences(sourcePath, sentence, statementId, argFields),
+  ]
+}
+
+function extractContentReferences(
+  sourcePath: AbsPath,
+  sentence: ISentence,
+  statementId: number,
+  field: ReturnType<typeof readEditorFields>[number]['field'] | undefined,
+): AssetReferenceRecord[] {
+  if (field?.type !== 'file') {
+    return []
+  }
+
+  const { assetType } = field.fileConfig
+  if (assetType === 'scene' && sentence.command === commandType.choose) {
+    return parseChooseContent(sentence.content)
+      .flatMap((item, index) =>
+        createReferenceRecord(sourcePath, 'scene', assetType, item.file, `choose[${index}].file`, statementId),
+      )
+  }
+
+  return createReferenceRecord(sourcePath, 'scene', assetType, sentence.content, '__content__', statementId)
+}
+
+function extractArgReferences(
+  sourcePath: AbsPath,
+  sentence: ISentence,
+  statementId: number,
+  argFields: ReturnType<typeof deriveArgFieldsFromEditorFields>,
+): AssetReferenceRecord[] {
+  return argFields.flatMap((argField) => {
+    if (argField.jsonMeta || argField.field.type !== 'file') {
+      return []
+    }
+
+    const argKey = readArgFieldStorageKey(argField)
+    const item = sentence.args.find((argItem: arg) => argItem.key === argKey)
+    if (!item || typeof item.value !== 'string') {
+      return []
+    }
+
+    return createReferenceRecord(
+      sourcePath,
+      'scene',
+      argField.field.fileConfig.assetType,
+      item.value,
+      argKey,
+      statementId,
+    )
+  })
+}
+
+function createReferenceRecord(
+  sourcePath: AbsPath,
+  sourceKind: AssetReferenceSourceKind,
+  assetType: string,
+  value: string,
+  fieldKey: string,
+  statementId?: number,
+): AssetReferenceRecord[] {
+  if (!shouldIndexAssetReferenceValue(assetType, value)) {
+    return []
+  }
+
+  const assetKey = createReferencedAssetKey(assetType, value)
+  if (!assetKey) {
+    return []
+  }
+
+  return [{
+    sourcePath,
+    sourceKind,
+    assetKey,
+    fieldKey,
+    ...(statementId === undefined ? {} : { statementId }),
+  }]
+}
+
+function createGameConfigReferenceRecords(
+  sourcePath: AbsPath,
+  fieldKey: string,
+  assetType: string,
+  value: string | undefined,
+  options: { splitValues?: boolean } = {},
+): AssetReferenceRecord[] {
+  if (!value) {
+    return []
+  }
+
+  const values = options.splitValues
+    ? value.split('|').map(item => item.trim()).filter(Boolean)
+    : [value]
+
+  return values.flatMap(item =>
+    createReferenceRecord(sourcePath, 'game-config', assetType, item, fieldKey),
+  )
+}
+
+function isGameConfigPath(gamePath: AbsPath, path: AbsPath): boolean {
+  return path === gameConfigPath(gamePath)
+}
+
+function isScenePath(gamePath: AbsPath, path: AbsPath): boolean {
+  const sceneRootPath = gameSceneDir(gamePath)
+  return path.startsWith(`${sceneRootPath}/`) && path.endsWith('.txt')
+}

--- a/src/services/resource-index/service.ts
+++ b/src/services/resource-index/service.ts
@@ -1,5 +1,6 @@
 import { useFileSystemEvents } from '~/composables/useFileSystemEvents'
 import { AbsPath } from '~/domain/path'
+import { gameConfigPath, gameSceneDir } from '~/services/platform/app-paths'
 import { useWorkspaceStore } from '~/stores/workspace'
 
 import {
@@ -189,6 +190,9 @@ async function rebuildReferenceForPath(gamePath: AbsPath, path: AbsPath): Promis
   if (shouldDeferPathUpdate(currentState, gamePath)) {
     return
   }
+  if (path !== gameConfigPath(gamePath) && !(path.startsWith(`${gameSceneDir(gamePath)}/`) && path.endsWith('.txt'))) {
+    return
+  }
 
   const updateVersion = beginReferenceSourceUpdate([path])
   const references = await rebuildReferenceSource(currentState.references, gamePath, path)
@@ -219,6 +223,7 @@ function cancelReferenceSourceUpdates(sourcePaths: AbsPath[]): void {
   const cancellationVersion = ++referenceSourceUpdateVersion
   for (const sourcePath of sourcePaths) {
     referenceSourceUpdateVersions.set(sourcePath, cancellationVersion)
+    referenceSourceUpdateVersions.delete(sourcePath)
   }
 }
 

--- a/src/services/resource-index/service.ts
+++ b/src/services/resource-index/service.ts
@@ -1,7 +1,5 @@
-import { effectScope } from 'vue'
-
 import { useFileSystemEvents } from '~/composables/useFileSystemEvents'
-import { AbsPath, RelPath } from '~/domain/path'
+import { AbsPath } from '~/domain/path'
 import { useWorkspaceStore } from '~/stores/workspace'
 
 import {
@@ -10,25 +8,43 @@ import {
   createEmptyAssetCatalogSnapshot,
   hasAssetInCatalog,
   isPathWithinGameRoot,
+  listAssetsByAssetType,
   removeAssetPathFromCatalog,
   renameAssetPathInCatalog,
+  resolveAssetByAbsolutePath,
 } from './catalog'
+import {
+  buildAssetReferenceIndex,
+  createEmptyAssetReferenceIndexSnapshot,
+  findMissingAssetReferences,
+  getReferencesFromSource,
+  getReferencesToAsset,
+  rebuildReferenceSource,
+  removeReferenceSource,
+  renameReferenceSource,
+} from './references'
 
-type ResourceCatalogStatus = 'idle' | 'building' | 'ready' | 'degraded'
+import type { AssetCatalogSnapshot } from './catalog'
+import type { AssetKey } from './keys'
+import type { AssetReferenceIndexSnapshot, AssetReferenceRecord } from './references'
+
+type ResourceIndexStatus = 'idle' | 'building' | 'ready' | 'degraded'
 
 const DIRECTORY_REBUILD_DEBOUNCE_MS = 200
 
-interface ResourceCatalogState {
-  status: ResourceCatalogStatus
+interface ResourceIndexState {
+  status: ResourceIndexStatus
   gamePath?: AbsPath
-  snapshot: ReturnType<typeof createEmptyAssetCatalogSnapshot>
+  catalog: AssetCatalogSnapshot
+  references: AssetReferenceIndexSnapshot
   dirty: boolean
 }
 
-const resourceCatalogState = shallowRef<ResourceCatalogState>({
+const resourceIndexState = shallowRef<ResourceIndexState>({
   status: 'idle',
   gamePath: undefined,
-  snapshot: createEmptyAssetCatalogSnapshot(),
+  catalog: createEmptyAssetCatalogSnapshot(),
+  references: createEmptyAssetReferenceIndexSnapshot(),
   dirty: false,
 })
 
@@ -36,9 +52,11 @@ let buildVersion = 0
 let bootstrapConsumerCount = 0
 let bootstrapScope: ReturnType<typeof effectScope> | undefined
 let pendingDirectoryRebuildTimer: ReturnType<typeof setTimeout> | undefined
+let referenceSourceUpdateVersion = 0
+const referenceSourceUpdateVersions = new Map<AbsPath, number>()
 
-function setCatalogState(nextState: ResourceCatalogState): void {
-  resourceCatalogState.value = nextState
+function setResourceIndexState(nextState: ResourceIndexState): void {
+  resourceIndexState.value = nextState
 }
 
 function clearPendingDirectoryRebuild(): void {
@@ -52,89 +70,219 @@ function scheduleDirectoryRebuild(gamePath: AbsPath): void {
   clearPendingDirectoryRebuild()
   pendingDirectoryRebuildTimer = setTimeout(() => {
     pendingDirectoryRebuildTimer = undefined
-    if (resourceCatalogState.value.gamePath !== gamePath) {
+    if (resourceIndexState.value.gamePath !== gamePath) {
       return
     }
-    void rebuildCatalog(gamePath)
+    void rebuildResourceIndex(gamePath)
   }, DIRECTORY_REBUILD_DEBOUNCE_MS)
 }
 
-function clearCatalogState(): void {
+function clearResourceIndexState(): void {
   buildVersion += 1
+  referenceSourceUpdateVersions.clear()
   clearPendingDirectoryRebuild()
-  setCatalogState({
+  setResourceIndexState({
     status: 'idle',
     gamePath: undefined,
-    snapshot: createEmptyAssetCatalogSnapshot(),
+    catalog: createEmptyAssetCatalogSnapshot(),
+    references: createEmptyAssetReferenceIndexSnapshot(),
     dirty: false,
   })
 }
 
-async function rebuildCatalog(gamePath: AbsPath): Promise<void> {
+async function rebuildResourceIndex(gamePath: AbsPath): Promise<void> {
   const currentBuildVersion = ++buildVersion
+  referenceSourceUpdateVersions.clear()
 
-  setCatalogState({
+  setResourceIndexState({
     status: 'building',
     gamePath,
-    snapshot: createEmptyAssetCatalogSnapshot(),
+    catalog: createEmptyAssetCatalogSnapshot(),
+    references: createEmptyAssetReferenceIndexSnapshot(),
     dirty: false,
   })
 
   try {
-    const snapshot = await buildAssetCatalog(gamePath)
+    const catalog = await buildAssetCatalog(gamePath)
+    const references = await buildAssetReferenceIndex(gamePath, catalog)
     if (currentBuildVersion !== buildVersion) {
       return
     }
 
-    const needsFollowUpRebuild = resourceCatalogState.value.gamePath === gamePath && resourceCatalogState.value.dirty
+    const needsFollowUpRebuild = resourceIndexState.value.gamePath === gamePath && resourceIndexState.value.dirty
 
-    setCatalogState({
+    setResourceIndexState({
       status: 'ready',
       gamePath,
-      snapshot,
+      catalog,
+      references,
       dirty: false,
     })
 
     if (needsFollowUpRebuild) {
-      void rebuildCatalog(gamePath)
+      void rebuildResourceIndex(gamePath)
     }
-  } catch {
+  } catch (error) {
+    logger.warn(`资源索引构建失败: ${error}`)
     if (currentBuildVersion !== buildVersion) {
       return
     }
 
-    setCatalogState({
+    setResourceIndexState({
       status: 'degraded',
       gamePath,
-      snapshot: createEmptyAssetCatalogSnapshot(),
+      catalog: createEmptyAssetCatalogSnapshot(),
+      references: createEmptyAssetReferenceIndexSnapshot(),
       dirty: false,
     })
   }
 }
 
-function applyCatalogSnapshot(
-  updater: (state: ResourceCatalogState) => ReturnType<typeof createEmptyAssetCatalogSnapshot>,
+function markBuildingStateDirty(state: ResourceIndexState): void {
+  if (resourceIndexState.value !== state || state.status !== 'building' || state.dirty) {
+    return
+  }
+
+  setResourceIndexState({
+    ...state,
+    dirty: true,
+  })
+}
+
+function shouldDeferPathUpdate(state: ResourceIndexState, gamePath: AbsPath): boolean {
+  if (state.gamePath !== gamePath) {
+    return true
+  }
+  if (state.status === 'building') {
+    markBuildingStateDirty(state)
+    return true
+  }
+  return state.status !== 'ready'
+}
+
+function applyReadyResourceIndexState(
+  updater: (state: ResourceIndexState) => Pick<ResourceIndexState, 'catalog' | 'references'>,
 ): void {
-  const currentState = resourceCatalogState.value
+  const currentState = resourceIndexState.value
   if (!currentState.gamePath) {
     return
   }
   if (currentState.status !== 'ready') {
     if (currentState.status === 'building') {
-      currentState.dirty = true
+      markBuildingStateDirty(currentState)
     }
     return
   }
 
-  setCatalogState({
+  const { catalog, references } = updater(currentState)
+  setResourceIndexState({
     status: currentState.status,
     gamePath: currentState.gamePath,
-    snapshot: updater(currentState),
+    catalog,
+    references,
     dirty: currentState.dirty,
   })
 }
 
-function bindResourceCatalogBootstrap(): void {
+async function rebuildReferenceForPath(gamePath: AbsPath, path: AbsPath): Promise<void> {
+  const currentState = resourceIndexState.value
+  if (shouldDeferPathUpdate(currentState, gamePath)) {
+    return
+  }
+
+  const updateVersion = beginReferenceSourceUpdate([path])
+  const references = await rebuildReferenceSource(currentState.references, gamePath, path)
+  applyReferenceSourceUpdate(gamePath, [path], path, getReferencesFromSource(references, path), updateVersion)
+}
+
+function beginReferenceSourceUpdate(sourcePaths: AbsPath[]): number {
+  const updateVersion = ++referenceSourceUpdateVersion
+  for (const sourcePath of sourcePaths) {
+    referenceSourceUpdateVersions.set(sourcePath, updateVersion)
+  }
+  return updateVersion
+}
+
+function isReferenceSourceUpdateCurrent(sourcePaths: AbsPath[], updateVersion: number): boolean {
+  return sourcePaths.every(sourcePath => referenceSourceUpdateVersions.get(sourcePath) === updateVersion)
+}
+
+function clearReferenceSourceUpdate(sourcePaths: AbsPath[], updateVersion: number): void {
+  for (const sourcePath of sourcePaths) {
+    if (referenceSourceUpdateVersions.get(sourcePath) === updateVersion) {
+      referenceSourceUpdateVersions.delete(sourcePath)
+    }
+  }
+}
+
+function cancelReferenceSourceUpdates(sourcePaths: AbsPath[]): void {
+  const cancellationVersion = ++referenceSourceUpdateVersion
+  for (const sourcePath of sourcePaths) {
+    referenceSourceUpdateVersions.set(sourcePath, cancellationVersion)
+  }
+}
+
+function replaceReferenceRecords(
+  snapshot: AssetReferenceIndexSnapshot,
+  removedSourcePaths: AbsPath[],
+  sourcePath: AbsPath,
+  records: AssetReferenceRecord[],
+): AssetReferenceIndexSnapshot {
+  const removedSourcePathSet = new Set<AbsPath>(removedSourcePaths)
+  return {
+    records: [
+      ...snapshot.records.filter(record => !removedSourcePathSet.has(record.sourcePath)),
+      ...records.filter(record => record.sourcePath === sourcePath),
+    ],
+  }
+}
+
+function applyReferenceSourceUpdate(
+  gamePath: AbsPath,
+  removedSourcePaths: AbsPath[],
+  sourcePath: AbsPath,
+  records: AssetReferenceRecord[],
+  updateVersion: number,
+): void {
+  const currentState = resourceIndexState.value
+  if (currentState.gamePath !== gamePath || currentState.status !== 'ready') {
+    return
+  }
+  if (!isReferenceSourceUpdateCurrent(removedSourcePaths, updateVersion)) {
+    return
+  }
+
+  setResourceIndexState({
+    ...currentState,
+    references: replaceReferenceRecords(
+      currentState.references,
+      removedSourcePaths,
+      sourcePath,
+      records,
+    ),
+  })
+  clearReferenceSourceUpdate(removedSourcePaths, updateVersion)
+}
+
+async function renameReferenceForPath(gamePath: AbsPath, oldPath: AbsPath, newPath: AbsPath): Promise<void> {
+  const currentState = resourceIndexState.value
+  if (shouldDeferPathUpdate(currentState, gamePath)) {
+    return
+  }
+
+  const affectedSourcePaths = [oldPath, newPath]
+  const updateVersion = beginReferenceSourceUpdate(affectedSourcePaths)
+  const references = await renameReferenceSource(currentState.references, gamePath, oldPath, newPath)
+  applyReferenceSourceUpdate(
+    gamePath,
+    affectedSourcePaths,
+    newPath,
+    getReferencesFromSource(references, newPath),
+    updateVersion,
+  )
+}
+
+function bindResourceIndexBootstrap(): void {
   bootstrapConsumerCount += 1
   if (bootstrapScope) {
     return
@@ -149,42 +297,42 @@ function bindResourceCatalogBootstrap(): void {
       () => workspaceStore.CWD,
       (gamePath) => {
         if (!gamePath) {
-          clearCatalogState()
+          clearResourceIndexState()
           return
         }
-        void rebuildCatalog(AbsPath.from(gamePath))
+        void rebuildResourceIndex(AbsPath.from(gamePath))
       },
       { immediate: true },
     )
 
     fileSystemEvents.on('file:created', (event) => {
-      const gamePath = resourceCatalogState.value.gamePath
-      if (!gamePath) {
+      const gamePath = resourceIndexState.value.gamePath
+      if (!gamePath || !isPathWithinGameRoot(gamePath, event.path)) {
         return
       }
 
-      if (!isPathWithinGameRoot(gamePath, event.path)) {
-        return
-      }
-
-      applyCatalogSnapshot(state => addAssetPathToCatalog(state.snapshot, gamePath, event.path))
+      applyReadyResourceIndexState(state => ({
+        catalog: addAssetPathToCatalog(state.catalog, gamePath, event.path),
+        references: state.references,
+      }))
+      void rebuildReferenceForPath(gamePath, event.path)
     })
 
     fileSystemEvents.on('file:removed', (event) => {
-      const gamePath = resourceCatalogState.value.gamePath
-      if (!gamePath) {
+      const gamePath = resourceIndexState.value.gamePath
+      if (!gamePath || !isPathWithinGameRoot(gamePath, event.path)) {
         return
       }
 
-      if (!isPathWithinGameRoot(gamePath, event.path)) {
-        return
-      }
-
-      applyCatalogSnapshot(state => removeAssetPathFromCatalog(state.snapshot, gamePath, event.path))
+      applyReadyResourceIndexState(state => ({
+        catalog: removeAssetPathFromCatalog(state.catalog, gamePath, event.path),
+        references: removeReferenceSource(state.references, event.path),
+      }))
+      cancelReferenceSourceUpdates([event.path])
     })
 
     fileSystemEvents.on('file:renamed', (event) => {
-      const gamePath = resourceCatalogState.value.gamePath
+      const gamePath = resourceIndexState.value.gamePath
       if (!gamePath) {
         return
       }
@@ -193,16 +341,32 @@ function bindResourceCatalogBootstrap(): void {
         return
       }
 
-      applyCatalogSnapshot(state => renameAssetPathInCatalog(
-        state.snapshot,
-        gamePath,
-        event.oldPath,
-        event.newPath,
-      ))
+      applyReadyResourceIndexState(state => ({
+        catalog: renameAssetPathInCatalog(
+          state.catalog,
+          gamePath,
+          event.oldPath,
+          event.newPath,
+        ),
+        references: state.references,
+      }))
+      void renameReferenceForPath(gamePath, event.oldPath, event.newPath)
     })
 
+    const rebuildReferenceOnFileChange = (path: AbsPath) => {
+      const gamePath = resourceIndexState.value.gamePath
+      if (!gamePath || !isPathWithinGameRoot(gamePath, path)) {
+        return
+      }
+
+      void rebuildReferenceForPath(gamePath, path)
+    }
+
+    fileSystemEvents.on('file:modified', event => rebuildReferenceOnFileChange(event.path))
+    fileSystemEvents.on('file:written', event => rebuildReferenceOnFileChange(event.path))
+
     const rebuildOnDirectoryChange = (path: AbsPath) => {
-      const gamePath = resourceCatalogState.value.gamePath
+      const gamePath = resourceIndexState.value.gamePath
       if (!gamePath) {
         return
       }
@@ -216,7 +380,7 @@ function bindResourceCatalogBootstrap(): void {
     fileSystemEvents.on('directory:created', event => rebuildOnDirectoryChange(event.path))
     fileSystemEvents.on('directory:removed', event => rebuildOnDirectoryChange(event.path))
     fileSystemEvents.on('directory:renamed', (event) => {
-      const { gamePath } = resourceCatalogState.value
+      const { gamePath } = resourceIndexState.value
       if (!gamePath) {
         return
       }
@@ -229,7 +393,7 @@ function bindResourceCatalogBootstrap(): void {
   })
 }
 
-function releaseResourceCatalogBootstrap(): void {
+function releaseResourceIndexBootstrap(): void {
   bootstrapConsumerCount = Math.max(0, bootstrapConsumerCount - 1)
   if (bootstrapConsumerCount > 0) {
     return
@@ -240,19 +404,37 @@ function releaseResourceCatalogBootstrap(): void {
   bootstrapScope = undefined
 }
 
-export function useResourceCatalogBootstrap() {
-  bindResourceCatalogBootstrap()
+export function useResourceIndexBootstrap() {
+  bindResourceIndexBootstrap()
 
   onScopeDispose(() => {
-    releaseResourceCatalogBootstrap()
+    releaseResourceIndexBootstrap()
   })
 }
 
-export function useResourceCatalog() {
+export function useResourceIndex() {
   return {
-    status: computed(() => resourceCatalogState.value.status),
-    hasAsset(assetType: string, relativePath: RelPath): boolean {
-      return hasAssetInCatalog(resourceCatalogState.value.snapshot, assetType, relativePath)
+    status: computed(() => resourceIndexState.value.status),
+    hasAssetKey(key: AssetKey): boolean {
+      return hasAssetInCatalog(resourceIndexState.value.catalog, key)
+    },
+    resolveByAbsolutePath(path: AbsPath) {
+      return resolveAssetByAbsolutePath(resourceIndexState.value.catalog, path)
+    },
+    listByAssetType(assetType: string) {
+      return listAssetsByAssetType(resourceIndexState.value.catalog, assetType)
+    },
+    getReferencesTo(key: AssetKey) {
+      return getReferencesToAsset(resourceIndexState.value.references, key)
+    },
+    getReferencesFrom(sourcePath: AbsPath) {
+      return getReferencesFromSource(resourceIndexState.value.references, sourcePath)
+    },
+    findMissingReferences() {
+      return findMissingAssetReferences(
+        resourceIndexState.value.references,
+        resourceIndexState.value.catalog,
+      )
     },
   }
 }

--- a/src/services/resource-index/values.ts
+++ b/src/services/resource-index/values.ts
@@ -10,12 +10,13 @@ function isVariableResourceReference(value: string): boolean {
 }
 
 export function shouldIndexAssetReferenceValue(assetType: string, value: string): boolean {
-  if (!value || isVariableResourceReference(value)) {
+  const trimmed = value.trim()
+  if (!trimmed || isVariableResourceReference(trimmed)) {
     return false
   }
 
   // scene 中不带 .txt 的值可能是 label，而不是文件路径。
-  if (assetType === 'scene' && !value.endsWith('.txt')) {
+  if (assetType === 'scene' && !trimmed.toLowerCase().endsWith('.txt')) {
     return false
   }
 
@@ -23,12 +24,13 @@ export function shouldIndexAssetReferenceValue(assetType: string, value: string)
 }
 
 export function createReferencedAssetKey(assetType: string, value: string): AssetKey | undefined {
-  if (!shouldIndexAssetReferenceValue(assetType, value)) {
+  const trimmed = value.trim()
+  if (!shouldIndexAssetReferenceValue(assetType, trimmed)) {
     return
   }
 
   try {
-    return createAssetKeyForType(assetType, RelPath.from(value))
+    return createAssetKeyForType(assetType, RelPath.from(trimmed))
   } catch {
     return
   }

--- a/src/services/resource-index/values.ts
+++ b/src/services/resource-index/values.ts
@@ -1,0 +1,35 @@
+import { RelPath } from '~/domain/path'
+
+import { createAssetKeyForType } from './keys'
+
+import type { AssetKey } from './keys'
+
+function isVariableResourceReference(value: string): boolean {
+  const trimmed = value.trim()
+  return /^\{[^{}]+\}$/.test(trimmed)
+}
+
+export function shouldIndexAssetReferenceValue(assetType: string, value: string): boolean {
+  if (!value || isVariableResourceReference(value)) {
+    return false
+  }
+
+  // scene 中不带 .txt 的值可能是 label，而不是文件路径。
+  if (assetType === 'scene' && !value.endsWith('.txt')) {
+    return false
+  }
+
+  return true
+}
+
+export function createReferencedAssetKey(assetType: string, value: string): AssetKey | undefined {
+  if (!shouldIndexAssetReferenceValue(assetType, value)) {
+    return
+  }
+
+  try {
+    return createAssetKeyForType(assetType, RelPath.from(value))
+  } catch {
+    return
+  }
+}


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [ ] 错误修复
- [x] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [x] 代码重构
- [x] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

1. 在现有资源清单基础上，为 `src/services/resource-index` 补齐资源引用索引能力。
2. 新增 `AssetKey`、引用记录和值过滤逻辑，统一资源身份和资源引用值的规范化方式。
3. 为 scene 文件和 game config 建立结构化引用提取，并提供：
   - `resolveByAbsolutePath`
   - `listByAssetType`
   - `getReferencesTo`
   - `getReferencesFrom`
   - `findMissingReferences`
4. 复用工作区文件事件做增量更新，覆盖资源文件、scene 文件和 game config 的局部重建，并补上并发更新的版本保护，避免旧切片覆盖新结果。
5. 将已有的 `file missing` 查询收敛到资源索引的统一资源值过滤和 `AssetKey` 查询逻辑，减少重复判定和语义漂移。
6. 补充测试，覆盖引用建立、缺失引用诊断、重命名/修改后的增量更新，以及并发更新保护等场景。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

此前资源索引已经承担了资源清单和热路径存在性查询的基础职责，但它还不能回答另一个同样关键的问题：某个资源被哪些结构化来源引用。

如果继续让不同用例各自解析场景文件、各自读取游戏配置、各自维护引用判断规则，就会持续出现：

1. 资源引用语义分散，难以保证一致；
2. 同类扫描逻辑重复实现，维护成本上升；
3. 后续缺失引用诊断、引用分析和引用重写缺少统一查询底座。

这次改动的目标是把资源索引从“资源清单”扩展为“资源清单 + 资源引用索引”，让资源相关功能可以共享同一套查询结果和增量更新机制。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
