### PR TITLE
✨ 支持可视化编辑器语句拖拽排序

### DIFF
--- a/src/components/app/DragOverlay.vue
+++ b/src/components/app/DragOverlay.vue
@@ -2,6 +2,7 @@
 import type { StyleValue } from 'vue'
 
 interface DragOverlayProps {
+  frameStyle?: StyleValue
   overlayStyle?: StyleValue
   visible?: boolean
 }
@@ -13,13 +14,18 @@ const props = defineProps<DragOverlayProps>()
   <Teleport to="body">
     <div
       v-if="props.visible"
-      class="pointer-events-none select-none left-0 top-0 fixed"
-      :style="props.overlayStyle"
+      class="pointer-events-none inset-0 fixed z-[9999] overflow-hidden"
+      :style="props.frameStyle"
       aria-hidden="true"
     >
-      <slot>
-        <div class="border border-border/70 rounded-md bg-background/90 h-8 min-w-16 shadow-lg backdrop-blur-sm" />
-      </slot>
+      <div
+        class="pointer-events-none select-none left-0 top-0 absolute"
+        :style="props.overlayStyle"
+      >
+        <slot>
+          <div class="border border-border/70 rounded-md bg-background/90 h-8 min-w-16 shadow-lg backdrop-blur-sm" />
+        </slot>
+      </div>
     </div>
   </Teleport>
 </template>

