### PR TITLE
✨ 支持资源浏览器拖拽转移

### DIFF
--- a/src/components/editor/AssetView.spec.ts
+++ b/src/components/editor/AssetView.spec.ts
@@ -12,9 +12,11 @@ import AssetView from './AssetView.vue'
 
 import type { Component, PropType } from 'vue'
 import type { FileSystemItem } from '~/stores/file'
+import type { FileSystemDragPayload } from '~/types/drag-drop'
 import type { FileViewerItem } from '~/types/file-viewer'
 
 const {
+  copyFileMock,
   createFileMock,
   createFolderMock,
   fileSystemEventHandlers,
@@ -29,6 +31,7 @@ const {
   useTabsStoreMock,
   useWorkspaceStoreMock,
 } = vi.hoisted(() => ({
+  copyFileMock: vi.fn(),
   createFileMock: vi.fn(),
   createFolderMock: vi.fn(),
   fileSystemEventHandlers: new Map<string, ((event: Record<string, unknown>) => void)[]>(),
@@ -141,6 +144,7 @@ vi.mock('~/composables/useFileSystemEvents', () => ({
 
 vi.mock('~/services/game-fs', () => ({
   gameFs: {
+    copyFile: copyFileMock,
     createFile: createFileMock,
     createFolder: createFolderMock,
   },
@@ -358,6 +362,118 @@ function createLoadingStateFileViewerStub() {
   })
 }
 
+function createFileViewerDragPayload(item: FileViewerItem): FileSystemDragPayload {
+  return {
+    isDir: item.isDir,
+    items: [{
+      isDir: item.isDir,
+      name: item.name,
+      path: item.path,
+    }],
+    mimeType: item.mimeType,
+    name: item.name,
+    path: item.path,
+    source: 'file-viewer',
+    type: 'file-system-item',
+  }
+}
+
+function createDragTransferFileViewerStub(operation: 'copy' | 'move' = 'move') {
+  return defineComponent({
+    name: 'StubDragTransferFileViewer',
+    props: {
+      canDropFileTransfer: {
+        type: Function,
+        default: undefined,
+      },
+      dropTargetDirectory: {
+        type: Object as PropType<FileViewerItem>,
+        default: undefined,
+      },
+      enableDragTransfer: {
+        type: Boolean,
+        default: false,
+      },
+      items: {
+        type: Array as PropType<FileViewerItem[]>,
+        required: true,
+      },
+    },
+    emits: ['fileTransferDrop'],
+    setup(props, { emit }) {
+      return () => {
+        const sourceItem = props.items.find(item => !item.isDir)
+        const targetDirectory = props.items.find(item => item.isDir) ?? props.dropTargetDirectory
+        const payload = sourceItem ? createFileViewerDragPayload(sourceItem) : undefined
+        const canDrop = payload && targetDirectory && props.canDropFileTransfer
+          ? props.canDropFileTransfer(payload, targetDirectory, operation)
+          : false
+
+        return h('div', [
+          h('output', { 'data-testid': 'file-viewer-drag-enabled' }, String(props.enableDragTransfer)),
+          h('output', { 'data-testid': 'file-viewer-root-drop-target' }, props.dropTargetDirectory?.path ?? ''),
+          h('output', { 'data-testid': 'file-viewer-can-drop' }, String(canDrop)),
+          h('button', {
+            'type': 'button',
+            'data-testid': 'emit-file-transfer-drop',
+            'disabled': !payload || !targetDirectory,
+            'onClick': () => {
+              if (payload && targetDirectory) {
+                emit('fileTransferDrop', payload, targetDirectory, operation)
+              }
+            },
+          }, 'drop'),
+        ])
+      }
+    },
+  })
+}
+
+function createAssetFileSystemItem(options: {
+  isDir: boolean
+  modifiedAt: number
+  name: string
+  path: string
+  mimeType?: string
+  size?: number
+}) {
+  return {
+    createdAt: 1,
+    modifiedAt: options.modifiedAt,
+    name: options.name,
+    path: options.path,
+    size: options.size ?? 0,
+    ...(options.isDir
+      ? { isDir: true }
+      : { isDir: false, mimeType: options.mimeType }),
+  }
+}
+
+function mockDragTransferFolderContents(): void {
+  getFolderContentsMock.mockResolvedValue([
+    createAssetFileSystemItem({
+      isDir: false,
+      mimeType: 'image/png',
+      modifiedAt: 2,
+      name: 'hero.png',
+      path: '/project/game/background/hero.png',
+      size: 1024,
+    }),
+    createAssetFileSystemItem({
+      isDir: true,
+      modifiedAt: 3,
+      name: 'folder',
+      path: '/project/game/background/folder',
+    }),
+  ])
+  useWorkspaceStoreMock.mockReturnValue(reactive({
+    currentGame: {
+      path: '/project',
+    },
+  }))
+  setPreviewUnavailable()
+}
+
 function createHarness(
   assetType: string = 'bg',
   options: {
@@ -431,6 +547,7 @@ describe('AssetView', () => {
   beforeEach(() => {
     fileSystemEventHandlers.clear()
     fileSystemEventsOnMock.mockReset()
+    copyFileMock.mockReset()
     createFileMock.mockReset()
     createFolderMock.mockReset()
     fileViewerScrollToIndexMock.mockReset()
@@ -444,6 +561,7 @@ describe('AssetView', () => {
     useWorkspaceStoreMock.mockReset()
 
     getFolderContentsMock.mockResolvedValue([])
+    copyFileMock.mockResolvedValue('/project/game/background/folder/hero.png')
     createFileMock.mockResolvedValue('/project/game/background/新建文件.json')
     createFolderMock.mockResolvedValue('/project/game/background/新建文件夹')
     pathOperationPerformMock.mockResolvedValue({
@@ -1004,6 +1122,53 @@ describe('AssetView', () => {
     await expect.element(page.getByTestId('file-tree-context-menu-root')).toHaveAttribute('data-item-path', '/games/demo/game/background')
     await expect.element(page.getByTestId('file-tree-context-menu-root')).toHaveAttribute('data-item-name', 'background')
     await expect.element(page.getByTestId('file-tree-context-menu-root')).toHaveAttribute('data-is-root', 'true')
+  })
+
+  it('会把 FileViewer 的 move drop 交给 pathOperation 执行', async () => {
+    mockDragTransferFolderContents()
+
+    renderInBrowser(createHarness('background'), {
+      global: {
+        stubs: {
+          ...commonGlobalStubs,
+          FileViewer: createDragTransferFileViewerStub('move'),
+        },
+      },
+    })
+
+    await expect.element(page.getByTestId('file-viewer-drag-enabled')).toHaveTextContent('true')
+    await expect.element(page.getByTestId('file-viewer-root-drop-target')).toHaveTextContent('/project/game/background')
+    await expect.element(page.getByTestId('file-viewer-can-drop')).toHaveTextContent('true')
+
+    await page.getByTestId('emit-file-transfer-drop').click()
+
+    expect(pathOperationPerformMock).toHaveBeenCalledWith({
+      kind: 'move',
+      sourcePath: '/project/game/background/hero.png',
+      target: { type: 'directory', directory: '/project/game/background/folder' },
+    }, expect.any(Function))
+    expect(copyFileMock).not.toHaveBeenCalled()
+    expect(handleErrorMock).not.toHaveBeenCalled()
+  })
+
+  it('会把 FileViewer 的 copy drop 交给 gameFs.copyFile 执行', async () => {
+    mockDragTransferFolderContents()
+
+    renderInBrowser(createHarness('background'), {
+      global: {
+        stubs: {
+          ...commonGlobalStubs,
+          FileViewer: createDragTransferFileViewerStub('copy'),
+        },
+      },
+    })
+
+    await expect.element(page.getByTestId('file-viewer-can-drop')).toHaveTextContent('true')
+    await page.getByTestId('emit-file-transfer-drop').click()
+
+    expect(copyFileMock).toHaveBeenCalledWith('/project/game/background/hero.png', '/project/game/background/folder')
+    expect(pathOperationPerformMock).not.toHaveBeenCalled()
+    expect(handleErrorMock).not.toHaveBeenCalled()
   })
 
   it('仅 animation 和 template 目录的右键菜单会显示创建文件入口', async () => {

--- a/src/components/editor/AssetView.vue
+++ b/src/components/editor/AssetView.vue
@@ -7,7 +7,13 @@ import { PopoverAnchor } from '~/components/ui/popover'
 import { useFileSystemEvents } from '~/composables/useFileSystemEvents'
 import { usePathOperationFeedback } from '~/composables/usePathOperationFeedback'
 import { AbsPath, RelPath } from '~/domain/path'
-import { getFileTreeNameSelectionEnd, resolveFileTreeDefaultFileDraft } from '~/features/editor/file-tree/file-tree'
+import {
+  canDropFileTreeTransferItemsToDirectory,
+  getFileTreeNameSelectionEnd,
+  getFileTreeTransferPayloadItems,
+  resolveDroppableFileTreeTransferItems,
+  resolveFileTreeDefaultFileDraft,
+} from '~/features/editor/file-tree/file-tree'
 import { gameFs } from '~/services/game-fs'
 import { pathOperation } from '~/services/path-operation'
 import { createPathOperationRewriteConfirm } from '~/services/path-operation-confirm'
@@ -20,6 +26,8 @@ import { FileViewerItem, FileViewerSortBy, FileViewerSortOrder } from '~/types/f
 import { handleError } from '~/utils/error-handler'
 
 import type { FileSystemEvent } from '~/composables/useFileSystemEvents'
+import type { FileTreeTransferItem } from '~/features/editor/file-tree/file-tree'
+import type { DragTransferOperation, FileSystemDragPayload } from '~/types/drag-drop'
 
 interface AssetViewProps {
   assetType: string
@@ -200,6 +208,94 @@ const currentDirectoryContextMenuItem = $computed(() => {
     source: fileStore.getItemByPath(AbsPath.from(directoryPath))?.source,
   }
 })
+
+function canDropFileTransferItems(
+  items: readonly FileTreeTransferItem[],
+  targetDirectory: FileViewerItem,
+  operation: DragTransferOperation,
+): boolean {
+  if (!targetDirectory.isDir) {
+    return false
+  }
+
+  return canDropFileTreeTransferItemsToDirectory(items, targetDirectory.path, operation)
+}
+
+function canDropFileTransfer(
+  payload: FileSystemDragPayload,
+  targetDirectory: FileViewerItem,
+  operation: DragTransferOperation,
+): boolean {
+  return canDropFileTransferItems(
+    getFileTreeTransferPayloadItems(payload),
+    targetDirectory,
+    operation,
+  )
+}
+
+function resolveDroppableFileTransferItems(
+  payload: FileSystemDragPayload,
+  targetDirectory: FileViewerItem,
+  operation: DragTransferOperation,
+): FileTreeTransferItem[] | undefined {
+  if (!targetDirectory.isDir) {
+    return
+  }
+
+  return resolveDroppableFileTreeTransferItems(payload, targetDirectory.path, operation)
+}
+
+async function moveFileTransferItems(
+  items: readonly FileTreeTransferItem[],
+  targetDirectory: FileViewerItem,
+): Promise<void> {
+  for (const item of items) {
+    // eslint-disable-next-line no-await-in-loop -- 多文件移动按用户拖拽顺序串行执行，避免确认框和 path-operation registry 交错。
+    const result = await pathOperation.perform({
+      kind: 'move',
+      sourcePath: AbsPath.from(item.path),
+      target: { type: 'directory', directory: AbsPath.from(targetDirectory.path) },
+    }, confirmPathOperationRewrite)
+    pathOperationFeedback.reportWarnings(result.warnings)
+  }
+}
+
+async function copyFileTransferItems(
+  items: readonly FileTreeTransferItem[],
+  targetDirectory: FileViewerItem,
+): Promise<void> {
+  for (const item of items) {
+    // eslint-disable-next-line no-await-in-loop -- 多文件复制按用户拖拽顺序串行执行，保持与文件树粘贴入口一致。
+    await gameFs.copyFile(AbsPath.from(item.path), AbsPath.from(targetDirectory.path))
+  }
+}
+
+async function handleFileTransferDrop(
+  payload: FileSystemDragPayload,
+  targetDirectory: FileViewerItem,
+  operation: DragTransferOperation,
+): Promise<void> {
+  const items = resolveDroppableFileTransferItems(payload, targetDirectory, operation)
+  if (!items) {
+    return
+  }
+
+  try {
+    if (operation === 'copy') {
+      await copyFileTransferItems(items, targetDirectory)
+      return
+    }
+
+    await moveFileTransferItems(items, targetDirectory)
+  } catch (error) {
+    if (operation === 'copy') {
+      handleError(error)
+      return
+    }
+
+    pathOperationFeedback.reportError(error)
+  }
+}
 
 const renamePopoverAlign = $computed(() =>
   preferenceStore.assetViewMode === 'grid' ? 'center' : 'start',
@@ -651,6 +747,9 @@ for (const eventType of FILE_SYSTEM_REFRESH_EVENT_TYPES) {
     <FileViewer
       ref="fileViewerRef"
       :error-msg="errorMsg"
+      :can-drop-file-transfer="canDropFileTransfer"
+      :drop-target-directory="currentDirectoryContextMenuItem"
+      enable-drag-transfer
       :highlighted-item-path="renameTargetItem?.path"
       :is-loading="isLoading"
       :items="filteredItems"
@@ -662,6 +761,7 @@ for (const eventType of FILE_SYSTEM_REFRESH_EVENT_TYPES) {
       :zoom="preferenceStore.assetZoom[0]"
       @navigate="handleNavigate"
       @select="handleSelect"
+      @file-transfer-drop="handleFileTransferDrop"
       @update:sort-by="(value) => emit('update:sortBy', value)"
       @update:sort-order="(value) => emit('update:sortOrder', value)"
     >

--- a/src/components/file-viewer/FileViewer.spec.ts
+++ b/src/components/file-viewer/FileViewer.spec.ts
@@ -9,6 +9,7 @@ import { useFileViewerVirtualizer } from '~/components/file-viewer/useFileViewer
 import FileViewer from './FileViewer.vue'
 import FileViewerImageHoverCard from './FileViewerImageHoverCard.vue'
 
+import type { DragTransferOperation, FileSystemDragPayload } from '~/types/drag-drop'
 import type { FileViewerItem, FileViewerPreviewSize } from '~/types/file-viewer'
 
 const {
@@ -248,6 +249,10 @@ const FILE_VIEWER_PREVIEW_PROPS = Object.freeze({
   previewBaseUrl: 'http://127.0.0.1:8899/game/demo/',
   previewCwd: '/games/demo',
 })
+const FILE_VIEWER_DRAG_PREVIEW_SIZE = Object.freeze({
+  width: 64,
+  height: 64,
+})
 
 function createItem(index: number): FileViewerItem {
   return {
@@ -264,6 +269,32 @@ function createImageItem(index: number): FileViewerItem {
   return {
     ...createItem(index),
     mimeType: 'image/png',
+  }
+}
+
+function createDirectoryItem(index: number, options: Partial<Pick<FileViewerItem, 'name' | 'path'>> = {}): FileViewerItem {
+  return {
+    ...createItem(index),
+    isDir: true,
+    mimeType: undefined,
+    name: options.name ?? `folder-${index}`,
+    path: options.path ?? `/assets/folder-${index}`,
+  }
+}
+
+function createFileViewerDragPayload(item: FileViewerItem): FileSystemDragPayload {
+  return {
+    isDir: item.isDir,
+    items: [{
+      isDir: item.isDir,
+      name: item.name,
+      path: item.path,
+    }],
+    mimeType: item.mimeType,
+    name: item.name,
+    path: item.path,
+    source: 'file-viewer',
+    type: 'file-system-item',
   }
 }
 
@@ -419,6 +450,54 @@ async function leaveHoverImageTrigger(index: number = 0): Promise<void> {
   trigger?.dispatchEvent(new PointerEvent('pointerleave', { bubbles: true }))
   await nextTick()
   await nextTick()
+}
+
+function dispatchPointerEvent(
+  element: HTMLElement,
+  type: string,
+  options: {
+    clientX: number
+    clientY: number
+    pointerId: number
+  },
+): void {
+  element.dispatchEvent(new PointerEvent(type, {
+    bubbles: true,
+    button: 0,
+    buttons: type === 'pointerup' ? 0 : 1,
+    clientX: options.clientX,
+    clientY: options.clientY,
+    isPrimary: true,
+    pointerId: options.pointerId,
+  }))
+}
+
+function getFileViewerItemElement(item: FileViewerItem): HTMLElement {
+  const element = document.querySelector<HTMLElement>(`[data-file-viewer-path="${item.path}"]`)
+  expect(element).not.toBeNull()
+  return element!
+}
+
+function beginFileViewerDrag(element: HTMLElement): void {
+  dispatchPointerEvent(element, 'pointerdown', { clientX: 10, clientY: 10, pointerId: 1 })
+  dispatchPointerEvent(element, 'pointermove', { clientX: 24, clientY: 24, pointerId: 1 })
+}
+
+function endFileViewerDrag(element: HTMLElement): void {
+  dispatchPointerEvent(element, 'pointerup', { clientX: 24, clientY: 24, pointerId: 1 })
+}
+
+async function dragFileViewerItemToTarget(sourceElement: HTMLElement, targetElement: HTMLElement): Promise<void> {
+  const elementFromPointSpy = vi.spyOn(document, 'elementFromPoint')
+    .mockReturnValue(targetElement)
+
+  try {
+    beginFileViewerDrag(sourceElement)
+    endFileViewerDrag(sourceElement)
+    await nextTick()
+  } finally {
+    elementFromPointSpy.mockRestore()
+  }
 }
 
 describe('文件查看器布局与虚拟滚动', () => {
@@ -1476,5 +1555,258 @@ describe('FileViewer', () => {
     await nextTick()
 
     expect(scrollToIndexMock).toHaveBeenCalledWith(1)
+  })
+
+  it('启用拖拽后会将文件项作为 file-system-item 投放到目录项', async () => {
+    viewportWidthMock.value = 780
+
+    const sourceItem = createImageItem(1)
+    const targetDirectory = createDirectoryItem(2, {
+      name: 'folder',
+      path: '/assets/folder',
+    })
+    const drops: {
+      operation: DragTransferOperation
+      payload: FileSystemDragPayload
+      target: FileViewerItem
+    }[] = []
+
+    renderInBrowser(FileViewer, {
+      props: {
+        canDropFileTransfer: () => true,
+        enableDragTransfer: true,
+        items: [sourceItem, targetDirectory],
+        onFileTransferDrop: (
+          payload: FileSystemDragPayload,
+          target: FileViewerItem,
+          operation: DragTransferOperation,
+        ) => drops.push({ operation, payload, target }),
+        viewMode: 'grid',
+      },
+      global: {
+        stubs: globalStubs,
+      },
+    })
+    await nextTick()
+
+    const sourceElement = getFileViewerItemElement(sourceItem)
+    const targetElement = getFileViewerItemElement(targetDirectory)
+
+    await dragFileViewerItemToTarget(sourceElement, targetElement)
+
+    expect(drops).toEqual([{
+      operation: 'move',
+      payload: createFileViewerDragPayload(sourceItem),
+      target: targetDirectory,
+    }])
+  })
+
+  it('投放判断拒绝时不会触发 fileTransferDrop', async () => {
+    viewportWidthMock.value = 780
+
+    const sourceItem = createImageItem(1)
+    const targetDirectory = createDirectoryItem(2)
+    const onFileTransferDrop = vi.fn()
+
+    renderInBrowser(FileViewer, {
+      props: {
+        canDropFileTransfer: () => false,
+        enableDragTransfer: true,
+        items: [sourceItem, targetDirectory],
+        onFileTransferDrop,
+        viewMode: 'grid',
+      },
+      global: {
+        stubs: globalStubs,
+      },
+    })
+    await nextTick()
+
+    await dragFileViewerItemToTarget(
+      getFileViewerItemElement(sourceItem),
+      getFileViewerItemElement(targetDirectory),
+    )
+
+    expect(onFileTransferDrop).not.toHaveBeenCalled()
+  })
+
+  it('未提供投放判断时不会默认允许拖入目录项', async () => {
+    viewportWidthMock.value = 780
+
+    const sourceItem = createImageItem(1)
+    const targetDirectory = createDirectoryItem(2)
+    const onFileTransferDrop = vi.fn()
+
+    renderInBrowser(FileViewer, {
+      props: {
+        enableDragTransfer: true,
+        items: [sourceItem, targetDirectory],
+        onFileTransferDrop,
+        viewMode: 'grid',
+      },
+      global: {
+        stubs: globalStubs,
+      },
+    })
+    await nextTick()
+
+    await dragFileViewerItemToTarget(
+      getFileViewerItemElement(sourceItem),
+      getFileViewerItemElement(targetDirectory),
+    )
+
+    expect(onFileTransferDrop).not.toHaveBeenCalled()
+  })
+
+  it('拖拽图片资源时会在浮层显示中等缩略图', async () => {
+    viewportWidthMock.value = 780
+    mockBuiltInPreviewResolution()
+
+    const sourceItem = createImageItem(1)
+
+    renderInBrowser(FileViewer, {
+      props: {
+        ...FILE_VIEWER_PREVIEW_PROPS,
+        enableDragTransfer: true,
+        items: [sourceItem],
+        viewMode: 'grid',
+      },
+      global: {
+        stubs: globalStubs,
+      },
+    })
+    await nextTick()
+
+    const sourceElement = getFileViewerItemElement(sourceItem)
+
+    try {
+      beginFileViewerDrag(sourceElement)
+      await nextTick()
+
+      const preview = document.querySelector<HTMLElement>('[data-testid="file-viewer-drag-preview"]')
+      const thumbnail = document.querySelector<HTMLImageElement>('[data-testid="file-viewer-drag-preview-thumbnail"]')
+
+      expect(preview).not.toBeNull()
+      expect(thumbnail).not.toBeNull()
+      expect(thumbnail?.src).toContain('/assets/file-1.png')
+      expectBuiltInPreviewRequest(sourceItem, FILE_VIEWER_DRAG_PREVIEW_SIZE)
+    } finally {
+      endFileViewerDrag(sourceElement)
+    }
+  })
+
+  it('多个 FileViewer 挂载时只显示发起拖拽的浮层', async () => {
+    viewportWidthMock.value = 780
+
+    const sourceItem = createImageItem(1)
+    const otherItem = createImageItem(2)
+    const FileViewerHarness = defineComponent({
+      name: 'FileViewerDragOverlayHarness',
+      setup() {
+        return () => h('div', [
+          h(FileViewer, {
+            enableDragTransfer: true,
+            items: [sourceItem],
+            viewMode: 'grid',
+          }),
+          h(FileViewer, {
+            enableDragTransfer: true,
+            items: [otherItem],
+            viewMode: 'grid',
+          }),
+        ])
+      },
+    })
+
+    renderInBrowser(FileViewerHarness, {
+      global: {
+        stubs: globalStubs,
+      },
+    })
+    await nextTick()
+
+    const sourceElement = getFileViewerItemElement(sourceItem)
+
+    try {
+      beginFileViewerDrag(sourceElement)
+      await nextTick()
+
+      expect(document.querySelectorAll('[data-testid="file-viewer-drag-preview"]')).toHaveLength(1)
+    } finally {
+      endFileViewerDrag(sourceElement)
+    }
+  })
+
+  it('多个 FileViewer 挂载同一路径时只显示发起拖拽的浮层', async () => {
+    viewportWidthMock.value = 780
+
+    const sourceItem = createImageItem(1)
+    const FileViewerHarness = defineComponent({
+      name: 'FileViewerSamePathDragOverlayHarness',
+      setup() {
+        return () => h('div', [
+          h(FileViewer, {
+            enableDragTransfer: true,
+            items: [sourceItem],
+            viewMode: 'grid',
+          }),
+          h(FileViewer, {
+            enableDragTransfer: true,
+            items: [sourceItem],
+            viewMode: 'grid',
+          }),
+        ])
+      },
+    })
+
+    renderInBrowser(FileViewerHarness, {
+      global: {
+        stubs: globalStubs,
+      },
+    })
+    await nextTick()
+
+    const sourceElement = getFileViewerItemElement(sourceItem)
+
+    try {
+      beginFileViewerDrag(sourceElement)
+      await nextTick()
+
+      expect(document.querySelectorAll('[data-testid="file-viewer-drag-preview"]')).toHaveLength(1)
+    } finally {
+      endFileViewerDrag(sourceElement)
+    }
+  })
+
+  async function expectNativeThumbnailDragDisabled(viewMode: 'grid' | 'list'): Promise<void> {
+    viewportWidthMock.value = 780
+    mockBuiltInPreviewResolution()
+
+    const sourceItem = createImageItem(1)
+
+    renderInBrowser(FileViewer, {
+      props: {
+        ...FILE_VIEWER_PREVIEW_PROPS,
+        enableDragTransfer: true,
+        items: [sourceItem],
+        viewMode,
+      },
+      global: {
+        stubs: globalStubs,
+      },
+    })
+    await nextTick()
+
+    const thumbnail = document.querySelector<HTMLImageElement>(`img[alt="${sourceItem.name}"]`)
+    expect(thumbnail).not.toBeNull()
+    expect(thumbnail?.draggable).toBe(false)
+  }
+
+  it('会禁用网格资源缩略图的浏览器原生拖拽', async () => {
+    await expectNativeThumbnailDragDisabled('grid')
+  })
+
+  it('会禁用列表资源缩略图的浏览器原生拖拽', async () => {
+    await expectNativeThumbnailDragDisabled('list')
   })
 })

--- a/src/components/file-viewer/FileViewer.vue
+++ b/src/components/file-viewer/FileViewer.vue
@@ -1,10 +1,17 @@
 <script setup lang="ts">
+import { File, FileImage, FileJson2, FileMusic, FileVideo, Folder } from '@lucide/vue'
+
 import { useFileViewerLayout } from '~/components/file-viewer/useFileViewerLayout'
 import { useFileViewerVirtualizer } from '~/components/file-viewer/useFileViewerVirtualizer'
+import { useDragSession } from '~/composables/useDragSession'
+import { useDragSource } from '~/composables/useDragTransfer'
+import { useDroppableRegistry } from '~/composables/useDroppableRegistry'
 import { resolveAssetUrl } from '~/services/platform/asset-url'
 import { FileViewerItem, FileViewerPreviewSize, FileViewerSortBy, FileViewerSortOrder } from '~/types/file-viewer'
 import { createItemComparator } from '~/utils/sort'
 
+import type { StyleValue } from 'vue'
+import type { DragTransferOperation, FileSystemDragPayload } from '~/types/drag-drop'
 import type { SortableItemAccessor } from '~/utils/sort'
 
 interface FileViewerProps {
@@ -32,6 +39,16 @@ interface FileViewerProps {
   gridItemMinWidth?: number
   /** 缩放比例（50-150） */
   zoom?: number
+  /** 是否启用应用内资源拖拽转移 */
+  enableDragTransfer?: boolean
+  /** 当前目录 drop target，用于把资源拖入当前浏览目录 */
+  dropTargetDirectory?: FileViewerItem
+  /** 判断资源是否能投放到目标目录 */
+  canDropFileTransfer?: (
+    payload: FileSystemDragPayload,
+    targetDirectory: FileViewerItem,
+    operation: DragTransferOperation,
+  ) => boolean
 }
 
 interface FileViewerEmits {
@@ -43,6 +60,12 @@ interface FileViewerEmits {
   'update:sortBy': [sortBy: FileViewerSortBy]
   /** 更新排序方向 */
   'update:sortOrder': [sortOrder: FileViewerSortOrder]
+  /** 文件拖拽投放到目录 */
+  'fileTransferDrop': [
+    payload: FileSystemDragPayload,
+    targetDirectory: FileViewerItem,
+    operation: DragTransferOperation,
+  ]
 }
 
 interface FileViewerExpose {
@@ -70,12 +93,28 @@ const {
   errorMsg = '',
   gridItemMinWidth = 80,
   zoom,
+  enableDragTransfer = false,
+  dropTargetDirectory,
+  canDropFileTransfer,
 } = defineProps<FileViewerProps>()
 
 const emit = defineEmits<FileViewerEmits>()
 
 const scrollAreaRef = useTemplateRef<InstanceType<typeof ScrollArea>>('scrollAreaRef')
 const viewportElement = computed(() => scrollAreaRef.value?.viewport?.viewportElement as HTMLElement | undefined)
+const dragSession = useDragSession()
+const dropRegistry = useDroppableRegistry()
+let rootDropTargetElement = $ref<HTMLElement>()
+let rootDropTargetPath = $ref<string>()
+let isRootDropTargetActive = $ref(false)
+let ownedFileViewerDragPayload = $ref<FileSystemDragPayload>()
+
+const DRAG_OVERLAY_OFFSET_X = 6
+const DRAG_OVERLAY_OFFSET_Y = 6
+const DRAG_PREVIEW_SIZE = Object.freeze({
+  width: 64,
+  height: 64,
+})
 
 const { width: viewportWidth } = useElementSize(() => viewportElement.value)
 const contentWidth = computed(() => viewportWidth.value || 0)
@@ -148,6 +187,78 @@ const virtualizer = useFileViewerVirtualizer({
   viewportElement,
 })
 
+const fileDragSource = useDragSource<FileSystemDragPayload>({
+  autoScroll: {
+    container: viewportElement,
+    edgeSize: 40,
+  },
+  getData: getFileViewerDragPayload,
+  type: 'file-system-item',
+})
+
+const globalFileViewerPayload = $computed(() => {
+  const state = dragSession.state.value
+  if (
+    !state.isActive
+    || state.mode !== 'transfer'
+    || state.payload?.type !== 'file-system-item'
+    || state.payload.source !== 'file-viewer'
+  ) {
+    return
+  }
+
+  return state.payload
+})
+
+const activeFileViewerItem = $computed(() => {
+  if (!globalFileViewerPayload || globalFileViewerPayload !== ownedFileViewerDragPayload) {
+    return
+  }
+
+  return sortedItems.value.find(item => item.path === globalFileViewerPayload.path)
+})
+
+const activeFileViewerPayload = $computed(() => {
+  if (!enableDragTransfer || !activeFileViewerItem) {
+    return
+  }
+
+  return globalFileViewerPayload
+})
+
+const dragOverlayStyle = $computed<StyleValue | undefined>(() => {
+  const currentPosition = dragSession.state.value.currentPosition
+  if (!activeFileViewerPayload || !currentPosition) {
+    return
+  }
+
+  return {
+    transform: `translate3d(${currentPosition.x + DRAG_OVERLAY_OFFSET_X}px, ${currentPosition.y + DRAG_OVERLAY_OFFSET_Y}px, 0)`,
+    zIndex: '9999',
+  }
+})
+
+const dragPreviewName = $computed(() =>
+  activeFileViewerPayload?.name || activeFileViewerPayload?.path || '',
+)
+
+const dragPreviewThumbnailUrl = $computed(() => {
+  if (
+    !activeFileViewerItem
+    || activeFileViewerItem.isDir
+    || !activeFileViewerItem.mimeType?.startsWith('image/')
+    || !previewUrlResolver.value
+  ) {
+    return
+  }
+
+  return previewUrlResolver.value(activeFileViewerItem, DRAG_PREVIEW_SIZE)
+})
+
+const dragPreviewIcon = $computed(() =>
+  getDragPreviewIcon(activeFileViewerItem, activeFileViewerPayload),
+)
+
 watch(
   () => [
     viewMode,
@@ -163,6 +274,18 @@ watch(
   { flush: 'post' },
 )
 
+watch(
+  [viewportElement, () => enableDragTransfer, () => dropTargetDirectory],
+  () => {
+    registerRootDropTarget()
+  },
+  { flush: 'post', immediate: true },
+)
+
+tryOnUnmounted(() => {
+  unregisterRootDropTarget()
+})
+
 function handleItemClick(item: FileViewerItem) {
   if (!item.path) {
     return
@@ -172,6 +295,141 @@ function handleItemClick(item: FileViewerItem) {
     return
   }
   emit('select', item)
+}
+
+function getFileViewerDragPayload(element: HTMLElement): FileSystemDragPayload {
+  const { dataset } = element
+  const path = dataset.fileViewerPath ?? ''
+  const name = dataset.fileViewerItemName || path
+  const isDir = dataset.fileViewerIsDir === 'true'
+  const mimeType = dataset.fileViewerMimeType || undefined
+
+  ownedFileViewerDragPayload = {
+    isDir,
+    items: [{
+      isDir,
+      name,
+      path,
+    }],
+    name,
+    path,
+    ...(mimeType ? { mimeType } : {}),
+    source: 'file-viewer',
+    type: 'file-system-item',
+  }
+  return ownedFileViewerDragPayload
+}
+
+function getDragPreviewIcon(
+  item: FileViewerItem | undefined,
+  payload: FileSystemDragPayload | undefined,
+) {
+  if (item?.isDir ?? payload?.isDir) {
+    return Folder
+  }
+
+  const mimeType = item?.mimeType ?? payload?.mimeType ?? ''
+  if (mimeType.startsWith('image/')) {
+    return FileImage
+  }
+  if (mimeType.startsWith('audio/')) {
+    return FileMusic
+  }
+  if (mimeType.startsWith('video/')) {
+    return FileVideo
+  }
+  if (mimeType === 'application/json') {
+    return FileJson2
+  }
+
+  return File
+}
+
+function getDragSourceProps() {
+  return enableDragTransfer ? fileDragSource.sourceProps() : {}
+}
+
+function canDropOnDirectory(payload: FileSystemDragPayload, targetDirectory: FileViewerItem): boolean {
+  if (!enableDragTransfer || !targetDirectory.isDir) {
+    return false
+  }
+
+  return canDropFileTransfer?.(
+    payload,
+    targetDirectory,
+    dragSession.state.value.transferOperation,
+  ) ?? false
+}
+
+function handleRootDragEnter(payload: FileSystemDragPayload, targetDirectory: FileViewerItem): void {
+  if (canDropOnDirectory(payload, targetDirectory)) {
+    isRootDropTargetActive = true
+  }
+}
+
+function handleRootDragLeave(_payload: FileSystemDragPayload, targetDirectory: FileViewerItem): void {
+  if (dropTargetDirectory?.path === targetDirectory.path) {
+    isRootDropTargetActive = false
+  }
+}
+
+function handleRootDrop(payload: FileSystemDragPayload, targetDirectory: FileViewerItem): void {
+  isRootDropTargetActive = false
+  if (!canDropOnDirectory(payload, targetDirectory)) {
+    return
+  }
+
+  emit('fileTransferDrop', payload, targetDirectory, dragSession.state.value.transferOperation)
+}
+
+function unregisterRootDropTarget(): void {
+  if (!rootDropTargetElement) {
+    return
+  }
+
+  dropRegistry.unregisterDroppable(rootDropTargetElement)
+  rootDropTargetElement = undefined
+  rootDropTargetPath = undefined
+  isRootDropTargetActive = false
+}
+
+function registerRootDropTarget(): void {
+  const element = viewportElement.value
+  const targetDirectory = dropTargetDirectory
+
+  if (
+    rootDropTargetElement
+    && (
+      rootDropTargetElement !== element
+      || rootDropTargetPath !== targetDirectory?.path
+    )
+  ) {
+    unregisterRootDropTarget()
+  }
+
+  if (!enableDragTransfer || !targetDirectory?.isDir || !element) {
+    unregisterRootDropTarget()
+    return
+  }
+
+  rootDropTargetElement = element
+  rootDropTargetPath = targetDirectory.path
+  dropRegistry.registerDroppable(element, {
+    accept: 'file-system-item',
+    canDrop: payload => canDropOnDirectory(payload as FileSystemDragPayload, targetDirectory),
+    id: `file-viewer:root:${targetDirectory.path}`,
+    onDragEnter: payload => handleRootDragEnter(payload as FileSystemDragPayload, targetDirectory),
+    onDragLeave: payload => handleRootDragLeave(payload as FileSystemDragPayload, targetDirectory),
+    onDrop: payload => handleRootDrop(payload as FileSystemDragPayload, targetDirectory),
+  })
+}
+
+function handleBodyFileTransferDrop(
+  payload: FileSystemDragPayload,
+  targetDirectory: FileViewerItem,
+  operation: DragTransferOperation,
+): void {
+  emit('fileTransferDrop', payload, targetDirectory, operation)
 }
 
 function scrollToIndex(index: number) {
@@ -212,7 +470,12 @@ defineExpose(fileViewerExpose)
       @update:sort-by="(nextSortBy) => emit('update:sortBy', nextSortBy)"
       @update:sort-order="(nextSortOrder) => emit('update:sortOrder', nextSortOrder)"
     />
-    <div class="flex-1 min-h-0">
+    <div
+      :class="[
+        'flex-1 min-h-0',
+        isRootDropTargetActive ? 'bg-accent/35' : '',
+      ]"
+    >
       <ScrollArea ref="scrollAreaRef" class="flex-scroll-area h-full min-h-0">
         <ContextMenu v-if="isEmptyState && $slots['background-context-menu']">
           <ContextMenuTrigger as-child>
@@ -238,6 +501,9 @@ defineExpose(fileViewerExpose)
 
         <FileViewerBody
           v-else
+          :active-root-drop-target="isRootDropTargetActive"
+          :can-drop-file-transfer="canDropFileTransfer"
+          :enable-drag-transfer="enableDragTransfer"
           :highlighted-item-path="highlightedItemPath"
           :view-mode="viewMode"
           :virtual-rows="virtualizer.virtualRows.value"
@@ -252,7 +518,9 @@ defineExpose(fileViewerExpose)
           :show-list-created-at="layout.showListCreatedAt.value"
           :get-grid-row-items="virtualizer.getGridRowItems"
           :get-list-item="virtualizer.getListItem"
+          :get-drag-source-props="getDragSourceProps"
           :resolve-preview-url="previewUrlResolver"
+          @file-transfer-drop="handleBodyFileTransferDrop"
           @item-click="handleItemClick"
         >
           <template v-if="$slots.icon" #icon="{ item, iconSize }">
@@ -267,5 +535,29 @@ defineExpose(fileViewerExpose)
         </FileViewerBody>
       </ScrollArea>
     </div>
+    <DragOverlay :visible="activeFileViewerPayload !== undefined" :overlay-style="dragOverlayStyle">
+      <div class="text-popover-foreground p-2 border border-border/70 rounded-md bg-popover flex flex-col gap-1.5 w-20 shadow-lg items-center" data-testid="file-viewer-drag-preview">
+        <div class="flex size-16 items-center justify-center overflow-hidden">
+          <img
+            v-if="dragPreviewThumbnailUrl"
+            :alt="dragPreviewName"
+            :src="dragPreviewThumbnailUrl"
+            class="h-full w-full object-contain"
+            data-testid="file-viewer-drag-preview-thumbnail"
+            draggable="false"
+          >
+          <component
+            :is="dragPreviewIcon"
+            v-else
+            class="text-muted-foreground size-12"
+            data-testid="file-viewer-drag-preview-icon"
+            :stroke-width="1.5"
+          />
+        </div>
+        <span class="text-[11px] leading-snug text-center w-full truncate">
+          {{ dragPreviewName }}
+        </span>
+      </div>
+    </DragOverlay>
   </div>
 </template>

--- a/src/components/file-viewer/FileViewerBody.vue
+++ b/src/components/file-viewer/FileViewerBody.vue
@@ -2,9 +2,12 @@
 import { File, FileImage, FileJson2, FileMusic, FileVideo, Folder } from '@lucide/vue'
 
 import { loadFileViewerImageDimensions } from '~/components/file-viewer/fileViewerImageDimensions'
+import { useDragSession } from '~/composables/useDragSession'
+import { useDroppableRegistry } from '~/composables/useDroppableRegistry'
 import { formatFileSize } from '~/utils/format'
 import { isValidPositiveNumber } from '~/utils/sort'
 
+import type { DragTransferOperation, FileSystemDragPayload } from '~/types/drag-drop'
 import type { FileViewerItem, FileViewerPreviewSize, FileViewerVirtualRow } from '~/types/file-viewer'
 
 interface FileViewerDisplayItem {
@@ -17,7 +20,25 @@ interface FailedPreviewEntry {
   previewUrl: string
 }
 
+interface FileViewerDragSourceHandlers {
+  onClickCapture?: (event: MouseEvent) => void
+  onPointerdown?: (event: PointerEvent) => void
+}
+
+interface FileViewerDropTargetEntry {
+  element: HTMLElement
+  path: string
+}
+
 interface FileViewerBodyProps {
+  activeRootDropTarget?: boolean
+  enableDragTransfer?: boolean
+  canDropFileTransfer?: (
+    payload: FileSystemDragPayload,
+    targetDirectory: FileViewerItem,
+    operation: DragTransferOperation,
+  ) => boolean
+  getDragSourceProps?: () => FileViewerDragSourceHandlers
   highlightedItemPath?: string
   viewMode: 'list' | 'grid'
   virtualRows: FileViewerVirtualRow[]
@@ -36,6 +57,10 @@ interface FileViewerBodyProps {
 }
 
 const {
+  activeRootDropTarget = false,
+  enableDragTransfer = false,
+  canDropFileTransfer,
+  getDragSourceProps,
   highlightedItemPath,
   viewMode,
   virtualRows,
@@ -54,6 +79,11 @@ const {
 } = defineProps<FileViewerBodyProps>()
 
 const emit = defineEmits<{
+  fileTransferDrop: [
+    payload: FileSystemDragPayload,
+    targetDirectory: FileViewerItem,
+    operation: DragTransferOperation,
+  ]
   itemClick: [item: FileViewerItem]
 }>()
 
@@ -72,7 +102,11 @@ const failedPreviewUrls = reactive(new Map<string, FailedPreviewEntry>())
 const pendingHoverPreviewPreloads = new Map<string, Promise<void>>()
 const pendingHoverPreviewWarmupTimers = new Map<string, ReturnType<typeof setTimeout>>()
 const pendingPreviewRetryTimers = new Map<string, ReturnType<typeof setTimeout>>()
+const dropRegistry = useDroppableRegistry()
+const dragSession = useDragSession()
+const dropTargetEntries = new Map<string, FileViewerDropTargetEntry>()
 let openHoverPreviewPath = $ref<string>()
+let activeDropTargetPath = $ref<string>()
 
 const dateFormatter = new Intl.DateTimeFormat(undefined, {
   year: 'numeric',
@@ -115,6 +149,129 @@ function formatDateTime(timestamp: number): string {
 
 function handleItemClick(item: FileViewerItem): void {
   emit('itemClick', item)
+}
+
+function resolveHTMLElement(value: unknown): HTMLElement | undefined {
+  if (value instanceof HTMLElement) {
+    return value
+  }
+
+  return value && typeof value === 'object' && '$el' in value && value.$el instanceof HTMLElement ? value.$el : undefined
+}
+
+function canDropOnDirectory(payload: FileSystemDragPayload, targetDirectory: FileViewerItem): boolean {
+  if (!enableDragTransfer || !targetDirectory.isDir) {
+    return false
+  }
+
+  return canDropFileTransfer?.(
+    payload,
+    targetDirectory,
+    dragSession.state.value.transferOperation,
+  ) ?? false
+}
+
+function handleDragEnter(payload: FileSystemDragPayload, targetDirectory: FileViewerItem): void {
+  if (canDropOnDirectory(payload, targetDirectory)) {
+    activeDropTargetPath = targetDirectory.path
+  }
+}
+
+function handleDragLeave(_payload: FileSystemDragPayload, targetDirectory: FileViewerItem): void {
+  if (activeDropTargetPath === targetDirectory.path) {
+    activeDropTargetPath = undefined
+  }
+}
+
+function handleDrop(payload: FileSystemDragPayload, targetDirectory: FileViewerItem): void {
+  if (!canDropOnDirectory(payload, targetDirectory)) {
+    return
+  }
+
+  activeDropTargetPath = undefined
+  emit('fileTransferDrop', payload, targetDirectory, dragSession.state.value.transferOperation)
+}
+
+function unregisterDropTarget(key: string): void {
+  const entry = dropTargetEntries.get(key)
+  if (!entry) {
+    return
+  }
+
+  dropRegistry.unregisterDroppable(entry.element)
+  dropTargetEntries.delete(key)
+  if (activeDropTargetPath === key) {
+    activeDropTargetPath = undefined
+  }
+}
+
+function unregisterAllDropTargets(): void {
+  for (const key of dropTargetEntries.keys()) {
+    unregisterDropTarget(key)
+  }
+}
+
+function unregisterInvisibleDropTargets(visiblePaths: readonly string[]): void {
+  if (!enableDragTransfer) {
+    unregisterAllDropTargets()
+    return
+  }
+
+  const visiblePathSet = new Set(visiblePaths)
+  for (const key of dropTargetEntries.keys()) {
+    if (!visiblePathSet.has(key)) {
+      unregisterDropTarget(key)
+    }
+  }
+}
+
+function registerDropTarget(
+  key: string,
+  element: HTMLElement | undefined,
+  targetDirectory: FileViewerItem,
+): void {
+  const previousEntry = dropTargetEntries.get(key)
+  if (previousEntry && previousEntry.element !== element) {
+    unregisterDropTarget(key)
+  }
+
+  if (!enableDragTransfer || !targetDirectory.isDir || !element) {
+    unregisterDropTarget(key)
+    return
+  }
+
+  dropTargetEntries.set(key, {
+    element,
+    path: targetDirectory.path,
+  })
+  dropRegistry.registerDroppable(element, {
+    accept: 'file-system-item',
+    canDrop: payload => canDropOnDirectory(payload as FileSystemDragPayload, targetDirectory),
+    id: `file-viewer:${key}`,
+    onDragEnter: payload => handleDragEnter(payload as FileSystemDragPayload, targetDirectory),
+    onDragLeave: payload => handleDragLeave(payload as FileSystemDragPayload, targetDirectory),
+    onDrop: payload => handleDrop(payload as FileSystemDragPayload, targetDirectory),
+  })
+}
+
+function setFileViewerItemElement(value: unknown, item: FileViewerItem): void {
+  registerDropTarget(item.path, resolveHTMLElement(value), item)
+}
+
+function getFileViewerItemBind(item: FileViewerItem): FileViewerDragSourceHandlers {
+  if (!enableDragTransfer || !item.path) {
+    return {}
+  }
+
+  return getDragSourceProps?.() ?? {}
+}
+
+function getFileViewerDropTargetClass(item: FileViewerItem): string {
+  if (!item.isDir || activeDropTargetPath !== item.path) {
+    return ''
+  }
+
+  return 'bg-accent'
 }
 
 function clearPendingPreviewRetry(itemPath: string): void {
@@ -277,10 +434,11 @@ const visibleItemPaths = computed(() => {
     .filter((path): path is string => !!path)
 })
 
-watch(() => visibleItemPaths.value, (paths) => {
+watch([() => visibleItemPaths.value, () => enableDragTransfer], ([paths]) => {
   if (openHoverPreviewPath && !paths.includes(openHoverPreviewPath)) {
     openHoverPreviewPath = undefined
   }
+  unregisterInvisibleDropTargets(paths)
 })
 
 function getGridRowDisplayItems(rowIndex: number): FileViewerDisplayItem[] {
@@ -320,11 +478,19 @@ onUnmounted(() => {
   }
 
   pendingPreviewRetryTimers.clear()
+
+  unregisterAllDropTargets()
 })
 </script>
 
 <template>
-  <div class="min-h-full w-full relative" :style="{ height: `${totalSize}px` }">
+  <div
+    :class="[
+      'min-h-full w-full relative',
+      activeRootDropTarget ? 'bg-accent/35' : '',
+    ]"
+    :style="{ height: `${totalSize}px` }"
+  >
     <ContextMenu v-if="hasBackgroundContextMenu">
       <ContextMenuTrigger as-child>
         <div
@@ -362,12 +528,19 @@ onUnmounted(() => {
           :item="displayItem.item"
         >
           <button
+            v-bind="getFileViewerItemBind(displayItem.item)"
+            :ref="(value) => setFileViewerItemElement(value, displayItem.item)"
             type="button"
             data-file-viewer-item="true"
+            :data-file-viewer-is-dir="displayItem.item.isDir ? 'true' : 'false'"
+            :data-file-viewer-item-name="displayItem.item.name"
+            :data-file-viewer-mime-type="displayItem.item.mimeType"
             :data-file-viewer-path="displayItem.item.path"
             :class="[
               'p-1.5 rounded-md flex flex-col gap-1 pointer-events-auto items-center focus-visible:outline-none hover:bg-accent focus-visible:ring-1 focus-visible:ring-ring',
+              enableDragTransfer ? 'touch-none' : '',
               isItemHighlighted(displayItem.item.path) ? 'bg-accent ring-1 ring-ring/50' : '',
+              getFileViewerDropTargetClass(displayItem.item),
             ]"
             @click="handleItemClick(displayItem.item)"
           >
@@ -392,6 +565,7 @@ onUnmounted(() => {
                   :src="displayItem.previewUrl"
                   class="h-full w-full object-contain"
                   decoding="async"
+                  draggable="false"
                   loading="lazy"
                   @error="handleImageError(displayItem.item.path, displayItem.previewUrl)"
                 >
@@ -428,12 +602,19 @@ onUnmounted(() => {
           :item="displayItem.item"
         >
           <button
+            v-bind="getFileViewerItemBind(displayItem.item)"
+            :ref="(value) => setFileViewerItemElement(value, displayItem.item)"
             type="button"
             data-file-viewer-item="true"
+            :data-file-viewer-is-dir="displayItem.item.isDir ? 'true' : 'false'"
+            :data-file-viewer-item-name="displayItem.item.name"
+            :data-file-viewer-mime-type="displayItem.item.mimeType"
             :data-file-viewer-path="displayItem.item.path"
             :class="[
               'p-2 rounded-md flex gap-2 w-full pointer-events-auto items-center focus-visible:outline-none hover:bg-accent focus-visible:ring-1 focus-visible:ring-ring',
+              enableDragTransfer ? 'touch-none' : '',
               isItemHighlighted(displayItem.item.path) ? 'bg-accent ring-1 ring-ring/50' : '',
+              getFileViewerDropTargetClass(displayItem.item),
             ]"
             :style="{ height: `${listItemHeight}px` }"
             @click="handleItemClick(displayItem.item)"
@@ -460,6 +641,7 @@ onUnmounted(() => {
                     :src="displayItem.previewUrl"
                     class="h-full w-full object-contain"
                     decoding="async"
+                    draggable="false"
                     loading="lazy"
                     @error="handleImageError(displayItem.item.path, displayItem.previewUrl)"
                   >

--- a/src/features/editor/file-tree/__tests__/file-tree.test.ts
+++ b/src/features/editor/file-tree/__tests__/file-tree.test.ts
@@ -2,11 +2,15 @@ import { describe, expect, it } from 'vitest'
 
 import {
   canCopyFileTreeItemsToDirectory,
+  canDropFileTreeTransferItemsToDirectory,
+  canDropFileTreeTransferPayloadToDirectory,
   canMoveFileTreeItemsToDirectory,
   getFileTreeNameSelectionEnd,
+  getFileTreeTransferPayloadItems,
   hasFileTreeDuplicateName,
   insertCreatingFileTreeItem,
   normalizeFileTreeTransferItems,
+  resolveDroppableFileTreeTransferItems,
   resolveFileTreeCreateBlurAction,
   resolveFileTreeCreateStart,
   resolveFileTreeRenameBlurAction,
@@ -404,6 +408,75 @@ describe('fileTree', () => {
       ])).toEqual([
         { isDir: true, path: '/project/scene/chapter' },
         { isDir: false, path: '/project/scene/ending.txt' },
+      ])
+    })
+
+    it('会从 payload items 或单项 payload 中解析投放集合', () => {
+      expect(getFileTreeTransferPayloadItems({
+        isDir: false,
+        items: [
+          { isDir: false, name: 'branch.txt', path: '/project/scene/chapter/branch.txt' },
+          { isDir: true, name: 'chapter', path: '/project/scene/chapter' },
+        ],
+        name: 'branch.txt',
+        path: '/project/scene/chapter/branch.txt',
+        source: 'file-tree',
+        type: 'file-system-item',
+      })).toEqual([
+        { isDir: true, name: 'chapter', path: '/project/scene/chapter' },
+      ])
+
+      expect(getFileTreeTransferPayloadItems({
+        isDir: false,
+        name: 'start.txt',
+        path: '/project/scene/start.txt',
+        source: 'file-viewer',
+        type: 'file-system-item',
+      })).toEqual([
+        { isDir: false, name: 'start.txt', path: '/project/scene/start.txt' },
+      ])
+    })
+
+    it('会按 move 和 copy 语义判断是否能投放到目录', () => {
+      const directoryItem = { isDir: true, path: '/project/scene/chapter' }
+
+      expect(canDropFileTreeTransferItemsToDirectory(
+        [directoryItem],
+        '/project/scene',
+        'move',
+      )).toBe(false)
+      expect(canDropFileTreeTransferItemsToDirectory(
+        [directoryItem],
+        '/project/scene',
+        'copy',
+      )).toBe(true)
+    })
+
+    it('会复用 payload 规则解析可投放集合', () => {
+      const payload = {
+        isDir: true,
+        name: 'chapter',
+        path: '/project/scene/chapter',
+        source: 'file-viewer' as const,
+        type: 'file-system-item' as const,
+      }
+
+      expect(canDropFileTreeTransferPayloadToDirectory(
+        payload,
+        '/project/scene/chapter/nested',
+        'copy',
+      )).toBe(false)
+      expect(resolveDroppableFileTreeTransferItems(
+        payload,
+        '/project/scene/chapter/nested',
+        'copy',
+      )).toBeUndefined()
+      expect(resolveDroppableFileTreeTransferItems(
+        payload,
+        '/project/scene',
+        'copy',
+      )).toEqual([
+        { isDir: true, name: 'chapter', path: '/project/scene/chapter' },
       ])
     })
   })

--- a/src/features/editor/file-tree/file-tree.ts
+++ b/src/features/editor/file-tree/file-tree.ts
@@ -1,5 +1,7 @@
 import { AbsPath } from '~/domain/path'
 
+import type { DragTransferOperation, FileSystemDragPayload } from '~/types/drag-drop'
+
 export interface FileTreeItemAccessor<T> {
   getChildren: (item: T) => T[] | undefined
   getName: (item: T) => string
@@ -75,6 +77,8 @@ export interface ResolveFileTreeCopyTargetOptions {
   }[]
   targetDirectoryPath: string
 }
+
+export type FileTreeTransferItem = NonNullable<FileSystemDragPayload['items']>[number]
 
 export function getFileTreeParentPath(path: string): string {
   return path.replace(/[\\/][^\\/]+$/, '')
@@ -347,6 +351,59 @@ export function normalizeFileTreeTransferItems<T extends { path: string }>(items
       && isPathWithin(item.path, other.path),
     ),
   )
+}
+
+export function getFileTreeTransferPayloadItems(payload: FileSystemDragPayload): FileTreeTransferItem[] {
+  return normalizeFileTreeTransferItems(
+    payload.items?.length
+      ? payload.items
+      : [{
+          isDir: payload.isDir,
+          name: payload.name,
+          path: payload.path,
+        }],
+  )
+}
+
+export function canDropFileTreeTransferItemsToDirectory(
+  items: readonly FileTreeTransferItem[],
+  targetDirectoryPath: string,
+  operation: DragTransferOperation = 'move',
+): boolean {
+  if (operation === 'copy') {
+    return canCopyFileTreeItemsToDirectory({
+      sourceItems: items,
+      targetDirectoryPath,
+    })
+  }
+
+  return canMoveFileTreeItemsToDirectory({
+    sourcePaths: items.map(item => item.path),
+    targetDirectoryPath,
+  })
+}
+
+export function canDropFileTreeTransferPayloadToDirectory(
+  payload: FileSystemDragPayload,
+  targetDirectoryPath: string,
+  operation: DragTransferOperation = 'move',
+): boolean {
+  return canDropFileTreeTransferItemsToDirectory(
+    getFileTreeTransferPayloadItems(payload),
+    targetDirectoryPath,
+    operation,
+  )
+}
+
+export function resolveDroppableFileTreeTransferItems(
+  payload: FileSystemDragPayload,
+  targetDirectoryPath: string,
+  operation: DragTransferOperation = 'move',
+): FileTreeTransferItem[] | undefined {
+  const items = getFileTreeTransferPayloadItems(payload)
+  return canDropFileTreeTransferItemsToDirectory(items, targetDirectoryPath, operation)
+    ? items
+    : undefined
 }
 
 export function insertCreatingFileTreeItem<T, TFlattened extends FileTreeFlattenedItemLike<T>>(

--- a/src/features/editor/file-tree/useFileTreeController.ts
+++ b/src/features/editor/file-tree/useFileTreeController.ts
@@ -2,14 +2,13 @@ import { useFileSystemEvents } from '~/composables/useFileSystemEvents'
 import { usePathOperationFeedback } from '~/composables/usePathOperationFeedback'
 import { AbsPath } from '~/domain/path'
 import {
-  canCopyFileTreeItemsToDirectory,
-  canMoveFileTreeItemsToDirectory,
+  canDropFileTreeTransferPayloadToDirectory,
   findFileTreeItemByPath,
   getFileTreeNameSelectionEnd,
   getFileTreeParentPath,
   hasFileTreeDuplicateName,
   insertCreatingFileTreeItem,
-  normalizeFileTreeTransferItems,
+  resolveDroppableFileTreeTransferItems,
   resolveFileTreeCreateBlurAction,
   resolveFileTreeCreateStart,
   resolveFileTreeRenameBlurAction,
@@ -638,61 +637,16 @@ export function useFileTreeController<T extends object>(options: UseFileTreeCont
     startCreating(fileItem.path, 'folder')
   }
 
-  type FileSystemDragItem = NonNullable<FileSystemDragPayload['items']>[number]
-
-  function getFileSystemDragItems(payload: FileSystemDragPayload): FileSystemDragItem[] {
-    return normalizeFileTreeTransferItems(
-      payload.items?.length
-        ? payload.items
-        : [{
-            isDir: payload.isDir,
-            name: payload.name,
-            path: payload.path,
-          }],
-    )
-  }
-
-  function canDropFileSystemDragItems(
-    items: readonly FileSystemDragItem[],
-    targetDirectoryPath: string,
-    operation: DragTransferOperation = 'move',
-  ): boolean {
-    if (operation === 'copy') {
-      return canCopyFileTreeItemsToDirectory({
-        sourceItems: items,
-        targetDirectoryPath,
-      })
-    }
-
-    return canMoveFileTreeItemsToDirectory({
-      sourcePaths: items.map(item => item.path),
-      targetDirectoryPath,
-    })
-  }
-
   function canDropFileSystemItems(
     payload: FileSystemDragPayload,
     targetDirectoryPath: string,
     operation: DragTransferOperation = 'move',
   ): boolean {
-    return canDropFileSystemDragItems(
-      getFileSystemDragItems(payload),
+    return canDropFileTreeTransferPayloadToDirectory(
+      payload,
       targetDirectoryPath,
       operation,
     )
-  }
-
-  function resolveDroppableFileSystemItems(
-    payload: FileSystemDragPayload,
-    targetDirectoryPath: string,
-    operation: DragTransferOperation = 'move',
-  ): FileSystemDragItem[] | undefined {
-    const items = getFileSystemDragItems(payload)
-    if (!canDropFileSystemDragItems(items, targetDirectoryPath, operation)) {
-      return
-    }
-
-    return items
   }
 
   function expandDirectory(path: string): void {
@@ -704,7 +658,7 @@ export function useFileTreeController<T extends object>(options: UseFileTreeCont
   }
 
   async function moveFileSystemItems(payload: FileSystemDragPayload, targetDirectoryPath: string): Promise<void> {
-    const items = resolveDroppableFileSystemItems(payload, targetDirectoryPath)
+    const items = resolveDroppableFileTreeTransferItems(payload, targetDirectoryPath)
     if (!items) {
       return
     }
@@ -723,7 +677,7 @@ export function useFileTreeController<T extends object>(options: UseFileTreeCont
   }
 
   async function copyFileSystemItems(payload: FileSystemDragPayload, targetDirectoryPath: string): Promise<void> {
-    const items = resolveDroppableFileSystemItems(payload, targetDirectoryPath, 'copy')
+    const items = resolveDroppableFileTreeTransferItems(payload, targetDirectoryPath, 'copy')
     if (!items) {
       return
     }


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [ ] 错误修复
- [x] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [x] 代码重构
- [x] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

1. 为 `FileViewer` 接入 drag source / drop target，支持将资源项拖入目录项以及当前目录根投放区。
2. 为资源浏览器补充投放高亮、拖拽预览和 drop 事件分发，使拖拽反馈与目标识别完整可用。
3. 在 `AssetView` 中承接 `fileTransferDrop`：`move` 走 `pathOperation.perform`，`copy` 走 `gameFs.copyFile`，并保持与现有资源操作一致的错误处理与反馈。
4. 抽取并复用 `file-tree` 中的 transfer payload 解析、非法目标校验和 droppable item 解析逻辑，避免资源浏览器与文件树维护两套规则。
5. 补充 `FileViewer`、`AssetView` 和 `file-tree` helper 测试，覆盖 move/copy 语义、非法 drop 拒绝和拖拽事件发射。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

当前资源浏览器缺少直接的拖拽转移入口，整理资源目录时仍然需要依赖右键菜单操作，交互路径不完整。

这次改动把资源浏览器的文件系统拖拽语义补齐，并与现有文件树转移规则保持一致，减少重复实现和后续行为漂移的风险，同时为后续其他投放场景复用同一套 `file-system-item` 契约打基础。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
