### PR TITLE
✨ 支持场景文件树拖拽转移

### DIFF
--- a/src/commands/__tests__/fs.test.ts
+++ b/src/commands/__tests__/fs.test.ts
@@ -90,4 +90,24 @@ describe('fsCmds', () => {
       'C:/project/target/source.txt',
     )
   })
+
+  it('moveFile 接收计划目标名时不再自行生成唯一名称', async () => {
+    statMock.mockResolvedValue({ isDirectory: false })
+
+    await expect(
+      fsCmds.moveFile(
+        AbsPath.from('/project/source.txt'),
+        AbsPath.from('/project/target'),
+        'source (1).txt',
+      ),
+    )
+      .resolves
+      .toBe('/project/target/source (1).txt')
+
+    expect(existsMock).not.toHaveBeenCalled()
+    expect(renameMock).toHaveBeenCalledWith(
+      '/project/source.txt',
+      '/project/target/source (1).txt',
+    )
+  })
 })

--- a/src/commands/fs.ts
+++ b/src/commands/fs.ts
@@ -142,11 +142,11 @@ interface DestinationPath {
 /**
  * 获取目标路径（用于复制和移动操作）
  */
-async function getDestinationPath(sourcePath: AbsPath, targetPath: AbsPath): Promise<DestinationPath> {
+async function getDestinationPath(sourcePath: AbsPath, targetPath: AbsPath, targetName?: string): Promise<DestinationPath> {
   const sourceName = AbsPath.basename(sourcePath)
   const sourceStat = await stat(sourcePath)
   const isDir = sourceStat.isDirectory
-  const uniqueName = await generateUniqueFileName(targetPath, sourceName, isDir)
+  const uniqueName = targetName ?? await generateUniqueFileName(targetPath, sourceName, isDir)
   const destPath = AbsPath.append(targetPath, uniqueName)
   return { destPath, isDir }
 }
@@ -157,8 +157,8 @@ async function copyFile(sourcePath: AbsPath, targetPath: AbsPath): Promise<AbsPa
   return destPath
 }
 
-async function moveFile(sourcePath: AbsPath, targetPath: AbsPath): Promise<AbsPath> {
-  const { destPath } = await getDestinationPath(sourcePath, targetPath)
+async function moveFile(sourcePath: AbsPath, targetPath: AbsPath, targetName?: string): Promise<AbsPath> {
+  const { destPath } = await getDestinationPath(sourcePath, targetPath, targetName)
   await rename(sourcePath, destPath)
   return destPath
 }

--- a/src/components/editor/FileTree.spec.ts
+++ b/src/components/editor/FileTree.spec.ts
@@ -1080,6 +1080,48 @@ describe('FileTree', () => {
     await expect.element(page.getByText('scene.txt')).toBeInTheDocument()
   })
 
+  it('rootPath 异步更新后会重新注册根目录拖拽目标', async () => {
+    vi.useFakeTimers()
+    const { reactiveProps } = renderReactiveFileTree({
+      enableDragTransfer: true,
+      getKey: (item: Record<string, unknown>) => String(item.path),
+      items: [
+        {
+          name: 'chapter',
+          path: '/project/chapter',
+          children: [
+            {
+              name: 'scene.txt',
+              path: '/project/chapter/scene.txt',
+            },
+          ],
+        },
+      ],
+      rootPath: '',
+    })
+
+    expect(document.querySelector('[data-drop-target-id="file-tree:root-area"]')).toBeNull()
+    expect(document.querySelector('[data-drop-target-id="file-tree:root-container"]')).toBeNull()
+
+    reactiveProps.rootPath = '/project'
+    await nextTick()
+
+    const source = document.querySelector<HTMLElement>('[data-file-tree-path="/project/chapter/scene.txt"]')
+    const rootArea = document.querySelector<HTMLElement>('[data-drop-target-id="file-tree:root-area"]')
+    const rootContainer = document.querySelector<HTMLElement>('[data-drop-target-id="file-tree:root-container"]')
+    if (!source || !rootArea || !rootContainer) {
+      throw new TypeError('预期 rootPath 更新后重新注册根目录拖拽目标')
+    }
+
+    await dragBetween(source, rootArea)
+
+    expect(pathOperationPerformMock).toHaveBeenCalledWith({
+      kind: 'move',
+      sourcePath: '/project/chapter/scene.txt',
+      target: { type: 'directory', directory: '/project' },
+    }, expect.any(Function))
+  })
+
   it('按住 Ctrl 拖拽文件到目录时会复制而不是移动', async () => {
     vi.useFakeTimers()
     renderFileTree({

--- a/src/components/editor/FileTree.spec.ts
+++ b/src/components/editor/FileTree.spec.ts
@@ -8,6 +8,7 @@ import { useShortcutContext } from '~/features/editor/shortcut/useShortcutContex
 import { useShortcutDispatcher } from '~/features/editor/shortcut/useShortcutDispatcher'
 
 const {
+  gameFsCopyFileMock,
   handleErrorMock,
   pathOperationPerformMock,
   useModalStoreMock,
@@ -15,12 +16,21 @@ const {
   useTabsStoreMock,
   useWorkspaceStoreMock,
 } = vi.hoisted(() => ({
+  gameFsCopyFileMock: vi.fn(),
   handleErrorMock: vi.fn(),
   pathOperationPerformMock: vi.fn(),
   useModalStoreMock: vi.fn(),
   useEditorUIStateStoreMock: vi.fn(),
   useTabsStoreMock: vi.fn(),
   useWorkspaceStoreMock: vi.fn(),
+}))
+
+vi.mock('~/services/game-fs', () => ({
+  gameFs: {
+    copyFile: gameFsCopyFileMock,
+    createFile: vi.fn(),
+    createFolder: vi.fn(),
+  },
 }))
 
 vi.mock('~/services/path-operation', () => ({
@@ -82,6 +92,130 @@ interface Deferred<T> {
   promise: Promise<T>
   reject: (reason?: unknown) => void
   resolve: (value: T) => void
+}
+
+const fileTreeBrowserOptions = {
+  messages: {
+    'zh-Hans': {
+      edit: {
+        fileTree: {
+          dragPreviewCount: '{count} 个文件',
+        },
+      },
+    },
+  },
+}
+
+function createPointerEvent(
+  type: string,
+  options: PointerEventInit & { target?: EventTarget } = {},
+): PointerEvent {
+  const event = new PointerEvent(type, {
+    bubbles: true,
+    button: 0,
+    buttons: 1,
+    cancelable: true,
+    clientX: 0,
+    clientY: 0,
+    isPrimary: true,
+    pointerId: 1,
+    ...options,
+  })
+  if (options.target) {
+    Object.defineProperty(event, 'target', {
+      configurable: true,
+      value: options.target,
+    })
+  }
+  return event
+}
+
+async function hoverDragTarget(source: HTMLElement, target: HTMLElement): Promise<() => Promise<void>> {
+  const elementFromPointMock = vi.spyOn(document, 'elementFromPoint').mockReturnValue(target)
+
+  source.dispatchEvent(createPointerEvent('pointerdown', {
+    clientX: 10,
+    clientY: 10,
+    target: source,
+  }))
+  source.dispatchEvent(createPointerEvent('pointermove', {
+    clientX: 24,
+    clientY: 24,
+    target: source,
+  }))
+  target.dispatchEvent(createPointerEvent('pointermove', {
+    clientX: 24,
+    clientY: 24,
+    target,
+  }))
+  await vi.advanceTimersByTimeAsync(16)
+  await nextTick()
+
+  return async () => {
+    source.dispatchEvent(createPointerEvent('pointerup', {
+      clientX: 24,
+      clientY: 24,
+      target: source,
+    }))
+    await Promise.resolve()
+    await nextTick()
+    elementFromPointMock.mockRestore()
+  }
+}
+
+async function dragBetweenWithModifier(
+  source: HTMLElement,
+  target: HTMLElement,
+  modifier: Pick<PointerEventInit, 'altKey' | 'ctrlKey' | 'metaKey'>,
+): Promise<void> {
+  const elementFromPointMock = vi.spyOn(document, 'elementFromPoint').mockReturnValue(target)
+
+  source.dispatchEvent(createPointerEvent('pointerdown', {
+    clientX: 10,
+    clientY: 10,
+    ...modifier,
+    target: source,
+  }))
+  source.dispatchEvent(createPointerEvent('pointermove', {
+    clientX: 24,
+    clientY: 24,
+    ...modifier,
+    target: source,
+  }))
+  target.dispatchEvent(createPointerEvent('pointermove', {
+    clientX: 24,
+    clientY: 24,
+    ...modifier,
+    target,
+  }))
+  await vi.advanceTimersByTimeAsync(16)
+  await nextTick()
+  source.dispatchEvent(createPointerEvent('pointerup', {
+    clientX: 24,
+    clientY: 24,
+    ...modifier,
+    target: source,
+  }))
+  await Promise.resolve()
+  await nextTick()
+  elementFromPointMock.mockRestore()
+}
+
+async function dragBetween(source: HTMLElement, target: HTMLElement): Promise<void> {
+  const finishDrag = await hoverDragTarget(source, target)
+  await finishDrag()
+}
+
+async function clickWithModifier(
+  element: HTMLElement,
+  modifier: Pick<MouseEventInit, 'ctrlKey' | 'metaKey' | 'shiftKey'>,
+): Promise<void> {
+  element.dispatchEvent(new MouseEvent('click', {
+    bubbles: true,
+    cancelable: true,
+    ...modifier,
+  }))
+  await nextTick()
 }
 
 function flattenItems(
@@ -229,7 +363,7 @@ const globalStubs = {
   }),
   TreeItem: defineComponent({
     name: 'StubTreeItem',
-    emits: ['auxclick', 'click', 'dblclick', 'keydown.enter', 'keydown.escape', 'keydown.f2'],
+    emits: ['auxclick', 'click', 'clickCapture', 'dblclick', 'keydown.enter', 'keydown.escape', 'keydown.f2', 'pointerdown'],
     setup(_, { attrs, emit, slots }) {
       return () => h('div', {
         ...attrs,
@@ -237,6 +371,7 @@ const globalStubs = {
         tabIndex: 0,
         onAuxclick: (event: MouseEvent) => emit('auxclick', event),
         onClick: (event: MouseEvent) => emit('click', event),
+        onClickCapture: (event: MouseEvent) => emit('clickCapture', event),
         onDblclick: (event: MouseEvent) => emit('dblclick', event),
         onKeydown: (event: KeyboardEvent) => {
           if (event.key === 'Enter') {
@@ -249,6 +384,7 @@ const globalStubs = {
             emit('keydown.f2', event)
           }
         },
+        onPointerdown: (event: PointerEvent) => emit('pointerdown', event),
       }, slots.default?.({ isExpanded: false }))
     },
   }),
@@ -285,6 +421,7 @@ function renderFileTree(props: Record<string, unknown>) {
   })
 
   return renderInBrowser(ShortcutHarness, {
+    browser: fileTreeBrowserOptions,
     global: {
       plugins: [createPinia()],
       stubs: globalStubs,
@@ -319,6 +456,7 @@ function renderReactiveFileTree(initialProps: Record<string, unknown>) {
   })
 
   renderInBrowser(ShortcutHarness, {
+    browser: fileTreeBrowserOptions,
     global: {
       plugins: [createPinia()],
       stubs: globalStubs,
@@ -333,9 +471,12 @@ function renderReactiveFileTree(initialProps: Record<string, unknown>) {
 describe('FileTree', () => {
   afterEach(() => {
     vi.clearAllMocks()
+    vi.useRealTimers()
   })
 
   beforeEach(() => {
+    vi.restoreAllMocks()
+    gameFsCopyFileMock.mockReset()
     handleErrorMock.mockReset()
     pathOperationPerformMock.mockReset()
     useModalStoreMock.mockReset()
@@ -343,6 +484,7 @@ describe('FileTree', () => {
     useTabsStoreMock.mockReset()
     useWorkspaceStoreMock.mockReset()
 
+    gameFsCopyFileMock.mockResolvedValue('/project/archive/scene.txt')
     pathOperationPerformMock.mockResolvedValue({ cancelled: false, finalPath: '/project/renamed.txt', warnings: [] })
     useModalStoreMock.mockReturnValue({
       open: vi.fn(),
@@ -392,6 +534,254 @@ describe('FileTree', () => {
         path: '/project/scene.txt',
       }),
     }))
+  })
+
+  it('外部 selectedItem 变化时会同步文件树高亮', async () => {
+    const { reactiveProps } = renderReactiveFileTree({
+      getKey: (item: Record<string, unknown>) => String(item.path),
+      items: [
+        {
+          name: 'a.txt',
+          path: '/project/a.txt',
+        },
+        {
+          name: 'b.txt',
+          path: '/project/b.txt',
+        },
+      ],
+      selectedItem: undefined,
+    })
+
+    const first = document.querySelector<HTMLElement>('[data-file-tree-path="/project/a.txt"]')
+    const second = document.querySelector<HTMLElement>('[data-file-tree-path="/project/b.txt"]')
+    if (!first || !second) {
+      throw new TypeError('预期文件树渲染两个文件项')
+    }
+
+    expect(first.dataset.fileTreeSelected).toBeUndefined()
+    expect(second.dataset.fileTreeSelected).toBeUndefined()
+
+    reactiveProps.selectedItem = {
+      name: 'b.txt',
+      path: '/project/b.txt',
+    }
+    await nextTick()
+
+    expect(first.dataset.fileTreeSelected).toBeUndefined()
+    expect(second.dataset.fileTreeSelected).toBe('true')
+  })
+
+  it('Ctrl 点击会累加选中，拖拽已选中项时会移动整个选中集合', async () => {
+    vi.useFakeTimers()
+    const onClick = vi.fn()
+    renderFileTree({
+      enableDragTransfer: true,
+      getKey: (item: Record<string, unknown>) => String(item.path),
+      items: [
+        {
+          name: 'a.txt',
+          path: '/project/a.txt',
+        },
+        {
+          name: 'b.txt',
+          path: '/project/b.txt',
+        },
+        {
+          name: 'target',
+          path: '/project/target',
+          children: [],
+        },
+      ],
+      onClick,
+      rootPath: '/project',
+    })
+
+    const first = document.querySelector<HTMLElement>('[data-file-tree-path="/project/a.txt"]')
+    const second = document.querySelector<HTMLElement>('[data-file-tree-path="/project/b.txt"]')
+    const target = document.querySelector<HTMLElement>('[data-file-tree-path="/project/target"]')
+    if (!first || !second || !target) {
+      throw new TypeError('预期文件树渲染两个源文件和目标目录')
+    }
+
+    await clickWithModifier(first, { ctrlKey: true })
+    await clickWithModifier(second, { ctrlKey: true })
+
+    expect(first.dataset.fileTreeSelected).toBe('true')
+    expect(second.dataset.fileTreeSelected).toBe('true')
+    expect(onClick).not.toHaveBeenCalled()
+
+    const finishDrag = await hoverDragTarget(first, target)
+    const dragPreview = page.getByTestId('file-tree-drag-preview')
+
+    await expect.element(dragPreview.getByText('a.txt')).toBeInTheDocument()
+    await expect.element(dragPreview.getByText('2 个文件')).toBeInTheDocument()
+
+    await finishDrag()
+
+    expect(pathOperationPerformMock).toHaveBeenNthCalledWith(1, {
+      kind: 'move',
+      sourcePath: '/project/a.txt',
+      target: { type: 'directory', directory: '/project/target' },
+    }, expect.any(Function))
+    expect(pathOperationPerformMock).toHaveBeenNthCalledWith(2, {
+      kind: 'move',
+      sourcePath: '/project/b.txt',
+      target: { type: 'directory', directory: '/project/target' },
+    }, expect.any(Function))
+  })
+
+  it('拖拽集合包含祖先目录时会忽略其子项，避免重复移动失效路径', async () => {
+    vi.useFakeTimers()
+    renderFileTree({
+      enableDragTransfer: true,
+      getKey: (item: Record<string, unknown>) => String(item.path),
+      items: [
+        {
+          children: [
+            {
+              name: 'branch.txt',
+              path: '/project/chapter/branch.txt',
+            },
+          ],
+          name: 'chapter',
+          path: '/project/chapter',
+        },
+        {
+          name: 'target',
+          path: '/project/target',
+          children: [],
+        },
+      ],
+      rootPath: '/project',
+    })
+
+    const directory = document.querySelector<HTMLElement>('[data-file-tree-path="/project/chapter"]')
+    const child = document.querySelector<HTMLElement>('[data-file-tree-path="/project/chapter/branch.txt"]')
+    const target = document.querySelector<HTMLElement>('[data-file-tree-path="/project/target"]')
+    if (!directory || !child || !target) {
+      throw new TypeError('预期文件树渲染父目录、子文件和目标目录')
+    }
+
+    await clickWithModifier(directory, { ctrlKey: true })
+    await clickWithModifier(child, { ctrlKey: true })
+    await dragBetween(directory, target)
+
+    expect(pathOperationPerformMock).toHaveBeenCalledTimes(1)
+    expect(pathOperationPerformMock).toHaveBeenCalledWith({
+      kind: 'move',
+      sourcePath: '/project/chapter',
+      target: { type: 'directory', directory: '/project/target' },
+    }, expect.any(Function))
+  })
+
+  it('Ctrl 点击已选中项会取消选中并从拖拽集合中移除', async () => {
+    vi.useFakeTimers()
+    renderFileTree({
+      enableDragTransfer: true,
+      getKey: (item: Record<string, unknown>) => String(item.path),
+      items: [
+        {
+          name: 'a.txt',
+          path: '/project/a.txt',
+        },
+        {
+          name: 'b.txt',
+          path: '/project/b.txt',
+        },
+        {
+          name: 'target',
+          path: '/project/target',
+          children: [],
+        },
+      ],
+      rootPath: '/project',
+    })
+
+    const first = document.querySelector<HTMLElement>('[data-file-tree-path="/project/a.txt"]')
+    const second = document.querySelector<HTMLElement>('[data-file-tree-path="/project/b.txt"]')
+    const target = document.querySelector<HTMLElement>('[data-file-tree-path="/project/target"]')
+    if (!first || !second || !target) {
+      throw new TypeError('预期文件树渲染两个源文件和目标目录')
+    }
+
+    await clickWithModifier(first, { ctrlKey: true })
+    await clickWithModifier(second, { ctrlKey: true })
+    await clickWithModifier(first, { ctrlKey: true })
+
+    expect(first.dataset.fileTreeSelected).toBeUndefined()
+    expect(second.dataset.fileTreeSelected).toBe('true')
+
+    await dragBetween(second, target)
+
+    expect(pathOperationPerformMock).toHaveBeenCalledTimes(1)
+    expect(pathOperationPerformMock).toHaveBeenCalledWith({
+      kind: 'move',
+      sourcePath: '/project/b.txt',
+      target: { type: 'directory', directory: '/project/target' },
+    }, expect.any(Function))
+  })
+
+  it('Shift 点击会按当前可见顺序范围选中并支持拖拽整个范围', async () => {
+    vi.useFakeTimers()
+    const onClick = vi.fn()
+    renderFileTree({
+      enableDragTransfer: true,
+      getKey: (item: Record<string, unknown>) => String(item.path),
+      items: [
+        {
+          name: 'a.txt',
+          path: '/project/a.txt',
+        },
+        {
+          name: 'b.txt',
+          path: '/project/b.txt',
+        },
+        {
+          name: 'c.txt',
+          path: '/project/c.txt',
+        },
+        {
+          name: 'target',
+          path: '/project/target',
+          children: [],
+        },
+      ],
+      onClick,
+      rootPath: '/project',
+    })
+
+    const first = document.querySelector<HTMLElement>('[data-file-tree-path="/project/a.txt"]')
+    const second = document.querySelector<HTMLElement>('[data-file-tree-path="/project/b.txt"]')
+    const third = document.querySelector<HTMLElement>('[data-file-tree-path="/project/c.txt"]')
+    const target = document.querySelector<HTMLElement>('[data-file-tree-path="/project/target"]')
+    if (!first || !second || !third || !target) {
+      throw new TypeError('预期文件树渲染三个源文件和目标目录')
+    }
+
+    await page.getByText('a.txt').click()
+    await clickWithModifier(third, { shiftKey: true })
+
+    expect(first.dataset.fileTreeSelected).toBe('true')
+    expect(second.dataset.fileTreeSelected).toBe('true')
+    expect(third.dataset.fileTreeSelected).toBe('true')
+
+    await dragBetween(second, target)
+
+    expect(pathOperationPerformMock).toHaveBeenNthCalledWith(1, {
+      kind: 'move',
+      sourcePath: '/project/a.txt',
+      target: { type: 'directory', directory: '/project/target' },
+    }, expect.any(Function))
+    expect(pathOperationPerformMock).toHaveBeenNthCalledWith(2, {
+      kind: 'move',
+      sourcePath: '/project/b.txt',
+      target: { type: 'directory', directory: '/project/target' },
+    }, expect.any(Function))
+    expect(pathOperationPerformMock).toHaveBeenNthCalledWith(3, {
+      kind: 'move',
+      sourcePath: '/project/c.txt',
+      target: { type: 'directory', directory: '/project/target' },
+    }, expect.any(Function))
   })
 
   it('按 F2 重命名后回车会调用 pathOperation.perform', async () => {
@@ -641,5 +1031,250 @@ describe('FileTree', () => {
         path: '/project/second.txt',
       },
     })
+  })
+
+  it('拖拽文件到目录时会悬停展开并通过 pathOperation.perform 移动', async () => {
+    vi.useFakeTimers()
+    const setFileTreeExpandedMock = vi.fn()
+    useEditorUIStateStoreMock.mockReturnValue({
+      getFileTreeExpanded: vi.fn(() => []),
+      setFileTreeExpanded: setFileTreeExpandedMock,
+    })
+    renderFileTree({
+      enableDragTransfer: true,
+      getKey: (item: Record<string, unknown>) => String(item.path),
+      items: [
+        {
+          name: 'archive',
+          path: '/project/archive',
+          children: [],
+        },
+        {
+          name: 'scene.txt',
+          path: '/project/scene.txt',
+        },
+      ],
+      rootPath: '/project',
+      treeName: 'scene',
+    })
+
+    const source = document.querySelector<HTMLElement>('[data-file-tree-path="/project/scene.txt"]')
+    const target = document.querySelector<HTMLElement>('[data-file-tree-path="/project/archive"]')
+    if (!source || !target) {
+      throw new TypeError('预期文件树渲染源文件和目标目录')
+    }
+
+    const finishDrag = await hoverDragTarget(source, target)
+
+    await vi.advanceTimersByTimeAsync(800)
+    await nextTick()
+    expect(setFileTreeExpandedMock).toHaveBeenCalledWith('game-1', 'scene', ['/project/archive'])
+
+    await finishDrag()
+
+    expect(pathOperationPerformMock).toHaveBeenCalledWith({
+      kind: 'move',
+      sourcePath: '/project/scene.txt',
+      target: { type: 'directory', directory: '/project/archive' },
+    }, expect.any(Function))
+    await expect.element(page.getByText('scene.txt')).toBeInTheDocument()
+  })
+
+  it('按住 Ctrl 拖拽文件到目录时会复制而不是移动', async () => {
+    vi.useFakeTimers()
+    renderFileTree({
+      enableDragTransfer: true,
+      getKey: (item: Record<string, unknown>) => String(item.path),
+      items: [
+        {
+          name: 'archive',
+          path: '/project/archive',
+          children: [],
+        },
+        {
+          name: 'scene.txt',
+          path: '/project/scene.txt',
+        },
+      ],
+      rootPath: '/project',
+    })
+
+    const source = document.querySelector<HTMLElement>('[data-file-tree-path="/project/scene.txt"]')
+    const target = document.querySelector<HTMLElement>('[data-file-tree-path="/project/archive"]')
+    if (!source || !target) {
+      throw new TypeError('预期文件树渲染源文件和目标目录')
+    }
+
+    await dragBetweenWithModifier(source, target, { ctrlKey: true })
+
+    expect(gameFsCopyFileMock).toHaveBeenCalledWith('/project/scene.txt', '/project/archive')
+    expect(pathOperationPerformMock).not.toHaveBeenCalled()
+  })
+
+  it('拖拽文件到展开目录中的子文件时会以父目录为目标', async () => {
+    vi.useFakeTimers()
+    renderFileTree({
+      enableDragTransfer: true,
+      getKey: (item: Record<string, unknown>) => String(item.path),
+      items: [
+        {
+          name: 'archive',
+          path: '/project/archive',
+          children: [
+            {
+              name: 'existing.txt',
+              path: '/project/archive/existing.txt',
+            },
+          ],
+        },
+        {
+          name: 'scene.txt',
+          path: '/project/scene.txt',
+        },
+      ],
+      rootPath: '/project',
+    })
+
+    const source = document.querySelector<HTMLElement>('[data-file-tree-path="/project/scene.txt"]')
+    const target = document.querySelector<HTMLElement>('[data-file-tree-path="/project/archive/existing.txt"]')
+    if (!source || !target) {
+      throw new TypeError('预期文件树渲染源文件、目录和目录中的目标文件')
+    }
+
+    const finishDrag = await hoverDragTarget(source, target)
+
+    await finishDrag()
+
+    expect(pathOperationPerformMock).toHaveBeenCalledWith({
+      kind: 'move',
+      sourcePath: '/project/scene.txt',
+      target: { type: 'directory', directory: '/project/archive' },
+    }, expect.any(Function))
+  })
+
+  it('拖拽目录到它的父目录时不会调用 pathOperation.perform', async () => {
+    vi.useFakeTimers()
+    renderFileTree({
+      enableDragTransfer: true,
+      getKey: (item: Record<string, unknown>) => String(item.path),
+      items: [
+        {
+          name: 'chapter',
+          path: '/project/chapter',
+          children: [
+            {
+              name: 'branch',
+              path: '/project/chapter/branch/',
+              children: [],
+            },
+          ],
+        },
+      ],
+      rootPath: '/project',
+    })
+
+    const source = document.querySelector<HTMLElement>('[data-file-tree-path="/project/chapter/branch/"]')
+    const target = document.querySelector<HTMLElement>('[data-file-tree-path="/project/chapter"]')
+    if (!source || !target) {
+      throw new TypeError('预期文件树渲染源目录和父目录')
+    }
+
+    await dragBetween(source, target)
+
+    expect(pathOperationPerformMock).not.toHaveBeenCalled()
+  })
+
+  it('父子目录间连续反向拖拽时会使用更新后的源路径和目标目录', async () => {
+    vi.useFakeTimers()
+    const { reactiveProps } = renderReactiveFileTree({
+      enableDragTransfer: true,
+      getKey: (item: Record<string, unknown>) => String(item.path),
+      items: [
+        {
+          name: 'chapter',
+          path: '/project/chapter',
+          children: [],
+        },
+        {
+          name: 'scene.txt',
+          path: '/project/scene.txt',
+        },
+      ],
+      rootPath: '/project',
+    })
+
+    const firstSource = document.querySelector<HTMLElement>('[data-file-tree-path="/project/scene.txt"]')
+    const firstTarget = document.querySelector<HTMLElement>('[data-file-tree-path="/project/chapter"]')
+    if (!firstSource || !firstTarget) {
+      throw new TypeError('预期文件树渲染父目录源文件和子目录目标')
+    }
+
+    await dragBetween(firstSource, firstTarget)
+    expect(pathOperationPerformMock).toHaveBeenLastCalledWith({
+      kind: 'move',
+      sourcePath: '/project/scene.txt',
+      target: { type: 'directory', directory: '/project/chapter' },
+    }, expect.any(Function))
+
+    reactiveProps.items = [
+      {
+        name: 'chapter',
+        path: '/project/chapter',
+        children: [
+          {
+            name: 'scene.txt',
+            path: '/project/chapter/scene.txt',
+          },
+        ],
+      },
+      {
+        name: 'readme.txt',
+        path: '/project/readme.txt',
+      },
+    ]
+    await nextTick()
+
+    const secondSource = document.querySelector<HTMLElement>('[data-file-tree-path="/project/chapter/scene.txt"]')
+    const secondTarget = document.querySelector<HTMLElement>('[data-file-tree-path="/project/readme.txt"]')
+    if (!secondSource || !secondTarget) {
+      throw new TypeError('预期文件树渲染子目录源文件和根目录目标文件')
+    }
+
+    await dragBetween(secondSource, secondTarget)
+    expect(pathOperationPerformMock).toHaveBeenLastCalledWith({
+      kind: 'move',
+      sourcePath: '/project/chapter/scene.txt',
+      target: { type: 'directory', directory: '/project' },
+    }, expect.any(Function))
+    expect(pathOperationPerformMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('拖拽到文件行时不会触发移动', async () => {
+    vi.useFakeTimers()
+    renderFileTree({
+      enableDragTransfer: true,
+      getKey: (item: Record<string, unknown>) => String(item.path),
+      items: [
+        {
+          name: 'first.txt',
+          path: '/project/first.txt',
+        },
+        {
+          name: 'second.txt',
+          path: '/project/second.txt',
+        },
+      ],
+      rootPath: '/project',
+    })
+
+    const source = document.querySelector<HTMLElement>('[data-file-tree-path="/project/first.txt"]')
+    const target = document.querySelector<HTMLElement>('[data-file-tree-path="/project/second.txt"]')
+    if (!source || !target) {
+      throw new TypeError('预期文件树渲染两个文件项')
+    }
+
+    await dragBetween(source, target)
+
+    expect(pathOperationPerformMock).not.toHaveBeenCalled()
   })
 })

--- a/src/components/editor/FileTree.vue
+++ b/src/components/editor/FileTree.vue
@@ -1,15 +1,22 @@
 <script setup lang="ts" generic="T extends object">
 import { LucideFile, LucideFolder, LucideFolderOpen } from '@lucide/vue'
 
+import { useDragSession } from '~/composables/useDragSession'
+import { useDragSource } from '~/composables/useDragTransfer'
+import { useDroppableRegistry } from '~/composables/useDroppableRegistry'
+import { AbsPath } from '~/domain/path'
+import { normalizeFileTreeTransferItems } from '~/features/editor/file-tree/file-tree'
 import { useFileTreeController } from '~/features/editor/file-tree/useFileTreeController'
 import { useShortcut } from '~/features/editor/shortcut/useShortcut'
 import { useShortcutContext } from '~/features/editor/shortcut/useShortcutContext'
 import { useModalStore } from '~/stores/modal'
 import { FileViewerSortBy, FileViewerSortOrder } from '~/types/file-viewer'
+import { handleError } from '~/utils/error-handler'
 
 import type { FlattenedItem } from 'reka-ui'
-import type { ShallowRef } from 'vue'
+import type { ShallowRef, StyleValue } from 'vue'
 import type { FileTreeDefaultFileNameParts } from '~/features/editor/file-tree/file-tree'
+import type { FileSystemDragPayload } from '~/types/drag-drop'
 
 interface Props {
   items: T[]
@@ -27,6 +34,8 @@ interface Props {
   openCreatedFileInTab?: boolean
   sortBy?: FileViewerSortBy
   sortOrder?: FileViewerSortOrder
+  enableDragTransfer?: boolean
+  rootPath?: string
 }
 
 const {
@@ -45,10 +54,12 @@ const {
   openCreatedFileInTab = false,
   sortBy = 'name',
   sortOrder = 'asc',
+  enableDragTransfer = false,
+  rootPath,
 } = defineProps<Props>()
 const inputRef: Readonly<ShallowRef<unknown>> = useTemplateRef('inputRef')
 const creatingInputRef: Readonly<ShallowRef<unknown>> = useTemplateRef('creatingInputRef')
-const fileTreeContainerRef: Readonly<ShallowRef<HTMLDivElement | null>> = useTemplateRef<HTMLDivElement>('fileTreeContainerRef')
+const fileTreeContainerRef = shallowRef<HTMLDivElement>()
 
 const emit = defineEmits<{
   click: [item: FlattenedItem<T>]
@@ -60,6 +71,8 @@ const emit = defineEmits<{
 
 const selectedItem = defineModel<T>('selectedItem')
 const modalStore = useModalStore()
+const dragSession = useDragSession()
+const dropRegistry = useDroppableRegistry()
 
 const { t } = useI18n()
 const scrollAreaRef: Readonly<ShallowRef<unknown>> = useTemplateRef('scrollAreaRef')
@@ -84,10 +97,15 @@ const {
   handleEscapeKey,
   handleRename,
   handleRenameBlur,
+  handleScroll,
   isCreateDuplicate,
   isCreatingItem,
   isRenameDuplicate,
   isRenaming,
+  canDropFileSystemItems,
+  copyFileSystemItems,
+  expandDirectory,
+  moveFileSystemItems,
   processFlattenItems,
   startCreating,
   toFileItem,
@@ -111,6 +129,7 @@ const {
   sortOrder: () => sortOrder,
   treeName: () => treeName,
 })
+const fileTreeViewportRef = computed(() => getViewportElement())
 
 // 暴露创建入口和折叠操作给父组件，便于 toolbar / 快捷键触发
 defineExpose({
@@ -122,6 +141,525 @@ defineExpose({
 function resolveItemBadgeText(item: T): string | undefined {
   return itemBadgeText?.(item)
 }
+
+interface FileTreeRenderedItem {
+  isDir: boolean
+  name: string
+  path: string
+}
+
+interface FileTreeDragSourceHandlers {
+  onClickCapture?: (event: MouseEvent) => void
+  onPointerdown?: (event: PointerEvent) => void
+}
+
+interface FileTreeCreatingRenderItem {
+  item: FlattenedItem<T>
+  kind: 'creating'
+}
+
+interface FileTreeFileRenderItem {
+  ancestorDirectoryPaths: string[]
+  dropTarget: FileTreeRenderedItem
+  fileItem: FileTreeRenderedItem
+  item: FlattenedItem<T>
+  kind: 'file'
+}
+
+type FileTreeRenderItem = FileTreeCreatingRenderItem | FileTreeFileRenderItem
+
+interface FileTreeDirectoryStackItem {
+  fileItem: FileTreeRenderedItem
+  level: number
+}
+
+const HOVER_EXPAND_DELAY = 800
+const DRAG_OVERLAY_OFFSET_X = 6
+const DRAG_OVERLAY_OFFSET_Y = 6
+const dropTargetElements = new Map<string, HTMLElement>()
+let renderedFileTreePaths: string[] = []
+let activeDropTargetPath = $ref<string>()
+let pendingExpandPath = $ref<string>()
+let selectedFileTreePaths = $ref<string[]>([])
+let selectionAnchorPath = $ref<string>()
+let hoverExpandTimerId: ReturnType<typeof setTimeout> | undefined
+
+const fileDragSource = useDragSource<FileSystemDragPayload>({
+  autoScroll: {
+    container: fileTreeViewportRef,
+    edgeSize: 40,
+  },
+  getData: getFileSystemDragPayload,
+  type: 'file-system-item',
+})
+
+const effectiveRootPath = $computed(() => rootPath ?? getRootPath())
+
+const activeFileTreePayload = $computed(() => {
+  const state = dragSession.state.value
+  if (
+    !state.isActive
+    || state.mode !== 'transfer'
+    || state.payload?.type !== 'file-system-item'
+    || state.payload.source !== 'file-tree'
+  ) {
+    return
+  }
+
+  return state.payload
+})
+
+const rootFileItem = $computed<FileTreeRenderedItem>(() => ({
+  isDir: true,
+  name: '',
+  path: effectiveRootPath,
+}))
+
+const dragPreviewItems = $computed(() => {
+  const payload = activeFileTreePayload
+  if (!payload) {
+    return []
+  }
+
+  return payload.items?.length
+    ? payload.items
+    : [{
+        isDir: payload.isDir,
+        name: payload.name,
+        path: payload.path,
+      }]
+})
+
+const isMultipleDragPreview = $computed(() => dragPreviewItems.length > 1)
+const dragPreviewName = $computed(() => {
+  const firstItem = dragPreviewItems[0]
+  if (!firstItem) {
+    return ''
+  }
+
+  return firstItem.name || firstItem.path.split('/').at(-1) || firstItem.path
+})
+
+const dragPreviewCountLabel = $computed(() =>
+  t('edit.fileTree.dragPreviewCount', { count: dragPreviewItems.length }),
+)
+
+const dragOverlayStyle = $computed<StyleValue | undefined>(() => {
+  const currentPosition = dragSession.state.value.currentPosition
+  if (!activeFileTreePayload || !currentPosition) {
+    return
+  }
+
+  return {
+    transform: `translate3d(${currentPosition.x + DRAG_OVERLAY_OFFSET_X}px, ${currentPosition.y + DRAG_OVERLAY_OFFSET_Y}px, 0)`,
+    zIndex: '9999',
+  }
+})
+
+function resolveHTMLElement(value: unknown): HTMLElement | undefined {
+  if (value instanceof HTMLElement) {
+    return value
+  }
+
+  return value && typeof value === 'object' && '$el' in value && value.$el instanceof HTMLElement ? value.$el : undefined
+}
+
+function setFileTreeContainerElement(value: unknown): void {
+  const element = resolveHTMLElement(value)
+  fileTreeContainerRef.value = element instanceof HTMLDivElement ? element : undefined
+  registerDropTarget('root-container', fileTreeContainerRef.value, {
+    isDir: true,
+    name: '',
+    path: effectiveRootPath,
+  })
+}
+
+function setRootDropAreaElement(value: unknown): void {
+  registerDropTarget('root-area', resolveHTMLElement(value), {
+    isDir: true,
+    name: '',
+    path: effectiveRootPath,
+  })
+}
+
+function reportFileTreeMoveError(error: unknown): void {
+  if (error instanceof Error) {
+    handleError(error)
+    return
+  }
+
+  handleError(new Error(String(error)))
+}
+
+function getRenderedFileItem(item: FlattenedItem<T>): FileTreeRenderedItem {
+  const fileItem = toFileItem(item)
+  itemMap.set(fileItem.path, item)
+  return fileItem
+}
+
+function getRenderedFileItemByPath(path: string): FileTreeRenderedItem | undefined {
+  const item = itemMap.get(path)
+  return item ? toFileItem(item) : undefined
+}
+
+function getRenderedItems(flattenItems: FlattenedItem<T>[]): FileTreeRenderItem[] {
+  const directoryStack: FileTreeDirectoryStackItem[] = []
+  const nextRenderedFileTreePaths: string[] = []
+  itemMap.clear()
+
+  const renderItems: FileTreeRenderItem[] = processFlattenItems(flattenItems).map((item) => {
+    if (isCreatingItem(item)) {
+      return {
+        item,
+        kind: 'creating' as const,
+      }
+    }
+
+    let currentParent = directoryStack.at(-1)
+    while (currentParent && currentParent.level >= item.level) {
+      directoryStack.pop()
+      currentParent = directoryStack.at(-1)
+    }
+
+    const fileItem = getRenderedFileItem(item)
+    const ancestorDirectoryPaths = [effectiveRootPath, ...directoryStack.map(entry => entry.fileItem.path)]
+    const dropTarget = item.hasChildren
+      ? fileItem
+      : currentParent?.fileItem ?? rootFileItem
+
+    if (item.hasChildren) {
+      directoryStack.push({
+        fileItem,
+        level: item.level,
+      })
+    }
+
+    nextRenderedFileTreePaths.push(fileItem.path)
+
+    return {
+      ancestorDirectoryPaths,
+      dropTarget,
+      fileItem,
+      item,
+      kind: 'file' as const,
+    }
+  })
+
+  renderedFileTreePaths = nextRenderedFileTreePaths
+  return renderItems
+}
+
+function toUniquePaths(paths: readonly string[]): string[] {
+  return [...new Set(paths.filter(path => path.length > 0))]
+}
+
+function setSelectedFileTreePaths(paths: readonly string[]): void {
+  selectedFileTreePaths = toUniquePaths(paths)
+}
+
+function syncSelectedFileTreePaths(path?: string): void {
+  if (!path) {
+    setSelectedFileTreePaths([])
+    selectionAnchorPath = undefined
+    return
+  }
+
+  if (
+    selectedFileTreePaths.length === 1
+    && AbsPath.equals(AbsPath.from(selectedFileTreePaths[0]), AbsPath.from(path))
+  ) {
+    selectionAnchorPath = path
+    return
+  }
+
+  setSelectedFileTreePaths([path])
+  selectionAnchorPath = path
+}
+
+function getFileTreePathRange(fromPath: string | undefined, toPath: string): string[] {
+  if (!fromPath) {
+    return [toPath]
+  }
+
+  const fromIndex = renderedFileTreePaths.indexOf(fromPath)
+  const toIndex = renderedFileTreePaths.indexOf(toPath)
+  if (fromIndex === -1 || toIndex === -1) {
+    return [toPath]
+  }
+
+  const startIndex = Math.min(fromIndex, toIndex)
+  const endIndex = Math.max(fromIndex, toIndex)
+  return renderedFileTreePaths.slice(startIndex, endIndex + 1)
+}
+
+function isFileTreePathSelected(path: string): boolean {
+  return selectedFileTreePaths.includes(path)
+}
+
+function getSelectedRenderedFileItems(): FileTreeRenderedItem[] {
+  return renderedFileTreePaths
+    .filter(path => selectedFileTreePaths.includes(path))
+    .map(path => getRenderedFileItemByPath(path))
+    .filter((item): item is FileTreeRenderedItem => item !== undefined)
+}
+
+function getFileTreeSelectedItems(sourceItem: FileTreeRenderedItem): FileTreeRenderedItem[] {
+  if (!isFileTreePathSelected(sourceItem.path) || selectedFileTreePaths.length <= 1) {
+    return [sourceItem]
+  }
+
+  const selectedItems = getSelectedRenderedFileItems()
+  return normalizeFileTreeTransferItems(selectedItems.length > 0 ? selectedItems : [sourceItem])
+}
+
+function stopFileTreeSelectionEvent(event: MouseEvent): void {
+  event.preventDefault()
+  event.stopPropagation()
+  event.stopImmediatePropagation?.()
+}
+
+function handleModifiedFileTreeItemSelection(event: MouseEvent, item: FlattenedItem<T>): boolean {
+  if (isRenaming(item)) {
+    return false
+  }
+
+  const fileItem = toFileItem(item)
+  const shouldExtendRange = event.shiftKey
+  const shouldToggle = event.ctrlKey || event.metaKey
+  if (!shouldExtendRange && !shouldToggle) {
+    return false
+  }
+
+  stopFileTreeSelectionEvent(event)
+  if (shouldExtendRange) {
+    const rangePaths = getFileTreePathRange(selectionAnchorPath, fileItem.path)
+    setSelectedFileTreePaths(shouldToggle
+      ? [...selectedFileTreePaths, ...rangePaths]
+      : rangePaths)
+    return true
+  }
+
+  setSelectedFileTreePaths(isFileTreePathSelected(fileItem.path)
+    ? selectedFileTreePaths.filter(path => path !== fileItem.path)
+    : [...selectedFileTreePaths, fileItem.path])
+  selectionAnchorPath = fileItem.path
+  return true
+}
+
+function handleFileTreeItemClickCapture(event: MouseEvent, item: FlattenedItem<T>): void {
+  handleModifiedFileTreeItemSelection(event, item)
+}
+
+function handleFileTreeItemPointerDown(event: PointerEvent, item: FlattenedItem<T>): void {
+  if (
+    event.button !== 0
+    || event.ctrlKey
+    || event.metaKey
+    || event.shiftKey
+    || isRenaming(item)
+  ) {
+    return
+  }
+
+  const fileItem = toFileItem(item)
+  if (!isFileTreePathSelected(fileItem.path)) {
+    setSelectedFileTreePaths([fileItem.path])
+    selectionAnchorPath = fileItem.path
+  }
+}
+
+function handleFileTreeItemClick(event: MouseEvent, item: FlattenedItem<T>): void {
+  if (handleModifiedFileTreeItemSelection(event, item) || isRenaming(item)) {
+    return
+  }
+
+  const fileItem = toFileItem(item)
+  setSelectedFileTreePaths([fileItem.path])
+  selectionAnchorPath = fileItem.path
+  emit('click', item)
+}
+
+watch(() => {
+  const currentSelectedItem = selectedItem.value as Record<string, unknown> | undefined
+  return typeof currentSelectedItem?.path === 'string' ? currentSelectedItem.path : undefined
+}, syncSelectedFileTreePaths, { immediate: true })
+
+function getFileSystemDragPayload(element: HTMLElement): FileSystemDragPayload {
+  const path = element.dataset.fileTreePath ?? ''
+  const fileItem = getRenderedFileItemByPath(path)
+    ?? {
+      isDir: element.dataset.fileTreeIsDir === 'true',
+      name: element.dataset.fileTreeName ?? '',
+      path,
+    }
+  const dragItems = getFileTreeSelectedItems(fileItem)
+
+  return {
+    isDir: fileItem.isDir,
+    items: dragItems.map(item => ({
+      isDir: item.isDir,
+      name: item.name,
+      path: item.path,
+    })),
+    name: fileItem.name,
+    path: fileItem.path,
+    source: 'file-tree',
+    type: 'file-system-item',
+  }
+}
+
+function clearHoverExpandTimer(path?: string): void {
+  if (path && pendingExpandPath !== path) {
+    return
+  }
+
+  if (hoverExpandTimerId !== undefined) {
+    clearTimeout(hoverExpandTimerId)
+    hoverExpandTimerId = undefined
+  }
+  pendingExpandPath = undefined
+}
+
+function scheduleHoverExpand(path: string): void {
+  clearHoverExpandTimer()
+  pendingExpandPath = path
+  hoverExpandTimerId = setTimeout(() => {
+    if (pendingExpandPath === path) {
+      expandDirectory(path)
+    }
+    clearHoverExpandTimer(path)
+  }, HOVER_EXPAND_DELAY)
+}
+
+function isDropAllowed(payload: FileSystemDragPayload, fileItem: Pick<FileTreeRenderedItem, 'isDir' | 'path'>): boolean {
+  if (!fileItem.isDir) {
+    return false
+  }
+
+  return canDropFileSystemItems(payload, fileItem.path, dragSession.state.value.transferOperation)
+}
+
+function handleDragEnter(payload: FileSystemDragPayload, fileItem: Pick<FileTreeRenderedItem, 'isDir' | 'path'>): void {
+  if (!isDropAllowed(payload, fileItem)) {
+    return
+  }
+
+  activeDropTargetPath = fileItem.path
+  if (fileItem.path !== effectiveRootPath) {
+    scheduleHoverExpand(fileItem.path)
+  }
+}
+
+function handleDragLeave(_payload: FileSystemDragPayload, fileItem: Pick<FileTreeRenderedItem, 'path'>): void {
+  if (activeDropTargetPath === fileItem.path) {
+    activeDropTargetPath = undefined
+  }
+  clearHoverExpandTimer(fileItem.path)
+}
+
+async function handleDrop(payload: FileSystemDragPayload, fileItem: Pick<FileTreeRenderedItem, 'isDir' | 'path'>): Promise<void> {
+  clearHoverExpandTimer(fileItem.path)
+  if (!isDropAllowed(payload, fileItem)) {
+    return
+  }
+
+  try {
+    const operation = dragSession.state.value.transferOperation
+    await (operation === 'copy' ? copyFileSystemItems(payload, fileItem.path) : moveFileSystemItems(payload, fileItem.path))
+  } catch (error) {
+    reportFileTreeMoveError(error)
+  } finally {
+    if (activeDropTargetPath === fileItem.path) {
+      activeDropTargetPath = undefined
+    }
+  }
+}
+
+function registerDropTarget(
+  key: string,
+  element: HTMLElement | undefined,
+  fileItem: Pick<FileTreeRenderedItem, 'isDir' | 'name' | 'path'>,
+): void {
+  const previousElement = dropTargetElements.get(key)
+  if (previousElement && previousElement !== element) {
+    dropRegistry.unregisterDroppable(previousElement)
+    dropTargetElements.delete(key)
+  }
+
+  if (!enableDragTransfer || !element || !fileItem.path) {
+    if (previousElement !== undefined && previousElement === element) {
+      dropRegistry.unregisterDroppable(previousElement)
+      dropTargetElements.delete(key)
+    }
+    return
+  }
+
+  dropTargetElements.set(key, element)
+  dropRegistry.registerDroppable(element, {
+    accept: 'file-system-item',
+    canDrop: payload => isDropAllowed(payload as FileSystemDragPayload, fileItem),
+    id: `file-tree:${key}`,
+    onDragEnter: payload => handleDragEnter(payload as FileSystemDragPayload, fileItem),
+    onDragLeave: payload => handleDragLeave(payload as FileSystemDragPayload, fileItem),
+    onDrop: payload => handleDrop(payload as FileSystemDragPayload, fileItem),
+  })
+}
+
+function setFileTreeItemElement(
+  value: unknown,
+  renderItem: FileTreeFileRenderItem,
+): void {
+  registerDropTarget(renderItem.fileItem.path, resolveHTMLElement(value), renderItem.dropTarget)
+}
+
+function getFileTreeDragSourceProps(item: FlattenedItem<T>) {
+  return enableDragTransfer && !isRenaming(item)
+    ? fileDragSource.sourceProps()
+    : {} as FileTreeDragSourceHandlers
+}
+
+function getFileTreeItemBind(item: FlattenedItem<T>) {
+  const dragSourceProps = getFileTreeDragSourceProps(item)
+
+  return {
+    ...item.bind,
+    ...dragSourceProps,
+    onClickCapture: (event: MouseEvent) => {
+      dragSourceProps.onClickCapture?.(event)
+      if (!event.defaultPrevented) {
+        handleFileTreeItemClickCapture(event, item)
+      }
+    },
+    onPointerdown: (event: PointerEvent) => {
+      handleFileTreeItemPointerDown(event, item)
+      dragSourceProps.onPointerdown?.(event)
+    },
+  }
+}
+
+function isFileTreeDropRangeActive(renderItem: FileTreeFileRenderItem): boolean {
+  return Boolean(
+    activeDropTargetPath !== undefined
+    && (
+      activeDropTargetPath === renderItem.fileItem.path
+      || renderItem.ancestorDirectoryPaths.includes(activeDropTargetPath)
+    ),
+  )
+}
+
+function getFileTreeDropTargetClass(renderItem: FileTreeFileRenderItem): string {
+  if (!isFileTreeDropRangeActive(renderItem)) {
+    return ''
+  }
+
+  return activeDropTargetPath === renderItem.fileItem.path
+    ? 'bg-accent outline outline-1 outline-primary/50'
+    : 'bg-accent/60'
+}
+
+const isRootDropTargetActive = $computed(() =>
+  activeDropTargetPath !== undefined && activeDropTargetPath === effectiveRootPath,
+)
 
 function isItemDimmed(item: T): boolean {
   return itemDimmed?.(item) ?? false
@@ -214,10 +752,18 @@ useShortcut(() => ({
   keys: enableContextMenu ? 'Delete' : '',
   when: { panelFocus: 'fileTree' },
 }))
+
+tryOnUnmounted(() => {
+  clearHoverExpandTimer()
+  for (const element of dropTargetElements.values()) {
+    dropRegistry.unregisterDroppable(element)
+  }
+  dropTargetElements.clear()
+})
 </script>
 
 <template>
-  <ScrollArea ref="scrollAreaRef" class="flex-scroll-area h-full">
+  <ScrollArea ref="scrollAreaRef" class="flex-scroll-area h-full" @scroll="handleScroll">
     <!-- 加载状态提示 -->
     <div v-if="isLoading" role="status" :aria-label="$t('common.loading')" class="flex h-full items-center justify-center">
       <div class="text-muted-foreground flex flex-col gap-3 items-center">
@@ -234,19 +780,25 @@ useShortcut(() => ({
       :items="sortedItems"
       :get-key="getKey"
       selection-behavior="replace"
-      class="text-13px h-full"
+      class="text-13px h-full min-h-0"
     >
       <TooltipProvider :skip-delay-duration="0" :ignore-non-keyboard-focus="true">
-        <div ref="fileTreeContainerRef" class="relative">
+        <div
+          :ref="setFileTreeContainerElement"
+          :class="[
+            'relative shrink-0',
+            isRootDropTargetActive ? 'bg-accent/35' : '',
+          ]"
+        >
           <template
-            v-for="item in processFlattenItems(flattenItemsSlot)"
-            :key="item._id"
+            v-for="renderItem in getRenderedItems(flattenItemsSlot)"
+            :key="renderItem.item._id"
           >
             <!-- 创建项的特殊渲染 -->
-            <template v-if="isCreatingItem(item)">
+            <template v-if="renderItem.kind === 'creating'">
               <TreeItem
-                v-bind="item.bind"
-                :level="item.level"
+                v-bind="renderItem.item.bind"
+                :level="renderItem.item.level"
                 :has-children="createState.type === 'folder'"
               >
                 <TreeItemLabel :has-children="createState.type === 'folder'">
@@ -277,12 +829,7 @@ useShortcut(() => ({
             <!-- 正常项的渲染 -->
             <FileTreeContextMenu
               v-else
-              :item="(() => {
-                const flattenedItem = item as FlattenedItem<T>
-                const fileItem = toFileItem(flattenedItem)
-                itemMap.set(fileItem.path, flattenedItem)
-                return fileItem
-              })()"
+              :item="renderItem.fileItem"
               :on-rename="handleContextMenuRename"
               :on-create-file="handleContextMenuCreateFile"
               :on-create-folder="handleContextMenuCreateFolder"
@@ -290,26 +837,30 @@ useShortcut(() => ({
             >
               <TreeItem
                 v-slot="{ isExpanded }"
-                v-bind="item.bind"
-                :level="item.level"
-                :has-children="item.hasChildren"
-                :data-file-tree-path="toFileItem(item as FlattenedItem<T>).path"
-                class="cursor-pointer"
-                @keydown.enter.prevent="handleEnterKey(item as FlattenedItem<T>)"
-                @keydown.escape.prevent="handleEscapeKey(item as FlattenedItem<T>)"
-                @click="() => {
-                  if (!isRenaming(item as FlattenedItem<T>)) {
-                    emit('click', item as FlattenedItem<T>)
-                  }
-                }"
-                @dblclick="emit('dblclick', item as FlattenedItem<T>)"
-                @auxclick="(e: MouseEvent) => e.button === 1 && emit('auxclick', item as FlattenedItem<T>)"
+                v-bind="getFileTreeItemBind(renderItem.item)"
+                :ref="(value) => setFileTreeItemElement(value, renderItem)"
+                :level="renderItem.item.level"
+                :has-children="renderItem.item.hasChildren"
+                :data-file-tree-path="renderItem.fileItem.path"
+                :data-file-tree-is-dir="renderItem.fileItem.isDir ? 'true' : 'false'"
+                :data-file-tree-name="renderItem.fileItem.name"
+                :data-file-tree-selected="isFileTreePathSelected(renderItem.fileItem.path) ? 'true' : undefined"
+                :class="[
+                  'cursor-pointer touch-none',
+                  isFileTreePathSelected(renderItem.fileItem.path) ? 'bg-accent' : '',
+                  getFileTreeDropTargetClass(renderItem),
+                ]"
+                @keydown.enter.prevent="handleEnterKey(renderItem.item)"
+                @keydown.escape.prevent="handleEscapeKey(renderItem.item)"
+                @click="(event: MouseEvent) => handleFileTreeItemClick(event, renderItem.item)"
+                @dblclick="emit('dblclick', renderItem.item)"
+                @auxclick="(e: MouseEvent) => e.button === 1 && emit('auxclick', renderItem.item)"
               >
                 <Tooltip :disabled="!enableTooltip">
                   <TooltipTrigger as-child>
-                    <TreeItemLabel :has-children="item.hasChildren">
+                    <TreeItemLabel :has-children="renderItem.item.hasChildren">
                       <span class="text-13px flex flex-1 gap-2 min-w-0 w-full items-center">
-                        <template v-if="item.hasChildren">
+                        <template v-if="renderItem.item.hasChildren">
                           <LucideFolderOpen
                             v-if="isExpanded"
                             class="text-muted-foreground size-4 pointer-events-none"
@@ -323,17 +874,17 @@ useShortcut(() => ({
                           v-else
                           class="text-muted-foreground size-4 pointer-events-none"
                         />
-                        <template v-if="isRenaming(item as FlattenedItem<T>)">
+                        <template v-if="isRenaming(renderItem.item)">
                           <Input
                             ref="inputRef"
                             v-model="renameState.value"
-                            :class="['px-0 py-0 h-5 text-13px!', isRenameDuplicate(item as FlattenedItem<T>) ? 'text-destructive focus-visible:ring-destructive' : '']"
+                            :class="['px-0 py-0 h-5 text-13px!', isRenameDuplicate(renderItem.item) ? 'text-destructive focus-visible:ring-destructive' : '']"
                             data-renaming-input
                             :disabled="renameState.isInProgress"
                             autofocus
-                            @blur="handleRenameBlur(item as FlattenedItem<T>)"
+                            @blur="handleRenameBlur(renderItem.item)"
                             @keydown.stop
-                            @keydown.enter="handleRename(item as FlattenedItem<T>)"
+                            @keydown.enter="handleRename(renderItem.item)"
                             @keydown.escape="handleCancelRename"
                           />
                         </template>
@@ -341,27 +892,27 @@ useShortcut(() => ({
                           v-else
                           :class="[
                             'flex flex-1 min-w-0 items-center gap-2',
-                            isItemDimmed((item as FlattenedItem<T>).value) ? 'opacity-70' : '',
+                            isItemDimmed(renderItem.item.value) ? 'opacity-70' : '',
                           ]"
                         >
                           <div class="whitespace-nowrap text-ellipsis overflow-hidden">
-                            {{ getItemName((item as FlattenedItem<T>).value) }}
+                            {{ getItemName(renderItem.item.value) }}
                           </div>
                           <span
-                            v-if="resolveItemBadgeText((item as FlattenedItem<T>).value)"
+                            v-if="resolveItemBadgeText(renderItem.item.value)"
                             class="text-[10px] text-muted-foreground leading-none px-1.5 py-0.5 rounded bg-muted shrink-0"
                           >
-                            {{ resolveItemBadgeText((item as FlattenedItem<T>).value) }}
+                            {{ resolveItemBadgeText(renderItem.item.value) }}
                           </span>
                         </div>
                       </span>
                     </TreeItemLabel>
                   </TooltipTrigger>
                   <TooltipContent
-                    v-if="tooltipContent && !isCreatingItem(item)"
+                    v-if="tooltipContent"
                     :disabled-portal="true"
                   >
-                    <p>{{ tooltipContent(item as FlattenedItem<T>) }}</p>
+                    <p>{{ tooltipContent(renderItem.item) }}</p>
                   </TooltipContent>
                 </Tooltip>
               </TreeItem>
@@ -369,17 +920,49 @@ useShortcut(() => ({
           </template>
         </div>
       </TooltipProvider>
-      <!-- 虚拟根目录区域 -->
+      <!-- 根目录空白区：内容不足一屏时填满剩余空间，内容溢出时保留一行可操作区域。 -->
       <FileTreeContextMenu
         v-if="enableContextMenu"
-        :item="{ path: getRootPath(), name: '', isDir: true }"
+        :item="{ path: effectiveRootPath, name: '', isDir: true }"
         :on-create-file="handleContextMenuCreateFile"
         :on-create-folder="handleContextMenuCreateFolder"
         is-root
         :disabled="false"
       >
-        <div class="h-full min-h-[26px]" />
+        <div
+          :ref="setRootDropAreaElement"
+          :class="[
+            'flex-1 min-h-[26px]',
+            isRootDropTargetActive ? 'bg-accent/60' : '',
+          ]"
+        />
       </FileTreeContextMenu>
     </Tree>
   </ScrollArea>
+
+  <DragOverlay :visible="activeFileTreePayload !== undefined" :overlay-style="dragOverlayStyle">
+    <div class="text-popover-foreground px-2 py-1.5 border border-border/70 rounded bg-popover flex gap-2 max-w-72 min-w-36 shadow-lg items-center" data-testid="file-tree-drag-preview">
+      <div class="shrink-0 size-5 relative">
+        <LucideFile
+          class="text-muted-foreground size-4 absolute"
+          :class="isMultipleDragPreview ? 'left-1 top-0.5' : 'left-0.5 top-0.5'"
+        />
+        <LucideFile
+          v-if="isMultipleDragPreview"
+          class="text-muted-foreground bg-popover size-4 left-0 top-0 absolute"
+        />
+      </div>
+      <div class="flex gap-2 min-w-0 items-center">
+        <span class="text-xs min-w-0 truncate">
+          {{ dragPreviewName }}
+        </span>
+        <span
+          v-if="isMultipleDragPreview"
+          class="text-[10px] text-muted-foreground leading-none px-1.5 py-0.5 rounded-sm bg-muted shrink-0"
+        >
+          {{ dragPreviewCountLabel }}
+        </span>
+      </div>
+    </div>
+  </DragOverlay>
 </template>

--- a/src/components/editor/FileTree.vue
+++ b/src/components/editor/FileTree.vue
@@ -60,6 +60,7 @@ const {
 const inputRef: Readonly<ShallowRef<unknown>> = useTemplateRef('inputRef')
 const creatingInputRef: Readonly<ShallowRef<unknown>> = useTemplateRef('creatingInputRef')
 const fileTreeContainerRef = shallowRef<HTMLDivElement>()
+const rootDropAreaRef = shallowRef<HTMLElement>()
 
 const emit = defineEmits<{
   click: [item: FlattenedItem<T>]
@@ -264,22 +265,20 @@ function resolveHTMLElement(value: unknown): HTMLElement | undefined {
   return value && typeof value === 'object' && '$el' in value && value.$el instanceof HTMLElement ? value.$el : undefined
 }
 
+function registerRootDropTargets(): void {
+  registerDropTarget('root-container', fileTreeContainerRef.value, rootFileItem)
+  registerDropTarget('root-area', rootDropAreaRef.value, rootFileItem)
+}
+
 function setFileTreeContainerElement(value: unknown): void {
   const element = resolveHTMLElement(value)
   fileTreeContainerRef.value = element instanceof HTMLDivElement ? element : undefined
-  registerDropTarget('root-container', fileTreeContainerRef.value, {
-    isDir: true,
-    name: '',
-    path: effectiveRootPath,
-  })
+  registerRootDropTargets()
 }
 
 function setRootDropAreaElement(value: unknown): void {
-  registerDropTarget('root-area', resolveHTMLElement(value), {
-    isDir: true,
-    name: '',
-    path: effectiveRootPath,
-  })
+  rootDropAreaRef.value = resolveHTMLElement(value)
+  registerRootDropTargets()
 }
 
 function reportFileTreeMoveError(error: unknown): void {
@@ -752,6 +751,10 @@ useShortcut(() => ({
   keys: enableContextMenu ? 'Delete' : '',
   when: { panelFocus: 'fileTree' },
 }))
+
+watch(() => effectiveRootPath, () => {
+  registerRootDropTargets()
+})
 
 tryOnUnmounted(() => {
   clearHoverExpandTimer()

--- a/src/components/editor/ScenePanel.spec.ts
+++ b/src/components/editor/ScenePanel.spec.ts
@@ -7,6 +7,7 @@ const {
   fileSystemEventHandlers,
   fileSystemEventsOnMock,
   gameSceneDirMock,
+  scrollIntoViewMock,
   useFileStoreMock,
   useTabsStoreMock,
   useWorkspaceStoreMock,
@@ -14,6 +15,7 @@ const {
   fileSystemEventHandlers: new Map<string, (event: unknown) => void>(),
   fileSystemEventsOnMock: vi.fn(),
   gameSceneDirMock: vi.fn(),
+  scrollIntoViewMock: vi.fn(),
   useFileStoreMock: vi.fn(),
   useTabsStoreMock: vi.fn(),
   useWorkspaceStoreMock: vi.fn(),
@@ -77,6 +79,25 @@ interface TreeNode {
   path: string
 }
 
+interface TestTab {
+  isPreview?: boolean
+  path: string
+}
+
+function createRect(rect: Partial<DOMRect>): DOMRect {
+  return {
+    bottom: rect.bottom ?? 0,
+    height: rect.height ?? 0,
+    left: rect.left ?? 0,
+    right: rect.right ?? 0,
+    toJSON: () => ({}),
+    top: rect.top ?? 0,
+    width: rect.width ?? 0,
+    x: rect.x ?? rect.left ?? 0,
+    y: rect.y ?? rect.top ?? 0,
+  } as DOMRect
+}
+
 function flattenNodes(items: TreeNode[]): TreeNode[] {
   return items.flatMap(item => [
     item,
@@ -111,19 +132,62 @@ const globalStubs = {
         type: Array,
         required: true,
       },
+      selectedItem: {
+        type: Object,
+        default: undefined,
+      },
     },
     emits: ['auxclick', 'click', 'dblclick', 'update:selectedItem'],
-    setup(props, { emit }) {
+    setup(props, { emit, expose }) {
+      const viewportRef = shallowRef<HTMLElement>()
+
+      function setViewportElement(element: unknown) {
+        const viewport = element instanceof HTMLElement ? element : undefined
+        viewportRef.value = viewport
+        if (viewport) {
+          viewport.getBoundingClientRect = () => createRect({
+            bottom: 100,
+            height: 100,
+            right: 240,
+            width: 240,
+          })
+        }
+      }
+
+      function setSelectedElement(element: unknown) {
+        const selectedElement = element instanceof HTMLElement ? element : undefined
+        if (!selectedElement) {
+          return
+        }
+
+        selectedElement.getBoundingClientRect = () => createRect({
+          bottom: 226,
+          height: 26,
+          right: 240,
+          top: 200,
+          width: 240,
+          y: 200,
+        })
+        selectedElement.scrollIntoView = scrollIntoViewMock as typeof selectedElement.scrollIntoView
+      }
+
+      expose({
+        getViewportElement: () => viewportRef.value,
+      })
+
       function renderItems(items: TreeNode[]) {
         return flattenNodes(items).map((item) => {
           const badgeText = (props.itemBadgeText as ((item: TreeNode) => string | undefined) | undefined)?.(item)
           const isDimmed = (props.itemDimmed as ((item: TreeNode) => boolean) | undefined)?.(item) ?? false
+          const isSelected = (props.selectedItem as TreeNode | undefined)?.path === item.path
 
           return h('div', {
             key: item.path,
           }, [
             h('button', {
+              'ref': isSelected ? setSelectedElement : undefined,
               'type': 'button',
+              'data-selected': isSelected ? '' : undefined,
               'data-dimmed': isDimmed ? 'true' : 'false',
               'onClick': () => emit('click', {
                 hasChildren: Array.isArray(item.children),
@@ -135,7 +199,10 @@ const globalStubs = {
         })
       }
 
-      return () => h('div', renderItems(props.items as TreeNode[]))
+      return () => h('div', {
+        'ref': setViewportElement,
+        'data-testid': 'scene-panel-viewport',
+      }, renderItems(props.items as TreeNode[]))
     },
   }),
 }
@@ -172,6 +239,16 @@ function createFileStore() {
   }
 }
 
+function createTabsStore(activeTab?: TestTab) {
+  return reactive({
+    activeTab,
+    tabs: [] as TestTab[],
+    findTabIndex: vi.fn(() => -1),
+    openTab: vi.fn(),
+    fixPreviewTab: vi.fn(),
+  })
+}
+
 describe('ScenePanel', () => {
   beforeEach(() => {
     vi.resetAllMocks()
@@ -186,13 +263,7 @@ describe('ScenePanel', () => {
 
     gameSceneDirMock.mockReturnValue('/games/demo/game/scene')
     useFileStoreMock.mockReturnValue(createFileStore())
-    useTabsStoreMock.mockReturnValue(reactive({
-      activeTab: undefined,
-      tabs: [],
-      findTabIndex: vi.fn(() => -1),
-      openTab: vi.fn(),
-      fixPreviewTab: vi.fn(),
-    }))
+    useTabsStoreMock.mockReturnValue(createTabsStore())
     useWorkspaceStoreMock.mockReturnValue(reactive({
       currentGame: {
         id: 'game-1',
@@ -225,13 +296,7 @@ describe('ScenePanel', () => {
   })
 
   it('点击文件时会通过 tabs store 打开标签页', async () => {
-    const tabsStore = reactive({
-      activeTab: undefined,
-      tabs: [],
-      findTabIndex: vi.fn(() => -1),
-      openTab: vi.fn(),
-      fixPreviewTab: vi.fn(),
-    })
+    const tabsStore = createTabsStore()
 
     useTabsStoreMock.mockReturnValue(tabsStore)
 
@@ -330,6 +395,36 @@ describe('ScenePanel', () => {
 
     await vi.waitFor(() => {
       expect(fileStore.getFolderContents.mock.calls.length).toBeGreaterThan(initialCalls)
+    })
+  })
+
+  it('active tab 路径变化时会滚动显示选中的场景文件', async () => {
+    const tabsStore = createTabsStore()
+    useTabsStoreMock.mockReturnValue(tabsStore)
+
+    renderInBrowser(ScenePanel, {
+      browser: {
+        i18nMode: 'localized',
+        messages: {
+          'zh-Hans': {
+            edit: {},
+          },
+        },
+      },
+      global: {
+        stubs: globalStubs,
+      },
+    })
+
+    await expect.element(page.getByText('branch.txt')).toBeVisible()
+    expect(scrollIntoViewMock).not.toHaveBeenCalled()
+
+    tabsStore.activeTab = {
+      path: '/games/demo/game/scene/chapter-1/branch.txt',
+    }
+
+    await vi.waitFor(() => {
+      expect(scrollIntoViewMock).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/src/components/editor/ScenePanel.vue
+++ b/src/components/editor/ScenePanel.vue
@@ -85,17 +85,31 @@ function handleAuxClick(item: FlattenedItem<ScenePanelTreeNode>) {
 }
 
 let selectedItem = $ref<ScenePanelTreeNode>()
+let pendingRevealPath = $ref<string>()
+let lastSyncedActiveTabPath = $ref(tabsStore.activeTab?.path)
+let hasLoadedSceneItems = $ref(false)
 
 function updateSelectedItemFromActiveTab() {
   const activeTab = tabsStore.activeTab
   if (!activeTab) {
     selectedItem = undefined
+    pendingRevealPath = undefined
+    lastSyncedActiveTabPath = undefined
     return
   }
 
   const foundNode = findScenePanelNodeByPath(items.value || [], activeTab.path)
-  if (foundNode) {
-    selectedItem = foundNode
+  if (!foundNode) {
+    lastSyncedActiveTabPath = activeTab.path
+    pendingRevealPath = undefined
+    return
+  }
+
+  selectedItem = foundNode
+  lastSyncedActiveTabPath = activeTab.path
+  if (pendingRevealPath === foundNode.path) {
+    pendingRevealPath = undefined
+    nextTick(scrollToSelectedItem)
   }
 }
 
@@ -125,16 +139,14 @@ function scrollToSelectedItem() {
   }
 }
 
-watch($$(selectedItem), () => {
-  if (selectedItem) {
-    nextTick(scrollToSelectedItem)
-  }
+watch(() => tabsStore.activeTab?.path, (path) => {
+  pendingRevealPath = hasLoadedSceneItems && path && path !== lastSyncedActiveTabPath ? path : undefined
+  updateSelectedItemFromActiveTab()
 })
-
-watch(() => tabsStore.activeTab, updateSelectedItemFromActiveTab)
 
 watch(items, () => {
   if (items.value?.length) {
+    hasLoadedSceneItems = true
     updateSelectedItemFromActiveTab()
   }
 })
@@ -212,6 +224,8 @@ onScopeDispose(() => {
       :tooltip-content="(item) => item.value.path"
       :is-loading="isLoading"
       tree-name="scene"
+      enable-drag-transfer
+      :root-path="scenePath"
       :default-file-name-parts="{ stem: '', extension: '.txt' }"
       @click="handleClick"
       @dblclick="handleDoubleClick"

--- a/src/composables/__tests__/useDragSession.test.ts
+++ b/src/composables/__tests__/useDragSession.test.ts
@@ -31,6 +31,7 @@ describe('useDragSession', () => {
       mode: 'sort',
       payload: tabPayload,
       startPosition: { x: 12, y: 24 },
+      transferOperation: 'move',
     })
   })
 
@@ -47,6 +48,7 @@ describe('useDragSession', () => {
       mode: null,
       payload: null,
       startPosition: null,
+      transferOperation: 'move',
     })
   })
 })

--- a/src/composables/__tests__/useDragTransfer.test.ts
+++ b/src/composables/__tests__/useDragTransfer.test.ts
@@ -1,0 +1,517 @@
+/* eslint-disable unicorn/no-null -- 测试需要模拟 DOM PointerEvent 的 null target 语义 */
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { useDragSession } from '../useDragSession'
+import { useDragSource } from '../useDragTransfer'
+import { useDroppableRegistry } from '../useDroppableRegistry'
+
+import type { Ref } from 'vue'
+import type { FileSystemDragPayload } from '~/types/drag-drop'
+
+type ListenerMap = Record<string, Set<EventListenerOrEventListenerObject>>
+
+interface PointerLikeEvent {
+  altKey?: boolean
+  button?: number
+  buttons?: number
+  clientX?: number
+  clientY?: number
+  ctrlKey?: boolean
+  currentTarget?: EventTarget | null
+  isPrimary?: boolean
+  metaKey?: boolean
+  pointerId: number
+  target?: EventTarget | null
+  preventDefault?: () => void
+}
+
+interface TestDragElement extends HTMLElement {
+  dispatch: (eventName: string, payload: PointerLikeEvent) => void
+  listeners: ListenerMap
+}
+
+const originalAddEventListener = globalThis.addEventListener
+const originalRemoveEventListener = globalThis.removeEventListener
+const globalListenerMap: ListenerMap = {}
+
+const filePayload: FileSystemDragPayload = {
+  isDir: false,
+  name: 'start.txt',
+  path: '/project/game/scene/start.txt',
+  source: 'file-tree',
+  type: 'file-system-item',
+}
+
+function createPointerEvent(overrides: PointerLikeEvent): PointerEvent {
+  const { pointerId, ...rest } = overrides
+
+  return {
+    altKey: false,
+    button: 0,
+    buttons: 1,
+    clientX: 0,
+    clientY: 0,
+    ctrlKey: false,
+    currentTarget: null,
+    isPrimary: true,
+    metaKey: false,
+    pointerId,
+    preventDefault: vi.fn(),
+    target: null,
+    ...rest,
+  } as PointerEvent
+}
+
+function invokeListener(listener: EventListenerOrEventListenerObject, payload: PointerLikeEvent) {
+  if (typeof listener === 'function') {
+    listener(createPointerEvent(payload) as unknown as Event)
+    return
+  }
+
+  listener.handleEvent(createPointerEvent(payload) as unknown as Event)
+}
+
+function createDragElement(): TestDragElement {
+  const listeners: ListenerMap = {}
+  const capturedPointers = new Set<number>()
+  const element = {
+    addEventListener(event: string, listener: EventListenerOrEventListenerObject) {
+      if (!listeners[event]) {
+        listeners[event] = new Set()
+      }
+      listeners[event].add(listener)
+    },
+    closest: vi.fn(() => null),
+    contains: vi.fn(() => true),
+    dispatch(eventName: string, payload: PointerLikeEvent) {
+      for (const listener of listeners[eventName] ?? []) {
+        invokeListener(listener, payload)
+      }
+    },
+    hasPointerCapture(pointerId: number) {
+      return capturedPointers.has(pointerId)
+    },
+    listeners,
+    releasePointerCapture(pointerId: number) {
+      capturedPointers.delete(pointerId)
+    },
+    removeEventListener(event: string, listener: EventListenerOrEventListenerObject) {
+      listeners[event]?.delete(listener)
+    },
+    setPointerCapture(pointerId: number) {
+      capturedPointers.add(pointerId)
+    },
+    style: {
+      touchAction: '',
+    },
+  }
+
+  return element as unknown as TestDragElement
+}
+
+function createTargetElement(): HTMLElement {
+  return {
+    dataset: {},
+    parentElement: null,
+  } as unknown as HTMLElement
+}
+
+function createScrollContainer(): HTMLElement {
+  let scrollTop = 20
+  let hasScrolled = false
+
+  return {
+    get scrollTop() {
+      return scrollTop
+    },
+    set scrollTop(value: number) {
+      scrollTop = value
+    },
+    getBoundingClientRect: () => ({
+      bottom: 100,
+      height: 100,
+      left: 0,
+      right: 100,
+      top: 0,
+      width: 100,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    }),
+    scrollBy: vi.fn((options: ScrollToOptions) => {
+      if (hasScrolled) {
+        return
+      }
+      hasScrolled = true
+      scrollTop += options.top ?? 0
+    }),
+    scrollLeft: 0,
+  } as unknown as HTMLElement
+}
+
+function createScrollContainerRef(container: HTMLElement): Ref<HTMLElement | undefined> {
+  return shallowRef(container)
+}
+
+function registerTestDropTarget(
+  target: HTMLElement,
+  options: {
+    canDrop?: () => boolean
+    onDragEnter?: () => void
+    onDragLeave?: () => void
+    onDrop?: (payload: FileSystemDragPayload, target: HTMLElement) => void
+  } = {},
+) {
+  const registry = useDroppableRegistry()
+  registry.registerDroppable(target, {
+    accept: 'file-system-item',
+    canDrop: options.canDrop,
+    id: 'folder',
+    onDragEnter: options.onDragEnter,
+    onDragLeave: options.onDragLeave,
+    onDrop: (payload, element) => options.onDrop?.(payload as FileSystemDragPayload, element),
+  })
+  return registry
+}
+
+function setupDragDocument(dropTarget: Element | null = null) {
+  vi.stubGlobal('document', {
+    documentElement: {
+      style: {
+        userSelect: '',
+      },
+    },
+    elementFromPoint: vi.fn(() => dropTarget),
+  })
+}
+
+function setupAnimationFrame() {
+  let currentTimestamp = 0
+
+  vi.stubGlobal('requestAnimationFrame', vi.fn((callback: FrameRequestCallback) => {
+    currentTimestamp += 16
+    callback(currentTimestamp)
+    return 0
+  }))
+  vi.stubGlobal('cancelAnimationFrame', vi.fn())
+}
+
+function setupGlobalListeners() {
+  const mockedGlobal = globalThis as unknown as {
+    addEventListener: typeof globalThis.addEventListener
+    removeEventListener: typeof globalThis.removeEventListener
+  }
+
+  mockedGlobal.addEventListener = ((event: string, listener: EventListenerOrEventListenerObject) => {
+    if (!globalListenerMap[event]) {
+      globalListenerMap[event] = new Set()
+    }
+    globalListenerMap[event].add(listener)
+  }) as typeof globalThis.addEventListener
+
+  mockedGlobal.removeEventListener = ((event: string, listener: EventListenerOrEventListenerObject) => {
+    globalListenerMap[event]?.delete(listener)
+  }) as typeof globalThis.removeEventListener
+}
+
+function startDrag(
+  element: TestDragElement,
+  pointerId: number,
+  x: number,
+  y: number,
+  options: Partial<PointerLikeEvent> = {},
+) {
+  element.dispatch('pointermove', {
+    clientX: x,
+    clientY: y,
+    pointerId,
+    target: element,
+    ...options,
+  })
+}
+
+function moveDrag(element: TestDragElement, payload: PointerLikeEvent) {
+  element.dispatch('pointermove', payload)
+}
+
+afterEach(() => {
+  useDragSession().cancel()
+  for (const key of Object.keys(globalListenerMap)) {
+    globalListenerMap[key].clear()
+    delete globalListenerMap[key]
+  }
+  vi.useRealTimers()
+  globalThis.addEventListener = originalAddEventListener
+  globalThis.removeEventListener = originalRemoveEventListener
+  vi.unstubAllGlobals()
+})
+
+describe('useDragTransfer', () => {
+  it('useDragTransferSource 会在拖拽开始后写入 transfer 会话并更新目标命中', () => {
+    setupGlobalListeners()
+    const target = createTargetElement()
+    setupDragDocument(target)
+    setupAnimationFrame()
+    const session = useDragSession()
+    const onDrop = vi.fn()
+    const onDragEnter = vi.fn()
+    const sourceElement = createDragElement()
+    const source = useDragSource<FileSystemDragPayload>({
+      getData: () => filePayload,
+      type: 'file-system-item',
+    })
+    const registry = registerTestDropTarget(target, {
+      onDragEnter,
+      onDrop,
+    })
+
+    source.sourceProps().onPointerdown(createPointerEvent({
+      clientX: 10,
+      clientY: 10,
+      currentTarget: sourceElement,
+      pointerId: 1,
+      target: sourceElement,
+    }))
+    startDrag(sourceElement, 1, 20, 20)
+
+    expect(session.state.value).toMatchObject({
+      currentDropTarget: target,
+      isActive: true,
+      mode: 'transfer',
+      payload: filePayload,
+    })
+    expect(onDragEnter).toHaveBeenCalledTimes(1)
+    expect(registry.hoveredTarget.value).toBe(target)
+    expect(registry.isDropAllowed.value).toBe(true)
+
+    sourceElement.dispatch('pointerup', {
+      clientX: 20,
+      clientY: 20,
+      pointerId: 1,
+      target: sourceElement,
+    })
+
+    expect(onDrop).toHaveBeenCalledWith(filePayload, target)
+  })
+
+  it('命中不允许的目标时会保留悬停状态但不执行 drop', () => {
+    setupGlobalListeners()
+    const target = createTargetElement()
+    setupDragDocument(target)
+    setupAnimationFrame()
+    const sourceElement = createDragElement()
+    const onDrop = vi.fn()
+    const onDragEnter = vi.fn()
+    const source = useDragSource<FileSystemDragPayload>({
+      getData: () => filePayload,
+      type: 'file-system-item',
+    })
+    const registry = registerTestDropTarget(target, {
+      canDrop: () => false,
+      onDragEnter,
+      onDrop,
+    })
+
+    source.sourceProps().onPointerdown(createPointerEvent({
+      clientX: 10,
+      clientY: 10,
+      currentTarget: sourceElement,
+      pointerId: 2,
+      target: sourceElement,
+    }))
+    startDrag(sourceElement, 2, 20, 20)
+
+    expect(onDragEnter).toHaveBeenCalledTimes(1)
+    expect(registry.hoveredTarget.value).toBe(target)
+    expect(registry.isDropAllowed.value).toBe(false)
+
+    sourceElement.dispatch('pointerup', {
+      clientX: 20,
+      clientY: 20,
+      pointerId: 2,
+      target: sourceElement,
+    })
+
+    expect(onDrop).not.toHaveBeenCalled()
+  })
+
+  it('拖拽结束后若未收到 click 事件会自动清理点击抑制状态', () => {
+    vi.useFakeTimers()
+    setupGlobalListeners()
+    const target = createTargetElement()
+    setupDragDocument(target)
+    setupAnimationFrame()
+    const sourceElement = createDragElement()
+    const source = useDragSource<FileSystemDragPayload>({
+      getData: () => filePayload,
+      type: 'file-system-item',
+    })
+    const sourceProps = source.sourceProps()
+    registerTestDropTarget(target)
+
+    sourceProps.onPointerdown(createPointerEvent({
+      clientX: 10,
+      clientY: 10,
+      currentTarget: sourceElement,
+      pointerId: 8,
+      target: sourceElement,
+    }))
+    startDrag(sourceElement, 8, 20, 20)
+    sourceElement.dispatch('pointerup', {
+      clientX: 20,
+      clientY: 20,
+      pointerId: 8,
+      target: sourceElement,
+    })
+
+    vi.runAllTimers()
+
+    const clickEvent = {
+      preventDefault: vi.fn(),
+      stopImmediatePropagation: vi.fn(),
+      stopPropagation: vi.fn(),
+    } as unknown as MouseEvent
+
+    sourceProps.onClickCapture(clickEvent)
+
+    expect(clickEvent.preventDefault).not.toHaveBeenCalled()
+  })
+
+  it('按住 Ctrl 时会临时切换 transfer 会话为 copy，松开后恢复 move', () => {
+    setupGlobalListeners()
+    const target = createTargetElement()
+    setupDragDocument(target)
+    setupAnimationFrame()
+    const session = useDragSession()
+    const sourceElement = createDragElement()
+    const source = useDragSource<FileSystemDragPayload>({
+      getData: () => filePayload,
+      type: 'file-system-item',
+    })
+    registerTestDropTarget(target)
+
+    source.sourceProps().onPointerdown(createPointerEvent({
+      clientX: 10,
+      clientY: 10,
+      ctrlKey: true,
+      currentTarget: sourceElement,
+      pointerId: 3,
+      target: sourceElement,
+    }))
+    startDrag(sourceElement, 3, 20, 20, { ctrlKey: true })
+
+    expect(session.state.value.transferOperation).toBe('copy')
+
+    moveDrag(sourceElement, {
+      clientX: 24,
+      clientY: 24,
+      ctrlKey: false,
+      pointerId: 3,
+      target: sourceElement,
+    })
+
+    expect(session.state.value.transferOperation).toBe('move')
+
+    moveDrag(sourceElement, {
+      clientX: 28,
+      clientY: 28,
+      ctrlKey: true,
+      pointerId: 3,
+      target: sourceElement,
+    })
+
+    expect(session.state.value.transferOperation).toBe('copy')
+  })
+
+  it('配置自动滚动容器后会在拖拽靠近边缘时滚动', () => {
+    setupGlobalListeners()
+    const target = createTargetElement()
+    setupDragDocument(target)
+    setupAnimationFrame()
+    const sourceElement = createDragElement()
+    const scrollContainer = createScrollContainer()
+    const source = useDragSource<FileSystemDragPayload>({
+      autoScroll: {
+        container: createScrollContainerRef(scrollContainer),
+        edgeSize: 20,
+        maxSpeed: 200,
+      },
+      getData: () => filePayload,
+      type: 'file-system-item',
+    })
+    registerTestDropTarget(target)
+
+    source.sourceProps().onPointerdown(createPointerEvent({
+      clientX: 10,
+      clientY: 10,
+      currentTarget: sourceElement,
+      pointerId: 6,
+      target: sourceElement,
+    }))
+    startDrag(sourceElement, 6, 50, 95)
+
+    expect(scrollContainer.scrollBy).toHaveBeenCalledWith({
+      behavior: 'auto',
+      left: 0,
+      top: expect.any(Number),
+    })
+    expect(scrollContainer.scrollTop).toBeGreaterThan(20)
+
+    sourceElement.dispatch('pointerup', {
+      clientX: 50,
+      clientY: 95,
+      pointerId: 6,
+      target: sourceElement,
+    })
+  })
+
+  it('拖出自动滚动容器后不会继续滚动源容器', () => {
+    setupGlobalListeners()
+    const target = createTargetElement()
+    setupDragDocument(target)
+    setupAnimationFrame()
+    const sourceElement = createDragElement()
+    const scrollContainer = createScrollContainer()
+    const source = useDragSource<FileSystemDragPayload>({
+      autoScroll: {
+        container: createScrollContainerRef(scrollContainer),
+        edgeSize: 20,
+        maxSpeed: 200,
+      },
+      getData: () => filePayload,
+      type: 'file-system-item',
+    })
+    registerTestDropTarget(target)
+
+    source.sourceProps().onPointerdown(createPointerEvent({
+      clientX: 10,
+      clientY: 10,
+      currentTarget: sourceElement,
+      pointerId: 7,
+      target: sourceElement,
+    }))
+    startDrag(sourceElement, 7, 50, 95)
+
+    expect(scrollContainer.scrollBy).toHaveBeenCalled()
+    const scrollByMock = scrollContainer.scrollBy as unknown as ReturnType<typeof vi.fn>
+    const callCountBeforeLeaving = scrollByMock.mock.calls.length
+    const scrollTopBeforeLeaving = scrollContainer.scrollTop
+
+    moveDrag(sourceElement, {
+      clientX: 150,
+      clientY: 95,
+      pointerId: 7,
+      target: sourceElement,
+    })
+
+    expect(scrollByMock).toHaveBeenCalledTimes(callCountBeforeLeaving)
+    expect(scrollContainer.scrollTop).toBe(scrollTopBeforeLeaving)
+
+    sourceElement.dispatch('pointerup', {
+      clientX: 150,
+      clientY: 95,
+      pointerId: 7,
+      target: sourceElement,
+    })
+  })
+})

--- a/src/composables/__tests__/useDragTransfer.test.ts
+++ b/src/composables/__tests__/useDragTransfer.test.ts
@@ -41,6 +41,13 @@ const filePayload: FileSystemDragPayload = {
   source: 'file-tree',
   type: 'file-system-item',
 }
+const secondFilePayload: FileSystemDragPayload = {
+  isDir: false,
+  name: 'next.txt',
+  path: '/project/game/scene/next.txt',
+  source: 'file-tree',
+  type: 'file-system-item',
+}
 
 function createPointerEvent(overrides: PointerLikeEvent): PointerEvent {
   const { pointerId, ...rest } = overrides
@@ -159,7 +166,7 @@ function registerTestDropTarget(
     canDrop?: () => boolean
     onDragEnter?: () => void
     onDragLeave?: () => void
-    onDrop?: (payload: FileSystemDragPayload, target: HTMLElement) => void
+    onDrop?: (payload: FileSystemDragPayload, target: HTMLElement) => Promise<void> | void
   } = {},
 ) {
   const registry = useDroppableRegistry()
@@ -375,6 +382,73 @@ describe('useDragTransfer', () => {
     sourceProps.onClickCapture(clickEvent)
 
     expect(clickEvent.preventDefault).not.toHaveBeenCalled()
+  })
+
+  it('前一次异步 drop 完成后不会清理并发开始的新拖拽会话', async () => {
+    setupGlobalListeners()
+    const target = createTargetElement()
+    setupDragDocument(target)
+    setupAnimationFrame()
+    const session = useDragSession()
+    let resolveFirstDrop!: () => void
+    const onDrop = vi.fn(() => new Promise<void>((resolve) => {
+      resolveFirstDrop = resolve
+    }))
+    const sourceElement = createDragElement()
+    let nextPayload = filePayload
+    const source = useDragSource<FileSystemDragPayload>({
+      getData: () => nextPayload,
+      type: 'file-system-item',
+    })
+    const registry = registerTestDropTarget(target, {
+      onDrop,
+    })
+    const sourceProps = source.sourceProps()
+
+    sourceProps.onPointerdown(createPointerEvent({
+      clientX: 10,
+      clientY: 10,
+      currentTarget: sourceElement,
+      pointerId: 9,
+      target: sourceElement,
+    }))
+    startDrag(sourceElement, 9, 20, 20)
+    sourceElement.dispatch('pointerup', {
+      clientX: 20,
+      clientY: 20,
+      pointerId: 9,
+      target: sourceElement,
+    })
+
+    nextPayload = secondFilePayload
+    sourceProps.onPointerdown(createPointerEvent({
+      clientX: 30,
+      clientY: 30,
+      currentTarget: sourceElement,
+      pointerId: 10,
+      target: sourceElement,
+    }))
+    startDrag(sourceElement, 10, 40, 40)
+
+    expect(session.state.value).toMatchObject({
+      currentDropTarget: target,
+      isActive: true,
+      mode: 'transfer',
+      payload: secondFilePayload,
+      transferOperation: 'move',
+    })
+    expect(registry.hoveredTarget.value).toBe(target)
+
+    resolveFirstDrop()
+    await Promise.resolve()
+
+    expect(session.state.value).toMatchObject({
+      currentDropTarget: target,
+      isActive: true,
+      mode: 'transfer',
+      payload: secondFilePayload,
+      transferOperation: 'move',
+    })
   })
 
   it('按住 Ctrl 时会临时切换 transfer 会话为 copy，松开后恢复 move', () => {

--- a/src/composables/useDragSession.ts
+++ b/src/composables/useDragSession.ts
@@ -1,6 +1,6 @@
 /* eslint-disable unicorn/no-null -- 拖拽会话契约显式使用 null 表示无值 */
 import type { Ref } from 'vue'
-import type { DragMode, DragPayload, DragPosition } from '~/types/drag-drop'
+import type { DragMode, DragPayload, DragPosition, DragTransferOperation } from '~/types/drag-drop'
 
 export interface DragSessionState {
   currentDropTarget: HTMLElement | null
@@ -9,6 +9,7 @@ export interface DragSessionState {
   mode: DragMode | null
   payload: DragPayload | null
   startPosition: DragPosition | null
+  transferOperation: DragTransferOperation
 }
 
 export interface UseDragSessionReturn {
@@ -18,6 +19,7 @@ export interface UseDragSessionReturn {
   state: Readonly<Ref<DragSessionState>>
   updateDropTarget: (target: HTMLElement | null) => void
   updatePosition: (position: DragPosition) => void
+  updateTransferOperation: (operation: DragTransferOperation) => void
 }
 
 function createInitialState(): DragSessionState {
@@ -28,6 +30,7 @@ function createInitialState(): DragSessionState {
     mode: null,
     payload: null,
     startPosition: null,
+    transferOperation: 'move',
   }
 }
 
@@ -46,6 +49,7 @@ function start(mode: DragMode, payload: DragPayload, position: DragPosition) {
     mode,
     payload,
     startPosition: { ...position },
+    transferOperation: 'move',
   }
 }
 
@@ -73,6 +77,22 @@ function updateDropTarget(target: HTMLElement | null) {
   }
 }
 
+function updateTransferOperation(operation: DragTransferOperation) {
+  const state = dragSessionState.value
+  if (!state.isActive || state.mode !== 'transfer') {
+    return
+  }
+
+  if (state.transferOperation === operation) {
+    return
+  }
+
+  dragSessionState.value = {
+    ...state,
+    transferOperation: operation,
+  }
+}
+
 function end() {
   resetState()
 }
@@ -89,5 +109,6 @@ export function useDragSession(): UseDragSessionReturn {
     state: readonlyDragSessionState,
     updateDropTarget,
     updatePosition,
+    updateTransferOperation,
   }
 }

--- a/src/composables/useDragTransfer.ts
+++ b/src/composables/useDragTransfer.ts
@@ -180,12 +180,11 @@ export function useDragSource<TPayload extends DragPayload>(
       updateSessionTransferOperation(event)
       session.updatePosition(context.currentPosition)
       scheduleSuppressNextClickReset()
+      const dropResult = registry.drop(currentPayload, context.currentPosition)
       session.end()
-      void registry
-        .drop(currentPayload, context.currentPosition)
-        .catch((error: unknown) => {
-          void logger.error(`拖拽放置失败: ${error instanceof Error ? error.message : String(error)}`)
-        })
+      void dropResult.catch((error: unknown) => {
+        void logger.error(`拖拽放置失败: ${error instanceof Error ? error.message : String(error)}`)
+      })
     },
     onDragMove: (event, context) => {
       if (!payload) {

--- a/src/composables/useDragTransfer.ts
+++ b/src/composables/useDragTransfer.ts
@@ -1,0 +1,247 @@
+/* eslint-disable unicorn/no-null -- 拖拽会话契约显式使用 null 表示当前没有命中目标。 */
+import { useAutoScrollOnDrag } from './useAutoScrollOnDrag'
+import { useDragSession } from './useDragSession'
+import { useDroppableRegistry } from './useDroppableRegistry'
+import { usePointerDrag } from './usePointerDrag'
+
+import type { DragAutoScrollAxis } from './useAutoScrollOnDrag'
+import type { DragPayload, DragPosition, DragTransferOperation } from '~/types/drag-drop'
+
+export interface DragTransferAutoScrollOptions {
+  axis?: DragAutoScrollAxis
+  container: Readonly<Ref<HTMLElement | undefined>>
+  edgeSize?: number
+  maxSpeed?: number
+}
+
+export interface UseDragSourceOptions<TPayload extends DragPayload> {
+  autoScroll?: DragTransferAutoScrollOptions
+  getData: (element: HTMLElement) => TPayload
+  handleSelector?: string
+  type: TPayload['type']
+}
+
+export interface UseDragSourceReturn {
+  sourceProps: () => {
+    onClickCapture: (event: MouseEvent) => void
+    onPointerdown: (event: PointerEvent) => void
+  }
+}
+
+function hasClosest(value: EventTarget | null): value is EventTarget & { closest: (selector: string) => Element | null } {
+  return Boolean(value && typeof value === 'object' && 'closest' in value)
+}
+
+function isHTMLElement(value: unknown): value is HTMLElement {
+  if (!value || typeof value !== 'object') {
+    return false
+  }
+
+  if (typeof HTMLElement === 'undefined') {
+    return 'addEventListener' in value && 'removeEventListener' in value && 'style' in value
+  }
+
+  return value instanceof HTMLElement
+}
+
+function matchesSelectorInside(
+  event: PointerEvent,
+  sourceElement: HTMLElement,
+  selector: string | undefined,
+): boolean {
+  if (!selector || !hasClosest(event.target)) {
+    return false
+  }
+
+  const matched = event.target.closest(selector)
+  return matched !== null && sourceElement.contains(matched)
+}
+
+function canStartDragFromTarget(
+  event: PointerEvent,
+  sourceElement: HTMLElement,
+  handleSelector: string | undefined,
+): boolean {
+  return !handleSelector || matchesSelectorInside(event, sourceElement, handleSelector)
+}
+
+function resolveTransferOperation(event: PointerEvent): DragTransferOperation {
+  return event.ctrlKey || event.metaKey ? 'copy' : 'move'
+}
+
+function isPositionInAutoScrollLane(
+  position: DragPosition,
+  element: HTMLElement,
+  axis: DragAutoScrollAxis,
+): boolean {
+  const rect = element.getBoundingClientRect()
+  if (axis === 'horizontal') {
+    return position.y >= rect.top && position.y <= rect.bottom
+  }
+
+  return position.x >= rect.left && position.x <= rect.right
+}
+
+export function useDragSource<TPayload extends DragPayload>(
+  options: UseDragSourceOptions<TPayload>,
+): UseDragSourceReturn {
+  const session = useDragSession()
+  const registry = useDroppableRegistry()
+  const autoScrollOptions = options.autoScroll
+  const autoScrollAxis = autoScrollOptions?.axis ?? 'vertical'
+  let payload: TPayload | undefined
+  let suppressNextClick = false
+  let suppressNextClickResetTimer: ReturnType<typeof setTimeout> | undefined
+
+  function clearSuppressNextClickResetTimer(): void {
+    if (suppressNextClickResetTimer === undefined) {
+      return
+    }
+
+    clearTimeout(suppressNextClickResetTimer)
+    suppressNextClickResetTimer = undefined
+  }
+
+  function scheduleSuppressNextClickReset(): void {
+    clearSuppressNextClickResetTimer()
+    suppressNextClickResetTimer = setTimeout(() => {
+      suppressNextClick = false
+      suppressNextClickResetTimer = undefined
+    }, 0)
+  }
+
+  function updateHover(position: DragPosition): void {
+    if (!payload) {
+      return
+    }
+
+    const match = registry.updateHover(position, payload)
+    session.updateDropTarget(match.isDropAllowed ? match.target : null)
+  }
+
+  function updateAutoScroll(position: DragPosition): void {
+    const container = autoScrollOptions?.container.value
+    if (!container) {
+      return
+    }
+
+    if (!isPositionInAutoScrollLane(position, container, autoScrollAxis)) {
+      autoScroll.stop()
+      return
+    }
+
+    autoScroll.update(position)
+  }
+
+  const autoScroll = useAutoScrollOnDrag({
+    axis: autoScrollAxis,
+    container: autoScrollOptions?.container ?? shallowRef<HTMLElement>(),
+    edgeSize: autoScrollOptions?.edgeSize,
+    maxSpeed: autoScrollOptions?.maxSpeed,
+    onScroll: (position) => {
+      if (!payload || !session.state.value.isActive || session.state.value.mode !== 'transfer') {
+        return
+      }
+
+      session.updatePosition(position)
+      updateHover(position)
+    },
+  })
+
+  function updateSessionTransferOperation(event: PointerEvent): boolean {
+    const operation = resolveTransferOperation(event)
+    const previousOperation = session.state.value.transferOperation
+    session.updateTransferOperation(operation)
+    return previousOperation !== operation
+  }
+
+  const pointerDrag = usePointerDrag({
+    onDragCancel: () => {
+      autoScroll.stop()
+      registry.clearHover(payload)
+      session.cancel()
+      payload = undefined
+      clearSuppressNextClickResetTimer()
+      suppressNextClick = false
+    },
+    onDragEnd: (event, context) => {
+      const currentPayload = payload
+      payload = undefined
+
+      if (!currentPayload) {
+        autoScroll.stop()
+        clearSuppressNextClickResetTimer()
+        suppressNextClick = false
+        session.end()
+        return
+      }
+
+      autoScroll.stop()
+      updateSessionTransferOperation(event)
+      session.updatePosition(context.currentPosition)
+      scheduleSuppressNextClickReset()
+      void registry
+        .drop(currentPayload, context.currentPosition)
+        .catch((error: unknown) => {
+          void logger.error(`拖拽放置失败: ${error instanceof Error ? error.message : String(error)}`)
+        })
+        .finally(() => {
+          session.end()
+        })
+    },
+    onDragMove: (event, context) => {
+      if (!payload) {
+        return
+      }
+
+      const operationChanged = updateSessionTransferOperation(event)
+      session.updatePosition(context.currentPosition)
+      if (operationChanged) {
+        registry.clearHover(payload)
+      }
+      updateHover(context.currentPosition)
+      updateAutoScroll(context.currentPosition)
+    },
+    onDragStart: (event, context) => {
+      payload = options.getData(context.sourceElement)
+      if (payload.type !== options.type) {
+        payload = undefined
+        return false
+      }
+
+      clearSuppressNextClickResetTimer()
+      suppressNextClick = true
+      session.start('transfer', payload, context.startPosition)
+      updateSessionTransferOperation(event)
+      updateAutoScroll({ x: event.clientX, y: event.clientY })
+    },
+  })
+
+  return {
+    sourceProps() {
+      return {
+        onClickCapture: (event: MouseEvent) => {
+          if (!suppressNextClick) {
+            return
+          }
+
+          clearSuppressNextClickResetTimer()
+          suppressNextClick = false
+          event.preventDefault()
+          event.stopPropagation()
+          event.stopImmediatePropagation?.()
+        },
+        onPointerdown: (event: PointerEvent) => {
+          const sourceElement = event.currentTarget
+          if (!isHTMLElement(sourceElement)) {
+            return
+          }
+
+          if (canStartDragFromTarget(event, sourceElement, options.handleSelector)) {
+            pointerDrag.handlePointerDown(event)
+          }
+        },
+      }
+    },
+  }
+}

--- a/src/composables/useDragTransfer.ts
+++ b/src/composables/useDragTransfer.ts
@@ -180,13 +180,11 @@ export function useDragSource<TPayload extends DragPayload>(
       updateSessionTransferOperation(event)
       session.updatePosition(context.currentPosition)
       scheduleSuppressNextClickReset()
+      session.end()
       void registry
         .drop(currentPayload, context.currentPosition)
         .catch((error: unknown) => {
           void logger.error(`拖拽放置失败: ${error instanceof Error ? error.message : String(error)}`)
-        })
-        .finally(() => {
-          session.end()
         })
     },
     onDragMove: (event, context) => {

--- a/src/features/editor/file-tree/__tests__/file-tree.test.ts
+++ b/src/features/editor/file-tree/__tests__/file-tree.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  canCopyFileTreeItemsToDirectory,
+  canMoveFileTreeItemsToDirectory,
   getFileTreeNameSelectionEnd,
   hasFileTreeDuplicateName,
   insertCreatingFileTreeItem,
+  normalizeFileTreeTransferItems,
   resolveFileTreeCreateBlurAction,
   resolveFileTreeCreateStart,
   resolveFileTreeRenameBlurAction,
@@ -322,5 +325,86 @@ describe('fileTree', () => {
       type: 'file',
       value: 'branch.txt',
     })).toBe<FileTreeBlurAction>('submit')
+  })
+
+  describe('文件移动目标', () => {
+    it('会拒绝拖入自身、子目录和同父目录', () => {
+      expect(canMoveFileTreeItemsToDirectory({
+        sourcePaths: ['/project/scene/chapter'],
+        targetDirectoryPath: '/project/scene/chapter',
+      })).toBe(false)
+
+      expect(canMoveFileTreeItemsToDirectory({
+        sourcePaths: ['/project/scene/chapter'],
+        targetDirectoryPath: '/project/scene/chapter/nested',
+      })).toBe(false)
+
+      expect(canMoveFileTreeItemsToDirectory({
+        sourcePaths: ['/project/scene/start.txt'],
+        targetDirectoryPath: '/project/scene',
+      })).toBe(false)
+
+      expect(canMoveFileTreeItemsToDirectory({
+        sourcePaths: [String.raw`C:\project\scene\chapter`],
+        targetDirectoryPath: 'C:/project/scene',
+      })).toBe(false)
+
+      expect(canMoveFileTreeItemsToDirectory({
+        sourcePaths: ['/project/scene/chapter/'],
+        targetDirectoryPath: '/project/scene',
+      })).toBe(false)
+    })
+
+    it('所有来源都可以移动时才允许放置', () => {
+      expect(canMoveFileTreeItemsToDirectory({
+        sourcePaths: ['/project/scene/start.txt', '/project/scene/chapter'],
+        targetDirectoryPath: '/project/scene/archive',
+      })).toBe(true)
+
+      expect(canMoveFileTreeItemsToDirectory({
+        sourcePaths: ['/project/scene/start.txt', '/project/scene/archive'],
+        targetDirectoryPath: '/project/scene/archive',
+      })).toBe(false)
+    })
+  })
+
+  describe('文件复制目标', () => {
+    it('目录复制会拒绝拖入自身和子目录，但允许复制到同父目录', () => {
+      expect(canCopyFileTreeItemsToDirectory({
+        sourceItems: [{ isDir: true, path: '/project/scene/chapter' }],
+        targetDirectoryPath: '/project/scene/chapter',
+      })).toBe(false)
+
+      expect(canCopyFileTreeItemsToDirectory({
+        sourceItems: [{ isDir: true, path: '/project/scene/chapter' }],
+        targetDirectoryPath: '/project/scene/chapter/nested',
+      })).toBe(false)
+
+      expect(canCopyFileTreeItemsToDirectory({
+        sourceItems: [{ isDir: true, path: '/project/scene/chapter' }],
+        targetDirectoryPath: '/project/scene',
+      })).toBe(true)
+    })
+
+    it('文件复制允许复制到同父目录', () => {
+      expect(canCopyFileTreeItemsToDirectory({
+        sourceItems: [{ isDir: false, path: '/project/scene/start.txt' }],
+        targetDirectoryPath: '/project/scene',
+      })).toBe(true)
+    })
+  })
+
+  describe('拖拽集合规范化', () => {
+    it('会剔除已被祖先目录覆盖的后代项并保持其余顺序', () => {
+      expect(normalizeFileTreeTransferItems([
+        { isDir: false, path: '/project/scene/chapter/branch.txt' },
+        { isDir: true, path: '/project/scene/chapter' },
+        { isDir: false, path: '/project/scene/ending.txt' },
+        { isDir: false, path: '/project/scene/ending.txt' },
+      ])).toEqual([
+        { isDir: true, path: '/project/scene/chapter' },
+        { isDir: false, path: '/project/scene/ending.txt' },
+      ])
+    })
   })
 })

--- a/src/features/editor/file-tree/__tests__/useFileTreeController.test.ts
+++ b/src/features/editor/file-tree/__tests__/useFileTreeController.test.ts
@@ -1,5 +1,5 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { effectScope, nextTick, reactive, ref } from 'vue'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { effectScope, nextTick, reactive, ref, shallowRef } from 'vue'
 
 import { useFileSystemEvents } from '~/composables/useFileSystemEvents'
 import { AbsPath } from '~/domain/path'
@@ -25,12 +25,27 @@ interface TestFlattenedItem {
   value: TestTreeItem
 }
 
+class FakeHTMLElement {
+  clientHeight = 400
+  scrollHeight = 800
+  scrollLeft = 0
+  scrollTop = 0
+
+  scrollTo(options: ScrollToOptions): void {
+    this.scrollLeft = Number(options.left ?? this.scrollLeft)
+    const maxScrollTop = Math.max(0, this.scrollHeight - this.clientHeight)
+    this.scrollTop = Math.min(Math.max(0, Number(options.top ?? this.scrollTop)), maxScrollTop)
+  }
+}
+
 const {
   createFileMock,
   createFolderMock,
   fileSystemEventOnMock,
   getFileTreeExpandedMock,
+  getFileTreeScrollPositionMock,
   setFileTreeExpandedMock,
+  setFileTreeScrollPositionMock,
   useEditorUIStateStoreMock,
   useTabsStoreMock,
   useWorkspaceStoreMock,
@@ -39,7 +54,9 @@ const {
   createFolderMock: vi.fn(),
   fileSystemEventOnMock: vi.fn(),
   getFileTreeExpandedMock: vi.fn(),
+  getFileTreeScrollPositionMock: vi.fn(),
   setFileTreeExpandedMock: vi.fn(),
+  setFileTreeScrollPositionMock: vi.fn(),
   useEditorUIStateStoreMock: vi.fn(),
   useTabsStoreMock: vi.fn(),
   useWorkspaceStoreMock: vi.fn(),
@@ -142,6 +159,11 @@ function createFixture(options: {
   }
   openCreatedFileInTab?: boolean
   savedExpanded?: string[]
+  savedScrollPosition?: {
+    left: number
+    top: number
+  }
+  scrollAreaRef?: ReturnType<typeof shallowRef<unknown>>
 } = {}) {
   const items = reactive(createItems())
   const tabsStore = {
@@ -149,6 +171,7 @@ function createFixture(options: {
   }
 
   getFileTreeExpandedMock.mockReturnValue(options.savedExpanded ?? [])
+  getFileTreeScrollPositionMock.mockReturnValue(options.savedScrollPosition)
   const eventHandlers = new Map<string, (event: Record<string, unknown>) => void>()
   fileSystemEventOnMock.mockImplementation((eventType: string, handler: (event: Record<string, unknown>) => void) => {
     eventHandlers.set(eventType, handler)
@@ -163,7 +186,9 @@ function createFixture(options: {
   } as ReturnType<typeof useFileSystemEvents>)
   useEditorUIStateStoreMock.mockReturnValue({
     getFileTreeExpanded: getFileTreeExpandedMock,
+    getFileTreeScrollPosition: getFileTreeScrollPositionMock,
     setFileTreeExpanded: setFileTreeExpandedMock,
+    setFileTreeScrollPosition: setFileTreeScrollPositionMock,
   })
   useTabsStoreMock.mockReturnValue(tabsStore)
   useWorkspaceStoreMock.mockReturnValue({
@@ -172,6 +197,7 @@ function createFixture(options: {
     },
   })
 
+  const scrollAreaRef = options.scrollAreaRef ?? shallowRef<unknown>()
   const scope = effectScope()
   const controller = scope.run(() => useFileTreeController<TestTreeItem>({
     creatingInputRef: ref(),
@@ -188,7 +214,7 @@ function createFixture(options: {
     items: () => items,
     nameField: 'name',
     openCreatedFileInTab: () => options.openCreatedFileInTab ?? false,
-    scrollAreaRef: ref(),
+    scrollAreaRef,
     sortBy: () => 'name',
     sortOrder: () => 'asc',
     treeName: () => 'scene',
@@ -202,6 +228,7 @@ function createFixture(options: {
     controller,
     eventHandlers,
     items,
+    scrollAreaRef,
     scope,
     tabsStore,
   }
@@ -213,11 +240,18 @@ describe('useFileTreeController', () => {
     createFolderMock.mockReset()
     fileSystemEventOnMock.mockReset()
     getFileTreeExpandedMock.mockReset()
+    getFileTreeScrollPositionMock.mockReset()
     vi.mocked(pathOperation.perform).mockReset()
     setFileTreeExpandedMock.mockReset()
+    setFileTreeScrollPositionMock.mockReset()
     useEditorUIStateStoreMock.mockReset()
     useTabsStoreMock.mockReset()
     useWorkspaceStoreMock.mockReset()
+    vi.stubGlobal('HTMLElement', FakeHTMLElement)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
   })
 
   it('会优先恢复当前项目对应的展开状态并在变更后持久化', async () => {
@@ -247,6 +281,73 @@ describe('useFileTreeController', () => {
       type: 'file',
       value: 'untitled.txt',
     })
+
+    scope.stop()
+  })
+
+  it('会持久化并恢复当前项目对应的滚动位置', async () => {
+    const viewport = new FakeHTMLElement()
+    const scrollAreaRef = shallowRef<unknown>({
+      viewport: {
+        viewportElement: viewport,
+      },
+    })
+    const { controller, scope } = createFixture({
+      savedScrollPosition: {
+        left: 12,
+        top: 180,
+      },
+      scrollAreaRef,
+    })
+
+    await nextTick()
+    await nextTick()
+
+    expect(viewport.scrollTop).toBe(180)
+    expect(viewport.scrollLeft).toBe(12)
+
+    viewport.scrollTop = 220
+    viewport.scrollLeft = 20
+    controller.handleScroll({ target: viewport } as unknown as Event)
+    await nextTick()
+
+    expect(setFileTreeScrollPositionMock).toHaveBeenCalledWith('game-1', 'scene', {
+      left: 20,
+      top: 220,
+    })
+
+    scope.stop()
+  })
+
+  it('内容高度延迟增长后会重试恢复滚动位置', async () => {
+    const viewport = new FakeHTMLElement()
+    viewport.scrollHeight = viewport.clientHeight
+    const scrollAreaRef = shallowRef<unknown>({
+      viewport: {
+        viewportElement: viewport,
+      },
+    })
+    const { items, scope } = createFixture({
+      savedScrollPosition: {
+        left: 0,
+        top: 180,
+      },
+      scrollAreaRef,
+    })
+
+    await nextTick()
+    await nextTick()
+    expect(viewport.scrollTop).toBe(0)
+
+    viewport.scrollHeight = 800
+    items.push({
+      name: 'later.txt',
+      path: '/project/scene/later.txt',
+    })
+    await nextTick()
+    await nextTick()
+
+    expect(viewport.scrollTop).toBe(180)
 
     scope.stop()
   })

--- a/src/features/editor/file-tree/__tests__/useFileTreeController.test.ts
+++ b/src/features/editor/file-tree/__tests__/useFileTreeController.test.ts
@@ -352,6 +352,52 @@ describe('useFileTreeController', () => {
     scope.stop()
   })
 
+  it('滚动恢复完成前不会持久化中间滚动位置', async () => {
+    const viewport = new FakeHTMLElement()
+    viewport.scrollHeight = viewport.clientHeight
+    const scrollAreaRef = shallowRef<unknown>({
+      viewport: {
+        viewportElement: viewport,
+      },
+    })
+    const { controller, items, scope } = createFixture({
+      savedScrollPosition: {
+        left: 0,
+        top: 180,
+      },
+      scrollAreaRef,
+    })
+
+    await nextTick()
+    await nextTick()
+    expect(viewport.scrollTop).toBe(0)
+
+    viewport.scrollTop = 40
+    controller.handleScroll({ target: viewport } as unknown as Event)
+
+    expect(setFileTreeScrollPositionMock).not.toHaveBeenCalled()
+
+    viewport.scrollHeight = 800
+    items.push({
+      name: 'later.txt',
+      path: '/project/scene/later.txt',
+    })
+    await nextTick()
+    await nextTick()
+
+    expect(viewport.scrollTop).toBe(180)
+
+    viewport.scrollTop = 220
+    controller.handleScroll({ target: viewport } as unknown as Event)
+
+    expect(setFileTreeScrollPositionMock).toHaveBeenCalledWith('game-1', 'scene', {
+      left: 0,
+      top: 220,
+    })
+
+    scope.stop()
+  })
+
   it('目录重命名后会迁移已展开的目录路径', async () => {
     const { controller, eventHandlers, items, scope } = createFixture({
       savedExpanded: ['/project/scene', '/project/scene/chapter'],

--- a/src/features/editor/file-tree/file-tree.ts
+++ b/src/features/editor/file-tree/file-tree.ts
@@ -63,6 +63,19 @@ export interface ResolveFileTreeCreateBlurActionOptions {
   value: string
 }
 
+export interface ResolveFileTreeMoveTargetOptions {
+  sourcePaths: readonly string[]
+  targetDirectoryPath: string
+}
+
+export interface ResolveFileTreeCopyTargetOptions {
+  sourceItems: readonly {
+    isDir: boolean
+    path: string
+  }[]
+  targetDirectoryPath: string
+}
+
 export function getFileTreeParentPath(path: string): string {
   return path.replace(/[\\/][^\\/]+$/, '')
 }
@@ -262,6 +275,78 @@ export function hasFileTreeDuplicateName<T>(
 
     return accessor.getName(sibling).trim().toLowerCase() === trimmedName
   })
+}
+
+function isSamePath(left: string, right: string): boolean {
+  return AbsPath.equals(AbsPath.from(left), AbsPath.from(right))
+}
+
+function getNormalizedParentPath(path: string): string {
+  return AbsPath.parent(AbsPath.from(path))
+}
+
+function isPathWithin(path: string, root: string): boolean {
+  try {
+    return AbsPath.relativize(AbsPath.from(path), AbsPath.from(root)) !== ''
+  } catch {
+    return false
+  }
+}
+
+export function canMoveFileTreeItemsToDirectory(options: ResolveFileTreeMoveTargetOptions): boolean {
+  if (options.sourcePaths.length === 0 || !options.targetDirectoryPath) {
+    return false
+  }
+
+  return options.sourcePaths.every((sourcePath) => {
+    if (isSamePath(sourcePath, options.targetDirectoryPath)) {
+      return false
+    }
+
+    if (isSamePath(getNormalizedParentPath(sourcePath), options.targetDirectoryPath)) {
+      return false
+    }
+
+    return !isPathWithin(options.targetDirectoryPath, sourcePath)
+  })
+}
+
+export function canCopyFileTreeItemsToDirectory(options: ResolveFileTreeCopyTargetOptions): boolean {
+  if (options.sourceItems.length === 0 || !options.targetDirectoryPath) {
+    return false
+  }
+
+  return options.sourceItems.every((sourceItem) => {
+    if (!sourceItem.isDir) {
+      return true
+    }
+
+    if (isSamePath(sourceItem.path, options.targetDirectoryPath)) {
+      return false
+    }
+
+    return !isPathWithin(options.targetDirectoryPath, sourceItem.path)
+  })
+}
+
+export function normalizeFileTreeTransferItems<T extends { path: string }>(items: readonly T[]): T[] {
+  const uniqueItems: T[] = []
+
+  for (const item of items) {
+    if (!item.path || uniqueItems.some(existing => isSamePath(existing.path, item.path))) {
+      continue
+    }
+
+    uniqueItems.push(item)
+  }
+
+  // 祖先目录已经会连同整棵子树一起移动/复制；保留它的后代只会造成重复操作。
+  return uniqueItems.filter(item =>
+    !uniqueItems.some(other =>
+      other !== item
+      && isPathWithin(item.path, other.path),
+    ),
+  )
 }
 
 export function insertCreatingFileTreeItem<T, TFlattened extends FileTreeFlattenedItemLike<T>>(

--- a/src/features/editor/file-tree/useFileTreeController.ts
+++ b/src/features/editor/file-tree/useFileTreeController.ts
@@ -2,11 +2,14 @@ import { useFileSystemEvents } from '~/composables/useFileSystemEvents'
 import { usePathOperationFeedback } from '~/composables/usePathOperationFeedback'
 import { AbsPath } from '~/domain/path'
 import {
+  canCopyFileTreeItemsToDirectory,
+  canMoveFileTreeItemsToDirectory,
   findFileTreeItemByPath,
   getFileTreeNameSelectionEnd,
   getFileTreeParentPath,
   hasFileTreeDuplicateName,
   insertCreatingFileTreeItem,
+  normalizeFileTreeTransferItems,
   resolveFileTreeCreateBlurAction,
   resolveFileTreeCreateStart,
   resolveFileTreeRenameBlurAction,
@@ -23,6 +26,7 @@ import { createItemComparator } from '~/utils/sort'
 
 import type { FlattenedItem } from 'reka-ui'
 import type { FileTreeDefaultFileNameParts } from '~/features/editor/file-tree/file-tree'
+import type { DragTransferOperation, FileSystemDragPayload } from '~/types/drag-drop'
 import type { FileViewerSortBy, FileViewerSortOrder } from '~/types/file-viewer'
 import type { SortableItemAccessor } from '~/utils/sort'
 
@@ -38,6 +42,16 @@ interface PendingRenameResult {
 interface PendingDirectoryExpandedRewrite {
   newPath: string
   oldPath: string
+}
+
+interface FileTreeScrollContext {
+  gameId: string
+  treeName: string
+}
+
+interface FileTreeScrollRestoreMarker extends FileTreeScrollContext {
+  left: number
+  top: number
 }
 
 interface UseFileTreeControllerOptions<T extends object> {
@@ -221,6 +235,7 @@ export function useFileTreeController<T extends object>(options: UseFileTreeCont
   })
   const pendingRenameResult = ref<PendingRenameResult>()
   const pendingDirectoryExpandedRewrite = ref<PendingDirectoryExpandedRewrite>()
+  const restoredScrollContext = ref<FileTreeScrollRestoreMarker>()
 
   const BLUR_CANCEL_DELAY = 50
 
@@ -377,6 +392,62 @@ export function useFileTreeController<T extends object>(options: UseFileTreeCont
   const tabsStore = useTabsStore()
 
   const currentGameId = computed(() => workspaceStore.currentGame?.id)
+
+  function hasRestoredScrollPosition(gameId: string, treeName: string, left: number, top: number): boolean {
+    return restoredScrollContext.value?.gameId === gameId
+      && restoredScrollContext.value.treeName === treeName
+      && restoredScrollContext.value.left === left
+      && restoredScrollContext.value.top === top
+  }
+
+  function getScrollRestoreContext(): FileTreeScrollContext | undefined {
+    const gameId = currentGameId.value
+    const treeName = options.treeName()
+    if (!gameId || !treeName) {
+      return
+    }
+
+    return { gameId, treeName }
+  }
+
+  function restoreScrollPosition(): void {
+    const context = getScrollRestoreContext()
+    if (!context) {
+      return
+    }
+
+    const viewport = getViewportElement()
+    if (!viewport) {
+      return
+    }
+
+    const savedPosition = editorUIStateStore.getFileTreeScrollPosition(context.gameId, context.treeName)
+    if (!savedPosition) {
+      restoredScrollContext.value = {
+        ...context,
+        left: 0,
+        top: 0,
+      }
+      return
+    }
+
+    if (hasRestoredScrollPosition(context.gameId, context.treeName, savedPosition.left, savedPosition.top)) {
+      return
+    }
+
+    viewport.scrollTo({
+      left: savedPosition.left,
+      top: savedPosition.top,
+      behavior: 'auto',
+    })
+    if (viewport.scrollTop === savedPosition.top && viewport.scrollLeft === savedPosition.left) {
+      restoredScrollContext.value = {
+        ...context,
+        left: savedPosition.left,
+        top: savedPosition.top,
+      }
+    }
+  }
 
   function resolveExpandedState(): string[] {
     const treeName = options.treeName()
@@ -562,6 +633,104 @@ export function useFileTreeController<T extends object>(options: UseFileTreeCont
     startCreating(fileItem.path, 'folder')
   }
 
+  type FileSystemDragItem = NonNullable<FileSystemDragPayload['items']>[number]
+
+  function getFileSystemDragItems(payload: FileSystemDragPayload): FileSystemDragItem[] {
+    return normalizeFileTreeTransferItems(
+      payload.items?.length
+        ? payload.items
+        : [{
+            isDir: payload.isDir,
+            name: payload.name,
+            path: payload.path,
+          }],
+    )
+  }
+
+  function canDropFileSystemDragItems(
+    items: readonly FileSystemDragItem[],
+    targetDirectoryPath: string,
+    operation: DragTransferOperation = 'move',
+  ): boolean {
+    if (operation === 'copy') {
+      return canCopyFileTreeItemsToDirectory({
+        sourceItems: items,
+        targetDirectoryPath,
+      })
+    }
+
+    return canMoveFileTreeItemsToDirectory({
+      sourcePaths: items.map(item => item.path),
+      targetDirectoryPath,
+    })
+  }
+
+  function canDropFileSystemItems(
+    payload: FileSystemDragPayload,
+    targetDirectoryPath: string,
+    operation: DragTransferOperation = 'move',
+  ): boolean {
+    return canDropFileSystemDragItems(
+      getFileSystemDragItems(payload),
+      targetDirectoryPath,
+      operation,
+    )
+  }
+
+  function resolveDroppableFileSystemItems(
+    payload: FileSystemDragPayload,
+    targetDirectoryPath: string,
+    operation: DragTransferOperation = 'move',
+  ): FileSystemDragItem[] | undefined {
+    const items = getFileSystemDragItems(payload)
+    if (!canDropFileSystemDragItems(items, targetDirectoryPath, operation)) {
+      return
+    }
+
+    return items
+  }
+
+  function expandDirectory(path: string): void {
+    if (!path || expanded.value.includes(path)) {
+      return
+    }
+
+    expanded.value = [...expanded.value, path]
+  }
+
+  async function moveFileSystemItems(payload: FileSystemDragPayload, targetDirectoryPath: string): Promise<void> {
+    const items = resolveDroppableFileSystemItems(payload, targetDirectoryPath)
+    if (!items) {
+      return
+    }
+
+    for (const item of items) {
+      // eslint-disable-next-line no-await-in-loop -- 多文件移动按用户拖拽顺序串行执行，避免确认框和 path-operation registry 交错。
+      const result = await pathOperation.perform({
+        kind: 'move',
+        sourcePath: AbsPath.from(item.path),
+        target: { type: 'directory', directory: AbsPath.from(targetDirectoryPath) },
+      }, confirmPathOperationRewrite)
+      pathOperationFeedback.reportWarnings(result.warnings)
+    }
+
+    expandDirectory(targetDirectoryPath)
+  }
+
+  async function copyFileSystemItems(payload: FileSystemDragPayload, targetDirectoryPath: string): Promise<void> {
+    const items = resolveDroppableFileSystemItems(payload, targetDirectoryPath, 'copy')
+    if (!items) {
+      return
+    }
+
+    for (const item of items) {
+      // eslint-disable-next-line no-await-in-loop -- 多文件复制按用户拖拽顺序串行执行，保持与文件树菜单粘贴入口一致。
+      await gameFs.copyFile(AbsPath.from(item.path), AbsPath.from(targetDirectoryPath))
+    }
+
+    expandDirectory(targetDirectoryPath)
+  }
+
   function handleEnterKey(item: FlattenedItem<T>): void {
     if (isRenaming(item) && !isRenameDuplicate(item)) {
       void handleRename(item)
@@ -582,7 +751,9 @@ export function useFileTreeController<T extends object>(options: UseFileTreeCont
   })
 
   watch([currentGameId, () => options.treeName()], () => {
+    restoredScrollContext.value = undefined
     expanded.value = resolveExpandedState()
+    nextTick(restoreScrollPosition)
   }, { immediate: true })
 
   const stopDirectoryRenamedListener = fileSystemEvents.on('directory:renamed', (event) => {
@@ -594,6 +765,8 @@ export function useFileTreeController<T extends object>(options: UseFileTreeCont
   onScopeDispose(stopDirectoryRenamedListener)
 
   watch(() => options.items(), (items) => {
+    nextTick(restoreScrollPosition)
+
     const pendingExpandedRewrite = pendingDirectoryExpandedRewrite.value
     if (pendingExpandedRewrite) {
       const renamedDirectory = findFileTreeItemByPath(items, pendingExpandedRewrite.newPath, fileTreeItemAccessor)
@@ -631,6 +804,23 @@ export function useFileTreeController<T extends object>(options: UseFileTreeCont
     return resolveViewportElement(options.scrollAreaRef.value)
   }
 
+  function handleScroll(event: Event): void {
+    const viewport = typeof HTMLElement !== 'undefined' && event.target instanceof HTMLElement
+      ? event.target
+      : getViewportElement()
+    if (!viewport) {
+      return
+    }
+
+    const context = getScrollRestoreContext()
+    if (context) {
+      editorUIStateStore.setFileTreeScrollPosition(context.gameId, context.treeName, {
+        left: viewport.scrollLeft,
+        top: viewport.scrollTop,
+      })
+    }
+  }
+
   return {
     createState,
     expanded,
@@ -652,10 +842,15 @@ export function useFileTreeController<T extends object>(options: UseFileTreeCont
     handleEscapeKey,
     handleRename,
     handleRenameBlur,
+    handleScroll,
     isCreateDuplicate,
     isCreatingItem,
     isRenameDuplicate,
     isRenaming,
+    canDropFileSystemItems,
+    copyFileSystemItems,
+    expandDirectory,
+    moveFileSystemItems,
     processFlattenItems,
     startCreating,
     toFileItem,

--- a/src/features/editor/file-tree/useFileTreeController.ts
+++ b/src/features/editor/file-tree/useFileTreeController.ts
@@ -410,6 +410,11 @@ export function useFileTreeController<T extends object>(options: UseFileTreeCont
     return { gameId, treeName }
   }
 
+  function hasCompletedScrollRestore(context: FileTreeScrollContext): boolean {
+    return restoredScrollContext.value?.gameId === context.gameId
+      && restoredScrollContext.value.treeName === context.treeName
+  }
+
   function restoreScrollPosition(): void {
     const context = getScrollRestoreContext()
     if (!context) {
@@ -813,7 +818,7 @@ export function useFileTreeController<T extends object>(options: UseFileTreeCont
     }
 
     const context = getScrollRestoreContext()
-    if (context) {
+    if (context && hasCompletedScrollRestore(context)) {
       editorUIStateStore.setFileTreeScrollPosition(context.gameId, context.treeName, {
         left: viewport.scrollLeft,
         top: viewport.scrollTop,

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -653,6 +653,7 @@ edit:
     pastePartialFailed: Partial paste failed ({failed}/{total})
     pasteMultipleSuccess: Successfully pasted {count} items
     viewHistory: View Version History
+    dragPreviewCount: "{count} file(s)"
   previewPanel:
     copyUrl: Copy URL
     refreshPreview: Refresh Preview

--- a/src/locales/ja.yml
+++ b/src/locales/ja.yml
@@ -653,6 +653,7 @@ edit:
     pastePartialFailed: 一部の貼り付けに失敗しました ({failed}/{total})
     pasteMultipleSuccess: "{count} 個のアイテムを貼り付けました"
     viewHistory: 履歴を表示
+    dragPreviewCount: "{count} 個のファイル"
   previewPanel:
     copyUrl: URLをコピー
     refreshPreview: プレビューを更新

--- a/src/locales/zh-Hans.yml
+++ b/src/locales/zh-Hans.yml
@@ -653,6 +653,7 @@ edit:
     pastePartialFailed: 部分粘贴失败 ({failed}/{total})
     pasteMultipleSuccess: 成功粘贴 {count} 个项目
     viewHistory: 查看历史版本
+    dragPreviewCount: "{count} 个文件"
   previewPanel:
     copyUrl: 复制地址
     refreshPreview: 刷新预览

--- a/src/locales/zh-Hant.yml
+++ b/src/locales/zh-Hant.yml
@@ -653,6 +653,7 @@ edit:
     pastePartialFailed: 部分貼上失敗 ({failed}/{total})
     pasteMultipleSuccess: 成功貼上 {count} 個項目
     viewHistory: 檢視歷史版本
+    dragPreviewCount: "{count} 個檔案"
   previewPanel:
     copyUrl: 複製網址
     refreshPreview: 重新整理預覽

--- a/src/services/__tests__/game-fs.test.ts
+++ b/src/services/__tests__/game-fs.test.ts
@@ -285,6 +285,25 @@ describe('gameFs', () => {
     expect(fsMoveFileMock).toHaveBeenCalledWith('/project/game/background/old.txt', '/project/game/background')
   })
 
+  it('native move 接收计划目标名时会透传给底层 fs adapter', async () => {
+    fsMoveFileMock.mockResolvedValue('/project/game/background/moved (1).txt')
+
+    await expect(gameFs.moveFile(
+      AbsPath.from('/project/game/background/old.txt'),
+      AbsPath.from('/project/game/background'),
+      'moved (1).txt',
+    )).resolves.toEqual({
+      echoMode: 'watcher',
+      newPath: '/project/game/background/moved (1).txt',
+    })
+
+    expect(fsMoveFileMock).toHaveBeenCalledWith(
+      '/project/game/background/old.txt',
+      '/project/game/background',
+      'moved (1).txt',
+    )
+  })
+
   it('缺少 currentGame 时不会把 CWD 下的 template 路径误判为覆盖层操作', async () => {
     useWorkspaceStoreMock.mockReturnValue({
       CWD: '/project',
@@ -323,7 +342,7 @@ describe('gameFs', () => {
       templatePath: '/templates/current',
     })
     vfsRenamePathMock.mockResolvedValue(RelPath.from('game/template/new.txt'))
-    vfsMovePathMock.mockResolvedValue(RelPath.from('game/template/folder/old.txt'))
+    vfsMovePathMock.mockResolvedValue(RelPath.from('game/template/folder/old (1).txt'))
     copyEntryMock.mockResolvedValueOnce('/project/game/copied.txt')
     createFileMock.mockResolvedValue('/project/game/created.txt')
     createFolderMock.mockResolvedValue('/project/game/folder')
@@ -339,9 +358,10 @@ describe('gameFs', () => {
     await expect(gameFs.moveFile(
       AbsPath.from('/project/game/template/old.txt'),
       AbsPath.from('/project/game/template/folder'),
+      'old (1).txt',
     )).resolves.toEqual({
       echoMode: 'synthetic',
-      newPath: '/project/game/template/folder/old.txt',
+      newPath: '/project/game/template/folder/old (1).txt',
     })
     await gameFs.deleteFile(AbsPath.from('/project/game/deleted.txt'), true)
 
@@ -358,7 +378,7 @@ describe('gameFs', () => {
       enginePath: '/engines/webgal',
       templatePath: '/templates/current',
       relPath: 'game/template/old.txt',
-      targetRelPath: 'game/template/folder/old.txt',
+      targetRelPath: 'game/template/folder/old (1).txt',
     })
     expect(copyEntryMock).toHaveBeenNthCalledWith(1, '/project/from.txt', '/project/game')
     expect(deleteEntryMock).toHaveBeenCalledOnce()

--- a/src/services/__tests__/path-operation-registry.test.ts
+++ b/src/services/__tests__/path-operation-registry.test.ts
@@ -5,6 +5,7 @@ import {
   clearPendingPathOperations,
   hasOverlappingPathOperation,
   lookupPathOperationByPath,
+  markPathOperationSettled,
   pathOperationRegistry,
   registerPathOperation,
   releasePathOperation,
@@ -127,5 +128,31 @@ describe('pathOperationRegistry', () => {
     expect(lookupPathOperationByPath(
       AbsPath.from('/project/game/background/new/chapter/bg.jpg'),
     )?.id).toBe(pendingId)
+  })
+
+  it('路径操作完成本地状态提交后不再阻断新的重叠操作，但仍吞掉 watcher 回声', () => {
+    const pendingId = registerPathOperation({
+      sourcePath: AbsPath.from('/project/game/scene/chapter/start.txt'),
+      targetPath: AbsPath.from('/project/game/scene/start.txt'),
+    })
+
+    updatePathOperationChannel(pendingId, {
+      echoMode: 'watcher',
+      expectedEchoes: 1,
+    })
+    markPathOperationSettled(pendingId)
+
+    expect(hasOverlappingPathOperation([
+      AbsPath.from('/project/game/scene/start.txt'),
+      AbsPath.from('/project/game/scene/chapter/start.txt'),
+    ])).toBe(false)
+
+    expect(pathOperationRegistry.consumeRenameEcho(
+      AbsPath.from('/project/game/scene/chapter/start.txt'),
+      AbsPath.from('/project/game/scene/start.txt'),
+    )).toBe(true)
+    expect(lookupPathOperationByPath(
+      AbsPath.from('/project/game/scene/start.txt'),
+    )).toBeUndefined()
   })
 })

--- a/src/services/__tests__/path-operation.test.ts
+++ b/src/services/__tests__/path-operation.test.ts
@@ -91,6 +91,7 @@ function createDeps(overrides: DeepPartial<PathOperationDeps> = {}): PathOperati
     },
     pathOperationRegistry: {
       hasOverlap: vi.fn(() => false),
+      markSettled: vi.fn(),
       register: vi.fn(() => 1),
       release: vi.fn(),
       updateChannel: vi.fn(),
@@ -185,6 +186,7 @@ describe('pathOperation', () => {
       echoMode: 'watcher',
       expectedEchoes: 1,
     })
+    expect(deps.pathOperationRegistry.markSettled).toHaveBeenCalledWith(1)
     expect(deps.pathOperationRegistry.release).not.toHaveBeenCalled()
   })
 
@@ -284,7 +286,7 @@ describe('pathOperation', () => {
     })
   })
 
-  it('目标路径未加载但磁盘已存在时会阻断 duplicate-target', async () => {
+  it('rename 目标路径未加载但磁盘已存在时会阻断 duplicate-target', async () => {
     existsMock.mockResolvedValue(true)
     const deps = createDeps({
       fileStore: {
@@ -304,6 +306,117 @@ describe('pathOperation', () => {
       filePath: '/project/game/background/renamed.jpg',
     }))
     expect(deps.gameFs.renameFile).not.toHaveBeenCalled()
+  })
+
+  it('move 目标存在同名文件时会在 plan 阶段保留两者，并让引用重写指向最终唯一路径', async () => {
+    const referencedRecord = {
+      assetKey: createAssetKey('asset', 'background', RelPath.from('bg.jpg')),
+      fieldKey: '__content__',
+      sourceKind: 'scene',
+      sourcePath: AbsPath.from('/project/game/scene/start.txt'),
+      statementId: 1,
+    } satisfies AssetReferenceRecord
+    existsMock.mockImplementation(async (path: AbsPath) =>
+      path === AbsPath.from('/project/game/background/archive/bg.jpg'),
+    )
+    const deps = createDeps({
+      fileStore: {
+        getItemByPath: vi.fn((path: AbsPath) => {
+          if (path === AbsPath.from('/project/game/background/bg.jpg')) {
+            return { isDir: false }
+          }
+          if (path === AbsPath.from('/project/game/background/archive/bg.jpg')) {
+            return { isDir: false }
+          }
+          return
+        }),
+      },
+      gameFs: {
+        moveFile: vi.fn(async (_sourcePath, targetDirectory) => ({
+          echoMode: 'watcher' as const,
+          newPath: AbsPath.append(targetDirectory, 'bg (1).jpg'),
+        })),
+      },
+      resourceIndex: {
+        getReferencesTo: vi.fn(() => [referencedRecord]),
+        listByAssetType: vi.fn(() => []),
+        resolveByAbsolutePath: vi.fn(() => ({
+          absolutePath: AbsPath.from('/project/game/background/bg.jpg'),
+          extension: '.jpg',
+          fileName: 'bg.jpg',
+          key: createAssetKey('asset', 'background', RelPath.from('bg.jpg')),
+        })),
+      },
+    })
+    const service = createPathOperationService(deps)
+
+    const result = await service.perform({
+      kind: 'move',
+      sourcePath: AbsPath.from('/project/game/background/bg.jpg'),
+      target: { type: 'directory', directory: AbsPath.from('/project/game/background/archive') },
+    }, async (): Promise<PathOperationConfirmDecision> => 'rewrite')
+
+    expect(result.finalPath).toBe('/project/game/background/archive/bg (1).jpg')
+    expect(result.plan.blockedReasons).toEqual([])
+    expect(result.plan.rewrites).toEqual([
+      expect.objectContaining({
+        after: 'changeBg:archive/bg (1).jpg;',
+        before: 'changeBg:bg.jpg;',
+        filePath: '/project/game/scene/start.txt',
+      }),
+    ])
+    expect(deps.gameFs.moveFile).toHaveBeenCalledWith(
+      '/project/game/background/bg.jpg',
+      '/project/game/background/archive',
+      'bg (1).jpg',
+    )
+  })
+
+  it('move 确认期间计划目标被占用时会重新 plan 到下一个唯一名称', async () => {
+    let firstUniqueTargetChecked = false
+    existsMock.mockImplementation(async (path: AbsPath) => {
+      if (path === AbsPath.from('/project/game/background/archive/bg.jpg')) {
+        return true
+      }
+      if (path !== AbsPath.from('/project/game/background/archive/bg (1).jpg')) {
+        return false
+      }
+      if (!firstUniqueTargetChecked) {
+        firstUniqueTargetChecked = true
+        return false
+      }
+      return true
+    })
+    const deps = createDeps({
+      fileStore: {
+        getItemByPath: vi.fn((path: AbsPath) => {
+          if (path === AbsPath.from('/project/game/background/bg.jpg')) {
+            return { isDir: false }
+          }
+          return
+        }),
+      },
+      gameFs: {
+        moveFile: vi.fn(async (_sourcePath, targetDirectory, targetName = 'bg.jpg') => ({
+          echoMode: 'watcher' as const,
+          newPath: AbsPath.append(targetDirectory, targetName),
+        })),
+      },
+    })
+    const service = createPathOperationService(deps)
+
+    const result = await service.perform({
+      kind: 'move',
+      sourcePath: AbsPath.from('/project/game/background/bg.jpg'),
+      target: { type: 'directory', directory: AbsPath.from('/project/game/background/archive') },
+    })
+
+    expect(result.finalPath).toBe('/project/game/background/archive/bg (2).jpg')
+    expect(deps.gameFs.moveFile).toHaveBeenCalledWith(
+      '/project/game/background/bg.jpg',
+      '/project/game/background/archive',
+      'bg (2).jpg',
+    )
   })
 
   it('确认后会写入场景补丁并广播 system-refactor 修改事件', async () => {
@@ -862,6 +975,83 @@ describe('pathOperation', () => {
     expect(renameFile).toHaveBeenLastCalledWith('/project/game/background/renamed.jpg', 'bg.jpg')
   })
 
+  it('move 回滚唯一目标名时会显式恢复源文件名', async () => {
+    const metadata = createTextMetadata('changeBg:bg.jpg;')
+    const referencedRecord = {
+      assetKey: createAssetKey('asset', 'background', RelPath.from('bg.jpg')),
+      fieldKey: '__content__',
+      sourceKind: 'scene',
+      sourcePath: AbsPath.from('/project/game/scene/start.txt'),
+      statementId: 1,
+    } satisfies AssetReferenceRecord
+    existsMock.mockImplementation(async (path: AbsPath) =>
+      path === AbsPath.from('/project/game/background/archive/bg.jpg'),
+    )
+    const moveFile = vi.fn(async (sourcePath: AbsPath, targetDirectory: AbsPath, targetName?: string) => ({
+      echoMode: 'watcher' as const,
+      newPath: AbsPath.append(targetDirectory, targetName ?? AbsPath.basename(sourcePath)),
+    }))
+    const deps = createDeps({
+      editor: {
+        applySystemRefactor: vi.fn(() => false),
+        peekSceneBuffer: vi.fn(() => ({
+          content: 'changeBg:bg.jpg;',
+          metadata,
+          revision: 'r1',
+        })),
+        peekSceneRevision: vi.fn(() => 'r1'),
+      },
+      fileStore: {
+        getItemByPath: vi.fn((path: AbsPath) => {
+          if (path === AbsPath.from('/project/game/background/bg.jpg')) {
+            return { isDir: false }
+          }
+          if (path === AbsPath.from('/project/game/background/archive/bg.jpg')) {
+            return { isDir: false }
+          }
+          return
+        }),
+      },
+      gameFs: {
+        moveFile,
+        readDocumentFile: vi.fn(async () => new TextEncoder().encode('changeBg:bg.jpg;')),
+        writeDocumentFile: vi.fn(),
+      },
+      resourceIndex: {
+        getReferencesTo: vi.fn(() => [referencedRecord]),
+        listByAssetType: vi.fn(() => []),
+        resolveByAbsolutePath: vi.fn(() => ({
+          absolutePath: AbsPath.from('/project/game/background/bg.jpg'),
+          extension: '.jpg',
+          fileName: 'bg.jpg',
+          key: createAssetKey('asset', 'background', RelPath.from('bg.jpg')),
+        })),
+      },
+    })
+    const service = createPathOperationService(deps)
+
+    const plan = await service.plan({
+      kind: 'move',
+      sourcePath: AbsPath.from('/project/game/background/bg.jpg'),
+      target: { type: 'directory', directory: AbsPath.from('/project/game/background/archive') },
+    })
+
+    await expect(service.apply(plan)).rejects.toMatchObject({ code: 'stale-plan' })
+
+    expect(moveFile).toHaveBeenNthCalledWith(
+      1,
+      '/project/game/background/bg.jpg',
+      '/project/game/background/archive',
+      'bg (1).jpg',
+    )
+    expect(moveFile).toHaveBeenNthCalledWith(
+      2,
+      '/project/game/background/archive/bg (1).jpg',
+      '/project/game/background',
+      'bg.jpg',
+    )
+  })
+
   it('回滚编辑器 buffer 重写时使用当前 revision', async () => {
     const metadata = createTextMetadata('changeBg:bg.jpg;')
     const referencedRecord = {
@@ -995,6 +1185,104 @@ describe('pathOperation', () => {
       echoMode: 'synthetic',
       expectedEchoes: 0,
     })
+    expect(deps.pathOperationRegistry.markSettled).toHaveBeenCalledWith(1)
     expect(deps.pathOperationRegistry.release).toHaveBeenCalledWith(1)
+  })
+
+  it.each([
+    {
+      firstSourcePath: '/project/game/scene/chapter/start.txt',
+      firstTargetDirectory: '/project/game/scene',
+      secondSourcePath: '/project/game/scene/start.txt',
+      secondTargetDirectory: '/project/game/scene/chapter',
+    },
+    {
+      firstSourcePath: '/project/game/scene/start.txt',
+      firstTargetDirectory: '/project/game/scene/chapter',
+      secondSourcePath: '/project/game/scene/chapter/start.txt',
+      secondTargetDirectory: '/project/game/scene',
+    },
+  ])('连续反向 move 不会被上一轮 watcher pending 阻断', async ({
+    firstSourcePath,
+    firstTargetDirectory,
+    secondSourcePath,
+    secondTargetDirectory,
+  }) => {
+    const pendingOperations = new Map<number, { blocksConflicts: boolean, sourcePath: AbsPath, targetPath: AbsPath }>()
+    let nextPendingId = 1
+    const hasOverlap = vi.fn((paths: readonly AbsPath[]) =>
+      [...pendingOperations.values()].some(pending =>
+        pending.blocksConflicts
+        && paths.some(path =>
+          path === pending.sourcePath
+          || path === pending.targetPath
+          || path.startsWith(`${pending.sourcePath}/`)
+          || path.startsWith(`${pending.targetPath}/`),
+        ),
+      ),
+    )
+    const register = vi.fn(({ sourcePath, targetPath }: { sourcePath: AbsPath, targetPath: AbsPath }) => {
+      const id = nextPendingId
+      nextPendingId += 1
+      pendingOperations.set(id, {
+        blocksConflicts: true,
+        sourcePath,
+        targetPath,
+      })
+      return id
+    })
+    const markSettled = vi.fn((id: number) => {
+      const pending = pendingOperations.get(id)
+      if (!pending) {
+        return false
+      }
+
+      pending.blocksConflicts = false
+      return true
+    })
+    const filePaths = new Set([
+      firstSourcePath,
+      '/project/game/scene/chapter',
+    ])
+    const deps = createDeps({
+      fileStore: {
+        applyPathMutation: vi.fn((oldPath: AbsPath, newPath: AbsPath) => {
+          filePaths.delete(oldPath)
+          filePaths.add(newPath)
+        }),
+        getItemByPath: vi.fn((path: AbsPath) => {
+          if (filePaths.has(path)) {
+            return { isDir: path === AbsPath.from('/project/game/scene/chapter') }
+          }
+          return
+        }),
+      },
+      gameFs: {
+        moveFile: vi.fn(async (sourcePath, targetDirectory) => ({
+          echoMode: 'watcher' as const,
+          newPath: AbsPath.append(targetDirectory, AbsPath.basename(sourcePath)),
+        })),
+      },
+      pathOperationRegistry: {
+        hasOverlap,
+        markSettled,
+        register,
+      },
+    })
+    const service = createPathOperationService(deps)
+
+    await service.perform({
+      kind: 'move',
+      sourcePath: AbsPath.from(firstSourcePath),
+      target: { type: 'directory', directory: AbsPath.from(firstTargetDirectory) },
+    })
+    await service.perform({
+      kind: 'move',
+      sourcePath: AbsPath.from(secondSourcePath),
+      target: { type: 'directory', directory: AbsPath.from(secondTargetDirectory) },
+    })
+
+    expect(deps.gameFs.moveFile).toHaveBeenCalledTimes(2)
+    expect(markSettled).toHaveBeenCalledTimes(2)
   })
 })

--- a/src/services/game-fs.ts
+++ b/src/services/game-fs.ts
@@ -139,10 +139,12 @@ async function renameNativePath(oldPath: AbsPath, newName: string): Promise<Path
   }
 }
 
-async function moveNativePath(sourcePath: AbsPath, targetDirectory: AbsPath): Promise<PathMutationResult> {
+async function moveNativePath(sourcePath: AbsPath, targetDirectory: AbsPath, targetName?: string): Promise<PathMutationResult> {
   return {
     echoMode: 'watcher',
-    newPath: await fsCmds.moveFile(sourcePath, targetDirectory),
+    newPath: targetName
+      ? await fsCmds.moveFile(sourcePath, targetDirectory, targetName)
+      : await fsCmds.moveFile(sourcePath, targetDirectory),
   }
 }
 
@@ -164,7 +166,11 @@ async function renameTemplateOverlayPath(oldPath: AbsPath, newName: string): Pro
   return createTemplateOverlayResult(context.projectPath, nextRelPath)
 }
 
-async function moveTemplateOverlayPath(sourcePath: AbsPath, targetDirectory: AbsPath): Promise<PathMutationResult> {
+async function moveTemplateOverlayPath(
+  sourcePath: AbsPath,
+  targetDirectory: AbsPath,
+  targetName?: string,
+): Promise<PathMutationResult> {
   const context = await resolveTemplateOverlayPathContext()
   const relPath = toProjectRelative(context.projectPath, sourcePath)
   const relTargetDirectory = toProjectRelative(context.projectPath, targetDirectory)
@@ -172,7 +178,7 @@ async function moveTemplateOverlayPath(sourcePath: AbsPath, targetDirectory: Abs
     throw new AppError('FS_ERROR', '不能移动项目根目录')
   }
 
-  const targetRelPath = RelPath.append(relTargetDirectory, AbsPath.basename(sourcePath))
+  const targetRelPath = RelPath.append(relTargetDirectory, targetName ?? AbsPath.basename(sourcePath))
   const movedRelPath = await vfsCmds.movePath({
     projectPath: context.projectPath,
     enginePath: context.enginePath,
@@ -265,12 +271,12 @@ async function copyFile(sourcePath: AbsPath, targetPath: AbsPath): Promise<AbsPa
   return result
 }
 
-async function moveFile(sourcePath: AbsPath, targetPath: AbsPath): Promise<PathMutationResult> {
+async function moveFile(sourcePath: AbsPath, targetPath: AbsPath, targetName?: string): Promise<PathMutationResult> {
   if (usesTemplateOverlayPath(sourcePath) || usesTemplateOverlayPath(targetPath)) {
-    return moveTemplateOverlayPath(sourcePath, targetPath)
+    return moveTemplateOverlayPath(sourcePath, targetPath, targetName)
   }
 
-  return moveNativePath(sourcePath, targetPath)
+  return moveNativePath(sourcePath, targetPath, targetName)
 }
 
 export const gameFs = {

--- a/src/services/path-operation-registry.ts
+++ b/src/services/path-operation-registry.ts
@@ -2,6 +2,7 @@ import type { AbsPath } from '~/domain/path'
 import type { PathEchoMode } from '~/services/path-mutation'
 
 export interface PendingPathOperation {
+  blocksConflicts: boolean
   id: number
   sourcePath: AbsPath
   targetPath: AbsPath
@@ -58,20 +59,13 @@ function clearCleanupTimer(id: number): void {
   cleanupTimers.delete(id)
 }
 
-function safeWarn(message: string): void {
-  try {
-    void logger.warn(message).catch(() => undefined)
-  } catch {
-    // 运行于非 Tauri 环境时，日志通道可能不可用。
-  }
-}
-
 export function registerPathOperation(input: RegisterPathOperationInput): number {
   const id = nextPendingPathOperationId
   nextPendingPathOperationId += 1
 
   const ttlMs = input.ttlMs ?? DEFAULT_TTL_MS
   pendingPathOperations.set(id, {
+    blocksConflicts: true,
     id,
     sourcePath: input.sourcePath,
     targetPath: input.targetPath,
@@ -82,7 +76,7 @@ export function registerPathOperation(input: RegisterPathOperationInput): number
     cleanupTimers.set(id, setTimeout(() => {
       const pending = pendingPathOperations.get(id)
       if (pending && pending.expectedEchoes > 0) {
-        safeWarn(`路径操作回声超时，已释放 pending: ${pending.sourcePath} -> ${pending.targetPath}`)
+        void logger.warn(`路径操作回声超时，已释放 pending: ${pending.sourcePath} -> ${pending.targetPath}`)
       }
       releasePathOperation(id)
     }, ttlMs))
@@ -125,11 +119,22 @@ function decrementPathOperationEcho(id: number): void {
 }
 
 export function hasOverlappingPathOperation(paths: readonly AbsPath[]): boolean {
-  return [...pendingPathOperations.values()].some(pending =>
+  return [...pendingPathOperations.values()].some(pending => pending.blocksConflicts && (
     paths.some(path =>
       hasPathOverlap(path, pending.sourcePath) || hasPathOverlap(path, pending.targetPath),
-    ),
+    )
+  ),
   )
+}
+
+export function markPathOperationSettled(id: number): boolean {
+  const pending = pendingPathOperations.get(id)
+  if (!pending) {
+    return false
+  }
+
+  pending.blocksConflicts = false
+  return true
 }
 
 function lookupPathOperationRenameEcho(
@@ -170,6 +175,7 @@ export const pathOperationRegistry = {
   register: registerPathOperation,
   updateChannel: updatePathOperationChannel,
   release: releasePathOperation,
+  markSettled: markPathOperationSettled,
   hasOverlap: hasOverlappingPathOperation,
   consumeRenameEcho: consumeRenamePathOperationEcho,
   lookupPathOperationByPath,

--- a/src/services/path-operation.ts
+++ b/src/services/path-operation.ts
@@ -17,6 +17,7 @@ import { useResourceIndex } from '~/services/resource-index/service'
 import { useEditorStore } from '~/stores/editor'
 import { useFileStore } from '~/stores/file'
 import { useWorkspaceStore } from '~/stores/workspace'
+import { buildUniqueEntryName } from '~/utils/entry-name'
 
 import type { GameConfigReadResult, GameConfigWritePayload } from '~/commands/game'
 import type { FileSystemEvent } from '~/composables/useFileSystemEvents'
@@ -129,7 +130,7 @@ export interface PathOperationDeps {
   gameFs: {
     readDocumentFile(path: AbsPath): Promise<Uint8Array>
     renameFile(oldPath: AbsPath, newName: string): Promise<PathMutationResult>
-    moveFile(sourcePath: AbsPath, targetDirectory: AbsPath): Promise<PathMutationResult>
+    moveFile(sourcePath: AbsPath, targetDirectory: AbsPath, targetName?: string): Promise<PathMutationResult>
     writeDocumentFile(path: AbsPath, content: Uint8Array): Promise<void>
   }
   gameManager: {
@@ -151,6 +152,7 @@ export interface PathOperationDeps {
       expectedEchoes: number
     }): boolean
     release(id: number): boolean
+    markSettled(id: number): boolean
     hasOverlap(paths: readonly AbsPath[]): boolean
   }
   resourceIndex: {
@@ -184,7 +186,7 @@ export class PathOperationError extends Error {
   }
 }
 
-function resolveTargetPath(input: PathOperationInput): AbsPath {
+function resolveNominalTargetPath(input: PathOperationInput): AbsPath {
   if (input.target.type === 'name') {
     return AbsPath.append(AbsPath.parent(input.sourcePath), input.target.name)
   }
@@ -192,12 +194,44 @@ function resolveTargetPath(input: PathOperationInput): AbsPath {
   return AbsPath.append(input.target.directory, AbsPath.basename(input.sourcePath))
 }
 
-async function isExistingTargetPath(path: AbsPath): Promise<boolean> {
+async function isExistingPath(deps: PathOperationDeps, path: AbsPath): Promise<boolean> {
+  if (deps.fileStore.getItemByPath(path)) {
+    return true
+  }
+
   try {
     return await exists(path)
   } catch {
     return false
   }
+}
+
+async function resolveMoveTargetPath(deps: PathOperationDeps, sourcePath: AbsPath, targetDirectory: AbsPath): Promise<AbsPath> {
+  const sourceItem = deps.fileStore.getItemByPath(sourcePath)
+  const sourceName = AbsPath.basename(sourcePath)
+  if (AbsPath.equals(AbsPath.parent(sourcePath), targetDirectory)) {
+    return AbsPath.append(targetDirectory, sourceName)
+  }
+
+  const existingNames = new Set<string>()
+  let nextName = sourceName
+
+  // 目标名需要按 “foo.ext -> foo (1).ext -> ...” 顺序探测，串行检查才能保持命名确定性。
+  // eslint-disable-next-line no-await-in-loop
+  while (await isExistingPath(deps, AbsPath.append(targetDirectory, nextName))) {
+    existingNames.add(nextName)
+    nextName = buildUniqueEntryName(sourceName, sourceItem?.isDir ?? false, existingNames)
+  }
+
+  return AbsPath.append(targetDirectory, nextName)
+}
+
+async function resolveTargetPath(deps: PathOperationDeps, input: PathOperationInput): Promise<AbsPath> {
+  if (input.kind === 'move' && input.target.type === 'directory') {
+    return await resolveMoveTargetPath(deps, input.sourcePath, input.target.directory)
+  }
+
+  return resolveNominalTargetPath(input)
 }
 
 async function createStableHash(content: string): Promise<string> {
@@ -764,6 +798,15 @@ async function buildReferenceRewrites(
 }
 
 async function validatePlanBaseline(deps: PathOperationDeps, plan: PathOperationPlan): Promise<void> {
+  if (plan.kind === 'move' && await isExistingPath(deps, plan.targetPath)) {
+    throw new PathOperationError(
+      'stale-plan',
+      t => t('edit.pathOperation.errors.stalePlan', {
+        path: plan.targetPath,
+      }),
+    )
+  }
+
   for (const file of plan.rollback.files) {
     // eslint-disable-next-line no-await-in-loop -- 乐观锁校验按 rollback 顺序短路，避免后续副作用基于过期计划继续推进。
     const currentRevision = await readCurrentBaselineRevision(deps, file)
@@ -875,7 +918,7 @@ async function rollbackPathSideEffect(
     return
   }
 
-  await deps.gameFs.moveFile(finalPath, AbsPath.parent(plan.sourcePath))
+  await deps.gameFs.moveFile(finalPath, AbsPath.parent(plan.sourcePath), AbsPath.basename(plan.sourcePath))
 }
 
 async function rollbackStorePathMutation(
@@ -1066,14 +1109,16 @@ async function migrateSceneHistory(
 
 export function createPathOperationService(deps: PathOperationDeps) {
   async function plan(input: PathOperationInput): Promise<PathOperationPlan> {
-    const targetPath = resolveTargetPath(input)
+    const targetPath = await resolveTargetPath(deps, input)
     const blockedReasons: PathOperationBlockReason[] = []
     const gamePath = deps.getGamePath()
 
     if (
       AbsPath.equals(input.sourcePath, targetPath)
-      || deps.fileStore.getItemByPath(targetPath)
-      || await isExistingTargetPath(targetPath)
+      || (
+        input.kind === 'rename'
+        && await isExistingPath(deps, targetPath)
+      )
     ) {
       blockedReasons.push({
         kind: 'duplicate-target',
@@ -1152,7 +1197,11 @@ export function createPathOperationService(deps: PathOperationDeps) {
 
       const fsResult = plan.kind === 'rename'
         ? await deps.gameFs.renameFile(plan.sourcePath, AbsPath.basename(plan.targetPath))
-        : await deps.gameFs.moveFile(plan.sourcePath, AbsPath.parent(plan.targetPath))
+        : await deps.gameFs.moveFile(
+            plan.sourcePath,
+            AbsPath.parent(plan.targetPath),
+            AbsPath.basename(plan.targetPath),
+          )
       appliedFsResult = fsResult
 
       deps.pathOperationRegistry.updateChannel(pendingId, {
@@ -1246,6 +1295,7 @@ export function createPathOperationService(deps: PathOperationDeps) {
       emitPathOperationEvent(deps, plan, fsResult.newPath, isDir)
       emitRewriteEvents(deps, plan.rewrites)
 
+      deps.pathOperationRegistry.markSettled(pendingId)
       if (fsResult.echoMode === 'synthetic') {
         deps.pathOperationRegistry.release(pendingId)
       }

--- a/src/stores/__tests__/editor-ui-state.test.ts
+++ b/src/stores/__tests__/editor-ui-state.test.ts
@@ -10,6 +10,7 @@ describe('useEditorUIStateStore', () => {
   beforeEach(() => {
     store = useEditorUIStateStore()
     store.fileTreeExpanded = {}
+    store.fileTreeScrollPositions = {}
   })
 
   it('按 gameId 和 treeName 读写文件树展开状态', () => {
@@ -25,6 +26,8 @@ describe('useEditorUIStateStore', () => {
   it('cleanupGame 只清理对应游戏的 UI 状态', () => {
     store.setFileTreeExpanded('game-1', 'scene', ['root'])
     store.setFileTreeExpanded('game-2', 'scene', ['other'])
+    store.setFileTreeScrollPosition('game-1', 'scene', { left: 0, top: 120 })
+    store.setFileTreeScrollPosition('game-2', 'scene', { left: 8, top: 240 })
 
     store.cleanupGame('game-1')
 
@@ -32,6 +35,30 @@ describe('useEditorUIStateStore', () => {
       'game-2': {
         scene: ['other'],
       },
+    })
+    expect(store.fileTreeScrollPositions).toEqual({
+      'game-2': {
+        scene: {
+          left: 8,
+          top: 240,
+        },
+      },
+    })
+  })
+
+  it('按 gameId 和 treeName 读写文件树滚动位置', () => {
+    expect(store.getFileTreeScrollPosition('game-1', 'scene')).toBeUndefined()
+
+    store.setFileTreeScrollPosition('game-1', 'scene', { left: 0, top: 120 })
+    store.setFileTreeScrollPosition('game-1', 'asset', { left: 24, top: 0 })
+
+    expect(store.getFileTreeScrollPosition('game-1', 'scene')).toEqual({
+      left: 0,
+      top: 120,
+    })
+    expect(store.getFileTreeScrollPosition('game-1', 'asset')).toEqual({
+      left: 24,
+      top: 0,
     })
   })
 })

--- a/src/stores/editor-ui-state.ts
+++ b/src/stores/editor-ui-state.ts
@@ -1,5 +1,10 @@
 import { defineStore } from 'pinia'
 
+export interface FileTreeScrollPosition {
+  left: number
+  top: number
+}
+
 /**
  * 编辑器 UI 状态 Store
  * 用于持久化项目级别的 UI 状态，如文件树展开状态等
@@ -9,6 +14,8 @@ export const useEditorUIStateStore = defineStore(
   () => {
     // 文件树展开状态：{ [gameId]: { [treeName]: expandedKeys[] } }
     const fileTreeExpanded = $ref<Record<string, Record<string, string[]>>>({})
+    // 文件树滚动位置：{ [gameId]: { [treeName]: { left, top } } }
+    const fileTreeScrollPositions = $ref<Record<string, Record<string, FileTreeScrollPosition>>>({})
 
     /**
      * 获取文件树展开状态
@@ -34,18 +41,46 @@ export const useEditorUIStateStore = defineStore(
     }
 
     /**
+     * 获取文件树滚动位置
+     * @param gameId 游戏项目 ID
+     * @param treeName 文件树名称
+     * @returns 文件树滚动位置
+     */
+    function getFileTreeScrollPosition(gameId: string, treeName: string): FileTreeScrollPosition | undefined {
+      return fileTreeScrollPositions[gameId]?.[treeName]
+    }
+
+    /**
+     * 设置文件树滚动位置
+     * @param gameId 游戏项目 ID
+     * @param treeName 文件树名称
+     * @param position 文件树滚动位置
+     */
+    function setFileTreeScrollPosition(gameId: string, treeName: string, position: FileTreeScrollPosition) {
+      if (!fileTreeScrollPositions[gameId]) {
+        fileTreeScrollPositions[gameId] = {}
+      }
+      fileTreeScrollPositions[gameId][treeName] = position
+    }
+
+    /**
      * 清理指定游戏的所有 UI 状态
      * @param gameId 游戏项目 ID
      */
     function cleanupGame(gameId: string) {
       delete fileTreeExpanded[gameId]
+      delete fileTreeScrollPositions[gameId]
     }
 
     return $$({
       fileTreeExpanded,
+      fileTreeScrollPositions,
       // 文件树展开状态
       getFileTreeExpanded,
       setFileTreeExpanded,
+      // 文件树滚动位置
+      getFileTreeScrollPosition,
+      setFileTreeScrollPosition,
       // 清理
       cleanupGame,
     })

--- a/src/types/drag-drop.ts
+++ b/src/types/drag-drop.ts
@@ -16,6 +16,8 @@ export type DragSourceType =
 
 export type DragMode = 'sort' | 'transfer'
 
+export type DragTransferOperation = 'copy' | 'move'
+
 export interface DragPayloadBase {
   source: DragSourceType
   type: DragEntityType
@@ -23,9 +25,17 @@ export interface DragPayloadBase {
 
 export interface FileSystemDragPayload extends DragPayloadBase {
   isDir: boolean
+  items?: FileSystemDragPayloadItem[]
+  name?: string
   mimeType?: string
   path: string
   type: 'file-system-item'
+}
+
+export interface FileSystemDragPayloadItem {
+  isDir: boolean
+  name?: string
+  path: string
 }
 
 export interface EditorTabDragPayload extends DragPayloadBase {


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [ ] 错误修复
- [x] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [x] 代码重构
- [x] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

- 为 `ScenePanel` 中的场景文件树接入 transfer drag source / drop target。
- 支持默认 `move`、按住 `Ctrl/Cmd` 临时切换为 `copy`、多选集合拖拽、拖拽预览，以及目录悬停 `800ms` 自动展开。
- 在悬停阶段拦截非法目标，包括拖入自身或子目录、非目录目标、同父目录无效移动等场景。
- `move` 统一走 `pathOperation.perform({ kind: 'move' })`，`copy` 复用现有 `gameFs.copyFile` 语义，保证与现有文件树入口一致。
- 为 `pathOperation` 的 `move` 分支补齐“同名保留两者”目标路径规划、最终路径引用重写、回滚恢复原名，以及 watcher pending 冲突释放语义。
- 持久化并恢复场景文件树的滚动位置，同时补齐 active tab 变化后的树节点选中与滚动对齐行为。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

- 需要为编辑器中的场景文件树补齐直观的拖拽转移能力，减少依赖菜单操作的路径调整成本。
- 这次改动同时验证了 transfer 拖拽基础设施、文件树多选拖拽、非法目标校验，以及 `move/copy` 与引用更新链路之间的协同是否稳定。
- 将场景文件树这条链路先打通后，后续其他面板可以复用同一套拖拽契约与路径操作语义。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