--- a/src/components/editor/EditorTabs.vue
+++ b/src/components/editor/EditorTabs.vue
@@ -155,6 +155,7 @@ onMounted(() => {
 
   <DragOverlay
     :visible="tabSort.overlayState.value !== undefined"
+    :frame-style="tabSort.overlayState.value?.overlayFrameStyle"
     :overlay-style="tabSort.overlayState.value?.overlayStyle"
   >
     <EditorTabButton

--- a/src/components/editor/VisualEditorScene.spec.ts
+++ b/src/components/editor/VisualEditorScene.spec.ts
@@ -1,13 +1,58 @@
 import { createPinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { page } from 'vitest/browser'
-import { computed, defineComponent, h, reactive } from 'vue'
+import { computed, defineComponent, h, nextTick, reactive, vShow, withDirectives } from 'vue'
 
 import { createBrowserContainerStub, renderInBrowser } from '~/__tests__/browser-render'
+import { useShortcutContextRegistry } from '~/features/editor/shortcut/shortcut-context-registry'
 
 import VisualEditorScene from './VisualEditorScene.vue'
 
+import type { StatementEntry } from '~/domain/script/sentence'
 import type { SceneVisualProjectionState } from '~/stores/editor'
+
+function createPointerEvent(type: string, overrides: PointerEventInit = {}): PointerEvent {
+  return new PointerEvent(type, {
+    bubbles: true,
+    button: 0,
+    buttons: type === 'pointerup' || type === 'pointercancel' ? 0 : 1,
+    cancelable: true,
+    isPrimary: true,
+    pointerId: 1,
+    pointerType: 'mouse',
+    ...overrides,
+  })
+}
+
+function setRect(element: HTMLElement, rect: DOMRect) {
+  Object.defineProperty(element, 'getBoundingClientRect', {
+    configurable: true,
+    value: () => rect,
+  })
+}
+
+function createVerticalRect(top: number, height: number = 48): DOMRect {
+  return {
+    bottom: top + height,
+    height,
+    left: 0,
+    right: 320,
+    top,
+    width: 320,
+    x: 0,
+    y: top,
+    toJSON: () => ({}),
+  }
+}
+
+function createStatementEntry(id: number, rawText: string): StatementEntry {
+  return {
+    id,
+    rawText,
+    parsed: undefined,
+    parseError: false,
+  }
+}
 
 const {
   handleCollapsedUpdateMock,
@@ -16,6 +61,8 @@ const {
   handleStatementDeleteMock,
   handleStatementUpdateMock,
   measureRowElementMock,
+  reorderStatementsMock,
+  statementSortVirtualAdapterMock,
   useEditSettingsStoreMock,
   usePreferenceStoreMock,
   useEditorStoreMock,
@@ -28,6 +75,17 @@ const {
   handleStatementDeleteMock: vi.fn(),
   handleStatementUpdateMock: vi.fn(),
   measureRowElementMock: vi.fn(),
+  reorderStatementsMock: vi.fn(),
+  statementSortVirtualAdapterMock: {
+    getEstimatedItemSize: vi.fn(() => 48),
+    getItemCount: vi.fn(() => 2),
+    getScrollOffset: vi.fn(() => 0),
+    getVisibleItems: vi.fn(() => [
+      { index: 0, size: 48, start: 0 },
+      { index: 1, size: 48, start: 48 },
+    ]),
+    invalidate: vi.fn(),
+  },
   useEditSettingsStoreMock: vi.fn(),
   useEditorStoreMock: vi.fn(),
   usePreferenceStoreMock: vi.fn(),
@@ -80,7 +138,11 @@ const globalStubs = {
           'aria-selected': props.selected,
           'role': 'option',
           'tabindex': props.selected ? 0 : -1,
-        }),
+        }, [
+          h('div', {
+            'data-statement-drag-handle': '',
+          }),
+        ]),
         h('button', {
           type: 'button',
           onClick: () => emit('select', props.entry.id),
@@ -105,8 +167,8 @@ function createSceneState(): SceneVisualProjectionState {
     kind: 'scene',
     path: '/project/scene.txt',
     statements: [
-      { id: 1, rawText: 'say:hello' },
-      { id: 2, rawText: 'say:world' },
+      createStatementEntry(1, 'say:hello'),
+      createStatementEntry(2, 'say:world'),
     ],
   } as SceneVisualProjectionState
 }
@@ -124,6 +186,15 @@ describe('VisualEditorScene', () => {
     handleStatementDeleteMock.mockReset()
     handleStatementUpdateMock.mockReset()
     measureRowElementMock.mockReset()
+    reorderStatementsMock.mockReset()
+    statementSortVirtualAdapterMock.getEstimatedItemSize.mockReturnValue(48)
+    statementSortVirtualAdapterMock.getItemCount.mockReturnValue(2)
+    statementSortVirtualAdapterMock.getScrollOffset.mockReturnValue(0)
+    statementSortVirtualAdapterMock.getVisibleItems.mockReturnValue([
+      { index: 0, size: 48, start: 0 },
+      { index: 1, size: 48, start: 48 },
+    ])
+    statementSortVirtualAdapterMock.invalidate.mockReset()
     useEditSettingsStoreMock.mockReset()
     useEditorStoreMock.mockReset()
     usePreferenceStoreMock.mockReset()
@@ -158,8 +229,10 @@ describe('VisualEditorScene', () => {
       isPositioning: computed(() => false),
       isStatementCollapsed: (statementId: number) => statementId === 2,
       measureRowElement: measureRowElementMock,
-      previousSpeakers: ['', 'Alice'],
+      previousSpeakers: computed(() => ['', 'Alice']),
+      reorderStatements: reorderStatementsMock,
       selectedStatementId: 2,
+      statementSortVirtualAdapter: statementSortVirtualAdapterMock,
       totalSize: 120,
       virtualRows: [
         { index: 0, key: 0, start: 0 },
@@ -220,6 +293,154 @@ describe('VisualEditorScene', () => {
 
     await expect.element(page.getByRole('button', { name: 'play-2' })).toHaveAttribute('disabled')
     expect(handlePlayToMock).not.toHaveBeenCalled()
+  })
+
+  it('语句列表项会暴露排序索引和拖拽手柄', async () => {
+    const state = createSceneState()
+    state.statements.push(createStatementEntry(3, 'say:again'))
+    statementSortVirtualAdapterMock.getEstimatedItemSize.mockReturnValue(100)
+    statementSortVirtualAdapterMock.getItemCount.mockReturnValue(3)
+    statementSortVirtualAdapterMock.getVisibleItems.mockReturnValue([
+      { index: 0, size: 100, start: 0 },
+      { index: 1, size: 100, start: 100 },
+      { index: 2, size: 100, start: 200 },
+    ])
+    useVisualEditorSceneRuntimeMock.mockReturnValue({
+      handleCollapsedUpdate: handleCollapsedUpdateMock,
+      handlePlayTo: handlePlayToMock,
+      handleSelect: handleSelectMock,
+      handleStatementDelete: handleStatementDeleteMock,
+      handleStatementUpdate: handleStatementUpdateMock,
+      isPositioning: computed(() => false),
+      isStatementCollapsed: () => false,
+      measureRowElement: measureRowElementMock,
+      previousSpeakers: computed(() => ['', 'Alice', 'Bob']),
+      reorderStatements: reorderStatementsMock,
+      selectedStatementId: 1,
+      statementSortVirtualAdapter: statementSortVirtualAdapterMock,
+      totalSize: 300,
+      virtualRows: [
+        { index: 0, key: 1, start: 0 },
+        { index: 1, key: 2, start: 100 },
+        { index: 2, key: 3, start: 200 },
+      ],
+    })
+
+    renderInBrowser(VisualEditorScene, {
+      props: {
+        state,
+      },
+      global: {
+        plugins: [createPinia()],
+        stubs: globalStubs,
+      },
+    })
+
+    const firstItem = document.querySelector<HTMLElement>('[data-drag-index="0"]')
+    expect(firstItem).not.toBeNull()
+    expect(firstItem!.dataset.dragIndex).toBe('0')
+    expect(firstItem!.querySelector('[data-statement-drag-handle]')).not.toBeNull()
+  })
+
+  it('拖拽语句手柄会提交语句重排', async () => {
+    renderInBrowser(VisualEditorScene, {
+      props: {
+        state: createSceneState(),
+      },
+      global: {
+        plugins: [createPinia()],
+        stubs: globalStubs,
+      },
+    })
+    await nextTick()
+
+    const listbox = document.querySelector<HTMLElement>('[role="listbox"]')
+    const firstItem = document.querySelector<HTMLElement>('[data-drag-index="0"]')
+    const secondItem = document.querySelector<HTMLElement>('[data-drag-index="1"]')
+    const handle = firstItem?.querySelector<HTMLElement>('[data-statement-drag-handle]')
+
+    expect(listbox).not.toBeNull()
+    expect(firstItem).not.toBeNull()
+    expect(secondItem).not.toBeNull()
+    expect(handle).not.toBeNull()
+
+    setRect(listbox!, createVerticalRect(0, 96))
+    setRect(firstItem!, createVerticalRect(0))
+    setRect(secondItem!, createVerticalRect(48))
+
+    handle!.dispatchEvent(createPointerEvent('pointerdown', { clientX: 8, clientY: 8 }))
+    globalThis.dispatchEvent(createPointerEvent('pointermove', { clientX: 8, clientY: 90 }))
+    globalThis.dispatchEvent(createPointerEvent('pointerup', { clientX: 8, clientY: 90 }))
+
+    await vi.waitFor(() => {
+      expect(reorderStatementsMock).toHaveBeenCalledWith(0, 1, { restoreSelectionPresentation: false })
+    })
+  })
+
+  it('拖拽语句排序后会恢复可视化编辑器快捷键焦点上下文', async () => {
+    renderInBrowser(VisualEditorScene, {
+      props: {
+        state: createSceneState(),
+      },
+      global: {
+        plugins: [createPinia()],
+        stubs: globalStubs,
+      },
+    })
+    await nextTick()
+
+    const listbox = document.querySelector<HTMLElement>('[role="listbox"]')
+    const firstItem = document.querySelector<HTMLElement>('[data-drag-index="0"]')
+    const secondItem = document.querySelector<HTMLElement>('[data-drag-index="1"]')
+    const handle = firstItem?.querySelector<HTMLElement>('[data-statement-drag-handle]')
+
+    expect(listbox).not.toBeNull()
+    expect(firstItem).not.toBeNull()
+    expect(secondItem).not.toBeNull()
+    expect(handle).not.toBeNull()
+
+    setRect(listbox!, createVerticalRect(0, 96))
+    setRect(firstItem!, createVerticalRect(0))
+    setRect(secondItem!, createVerticalRect(48))
+
+    handle!.dispatchEvent(createPointerEvent('pointerdown', { clientX: 8, clientY: 8 }))
+    globalThis.dispatchEvent(createPointerEvent('pointermove', { clientX: 8, clientY: 90 }))
+    globalThis.dispatchEvent(createPointerEvent('pointerup', { clientX: 8, clientY: 90 }))
+
+    await vi.waitFor(() => {
+      expect(reorderStatementsMock).toHaveBeenCalledWith(0, 1, { restoreSelectionPresentation: false })
+    })
+
+    expect(document.activeElement).toHaveAttribute('tabindex', '-1')
+    expect(useShortcutContextRegistry().resolveContext().panelFocus).toBe('editor')
+  })
+
+  it('根节点可承载父级运行时 directive', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const state = createSceneState()
+    const WrappedScene = defineComponent({
+      name: 'WrappedSceneWithDirective',
+      setup() {
+        return () => withDirectives(h(VisualEditorScene, { state }), [
+          [vShow, true],
+        ])
+      },
+    })
+
+    try {
+      renderInBrowser(WrappedScene, {
+        global: {
+          plugins: [createPinia()],
+          stubs: globalStubs,
+        },
+      })
+
+      expect(warnSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining('Runtime directive used on component with non-element root node'),
+      )
+    } finally {
+      warnSpy.mockRestore()
+    }
   })
 
   it('视觉模式请求焦点时会把焦点恢复到选中语句卡片', async () => {

--- a/src/components/editor/VisualEditorScene.vue
+++ b/src/components/editor/VisualEditorScene.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { useDragSort } from '~/composables/useDragSort'
 import { useShortcutContext } from '~/features/editor/shortcut/useShortcutContext'
 import { useVisualEditorFocusRequest } from '~/features/editor/visual-editor/useVisualEditorFocusRequest'
 import { useVisualEditorSceneRuntime } from '~/features/editor/visual-editor/useVisualEditorSceneRuntime'
@@ -19,6 +20,7 @@ const editSettings = useEditSettingsStore()
 const editorSurfaceRef = useTemplateRef<HTMLDivElement>('editorSurfaceRef')
 const preferenceStore = usePreferenceStore()
 const scrollAreaRef = useTemplateRef<InstanceType<typeof ScrollArea>>('scrollAreaRef')
+const statementListRef = useTemplateRef<HTMLElement>('statementListRef')
 const runtime = useVisualEditorSceneRuntime({
   getScrollArea: () => scrollAreaRef.value,
   getState: () => props.state,
@@ -34,10 +36,64 @@ const {
   isStatementCollapsed,
   measureRowElement,
   previousSpeakers,
+  reorderStatements,
   selectedStatementId,
+  statementSortVirtualAdapter,
   totalSize,
   virtualRows,
 } = runtime
+
+const statements = computed(() => props.state.statements)
+const scrollViewportRef = shallowRef<HTMLElement>()
+const statementReadonly = $computed(() => preferenceStore.showSidebar && editSettings.collapseStatementsOnSidebarOpen)
+const statementSort = useDragSort({
+  direction: 'vertical',
+  getKey: statement => String(statement.id),
+  getPayload: statement => ({
+    source: 'visual-editor',
+    statementId: statement.id,
+    type: 'scene-statement',
+  }),
+  handleSelector: '[data-statement-drag-handle]',
+  items: statements,
+  onSort: handleStatementSort,
+  scrollContainer: scrollViewportRef,
+  virtualAdapter: statementSortVirtualAdapter,
+})
+const statementOverlayState = computed(() => statementSort.overlayState.value)
+const statementOverlayIndex = computed(() => {
+  const overlayStatement = statementOverlayState.value?.item
+  if (!overlayStatement) {
+    return -1
+  }
+
+  return props.state.statements.findIndex(statement => statement.id === overlayStatement.id)
+})
+const statementOverlayPreviousSpeaker = computed(() => {
+  const overlayIndex = statementOverlayIndex.value
+  return overlayIndex === -1 ? '' : previousSpeakers.value[overlayIndex] ?? ''
+})
+
+function handleStatementSort(fromIndex: number, toIndex: number) {
+  reorderStatements(fromIndex, toIndex, { restoreSelectionPresentation: false })
+  editorSurfaceRef.value?.focus({ preventScroll: true })
+}
+
+function updateScrollViewportRef() {
+  scrollViewportRef.value = scrollAreaRef.value?.viewport?.viewportElement
+}
+
+function updateStatementSortRefs() {
+  statementSort.containerRef.value = statementListRef.value ?? undefined
+  updateScrollViewportRef()
+}
+
+function handleOverlayCollapsedUpdate(collapsed: boolean) {
+  const statementId = statementOverlayState.value?.item.id
+  if (statementId !== undefined) {
+    handleCollapsedUpdate(statementId, collapsed)
+  }
+}
 
 useShortcutContext({
   panelFocus: 'editor',
@@ -55,12 +111,15 @@ useVisualEditorFocusRequest({
   rootElement: editorSurfaceRef,
 })
 
+onMounted(() => {
+  updateStatementSortRefs()
+})
 </script>
 
 <template>
   <div ref="editorSurfaceRef" tabindex="-1" class="outline-none h-full">
     <ScrollArea ref="scrollAreaRef" class="h-full" :style="{ opacity: isPositioning ? 0 : 1 }">
-      <div role="listbox" :aria-label="$t('edit.visualEditor.statementList')" :style="{ height: `${totalSize}px`, width: '100%', position: 'relative' }">
+      <div ref="statementListRef" role="listbox" :aria-label="$t('edit.visualEditor.statementList')" :style="{ height: `${totalSize}px`, width: '100%', position: 'relative' }">
         <div
           v-for="row in virtualRows"
           :key="(row.key as number)"
@@ -76,22 +135,51 @@ useVisualEditorFocusRequest({
             transform: `translateY(${row.start}px)`,
           }"
         >
-          <VisualEditorStatementCard
-            :collapsed="isStatementCollapsed(props.state.statements[row.index].id)"
-            :entry="props.state.statements[row.index]"
-            :index="row.index"
-            :play-to-disabled="props.state.isDirty"
-            :selected="props.state.statements[row.index].id === selectedStatementId"
-            :readonly="preferenceStore.showSidebar && editSettings.collapseStatementsOnSidebarOpen"
-            :previous-speaker="previousSpeakers[row.index]"
-            @update="handleStatementUpdate"
-            @update:collapsed="val => handleCollapsedUpdate(props.state.statements[row.index].id, val)"
-            @select="handleSelect"
-            @delete="handleStatementDelete"
-            @play-to="handlePlayTo"
-          />
+          <div
+            v-bind="statementSort.getItemProps(row.index)"
+            :style="statementSort.getItemStyle(row.index)"
+          >
+            <VisualEditorStatementCard
+              :collapsed="isStatementCollapsed(props.state.statements[row.index].id)"
+              :entry="props.state.statements[row.index]"
+              :index="row.index"
+              :play-to-disabled="props.state.isDirty"
+              :selected="props.state.statements[row.index].id === selectedStatementId"
+              :readonly="statementReadonly"
+              :previous-speaker="previousSpeakers[row.index]"
+              @update="handleStatementUpdate"
+              @update:collapsed="val => handleCollapsedUpdate(props.state.statements[row.index].id, val)"
+              @select="handleSelect"
+              @delete="handleStatementDelete"
+              @play-to="handlePlayTo"
+            />
+          </div>
         </div>
       </div>
     </ScrollArea>
+
+    <DragOverlay
+      :visible="statementOverlayState !== undefined"
+      :frame-style="statementOverlayState?.overlayFrameStyle"
+      :overlay-style="statementOverlayState?.overlayStyle"
+    >
+      <VisualEditorStatementCard
+        v-if="statementOverlayState"
+        :collapsed="isStatementCollapsed(statementOverlayState.item.id)"
+        :entry="statementOverlayState.item"
+        :index="statementOverlayIndex"
+        :play-to-disabled="true"
+        :selected="statementOverlayState.item.id === selectedStatementId"
+        :readonly="statementReadonly"
+        :previous-speaker="statementOverlayPreviousSpeaker"
+        @update="handleStatementUpdate"
+        @update:collapsed="handleOverlayCollapsedUpdate"
+        @select="handleSelect"
+        @delete="handleStatementDelete"
+        @play-to="handlePlayTo"
+      >
+        <template #actions />
+      </VisualEditorStatementCard>
+    </DragOverlay>
   </div>
 </template>

--- a/src/components/editor/VisualEditorStatementCard.vue
+++ b/src/components/editor/VisualEditorStatementCard.vue
@@ -117,7 +117,7 @@ function paramBadgeClass(param: StatementCardPreviewParam): string {
     >
       <!-- 命令头部 -->
       <div class="flex gap-2 items-center justify-between">
-        <div class="flex gap-1 cursor-grab items-center active:cursor-grabbing">
+        <div class="flex gap-1 cursor-grab items-center active:cursor-grabbing" data-statement-drag-handle>
           <!-- 拖拽手柄 -->
           <div class="i-lucide-grip-vertical text-muted-foreground opacity-40 size-4 transition-opacity group-hover:opacity-70" />
           <!-- 序号 -->

--- a/src/composables/__tests__/useAutoScrollOnDrag.test.ts
+++ b/src/composables/__tests__/useAutoScrollOnDrag.test.ts
@@ -185,6 +185,40 @@ describe('useAutoScrollOnDrag', () => {
     })
   })
 
+  it('拖拽矩形同时越过两侧边缘时使用绝对值更大的滚动速度', () => {
+    const { flushAnimationFrame } = setupAnimationFrame()
+    const container = createTestContainer()
+    const containerRef = {
+      value: container as unknown as HTMLElement,
+    } as unknown as Ref<HTMLElement | undefined>
+    const autoScroll = useAutoScrollOnDrag({
+      axis: 'vertical',
+      container: containerRef,
+      edgeSize: 20,
+      maxSpeed: 200,
+    })
+
+    autoScroll.update({ x: 50, y: 50 }, {
+      bottom: 130,
+      left: 20,
+      right: 80,
+      top: -10,
+    }, {
+      bottom: 130,
+      left: 20,
+      right: 80,
+      top: 0,
+    })
+    flushAnimationFrame(100)
+    flushAnimationFrame(200)
+
+    expect(container.scrollBy).toHaveBeenLastCalledWith({
+      behavior: 'auto',
+      left: 0,
+      top: 20,
+    })
+  })
+
   it('默认边缘触发距离不会覆盖过大的容器内区域', () => {
     const { flushAnimationFrame } = setupAnimationFrame()
     const container = createTestContainer()

--- a/src/composables/__tests__/useAutoScrollOnDrag.test.ts
+++ b/src/composables/__tests__/useAutoScrollOnDrag.test.ts
@@ -11,6 +11,25 @@ interface TestScrollContainer {
   scrollBy: ReturnType<typeof vi.fn>
 }
 
+function createTestContainer(): TestScrollContainer {
+  return {
+    getBoundingClientRect: () => ({
+      bottom: 100,
+      height: 100,
+      left: 0,
+      right: 100,
+      top: 0,
+      width: 100,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    }),
+    scrollLeft: 0,
+    scrollTop: 0,
+    scrollBy: vi.fn(),
+  }
+}
+
 function setupAnimationFrame() {
   let nextFrameId = 1
   const callbacks = new Map<number, FrameRequestCallback>()
@@ -47,22 +66,7 @@ afterEach(() => {
 describe('useAutoScrollOnDrag', () => {
   it('指针靠近容器边缘时会按指定轴和时间增量滚动', () => {
     const { flushAnimationFrame } = setupAnimationFrame()
-    const container: TestScrollContainer = {
-      getBoundingClientRect: () => ({
-        bottom: 100,
-        height: 100,
-        left: 0,
-        right: 100,
-        top: 0,
-        width: 100,
-        x: 0,
-        y: 0,
-        toJSON: () => ({}),
-      }),
-      scrollLeft: 0,
-      scrollTop: 0,
-      scrollBy: vi.fn(),
-    }
+    const container = createTestContainer()
     const containerRef = {
       value: container as unknown as HTMLElement,
     } as unknown as Ref<HTMLElement | undefined>
@@ -80,28 +84,13 @@ describe('useAutoScrollOnDrag', () => {
     expect(container.scrollBy).toHaveBeenLastCalledWith({
       behavior: 'auto',
       left: 0,
-      top: 15,
+      top: 7.5,
     })
   })
 
   it('横向滚动不会写入纵向 scroll delta', () => {
     const { flushAnimationFrame } = setupAnimationFrame()
-    const container: TestScrollContainer = {
-      getBoundingClientRect: () => ({
-        bottom: 100,
-        height: 100,
-        left: 0,
-        right: 100,
-        top: 0,
-        width: 100,
-        x: 0,
-        y: 0,
-        toJSON: () => ({}),
-      }),
-      scrollLeft: 0,
-      scrollTop: 0,
-      scrollBy: vi.fn(),
-    }
+    const container = createTestContainer()
     const containerRef = {
       value: container as unknown as HTMLElement,
     } as unknown as Ref<HTMLElement | undefined>
@@ -118,30 +107,112 @@ describe('useAutoScrollOnDrag', () => {
 
     expect(container.scrollBy).toHaveBeenLastCalledWith({
       behavior: 'auto',
-      left: 15,
+      left: 7.5,
       top: 0,
     })
+  })
+
+  it('拖拽矩形触及容器边缘时即使指针未靠近边缘也会滚动', () => {
+    const { flushAnimationFrame } = setupAnimationFrame()
+    const container = createTestContainer()
+    const containerRef = {
+      value: container as unknown as HTMLElement,
+    } as unknown as Ref<HTMLElement | undefined>
+    const autoScroll = useAutoScrollOnDrag({
+      axis: 'vertical',
+      container: containerRef,
+      edgeSize: 20,
+      maxSpeed: 200,
+    })
+
+    autoScroll.update({ x: 50, y: 50 }, {
+      bottom: 95,
+      left: 20,
+      right: 80,
+      top: 35,
+    })
+    flushAnimationFrame(100)
+    flushAnimationFrame(200)
+
+    expect(container.scrollBy).toHaveBeenLastCalledWith({
+      behavior: 'auto',
+      left: 0,
+      top: 7.5,
+    })
+  })
+
+  it('速度边界越过容器边缘越深滚动越快', () => {
+    const { flushAnimationFrame } = setupAnimationFrame()
+    const container = createTestContainer()
+    const containerRef = {
+      value: container as unknown as HTMLElement,
+    } as unknown as Ref<HTMLElement | undefined>
+    const autoScroll = useAutoScrollOnDrag({
+      axis: 'vertical',
+      container: containerRef,
+      edgeSize: 20,
+      maxSpeed: 200,
+    })
+    const triggerBounds = {
+      bottom: 100,
+      left: 20,
+      right: 80,
+      top: 40,
+    }
+
+    autoScroll.update({ x: 50, y: 50 }, triggerBounds, {
+      ...triggerBounds,
+      bottom: 100,
+    })
+    flushAnimationFrame(100)
+    flushAnimationFrame(200)
+    expect(container.scrollBy).toHaveBeenLastCalledWith({
+      behavior: 'auto',
+      left: 0,
+      top: 10,
+    })
+
+    autoScroll.update({ x: 50, y: 50 }, triggerBounds, {
+      ...triggerBounds,
+      bottom: 120,
+    })
+    flushAnimationFrame(300)
+    flushAnimationFrame(400)
+    expect(container.scrollBy).toHaveBeenLastCalledWith({
+      behavior: 'auto',
+      left: 0,
+      top: 20,
+    })
+  })
+
+  it('默认边缘触发距离不会覆盖过大的容器内区域', () => {
+    const { flushAnimationFrame } = setupAnimationFrame()
+    const container = createTestContainer()
+    const containerRef = {
+      value: container as unknown as HTMLElement,
+    } as unknown as Ref<HTMLElement | undefined>
+    const autoScroll = useAutoScrollOnDrag({
+      axis: 'vertical',
+      container: containerRef,
+      maxSpeed: 200,
+    })
+
+    autoScroll.update({ x: 50, y: 50 }, {
+      bottom: 70,
+      left: 20,
+      right: 80,
+      top: 30,
+    })
+    flushAnimationFrame(100)
+    flushAnimationFrame(200)
+
+    expect(container.scrollBy).not.toHaveBeenCalled()
   })
 
   it('容器无法继续滚动时停止 RAF 循环且不触发滚动回调', () => {
     const { flushAnimationFrame, getPendingFrameCount } = setupAnimationFrame()
     const onScroll = vi.fn()
-    const container: TestScrollContainer = {
-      getBoundingClientRect: () => ({
-        bottom: 100,
-        height: 100,
-        left: 0,
-        right: 100,
-        top: 0,
-        width: 100,
-        x: 0,
-        y: 0,
-        toJSON: () => ({}),
-      }),
-      scrollLeft: 0,
-      scrollTop: 0,
-      scrollBy: vi.fn(),
-    }
+    const container = createTestContainer()
     const containerRef = {
       value: container as unknown as HTMLElement,
     } as unknown as Ref<HTMLElement | undefined>
@@ -160,7 +231,7 @@ describe('useAutoScrollOnDrag', () => {
     expect(container.scrollBy).toHaveBeenLastCalledWith({
       behavior: 'auto',
       left: 0,
-      top: 15,
+      top: 7.5,
     })
     expect(onScroll).not.toHaveBeenCalled()
     expect(getPendingFrameCount()).toBe(0)

--- a/src/composables/__tests__/useDragSort.test.ts
+++ b/src/composables/__tests__/useDragSort.test.ts
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { useDragSession } from '../useDragSession'
 import { useDragSort } from '../useDragSort'
 
+import type { DragSortVirtualAdapter } from '../useDragSort'
 import type { Ref, StyleValue } from 'vue'
 import type { EditorTabDragPayload } from '~/types/drag-drop'
 
@@ -79,10 +80,24 @@ function createRect(left: number, width: number, top: number = 0, height: number
   }
 }
 
+function createVerticalRect(top: number, height: number = 100, left: number = 0, width: number = 320): DOMRect {
+  return createRect(left, width, top, height)
+}
+
 function createIgnoredTarget(): TestTargetElement {
   const target = {
     closest(selector: string) {
       return selector === '[data-drag-ignore]' ? target as unknown as Element : null
+    },
+  }
+
+  return target as TestTargetElement
+}
+
+function createHandleTarget(): TestTargetElement {
+  const target = {
+    closest(selector: string) {
+      return selector === '[data-tab-handle]' ? target as unknown as Element : null
     },
   }
 
@@ -257,6 +272,45 @@ function createSortFixture(itemsRef: Ref<string[]> = shallowRef(['a', 'b', 'c'])
     itemsRef,
     onSort,
     sort,
+  }
+}
+
+function createVirtualSortFixture(viewportHeight: number = 300) {
+  const itemsRef = shallowRef(Array.from({ length: 50 }, (_value, index) => `item-${index}`))
+  const elements = [
+    createDragElement(20, createVerticalRect(0)),
+    createDragElement(21, createVerticalRect(100)),
+    createDragElement(22, createVerticalRect(200)),
+  ]
+  const onSort = vi.fn()
+  const virtualAdapter: DragSortVirtualAdapter = {
+    getEstimatedItemSize: () => 100,
+    getItemCount: () => itemsRef.value.length,
+    getScrollOffset: () => 2000,
+    getVisibleItems: () => [
+      { index: 20, size: 100, start: 2000 },
+      { index: 21, size: 100, start: 2100 },
+      { index: 22, size: 100, start: 2200 },
+    ],
+    invalidate: vi.fn(),
+  }
+  const sort = useDragSort<string>({
+    autoScroll: false,
+    direction: 'vertical',
+    getKey: item => item,
+    getPayload: () => tabPayload,
+    items: itemsRef,
+    onSort,
+    virtualAdapter,
+  })
+  sort.containerRef.value = createContainer(elements, createVerticalRect(0, viewportHeight))
+
+  return {
+    elements,
+    itemsRef,
+    onSort,
+    sort,
+    virtualAdapter,
   }
 }
 
@@ -487,6 +541,47 @@ describe('useDragSort', () => {
     expect(onSort).not.toHaveBeenCalled()
   })
 
+  it('命中手柄的 pointerdown 在后续 pointermove 目标变化后仍能启动排序', () => {
+    vi.useFakeTimers()
+    setupDragDocument()
+    setupAnimationFrame()
+    setupGlobalListeners()
+    const itemsRef = shallowRef(['a', 'b', 'c'])
+    const elements = [
+      createDragElement(0, createRect(0, 100)),
+      createDragElement(1, createRect(100, 100)),
+      createDragElement(2, createRect(200, 100)),
+    ]
+    const onSort = vi.fn()
+    const sort = useDragSort<string>({
+      autoScroll: false,
+      direction: 'horizontal',
+      getKey: item => item,
+      getPayload: () => tabPayload,
+      handleSelector: '[data-tab-handle]',
+      items: itemsRef,
+      onSort,
+    })
+    sort.containerRef.value = createContainer(elements)
+    const handleTarget = createHandleTarget()
+
+    sort.getItemProps(0).onPointerdown(createPointerEvent({
+      clientX: 10,
+      currentTarget: elements[0],
+      pointerId: 14,
+      target: handleTarget,
+    }))
+    startDrag(elements[0], 14, 260)
+    elements[0].dispatch('pointerup', {
+      clientX: 260,
+      pointerId: 14,
+      target: elements[0],
+    })
+    vi.runOnlyPendingTimers()
+
+    expect(onSort).toHaveBeenCalledWith(0, 2)
+  })
+
   it('settling 期间投影 key 序列变化时取消提交，避免插入到错误语义位置', () => {
     vi.useFakeTimers()
     setupDragDocument()
@@ -686,5 +781,209 @@ describe('useDragSort', () => {
 
     expect(container.scrollLeft).toBeGreaterThan(0)
     expect(sort.targetIndex.value).toBe(3)
+  })
+
+  it('拖拽项触及容器边缘时即使指针未靠近边缘也会触发自动滚动', () => {
+    setupDragDocument()
+    const { flushAnimationFrame } = setupControlledAnimationFrame()
+    setupGlobalListeners()
+    const elements = [
+      createDragElement(0, createRect(0, 100)),
+      createDragElement(1, createRect(100, 100)),
+      createDragElement(2, createRect(200, 100)),
+      createDragElement(3, createRect(300, 100)),
+      createDragElement(4, createRect(400, 100)),
+    ]
+    const sort = useDragSort<string>({
+      direction: 'horizontal',
+      getKey: item => item,
+      getPayload: () => tabPayload,
+      items: shallowRef(['a', 'b', 'c', 'd', 'e']),
+      onSort: vi.fn(),
+    })
+    const container = createScrollingContainer(elements, createRect(0, 250))
+    sort.containerRef.value = container
+
+    sort.getItemProps(0).onPointerdown(createPointerEvent({
+      clientX: 10,
+      currentTarget: elements[0],
+      pointerId: 26,
+      target: elements[0],
+    }))
+    startDrag(elements[0], 26, 160)
+
+    flushAnimationFrame(50)
+    flushAnimationFrame(100)
+    flushAnimationFrame(200)
+
+    expect(container.scrollLeft).toBeGreaterThan(0)
+  })
+
+  it('拖拽项贴边后继续向边缘外拖动会提高自动滚动速度', () => {
+    setupDragDocument()
+    const { flushAnimationFrame } = setupControlledAnimationFrame()
+    setupGlobalListeners()
+    const elements = [
+      createDragElement(0, createRect(0, 100)),
+      createDragElement(1, createRect(100, 100)),
+      createDragElement(2, createRect(200, 100)),
+      createDragElement(3, createRect(300, 100)),
+      createDragElement(4, createRect(400, 100)),
+    ]
+    const sort = useDragSort<string>({
+      direction: 'horizontal',
+      getKey: item => item,
+      getPayload: () => tabPayload,
+      items: shallowRef(['a', 'b', 'c', 'd', 'e']),
+      onSort: vi.fn(),
+    })
+    const container = createScrollingContainer(elements, createRect(0, 250))
+    sort.containerRef.value = container
+
+    sort.getItemProps(0).onPointerdown(createPointerEvent({
+      clientX: 10,
+      currentTarget: elements[0],
+      pointerId: 27,
+      target: elements[0],
+    }))
+    startDrag(elements[0], 27, 160)
+    flushAnimationFrame(50)
+    flushAnimationFrame(150)
+    const firstDelta = container.scrollLeft
+
+    moveDrag(27, 184)
+    flushAnimationFrame(250)
+    const secondDelta = container.scrollLeft - firstDelta
+
+    expect(secondDelta).toBeGreaterThan(firstDelta)
+  })
+
+  it('虚拟列表向下排序会等拖拽项前缘越过可见项中点后再更新 targetIndex', () => {
+    setupDragDocument()
+    setupAnimationFrame()
+    setupGlobalListeners()
+    const { elements, sort } = createVirtualSortFixture()
+
+    sort.getItemProps(20).onPointerdown(createPointerEvent({
+      clientX: 10,
+      clientY: 10,
+      currentTarget: elements[0],
+      pointerId: 21,
+      target: elements[0],
+    }))
+    startDrag(elements[0], 21, 10, 55)
+
+    expect(sort.targetIndex.value).toBe(20)
+
+    moveDrag(21, 10, 60)
+
+    expect(sort.targetIndex.value).toBe(21)
+
+    moveDrag(21, 10, 160)
+
+    expect(sort.targetIndex.value).toBe(22)
+    expect(sort.getItemStyle(21)).toMatchObject({
+      transform: 'translate3d(0, -100px, 0)',
+    })
+  })
+
+  it('虚拟列表向上排序会等拖拽项前缘越过可见项中点后再更新 targetIndex', () => {
+    setupDragDocument()
+    setupAnimationFrame()
+    setupGlobalListeners()
+    const { elements, sort } = createVirtualSortFixture()
+
+    sort.getItemProps(22).onPointerdown(createPointerEvent({
+      clientX: 10,
+      clientY: 210,
+      currentTarget: elements[2],
+      pointerId: 25,
+      target: elements[2],
+    }))
+    startDrag(elements[2], 25, 10, 165)
+
+    expect(sort.targetIndex.value).toBe(22)
+
+    moveDrag(25, 10, 160)
+
+    expect(sort.targetIndex.value).toBe(21)
+  })
+
+  it('虚拟列表指针落在不可见区时仍按拖拽项可视前缘计算 targetIndex', () => {
+    setupDragDocument()
+    setupAnimationFrame()
+    setupGlobalListeners()
+    const { elements, sort } = createVirtualSortFixture()
+
+    sort.getItemProps(20).onPointerdown(createPointerEvent({
+      clientX: 10,
+      clientY: 10,
+      currentTarget: elements[0],
+      pointerId: 22,
+      target: elements[0],
+    }))
+    startDrag(elements[0], 22, 10, 360)
+
+    expect(sort.targetIndex.value).toBe(22)
+  })
+
+  it('虚拟列表排序提交后会通知 virtualizer 重新测量', async () => {
+    vi.useFakeTimers()
+    setupDragDocument()
+    setupAnimationFrame()
+    setupGlobalListeners()
+    const { elements, onSort, sort, virtualAdapter } = createVirtualSortFixture()
+
+    sort.getItemProps(20).onPointerdown(createPointerEvent({
+      clientX: 10,
+      clientY: 10,
+      currentTarget: elements[0],
+      pointerId: 23,
+      target: elements[0],
+    }))
+    startDrag(elements[0], 23, 10, 360)
+    elements[0].dispatch('pointerup', {
+      clientX: 10,
+      clientY: 360,
+      pointerId: 23,
+      target: elements[0],
+    })
+
+    vi.runOnlyPendingTimers()
+    await nextTick()
+
+    expect(onSort).toHaveBeenCalledWith(20, 22)
+    expect(virtualAdapter.invalidate).toHaveBeenCalledOnce()
+  })
+
+  it('虚拟列表目标槽位在半可见底部项下方时 settling 位置保持真实槽位位置并裁剪到 viewport', () => {
+    setupDragDocument()
+    setupAnimationFrame()
+    setupGlobalListeners()
+    const { elements, sort } = createVirtualSortFixture(250)
+
+    sort.getItemProps(20).onPointerdown(createPointerEvent({
+      clientX: 10,
+      clientY: 10,
+      currentTarget: elements[0],
+      pointerId: 24,
+      target: elements[0],
+    }))
+    startDrag(elements[0], 24, 10, 240)
+    elements[0].dispatch('pointerup', {
+      clientX: 10,
+      clientY: 240,
+      pointerId: 24,
+      target: elements[0],
+    })
+
+    expect(sort.phase.value).toBe('settling')
+    expect(sort.targetIndex.value).toBe(22)
+    expect(styleRecord(sort.overlayState.value?.overlayStyle)).toMatchObject({
+      transform: 'translate3d(0px, 200px, 0)',
+    })
+    expect(styleRecord(sort.overlayState.value?.overlayFrameStyle)).toMatchObject({
+      clipPath: 'inset(0px calc(100% - 320px) calc(100% - 250px) 0px)',
+    })
   })
 })

--- a/src/composables/useAutoScrollOnDrag.ts
+++ b/src/composables/useAutoScrollOnDrag.ts
@@ -50,18 +50,18 @@ function calcAxisVelocity(
   maxSpeed: number,
 ): number {
   const accelerationDistance = edgeSize * 2
+  const startVelocity = triggerStart < startEdge + edgeSize
+    ? -maxSpeed * clamp((startEdge + edgeSize - speedStart) / accelerationDistance, 0, 1)
+    : 0
+  const endVelocity = triggerEnd > endEdge - edgeSize
+    ? maxSpeed * clamp((speedEnd - (endEdge - edgeSize)) / accelerationDistance, 0, 1)
+    : 0
 
-  if (triggerStart < startEdge + edgeSize) {
-    const ratio = clamp((startEdge + edgeSize - speedStart) / accelerationDistance, 0, 1)
-    return -maxSpeed * ratio
+  if (Math.abs(startVelocity) > Math.abs(endVelocity)) {
+    return startVelocity
   }
 
-  if (triggerEnd > endEdge - edgeSize) {
-    const ratio = clamp((speedEnd - (endEdge - edgeSize)) / accelerationDistance, 0, 1)
-    return maxSpeed * ratio
-  }
-
-  return 0
+  return endVelocity
 }
 
 function calcVelocity(

--- a/src/composables/useAutoScrollOnDrag.ts
+++ b/src/composables/useAutoScrollOnDrag.ts
@@ -1,7 +1,7 @@
 import type { Ref } from 'vue'
 import type { DragPosition } from '~/types/drag-drop'
 
-const DEFAULT_EDGE_SIZE = 40
+const DEFAULT_EDGE_SIZE = 24
 const DEFAULT_MAX_SPEED = 600
 
 export type DragAutoScrollAxis = 'horizontal' | 'vertical'
@@ -14,9 +14,20 @@ export interface UseAutoScrollOnDragOptions {
   onScroll?: (position: DragPosition) => void
 }
 
+export interface DragAutoScrollBounds {
+  bottom: number
+  left: number
+  right: number
+  top: number
+}
+
 export interface UseAutoScrollOnDragReturn {
   stop: () => void
-  update: (position: DragPosition) => void
+  update: (
+    position: DragPosition,
+    triggerBounds?: DragAutoScrollBounds,
+    speedBounds?: DragAutoScrollBounds,
+  ) => void
 }
 
 interface ScrollVelocity {
@@ -29,19 +40,24 @@ function clamp(value: number, min: number, max: number): number {
 }
 
 function calcAxisVelocity(
-  pointer: number,
+  triggerStart: number,
+  triggerEnd: number,
+  speedStart: number,
+  speedEnd: number,
   startEdge: number,
   endEdge: number,
   edgeSize: number,
   maxSpeed: number,
 ): number {
-  if (pointer < startEdge + edgeSize) {
-    const ratio = clamp((startEdge + edgeSize - pointer) / edgeSize, 0, 1)
+  const accelerationDistance = edgeSize * 2
+
+  if (triggerStart < startEdge + edgeSize) {
+    const ratio = clamp((startEdge + edgeSize - speedStart) / accelerationDistance, 0, 1)
     return -maxSpeed * ratio
   }
 
-  if (pointer > endEdge - edgeSize) {
-    const ratio = clamp((pointer - (endEdge - edgeSize)) / edgeSize, 0, 1)
+  if (triggerEnd > endEdge - edgeSize) {
+    const ratio = clamp((speedEnd - (endEdge - edgeSize)) / accelerationDistance, 0, 1)
     return maxSpeed * ratio
   }
 
@@ -49,20 +65,50 @@ function calcAxisVelocity(
 }
 
 function calcVelocity(
-  position: DragPosition,
+  triggerBounds: DragAutoScrollBounds,
+  speedBounds: DragAutoScrollBounds,
   rect: DOMRect,
   edgeSize: number,
   maxSpeed: number,
 ): ScrollVelocity {
   return {
-    x: calcAxisVelocity(position.x, rect.left, rect.right, edgeSize, maxSpeed),
-    y: calcAxisVelocity(position.y, rect.top, rect.bottom, edgeSize, maxSpeed),
+    x: calcAxisVelocity(
+      triggerBounds.left,
+      triggerBounds.right,
+      speedBounds.left,
+      speedBounds.right,
+      rect.left,
+      rect.right,
+      edgeSize,
+      maxSpeed,
+    ),
+    y: calcAxisVelocity(
+      triggerBounds.top,
+      triggerBounds.bottom,
+      speedBounds.top,
+      speedBounds.bottom,
+      rect.top,
+      rect.bottom,
+      edgeSize,
+      maxSpeed,
+    ),
+  }
+}
+
+function createPointBounds(position: DragPosition): DragAutoScrollBounds {
+  return {
+    bottom: position.y,
+    left: position.x,
+    right: position.x,
+    top: position.y,
   }
 }
 
 export function useAutoScrollOnDrag(options: UseAutoScrollOnDragOptions): UseAutoScrollOnDragReturn {
   const axis = options.axis ?? 'vertical'
   let pointerPosition: DragPosition | undefined
+  let scrollTriggerBounds: DragAutoScrollBounds | undefined
+  let scrollSpeedBounds: DragAutoScrollBounds | undefined
   let frameId = 0
   let lastTimestamp: number | undefined
 
@@ -73,11 +119,13 @@ export function useAutoScrollOnDrag(options: UseAutoScrollOnDragOptions): UseAut
     }
     lastTimestamp = undefined
     pointerPosition = undefined
+    scrollTriggerBounds = undefined
+    scrollSpeedBounds = undefined
   }
 
   function tick(timestamp: number) {
     const container = options.container.value
-    if (!container || !pointerPosition) {
+    if (!container || !pointerPosition || !scrollTriggerBounds || !scrollSpeedBounds) {
       stop()
       return
     }
@@ -85,7 +133,7 @@ export function useAutoScrollOnDrag(options: UseAutoScrollOnDragOptions): UseAut
     const edgeSize = Math.max(1, options.edgeSize ?? DEFAULT_EDGE_SIZE)
     const maxSpeed = Math.max(0, options.maxSpeed ?? DEFAULT_MAX_SPEED)
     const rect = container.getBoundingClientRect()
-    const velocity = calcVelocity(pointerPosition, rect, edgeSize, maxSpeed)
+    const velocity = calcVelocity(scrollTriggerBounds, scrollSpeedBounds, rect, edgeSize, maxSpeed)
     const axisVelocity = axis === 'horizontal' ? velocity.x : velocity.y
 
     if (axisVelocity === 0) {
@@ -135,8 +183,14 @@ export function useAutoScrollOnDrag(options: UseAutoScrollOnDragOptions): UseAut
     frameId = requestAnimationFrame(tick)
   }
 
-  function update(position: DragPosition) {
+  function update(
+    position: DragPosition,
+    triggerBounds: DragAutoScrollBounds = createPointBounds(position),
+    speedBounds: DragAutoScrollBounds = triggerBounds,
+  ) {
     pointerPosition = { ...position }
+    scrollTriggerBounds = { ...triggerBounds }
+    scrollSpeedBounds = { ...speedBounds }
     ensureTicking()
   }
 

--- a/src/composables/useDragSort.ts
+++ b/src/composables/useDragSort.ts
@@ -2,6 +2,7 @@ import { useAutoScrollOnDrag } from './useAutoScrollOnDrag'
 import { useDragSession } from './useDragSession'
 import { usePointerDrag } from './usePointerDrag'
 
+import type { DragAutoScrollBounds } from './useAutoScrollOnDrag'
 import type { Ref, StyleValue } from 'vue'
 import type { DragPayload, DragPosition } from '~/types/drag-drop'
 
@@ -11,8 +12,23 @@ export type DragSortPhase = 'dragging' | 'idle' | 'settling'
 export interface DragSortOverlayState<T> {
   item: T
   key: string
+  overlayFrameStyle: StyleValue
   overlayStyle: StyleValue
   phase: DragSortPhase
+}
+
+export interface DragSortVirtualItem {
+  index: number
+  size: number
+  start: number
+}
+
+export interface DragSortVirtualAdapter {
+  getEstimatedItemSize: () => number
+  getItemCount: () => number
+  getScrollOffset: () => number
+  getVisibleItems: () => DragSortVirtualItem[]
+  invalidate: () => void
 }
 
 export interface UseDragSortOptions<T> {
@@ -22,9 +38,10 @@ export interface UseDragSortOptions<T> {
   getPayload: (item: T, index: number, element: HTMLElement) => DragPayload
   handleSelector?: string
   ignoreSelector?: string
-  items: Ref<T[]>
+  items: Readonly<Ref<readonly T[]>>
   onSort: (fromIndex: number, targetIndex: number) => void
   scrollContainer?: Ref<HTMLElement | undefined>
+  virtualAdapter?: DragSortVirtualAdapter
 }
 
 export interface UseDragSortReturn<T> {
@@ -99,6 +116,13 @@ interface LayoutRect {
   mainStart: number
 }
 
+interface FixedRect {
+  height: number
+  width: number
+  x: number
+  y: number
+}
+
 const EMPTY_STYLE = {}
 const SETTLING_DURATION_MS = 120
 const SETTLING_TIMEOUT_MS = SETTLING_DURATION_MS + 40
@@ -143,11 +167,27 @@ function createTranslate(direction: DragSortDirection, distance: number): string
     : `translate3d(0, ${distance}px, 0)`
 }
 
+function getFixedRect(direction: DragSortDirection, rect: LayoutRect): FixedRect {
+  return {
+    height: Math.round(direction === 'horizontal' ? rect.crossSize : rect.mainSize),
+    width: Math.round(direction === 'horizontal' ? rect.mainSize : rect.crossSize),
+    x: Math.round(direction === 'horizontal' ? rect.mainStart : rect.crossStart),
+    y: Math.round(direction === 'horizontal' ? rect.crossStart : rect.mainStart),
+  }
+}
+
+function createOverlayFrameStyle(direction: DragSortDirection, viewport: DragSortViewportSnapshot): StyleValue {
+  const { height, width, x, y } = getFixedRect(direction, viewport)
+  const right = x + width
+  const bottom = y + height
+
+  return {
+    clipPath: `inset(${y}px calc(100% - ${right}px) calc(100% - ${bottom}px) ${x}px)`,
+  }
+}
+
 function createOverlayStyle(direction: DragSortDirection, rect: LayoutRect, transition: string): StyleValue {
-  const x = Math.round(direction === 'horizontal' ? rect.mainStart : rect.crossStart)
-  const y = Math.round(direction === 'horizontal' ? rect.crossStart : rect.mainStart)
-  const width = Math.round(direction === 'horizontal' ? rect.mainSize : rect.crossSize)
-  const height = Math.round(direction === 'horizontal' ? rect.crossSize : rect.mainSize)
+  const { height, width, x, y } = getFixedRect(direction, rect)
 
   return {
     height: `${height}px`,
@@ -156,6 +196,21 @@ function createOverlayStyle(direction: DragSortDirection, rect: LayoutRect, tran
     width: `${width}px`,
     zIndex: '9999',
   }
+}
+
+function createAutoScrollBoundsFromRect(direction: DragSortDirection, rect: LayoutRect): DragAutoScrollBounds {
+  const { height, width, x, y } = getFixedRect(direction, rect)
+
+  return {
+    bottom: y + height,
+    left: x,
+    right: x + width,
+    top: y,
+  }
+}
+
+function projectIndexAfterRemoval(index: number, removedIndex: number): number {
+  return index > removedIndex ? index - 1 : index
 }
 
 function hasClosest(value: EventTarget | null): value is EventTarget & { closest: (selector: string) => Element | null } {
@@ -256,7 +311,7 @@ export function useDragSort<T>(options: UseDragSortOptions<T>): UseDragSortRetur
 
     return {
       ...axis,
-      scrollOffset: getScrollOffset(viewport, options.direction),
+      scrollOffset: options.virtualAdapter?.getScrollOffset() ?? getScrollOffset(viewport, options.direction),
     }
   }
 
@@ -284,6 +339,62 @@ export function useDragSort<T>(options: UseDragSortOptions<T>): UseDragSortRetur
     }
   }
 
+  function createSnapshotItems(viewport: DragSortViewportSnapshot): DragSortItemSnapshot<T>[] {
+    return getItemElements()
+      .map(element => createSnapshotItem(element, viewport))
+      .filter((item): item is DragSortItemSnapshot<T> => item !== undefined)
+  }
+
+  function getVirtualItemAxis(
+    virtualItem: DragSortVirtualItem,
+    element: HTMLElement | undefined,
+    viewport: DragSortViewportSnapshot,
+  ): AxisRect {
+    if (element) {
+      return getAxisRect(element.getBoundingClientRect(), options.direction)
+    }
+
+    return {
+      crossSize: viewport.crossSize,
+      crossStart: viewport.crossStart,
+      mainSize: virtualItem.size,
+      mainStart: viewport.mainStart + virtualItem.start - viewport.scrollOffset,
+    }
+  }
+
+  function createVirtualSnapshotItems(
+    viewport: DragSortViewportSnapshot,
+  ): DragSortItemSnapshot<T>[] {
+    const adapter = options.virtualAdapter
+    if (!adapter) {
+      return []
+    }
+
+    const elementMap = new Map(getItemElements().map(element => [getElementIndex(element), element]))
+
+    return adapter.getVisibleItems()
+      .map((virtualItem): DragSortItemSnapshot<T> | undefined => {
+        const item = options.items.value[virtualItem.index]
+        if (item === undefined) {
+          return undefined
+        }
+
+        const element = elementMap.get(virtualItem.index)
+        const axis = getVirtualItemAxis(virtualItem, element, viewport)
+
+        return {
+          crossSize: axis.crossSize,
+          crossStart: axis.crossStart,
+          index: virtualItem.index,
+          item,
+          key: options.getKey(item, virtualItem.index, element),
+          mainSize: virtualItem.size,
+          mainStartInContent: virtualItem.start,
+        }
+      })
+      .filter((item): item is DragSortItemSnapshot<T> => item !== undefined)
+  }
+
   function createSnapshot(): DragSortSnapshot<T> | undefined {
     const viewport = getCurrentViewportSnapshot()
     if (!viewport) {
@@ -291,11 +402,20 @@ export function useDragSort<T>(options: UseDragSortOptions<T>): UseDragSortRetur
     }
 
     return {
-      items: getItemElements()
-        .map(element => createSnapshotItem(element, viewport))
-        .filter((item): item is DragSortItemSnapshot<T> => item !== undefined),
+      items: options.virtualAdapter
+        ? createVirtualSnapshotItems(viewport)
+        : createSnapshotItems(viewport),
       viewport,
     }
+  }
+
+  function getCurrentSnapshotItems(dragState: DragSortState<T>): DragSortItemSnapshot<T>[] {
+    if (!options.virtualAdapter) {
+      return dragState.snapshots
+    }
+
+    const viewport = getCurrentViewportSnapshot() ?? dragState.viewport
+    return createVirtualSnapshotItems(viewport)
   }
 
   function getProjectedItems(dragState: DragSortState<T> | undefined = state): ProjectedDragSortItem<T>[] {
@@ -305,15 +425,21 @@ export function useDragSort<T>(options: UseDragSortOptions<T>): UseDragSortRetur
 
     const { draggedItem } = dragState
 
-    return dragState.snapshots
+    return getCurrentSnapshotItems(dragState)
       .filter(item => item.key !== draggedItem.key)
-      .map((item, projectedIndex) => ({
-        ...item,
-        projectedIndex,
-        projectedMainStartInContent: item.index > draggedItem.index
-          ? item.mainStartInContent - draggedItem.mainSize
-          : item.mainStartInContent,
-      }))
+      .map((item, projectedIndex) => {
+        const nextProjectedIndex = options.virtualAdapter
+          ? projectIndexAfterRemoval(item.index, draggedItem.index)
+          : projectedIndex
+
+        return {
+          ...item,
+          projectedIndex: nextProjectedIndex,
+          projectedMainStartInContent: item.index > draggedItem.index
+            ? item.mainStartInContent - draggedItem.mainSize
+            : item.mainStartInContent,
+        }
+      })
   }
 
   function getProjectedKeys(items: readonly T[], draggedKey: string): string[] {
@@ -362,10 +488,17 @@ export function useDragSort<T>(options: UseDragSortOptions<T>): UseDragSortRetur
     pointerOffsetInItem: number,
   ): number {
     return clampMainStartInViewport(
-      getPointerMain(position, options.direction) - pointerOffsetInItem,
+      getLogicalOverlayMainStartInViewport(position, pointerOffsetInItem),
       viewport,
       draggedItem,
     )
+  }
+
+  function getLogicalOverlayMainStartInViewport(
+    position: DragPosition,
+    pointerOffsetInItem: number,
+  ): number {
+    return getPointerMain(position, options.direction) - pointerOffsetInItem
   }
 
   function getOverlayMainStartInContent(
@@ -403,7 +536,71 @@ export function useDragSort<T>(options: UseDragSortOptions<T>): UseDragSortRetur
     }
   }
 
+  function resolveEstimatedVirtualTargetIndex(
+    mainInContent: number,
+    adapter: DragSortVirtualAdapter,
+  ): number {
+    const itemCount = adapter.getItemCount()
+    if (itemCount === 0) {
+      return 0
+    }
+
+    const estimatedItemSize = Math.max(1, adapter.getEstimatedItemSize())
+    return clamp(
+      Math.round(mainInContent / estimatedItemSize),
+      0,
+      itemCount - 1,
+    )
+  }
+
+  function resolveVirtualTargetIndex(position: DragPosition): number | undefined {
+    const dragState = state
+    const adapter = options.virtualAdapter
+    if (!dragState || !adapter) {
+      return
+    }
+
+    const { draggedItem } = dragState
+    const overlayBounds = getOverlayMainBoundsInContent(position)
+    if (!overlayBounds) {
+      return
+    }
+
+    if (overlayBounds.start === draggedItem.mainStartInContent) {
+      return dragState.initialTargetIndex
+    }
+
+    const isMovingDown = overlayBounds.start > draggedItem.mainStartInContent
+    const leadingMainInContent = isMovingDown ? overlayBounds.end : overlayBounds.start
+    const projectedItems = getProjectedItems(dragState)
+    const firstProjectedItem = projectedItems[0]
+    const lastProjectedItem = projectedItems.at(-1)
+
+    if (firstProjectedItem && lastProjectedItem) {
+      const firstMainStart = firstProjectedItem.mainStartInContent
+      const lastMainEnd = lastProjectedItem.mainStartInContent + lastProjectedItem.mainSize
+
+      if (leadingMainInContent >= firstMainStart && leadingMainInContent <= lastMainEnd) {
+        const targetItem = projectedItems.find((item) => {
+          const midpoint = item.mainStartInContent + item.mainSize / 2
+          return isMovingDown
+            ? leadingMainInContent < midpoint
+            : leadingMainInContent <= midpoint
+        })
+        const nextIndex = targetItem?.projectedIndex ?? lastProjectedItem.projectedIndex + 1
+        return clamp(nextIndex, 0, Math.max(0, adapter.getItemCount() - 1))
+      }
+    }
+
+    return resolveEstimatedVirtualTargetIndex(leadingMainInContent, adapter)
+  }
+
   function resolveTargetIndex(position: DragPosition): number {
+    const virtualTargetIndex = resolveVirtualTargetIndex(position)
+    if (virtualTargetIndex !== undefined) {
+      return virtualTargetIndex
+    }
+
     const dragState = state
     const overlayBounds = getOverlayMainBoundsInContent(position)
 
@@ -435,10 +632,12 @@ export function useDragSort<T>(options: UseDragSortOptions<T>): UseDragSortRetur
     return nextIndex === -1 ? projectedItems.length : nextIndex
   }
 
-  function createOverlayRect(position: DragPosition): LayoutRect | undefined {
+  function createOverlayRect(
+    position: DragPosition,
+    viewport: DragSortViewportSnapshot,
+  ): LayoutRect | undefined {
     const dragState = state
-    const viewport = getCurrentViewportSnapshot()
-    if (!dragState || !viewport) {
+    if (!dragState) {
       return
     }
 
@@ -453,12 +652,51 @@ export function useDragSort<T>(options: UseDragSortOptions<T>): UseDragSortRetur
     return createLayoutRectFromMainStart(dragState, viewport, nextMainStart)
   }
 
+  function createLogicalOverlayRect(
+    position: DragPosition,
+    viewport: DragSortViewportSnapshot,
+  ): LayoutRect | undefined {
+    const dragState = state
+    if (!dragState) {
+      return
+    }
+
+    const nextMainStart = getLogicalOverlayMainStartInViewport(
+      position,
+      dragState.pointerOffsetInItem,
+    )
+
+    return createLayoutRectFromMainStart(dragState, viewport, nextMainStart)
+  }
+
+  function createAutoScrollBounds(
+    position: DragPosition,
+    createRect: (position: DragPosition, viewport: DragSortViewportSnapshot) => LayoutRect | undefined,
+  ): DragAutoScrollBounds | undefined {
+    const viewport = getCurrentViewportSnapshot()
+    if (!viewport) {
+      return
+    }
+
+    const rect = createRect(position, viewport)
+    if (!rect) {
+      return
+    }
+
+    return createAutoScrollBoundsFromRect(options.direction, rect)
+  }
+
   function getTargetSlotMainStartInContent(
     draggedItem: DragSortItemSnapshot<T>,
     projectedItems: ProjectedDragSortItem<T>[],
   ): number {
-    const clampedTargetIndex = clamp(targetIndex.value, 0, projectedItems.length)
-    const targetItem = projectedItems[clampedTargetIndex]
+    const maxTargetIndex = options.virtualAdapter
+      ? Math.max(0, options.virtualAdapter.getItemCount() - 1)
+      : projectedItems.length
+    const clampedTargetIndex = clamp(targetIndex.value, 0, maxTargetIndex)
+    const targetItem = options.virtualAdapter
+      ? projectedItems.find(item => item.projectedIndex >= clampedTargetIndex)
+      : projectedItems[clampedTargetIndex]
 
     if (targetItem) {
       return targetItem.projectedMainStartInContent
@@ -470,10 +708,9 @@ export function useDragSort<T>(options: UseDragSortOptions<T>): UseDragSortRetur
       : draggedItem.mainStartInContent
   }
 
-  function createTargetSlotRect(): LayoutRect | undefined {
+  function createTargetSlotRect(viewport: DragSortViewportSnapshot): LayoutRect | undefined {
     const dragState = state
-    const viewport = getCurrentViewportSnapshot()
-    if (!dragState || !viewport) {
+    if (!dragState) {
       return
     }
 
@@ -482,19 +719,26 @@ export function useDragSort<T>(options: UseDragSortOptions<T>): UseDragSortRetur
       draggedItem,
       getProjectedItems(dragState),
     )
-    const slotMainStart = clampMainStartInViewport(
-      viewport.mainStart + slotMainStartInContent - viewport.scrollOffset,
-      viewport,
-      draggedItem,
-    )
+    const slotMainStartInViewport = viewport.mainStart + slotMainStartInContent - viewport.scrollOffset
+    const slotMainStart = options.virtualAdapter
+      ? slotMainStartInViewport
+      : clampMainStartInViewport(slotMainStartInViewport, viewport, draggedItem)
 
     return createLayoutRectFromMainStart(dragState, viewport, slotMainStart)
   }
 
   function updateOverlay(position: DragPosition, nextPhase: DragSortPhase, transition: string) {
     const draggedItem = state?.draggedItem
-    const rect = nextPhase === 'settling' ? createTargetSlotRect() : createOverlayRect(position)
-    if (!draggedItem || !rect) {
+    const viewport = getCurrentViewportSnapshot()
+    if (!draggedItem || !viewport) {
+      overlayState.value = undefined
+      return
+    }
+
+    const rect = nextPhase === 'settling'
+      ? createTargetSlotRect(viewport)
+      : createOverlayRect(position, viewport)
+    if (!rect) {
       overlayState.value = undefined
       return
     }
@@ -502,6 +746,7 @@ export function useDragSort<T>(options: UseDragSortOptions<T>): UseDragSortRetur
     overlayState.value = {
       item: draggedItem.item,
       key: draggedItem.key,
+      overlayFrameStyle: createOverlayFrameStyle(options.direction, viewport),
       overlayStyle: createOverlayStyle(options.direction, rect, transition),
       phase: nextPhase,
     }
@@ -562,6 +807,11 @@ export function useDragSort<T>(options: UseDragSortOptions<T>): UseDragSortRetur
 
     if (snapshot.targetIndex !== snapshot.initialTargetIndex) {
       options.onSort(currentFromIndex, snapshot.targetIndex)
+      if (options.virtualAdapter) {
+        void nextTick(() => {
+          options.virtualAdapter?.invalidate()
+        })
+      }
     }
 
     endSortSession()
@@ -582,10 +832,6 @@ export function useDragSort<T>(options: UseDragSortOptions<T>): UseDragSortRetur
 
   function startSort(event: PointerEvent, sourceElement: HTMLElement, startPosition: DragPosition): boolean {
     if (phase.value === 'settling' || settlingTimerId !== undefined) {
-      return false
-    }
-
-    if (!isHandleAllowed(event, sourceElement, options.handleSelector)) {
       return false
     }
 
@@ -660,7 +906,11 @@ export function useDragSort<T>(options: UseDragSortOptions<T>): UseDragSortRetur
       updateDrag(currentPosition)
 
       if (options.autoScroll !== false) {
-        autoScroll.update(currentPosition)
+        autoScroll.update(
+          currentPosition,
+          createAutoScrollBounds(currentPosition, createOverlayRect),
+          createAutoScrollBounds(currentPosition, createLogicalOverlayRect),
+        )
       }
     },
     onDragStart: (event, context) => startSort(event, context.sourceElement, context.startPosition),
@@ -686,6 +936,10 @@ export function useDragSort<T>(options: UseDragSortOptions<T>): UseDragSortRetur
         }
 
         if (matchesSelectorInside(event, sourceElement, options.ignoreSelector)) {
+          return
+        }
+
+        if (!isHandleAllowed(event, sourceElement, options.handleSelector)) {
           return
         }
 

--- a/src/features/editor/visual-editor/__tests__/useVisualEditorSceneRuntime.test.ts
+++ b/src/features/editor/visual-editor/__tests__/useVisualEditorSceneRuntime.test.ts
@@ -9,6 +9,7 @@ import type { SceneVisualProjectionState } from '~/stores/editor'
 
 const {
   restoreSelectionAndScrollMock,
+  scrollToSelectedStatementMock,
   useCommandPanelBridgeBindingMock,
   useCommandPanelStoreMock,
   useEditSettingsStoreMock,
@@ -21,6 +22,7 @@ const {
   useVisualEditorSceneViewportMock,
 } = vi.hoisted(() => ({
   restoreSelectionAndScrollMock: vi.fn(async () => undefined),
+  scrollToSelectedStatementMock: vi.fn(async () => undefined),
   useCommandPanelBridgeBindingMock: vi.fn(),
   useCommandPanelStoreMock: vi.fn(),
   useEditSettingsStoreMock: vi.fn(),
@@ -121,6 +123,7 @@ describe('useVisualEditorSceneRuntime', () => {
 
   beforeEach(() => {
     restoreSelectionAndScrollMock.mockReset()
+    scrollToSelectedStatementMock.mockReset()
     useCommandPanelBridgeBindingMock.mockReset()
     useCommandPanelStoreMock.mockReset()
     useEditSettingsStoreMock.mockReset()
@@ -177,7 +180,14 @@ describe('useVisualEditorSceneRuntime', () => {
       isPositioning: computed(() => false),
       measureRowElement: vi.fn(),
       restoreSelectionAndScroll: restoreSelectionAndScrollMock,
-      scrollToSelectedStatement: vi.fn(async () => undefined),
+      scrollToSelectedStatement: scrollToSelectedStatementMock,
+      statementSortVirtualAdapter: {
+        getEstimatedItemSize: vi.fn(() => 100),
+        getItemCount: vi.fn(() => 0),
+        getScrollOffset: vi.fn(() => 0),
+        getVisibleItems: vi.fn(() => []),
+        invalidate: vi.fn(),
+      },
       totalSize: computed(() => 0),
       virtualRows: computed(() => []),
     })
@@ -393,6 +403,63 @@ describe('useVisualEditorSceneRuntime', () => {
     expect(applySceneStatementReorder).toHaveBeenCalledWith('/project/scene.txt', 0, 1)
     expect(syncScenePreview).not.toHaveBeenCalled()
     expect(scheduleAutoSaveIfEnabled).toHaveBeenCalledWith('/project/scene.txt')
+    expect(scrollToSelectedStatementMock).toHaveBeenCalledWith('auto')
+
+    scope.stop()
+  })
+
+  it('拖拽重排语句时不会触发滚动恢复', () => {
+    const scope = effectScope()
+    const state = createState([
+      {
+        id: 1,
+        parseError: false,
+        parsed: undefined,
+        rawText: 'say:first',
+      },
+      {
+        id: 2,
+        parseError: false,
+        parsed: undefined,
+        rawText: 'say:second',
+      },
+    ])
+    const applySceneStatementReorder = vi.fn()
+    const scheduleAutoSaveIfEnabled = vi.fn()
+
+    useEditorStoreMock.mockReturnValue(reactive({
+      applySceneStatementDelete: vi.fn(),
+      applySceneStatementInsert: vi.fn(),
+      applySceneStatementReorder,
+      applySceneStatementUpdate: vi.fn(),
+      consumePendingSceneProjectionActivation: vi.fn(() => false),
+      currentState: {
+        kind: 'scene',
+        path: '/project/scene.txt',
+        projection: 'visual',
+      },
+      getSceneSelection: vi.fn(() => ({
+        lastEditedStatementId: 1,
+        lastLineNumber: 1,
+        selectedStatementId: 1,
+      })),
+      isSceneStatementCollapsed: vi.fn(() => false),
+      scheduleAutoSaveIfEnabled,
+      setSceneStatementCollapsed: vi.fn(),
+      syncScenePreview: vi.fn(),
+      syncSceneSelectionFromStatement: vi.fn(),
+    }))
+
+    const runtime = scope.run(() => useVisualEditorSceneRuntime({
+      getScrollArea: () => undefined,
+      getState: () => state,
+    }))
+
+    runtime?.reorderStatements(0, 1, { restoreSelectionPresentation: false })
+
+    expect(applySceneStatementReorder).toHaveBeenCalledWith('/project/scene.txt', 0, 1)
+    expect(scheduleAutoSaveIfEnabled).toHaveBeenCalledWith('/project/scene.txt')
+    expect(scrollToSelectedStatementMock).not.toHaveBeenCalled()
 
     scope.stop()
   })

--- a/src/features/editor/visual-editor/__tests__/useVisualEditorSceneViewport.test.ts
+++ b/src/features/editor/visual-editor/__tests__/useVisualEditorSceneViewport.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { effectScope, shallowRef } from 'vue'
+
+import { useVisualEditorSceneViewport } from '../useVisualEditorSceneViewport'
+
+import type { ScrollArea } from '~/components/ui/scroll-area'
+import type { SceneVisualProjectionState } from '~/stores/editor'
+
+const { useVirtualizerMock } = vi.hoisted(() => ({
+  useVirtualizerMock: vi.fn(),
+}))
+
+vi.mock('@tanstack/vue-virtual', () => ({
+  useVirtualizer: useVirtualizerMock,
+}))
+
+function createState(): SceneVisualProjectionState {
+  return {
+    isDirty: false,
+    kind: 'scene',
+    path: '/project/scene.txt',
+    projection: 'visual',
+    statements: [
+      { id: 1, parseError: false, parsed: undefined, rawText: 'say:first' },
+      { id: 2, parseError: false, parsed: undefined, rawText: 'say:second' },
+    ],
+  } as SceneVisualProjectionState
+}
+
+function createScrollArea(viewportElement: HTMLElement): InstanceType<typeof ScrollArea> {
+  return {
+    viewport: {
+      viewportElement,
+    },
+  } as unknown as InstanceType<typeof ScrollArea>
+}
+
+describe('useVisualEditorSceneViewport', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  beforeEach(() => {
+    useVirtualizerMock.mockReset()
+  })
+
+  it('语句排序失效时只重测当前可见行，避免清空 virtualizer 尺寸缓存', () => {
+    const scope = effectScope()
+    const firstRow = { dataset: { index: '0' } } as unknown as HTMLElement
+    const secondRow = { dataset: { index: '1' } } as unknown as HTMLElement
+    const viewportElement = {
+      querySelectorAll: vi.fn(() => [firstRow, secondRow]),
+    } as unknown as HTMLElement
+    const virtualizer = {
+      getTotalSize: vi.fn(() => 200),
+      getVirtualItems: vi.fn(() => []),
+      measure: vi.fn(),
+      measureElement: vi.fn(),
+      scrollOffset: 0,
+      scrollToIndex: vi.fn(),
+    }
+
+    useVirtualizerMock.mockReturnValue(shallowRef(virtualizer))
+
+    const viewport = scope.run(() => useVisualEditorSceneViewport({
+      getScrollArea: () => createScrollArea(viewportElement),
+      getSelectedIndex: () => 0,
+      getState: createState,
+      restoreSelection: vi.fn(),
+    }))
+
+    viewport?.statementSortVirtualAdapter.invalidate()
+
+    expect(virtualizer.measure).not.toHaveBeenCalled()
+    expect(virtualizer.measureElement).toHaveBeenCalledWith(firstRow)
+    expect(virtualizer.measureElement).toHaveBeenCalledWith(secondRow)
+
+    scope.stop()
+  })
+})

--- a/src/features/editor/visual-editor/useVisualEditorSceneRuntime.ts
+++ b/src/features/editor/visual-editor/useVisualEditorSceneRuntime.ts
@@ -18,6 +18,10 @@ interface UseVisualEditorSceneRuntimeOptions {
   getState: () => SceneVisualProjectionState
 }
 
+interface StatementReorderOptions {
+  restoreSelectionPresentation?: boolean
+}
+
 export function useVisualEditorSceneRuntime(options: UseVisualEditorSceneRuntimeOptions) {
   const editorStore = useEditorStore()
   const editorViewStateStore = useEditorViewStateStore()
@@ -248,6 +252,27 @@ export function useVisualEditorSceneRuntime(options: UseVisualEditorSceneRuntime
     requestAutoSave()
   }
 
+  function reorderStatements(fromIndex: number, toIndex: number, reorderOptions: StatementReorderOptions = {}) {
+    const statementCount = state.value.statements.length
+    if (statementCount === 0 || fromIndex < 0 || fromIndex >= statementCount) {
+      return
+    }
+
+    const normalizedTargetIndex = Math.min(Math.max(toIndex, 0), statementCount - 1)
+    if (fromIndex === normalizedTargetIndex) {
+      return
+    }
+
+    editorStore.applySceneStatementReorder(state.value.path, fromIndex, normalizedTargetIndex)
+    if (reorderOptions.restoreSelectionPresentation ?? true) {
+      void restoreSelectedStatementPresentation({
+        align: 'auto',
+        focus: true,
+      })
+    }
+    requestAutoSave()
+  }
+
   function moveSelectedStatement(offset: -1 | 1) {
     const currentSelectedStatementId = readSelectedStatementId()
     const currentSelectedIndex = selectedIndex.value
@@ -260,12 +285,7 @@ export function useVisualEditorSceneRuntime(options: UseVisualEditorSceneRuntime
       return
     }
 
-    editorStore.applySceneStatementReorder(state.value.path, currentSelectedIndex, nextIndex)
-    void restoreSelectedStatementPresentation({
-      align: 'auto',
-      focus: true,
-    })
-    requestAutoSave()
+    reorderStatements(currentSelectedIndex, nextIndex)
   }
 
   function handleStatementDelete(id: number) {
@@ -567,7 +587,9 @@ export function useVisualEditorSceneRuntime(options: UseVisualEditorSceneRuntime
     isStatementCollapsed,
     measureRowElement: viewport.measureRowElement,
     previousSpeakers,
+    reorderStatements,
     selectedStatementId,
+    statementSortVirtualAdapter: viewport.statementSortVirtualAdapter,
     totalSize: viewport.totalSize,
     virtualRows: viewport.virtualRows,
   }

--- a/src/features/editor/visual-editor/useVisualEditorSceneViewport.ts
+++ b/src/features/editor/visual-editor/useVisualEditorSceneViewport.ts
@@ -2,6 +2,10 @@ import { useVirtualizer } from '@tanstack/vue-virtual'
 
 import { SceneVisualProjectionState } from '~/stores/editor'
 
+import type { DragSortVirtualAdapter } from '~/composables/useDragSort'
+
+const ESTIMATED_STATEMENT_ROW_SIZE = 100
+
 interface UseVisualEditorSceneViewportOptions {
   getScrollArea: () => InstanceType<typeof ScrollArea> | null | undefined
   getSelectedIndex: () => number
@@ -17,7 +21,7 @@ export function useVisualEditorSceneViewport(options: UseVisualEditorSceneViewpo
       count: state.value.statements.length,
       // eslint-disable-next-line unicorn/no-null
       getScrollElement: () => options.getScrollArea()?.viewport?.viewportElement ?? null,
-      estimateSize: () => 100,
+      estimateSize: () => ESTIMATED_STATEMENT_ROW_SIZE,
       overscan: 5,
       paddingStart: 8,
       paddingEnd: 8,
@@ -28,6 +32,29 @@ export function useVisualEditorSceneViewport(options: UseVisualEditorSceneViewpo
   const virtualRows = computed(() => rowVirtualizer.value.getVirtualItems())
   const totalSize = computed(() => rowVirtualizer.value.getTotalSize())
   const isPositioning = ref(false)
+
+  function measureVisibleStatementRows() {
+    const viewportElement = options.getScrollArea()?.viewport?.viewportElement
+    if (!viewportElement) {
+      return
+    }
+
+    for (const element of viewportElement.querySelectorAll<HTMLElement>('[data-index]')) {
+      rowVirtualizer.value.measureElement(element)
+    }
+  }
+
+  const statementSortVirtualAdapter: DragSortVirtualAdapter = {
+    getEstimatedItemSize: () => ESTIMATED_STATEMENT_ROW_SIZE,
+    getItemCount: () => state.value.statements.length,
+    getScrollOffset: () => rowVirtualizer.value.scrollOffset ?? 0,
+    getVisibleItems: () => rowVirtualizer.value.getVirtualItems().map(item => ({
+      index: item.index,
+      size: item.size,
+      start: item.start,
+    })),
+    invalidate: measureVisibleStatementRows,
+  }
   let scrollRequestId = 0
 
   function scrollToSelectedStatement(
@@ -116,6 +143,7 @@ export function useVisualEditorSceneViewport(options: UseVisualEditorSceneViewpo
     measureRowElement,
     restoreSelectionAndScroll,
     scrollToSelectedStatement,
+    statementSortVirtualAdapter,
     totalSize,
     virtualRows,
   }


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [ ] 错误修复
- [x] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [x] 代码重构
- [x] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

- 在 `VisualEditorScene` 中接入语句拖拽排序，支持通过语句卡片拖拽手柄调整场景语句顺序。
- 为 `useDragSort` 增加虚拟列表适配能力，包括可见项快照、目标索引推断、overlay 裁剪和排序提交后的 virtualizer 失效刷新。
- 调整 `useAutoScrollOnDrag` 的边缘判定逻辑，改为基于拖拽矩形的触发边界与速度边界计算自动滚动，提升贴边拖拽时的连续性。
- 在 visual editor runtime / viewport 中抽出 `reorderStatements` 与 `statementSortVirtualAdapter`，复用现有语句重排与自动保存链路。
- 补齐 `useDragSort`、`useAutoScrollOnDrag`、`VisualEditorScene`、`useVisualEditorSceneRuntime` 和 `useVisualEditorSceneViewport` 的测试覆盖。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

当前可视化编辑器的语句列表基于虚拟列表渲染，普通 DOM 列表排序逻辑不能直接复用到该场景。

这次改动的目标是把语句拖拽排序能力真正接到可视化编辑器中，并处理虚拟列表场景下的几个关键问题：

- 排序目标索引需要在部分行未挂载时仍然稳定推断；
- overlay 需要在 viewport 内保持正确定位和裁剪；
- 自动滚动需要根据拖拽项的实际矩形而不是单点指针位置触发；
- 排序提交后需要刷新 virtualizer 的测量结果，并继续走现有的自动保存与编辑器状态链路。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
