### PR TITLE
✨ 支持编辑器文件拖拽投放

### DIFF
--- a/src/__tests__/mocks/monaco.ts
+++ b/src/__tests__/mocks/monaco.ts
@@ -46,6 +46,7 @@ export interface MonacoEditorInstanceMock {
   addCommand: MonacoCommandMock
   deltaDecorations: Mock<(oldDecorations: string[], newDecorations: unknown[]) => string[]>
   dispose: Mock<() => void>
+  focus: Mock<() => void>
   getAction: Mock<(actionId: string) => MonacoActionMock | undefined>
   getDomNode: Mock<() => MonacoDomNodeMock | null>
   getModel: Mock<() => unknown>
@@ -120,6 +121,7 @@ function createEditorInstanceMock(): MonacoEditorInstanceMock {
     addCommand: vi.fn<(keybinding: number, handler: MonacoCommandHandler) => unknown>(),
     deltaDecorations: vi.fn<(oldDecorations: string[], newDecorations: unknown[]) => string[]>(),
     dispose: vi.fn<() => void>(),
+    focus: vi.fn<() => void>(),
     getAction: vi.fn<(actionId: string) => MonacoActionMock | undefined>(),
     getDomNode: vi.fn<() => MonacoDomNodeMock | null>(),
     getModel: vi.fn<() => unknown>(),
@@ -178,6 +180,15 @@ export function createMonacoMockModule() {
     KeyMod: {
       CtrlCmd: 2048,
     },
+    Position: class Position {
+      lineNumber: number
+      column: number
+
+      constructor(lineNumber: number, column: number) {
+        this.lineNumber = lineNumber
+        this.column = column
+      }
+    },
     Range: class Range {
       startLineNumber: number
       startColumn: number
@@ -194,10 +205,14 @@ export function createMonacoMockModule() {
     editor: {
       create: monacoMockState.create,
       MouseTargetType: {
+        CONTENT_EMPTY: 7,
         CONTENT_TEXT: 6,
         GUTTER_GLYPH_MARGIN: 2,
       },
       setTheme: monacoMockState.setTheme,
+      TrackedRangeStickiness: {
+        NeverGrowsWhenTypingAtEdges: 0,
+      },
     },
   }
 }

--- a/src/components/editor/TextEditor.spec.ts
+++ b/src/components/editor/TextEditor.spec.ts
@@ -1,6 +1,6 @@
 import * as monaco from 'monaco-editor'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { nextTick, reactive } from 'vue'
+import { nextTick, reactive, shallowRef } from 'vue'
 
 import { createBrowserLiteI18n } from '~/__tests__/browser'
 import { renderInBrowser } from '~/__tests__/browser-render'
@@ -22,12 +22,16 @@ const {
   runtimeReturnValue,
   useEditSettingsStoreMock,
   useEditorStoreMock,
+  useDragSessionMock,
+  useDroppableRegistryMock,
   useTextEditorRuntimeMock,
   useTabsStoreMock,
 } = vi.hoisted(() => {
   const ensureModelMock = vi.fn()
   const handleBeforeUnmountMock = vi.fn()
   const runtimeReturnValue = {
+    canHandleFileDrop: vi.fn(() => true),
+    clearFileDropHover: vi.fn(),
     currentEditorLanguage: { value: 'webgalscript' },
     ensureModel: ensureModelMock,
     handleBeforeUnmount: handleBeforeUnmountMock,
@@ -36,13 +40,17 @@ const {
     handleCursorSelectionChange: vi.fn(),
     handleEditorClick: vi.fn(),
     handleEditorCreated: vi.fn(),
+    handleFileDrop: vi.fn(),
     handleScrollChange: vi.fn(),
+    syncFileDropHover: vi.fn(),
   }
 
   return {
     ensureModelMock,
     handleBeforeUnmountMock,
     runtimeReturnValue,
+    useDragSessionMock: vi.fn(),
+    useDroppableRegistryMock: vi.fn(),
     useEditSettingsStoreMock: vi.fn(),
     useEditorStoreMock: vi.fn(),
     useTextEditorRuntimeMock: vi.fn(() => runtimeReturnValue),
@@ -52,6 +60,14 @@ const {
 
 vi.mock('~/features/editor/text-editor/useTextEditorRuntime', () => ({
   useTextEditorRuntime: useTextEditorRuntimeMock,
+}))
+
+vi.mock('~/composables/useDragSession', () => ({
+  useDragSession: useDragSessionMock,
+}))
+
+vi.mock('~/composables/useDroppableRegistry', () => ({
+  useDroppableRegistry: useDroppableRegistryMock,
 }))
 
 vi.mock('~/plugins/editor', () => ({
@@ -195,19 +211,52 @@ describe('TextEditor', () => {
     resetMonacoMockState()
     ensureModelMock.mockReset()
     handleBeforeUnmountMock.mockReset()
+    runtimeReturnValue.canHandleFileDrop.mockReset()
+    runtimeReturnValue.clearFileDropHover.mockReset()
     runtimeReturnValue.handleContentChange.mockReset()
     runtimeReturnValue.handleCursorPositionChange.mockReset()
     runtimeReturnValue.handleCursorSelectionChange.mockReset()
     runtimeReturnValue.handleEditorClick.mockReset()
     runtimeReturnValue.handleEditorCreated.mockReset()
+    runtimeReturnValue.handleFileDrop.mockReset()
     runtimeReturnValue.handleScrollChange.mockReset()
+    runtimeReturnValue.syncFileDropHover.mockReset()
+    runtimeReturnValue.canHandleFileDrop.mockReturnValue(true)
     useEditSettingsStoreMock.mockReset()
     useEditorStoreMock.mockReset()
+    useDragSessionMock.mockReset()
+    useDroppableRegistryMock.mockReset()
     useTabsStoreMock.mockReset()
     useTextEditorRuntimeMock.mockClear()
 
     ensureModelMock.mockReturnValue({
       id: 'model-1',
+    })
+    useDragSessionMock.mockReturnValue({
+      state: shallowRef({
+        currentDropTarget: undefined,
+        currentPosition: { x: 40, y: 20 },
+        isActive: true,
+        mode: 'transfer',
+        payload: {
+          source: 'file-viewer',
+          type: 'file-system-item',
+          path: '/games/demo/game/background/room.png',
+          isDir: false,
+        },
+        startPosition: { x: 40, y: 20 },
+        transferOperation: 'copy',
+      }),
+    })
+    useDroppableRegistryMock.mockReturnValue({
+      clearHover: vi.fn(),
+      drop: vi.fn(),
+      getMatchAt: vi.fn(),
+      hoveredTarget: shallowRef(),
+      isDropAllowed: shallowRef(false),
+      registerDroppable: vi.fn(),
+      unregisterDroppable: vi.fn(),
+      updateHover: vi.fn(),
     })
   })
 
@@ -300,8 +349,125 @@ describe('TextEditor', () => {
     await nextTick()
     await result.unmount()
 
+    expect(runtimeReturnValue.clearFileDropHover).toHaveBeenCalledTimes(1)
     expect(handleBeforeUnmountMock).toHaveBeenCalledTimes(1)
     expect(monacoMockState.editorInstance.dispose).toHaveBeenCalledTimes(1)
+  })
+
+  it('注册文本编辑器 drop target，并在 drop 时把 payload 与当前位置交给 runtime', async () => {
+    const registerDroppable = vi.fn()
+    const unregisterDroppable = vi.fn()
+    const hoveredTarget = shallowRef<HTMLElement>()
+    useDroppableRegistryMock.mockReturnValue({
+      clearHover: vi.fn(),
+      drop: vi.fn(),
+      getMatchAt: vi.fn(),
+      hoveredTarget,
+      isDropAllowed: shallowRef(false),
+      registerDroppable,
+      unregisterDroppable,
+      updateHover: vi.fn(),
+    })
+    useDragSessionMock.mockReturnValue({
+      state: shallowRef({
+        currentDropTarget: undefined,
+        currentPosition: { x: 40, y: 20 },
+        isActive: true,
+        mode: 'transfer',
+        payload: {
+          source: 'file-viewer',
+          type: 'file-system-item',
+          path: '/games/demo/game/background/room.png',
+          isDir: false,
+        },
+        startPosition: { x: 40, y: 20 },
+        transferOperation: 'copy',
+      }),
+    })
+
+    const { state } = createHarness()
+    const result = renderTextEditor(state)
+    await nextTick()
+
+    const [, config] = registerDroppable.mock.calls[0]
+    const payload = {
+      source: 'file-viewer',
+      type: 'file-system-item',
+      path: '/games/demo/game/background/room.png',
+      isDir: false,
+    } as const
+
+    config.onDragEnter(payload, document.createElement('div'))
+    expect(runtimeReturnValue.syncFileDropHover).toHaveBeenCalledWith(payload, { x: 40, y: 20 })
+
+    config.onDrop(payload, document.createElement('div'))
+    expect(runtimeReturnValue.handleFileDrop).toHaveBeenCalledWith(payload, { x: 40, y: 20 })
+
+    config.onDragLeave(payload, document.createElement('div'))
+    expect(runtimeReturnValue.clearFileDropHover).toHaveBeenCalled()
+
+    await result.unmount()
+    expect(unregisterDroppable).toHaveBeenCalledTimes(1)
+  })
+
+  it('文件投放成功后会恢复 Monaco 焦点', async () => {
+    const registerDroppable = vi.fn()
+    useDroppableRegistryMock.mockReturnValue({
+      clearHover: vi.fn(),
+      drop: vi.fn(),
+      getMatchAt: vi.fn(),
+      hoveredTarget: shallowRef(),
+      isDropAllowed: shallowRef(false),
+      registerDroppable,
+      unregisterDroppable: vi.fn(),
+      updateHover: vi.fn(),
+    })
+    runtimeReturnValue.handleFileDrop.mockReturnValue(true)
+
+    const { state } = createHarness('/project/scene-drop-focus.txt')
+    renderTextEditor(state)
+    await nextTick()
+
+    const [, config] = registerDroppable.mock.calls[0]
+    const payload = {
+      source: 'file-viewer',
+      type: 'file-system-item',
+      path: '/games/demo/game/background/room.png',
+      isDir: false,
+    } as const
+
+    config.onDrop(payload, document.createElement('div'))
+
+    expect(monacoMockState.editorInstance.focus).toHaveBeenCalledTimes(1)
+  })
+
+  it('animation 文本状态会拒绝脚本文件投放', async () => {
+    const registerDroppable = vi.fn()
+    runtimeReturnValue.canHandleFileDrop.mockReturnValue(false)
+    useDroppableRegistryMock.mockReturnValue({
+      clearHover: vi.fn(),
+      drop: vi.fn(),
+      getMatchAt: vi.fn(),
+      hoveredTarget: shallowRef(),
+      isDropAllowed: shallowRef(false),
+      registerDroppable,
+      unregisterDroppable: vi.fn(),
+      updateHover: vi.fn(),
+    })
+    const { state } = createHarness('/games/demo/game/animation/opening.json')
+    state.kind = 'animation'
+    state.textContent = '{}'
+
+    renderTextEditor(state)
+    await nextTick()
+
+    const config = registerDroppable.mock.calls[0]?.[1]
+    expect(config?.canDrop?.({
+      source: 'file-viewer',
+      type: 'file-system-item',
+      path: '/games/demo/game/background/room.png',
+      isDir: false,
+    }, document.createElement('div'))).toBe(false)
   })
 
   it('非场景文件不会启用 glyph margin', async () => {

--- a/src/components/editor/TextEditor.vue
+++ b/src/components/editor/TextEditor.vue
@@ -2,6 +2,8 @@
 import * as monaco from 'monaco-editor'
 
 import { colorMode } from '~/composables/color-mode'
+import { useDragSession } from '~/composables/useDragSession'
+import { useDroppableRegistry } from '~/composables/useDroppableRegistry'
 import { useShortcutContext } from '~/features/editor/shortcut/useShortcutContext'
 import { buildTextEditorOptions } from '~/features/editor/text-editor/text-editor-options'
 import { createTextEditorPlayToLineController } from '~/features/editor/text-editor/text-editor-play-to-line'
@@ -12,6 +14,7 @@ import { isEditableEditor, useEditorStore } from '~/stores/editor'
 import { useTabsStore } from '~/stores/tabs'
 
 import type { TextProjectionState } from '~/stores/editor'
+import type { FileSystemDragPayload } from '~/types/drag-drop'
 
 interface Props {
   state: TextProjectionState
@@ -21,6 +24,8 @@ const props = defineProps<Props>()
 const editorStore = useEditorStore()
 const tabsStore = useTabsStore()
 const editSettings = useEditSettingsStore()
+const dragSession = useDragSession()
+const dropRegistry = useDroppableRegistry()
 const { locale, t } = useI18n()
 const showPlayToLineGlyph = $computed(() => props.state.kind === 'scene')
 const disablePlayToLineGlyph = $computed(() => props.state.kind === 'scene' && props.state.isDirty)
@@ -41,6 +46,7 @@ const editorOptions = $computed<monaco.editor.IEditorConstructionOptions>(() =>
 let editor = $shallowRef<monaco.editor.IStandaloneCodeEditor>()
 let playToLineController = $shallowRef<ReturnType<typeof createTextEditorPlayToLineController>>()
 let editorContainer = $ref<HTMLElement>()
+let textDropTargetElement: HTMLElement | undefined
 let hasPendingPlayToLineGlyphSync = false
 const runtime = useTextEditorRuntime({
   editorRef: $$(editor),
@@ -58,6 +64,71 @@ const isCurrentTextProjectionActive = $computed(() => {
 
 function syncPlayToLineGlyph() {
   playToLineController?.syncFromEditorPosition()
+}
+
+function readCurrentDragPosition() {
+  return dragSession.state.value.currentPosition
+}
+
+function readCurrentFileDragPayload(): FileSystemDragPayload | undefined {
+  const payload = dragSession.state.value.payload
+  return payload?.type === 'file-system-item' ? payload : undefined
+}
+
+function unregisterTextDropTarget() {
+  if (!textDropTargetElement) {
+    return
+  }
+
+  dropRegistry.unregisterDroppable(textDropTargetElement)
+  textDropTargetElement = undefined
+}
+
+function registerTextDropTarget() {
+  if (!editorContainer) {
+    unregisterTextDropTarget()
+    return
+  }
+
+  if (textDropTargetElement === editorContainer) {
+    return
+  }
+
+  unregisterTextDropTarget()
+  textDropTargetElement = editorContainer
+  dropRegistry.registerDroppable(editorContainer, {
+    accept: 'file-system-item',
+    canDrop(payload) {
+      return payload.type === 'file-system-item'
+        && runtime.canHandleFileDrop(payload, readCurrentDragPosition())
+    },
+    id: `text-editor:${props.state.path}`,
+    onDragEnter(payload) {
+      if (payload.type === 'file-system-item') {
+        runtime.syncFileDropHover(payload, readCurrentDragPosition())
+      }
+    },
+    onDragLeave(payload) {
+      if (payload.type === 'file-system-item') {
+        runtime.clearFileDropHover()
+      }
+    },
+    onDrop(payload) {
+      if (payload.type !== 'file-system-item') {
+        return
+      }
+
+      const position = readCurrentDragPosition()
+      if (!position) {
+        runtime.clearFileDropHover()
+        return
+      }
+
+      if (runtime.handleFileDrop(payload, position)) {
+        editor?.focus()
+      }
+    },
+  })
 }
 
 useShortcutContext({
@@ -161,6 +232,7 @@ onMounted(() => {
   if (isCurrentTextProjectionActive) {
     createEditor()
   }
+  registerTextDropTarget()
 })
 
 watch(() => isCurrentTextProjectionActive, (isActive) => {
@@ -169,7 +241,28 @@ watch(() => isCurrentTextProjectionActive, (isActive) => {
   }
 })
 
+watch(() => props.state.path, () => {
+  if (textDropTargetElement) {
+    unregisterTextDropTarget()
+    registerTextDropTarget()
+  }
+})
+
+watch(() => dragSession.state.value.currentPosition, (position) => {
+  if (dropRegistry.hoveredTarget.value !== editorContainer) {
+    return
+  }
+
+  const payload = readCurrentFileDragPayload()
+  if (payload) {
+    runtime.syncFileDropHover(payload, position)
+  }
+})
+
 onUnmounted(() => {
+  runtime.clearFileDropHover()
+  unregisterTextDropTarget()
+
   if (editor) {
     playToLineController?.dispose()
     playToLineController = undefined
@@ -197,4 +290,18 @@ onUnmounted(() => {
 .monaco-editor .glyph-margin-widgets .cgmr.play-to-line-glyph.play-to-line-glyph-disabled {
   @apply cursor-not-allowed text-muted-foreground/50;
 }
+
+.monaco-editor.vs .text-editor-drop-caret,
+.monaco-editor.hc-light .text-editor-drop-caret {
+  border-right: 2px dotted #000000;
+}
+
+.monaco-editor.vs-dark .text-editor-drop-caret {
+  border-right: 2px dotted #aeafad;
+}
+
+.monaco-editor.hc-black .text-editor-drop-caret {
+  border-right: 2px dotted #ffffff;
+}
+
 </style>

--- a/src/components/editor/VisualEditorScene.spec.ts
+++ b/src/components/editor/VisualEditorScene.spec.ts
@@ -1,7 +1,7 @@
 import { createPinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { page } from 'vitest/browser'
-import { computed, defineComponent, h, nextTick, reactive, vShow, withDirectives } from 'vue'
+import { computed, defineComponent, h, nextTick, reactive, shallowRef, vShow, withDirectives } from 'vue'
 
 import { createBrowserContainerStub, renderInBrowser } from '~/__tests__/browser-render'
 import { useShortcutContextRegistry } from '~/features/editor/shortcut/shortcut-context-registry'
@@ -60,9 +60,11 @@ const {
   handleSelectMock,
   handleStatementDeleteMock,
   handleStatementUpdateMock,
+  handleFileDropMock,
   measureRowElementMock,
   reorderStatementsMock,
   statementSortVirtualAdapterMock,
+  useDroppableRegistryMock,
   useEditSettingsStoreMock,
   usePreferenceStoreMock,
   useEditorStoreMock,
@@ -74,6 +76,7 @@ const {
   handleSelectMock: vi.fn(),
   handleStatementDeleteMock: vi.fn(),
   handleStatementUpdateMock: vi.fn(),
+  handleFileDropMock: vi.fn(),
   measureRowElementMock: vi.fn(),
   reorderStatementsMock: vi.fn(),
   statementSortVirtualAdapterMock: {
@@ -91,6 +94,11 @@ const {
   usePreferenceStoreMock: vi.fn(),
   useTabsStoreMock: vi.fn(),
   useVisualEditorSceneRuntimeMock: vi.fn(),
+  useDroppableRegistryMock: vi.fn(),
+}))
+
+vi.mock('~/composables/useDroppableRegistry', () => ({
+  useDroppableRegistry: useDroppableRegistryMock,
 }))
 
 vi.mock('~/stores/edit-settings', () => ({
@@ -185,6 +193,7 @@ describe('VisualEditorScene', () => {
     handleSelectMock.mockReset()
     handleStatementDeleteMock.mockReset()
     handleStatementUpdateMock.mockReset()
+    handleFileDropMock.mockReset()
     measureRowElementMock.mockReset()
     reorderStatementsMock.mockReset()
     statementSortVirtualAdapterMock.getEstimatedItemSize.mockReturnValue(48)
@@ -200,6 +209,7 @@ describe('VisualEditorScene', () => {
     usePreferenceStoreMock.mockReset()
     useTabsStoreMock.mockReset()
     useVisualEditorSceneRuntimeMock.mockReset()
+    useDroppableRegistryMock.mockReset()
 
     useEditSettingsStoreMock.mockReturnValue(reactive({
       collapseStatementsOnSidebarOpen: true,
@@ -221,7 +231,9 @@ describe('VisualEditorScene', () => {
       shouldFocusEditor: false,
     }))
     useVisualEditorSceneRuntimeMock.mockReturnValue({
+      canHandleFileDrop: vi.fn(() => true),
       handleCollapsedUpdate: handleCollapsedUpdateMock,
+      handleFileDrop: handleFileDropMock,
       handlePlayTo: handlePlayToMock,
       handleSelect: handleSelectMock,
       handleStatementDelete: handleStatementDeleteMock,
@@ -238,6 +250,16 @@ describe('VisualEditorScene', () => {
         { index: 0, key: 0, start: 0 },
         { index: 1, key: 1, start: 48 },
       ],
+    })
+    useDroppableRegistryMock.mockReturnValue({
+      clearHover: vi.fn(),
+      drop: vi.fn(),
+      getMatchAt: vi.fn(),
+      hoveredTarget: shallowRef(),
+      isDropAllowed: shallowRef(false),
+      registerDroppable: vi.fn(),
+      unregisterDroppable: vi.fn(),
+      updateHover: vi.fn(),
     })
   })
 
@@ -306,7 +328,9 @@ describe('VisualEditorScene', () => {
       { index: 2, size: 100, start: 200 },
     ])
     useVisualEditorSceneRuntimeMock.mockReturnValue({
+      canHandleFileDrop: vi.fn(() => true),
       handleCollapsedUpdate: handleCollapsedUpdateMock,
+      handleFileDrop: handleFileDropMock,
       handlePlayTo: handlePlayToMock,
       handleSelect: handleSelectMock,
       handleStatementDelete: handleStatementDeleteMock,
@@ -340,6 +364,224 @@ describe('VisualEditorScene', () => {
     expect(firstItem).not.toBeNull()
     expect(firstItem!.dataset.dragIndex).toBe('0')
     expect(firstItem!.querySelector('[data-statement-drag-handle]')).not.toBeNull()
+  })
+
+  it('为 head / gap / update / tail 注册 drop target，并把 drop 目标传给 runtime', async () => {
+    const registerDroppable = vi.fn()
+    useDroppableRegistryMock.mockReturnValue({
+      clearHover: vi.fn(),
+      drop: vi.fn(),
+      getMatchAt: vi.fn(),
+      hoveredTarget: shallowRef(),
+      isDropAllowed: shallowRef(false),
+      registerDroppable,
+      unregisterDroppable: vi.fn(),
+      updateHover: vi.fn(),
+    })
+
+    const state = createSceneState()
+    renderInBrowser(VisualEditorScene, {
+      props: { state },
+      global: {
+        plugins: [createPinia()],
+        stubs: globalStubs,
+      },
+    })
+    await nextTick()
+
+    expect(registerDroppable).toHaveBeenCalledWith(
+      expect.any(HTMLElement),
+      expect.objectContaining({ id: 'visual-editor:head' }),
+    )
+    expect(registerDroppable).toHaveBeenCalledWith(
+      expect.any(HTMLElement),
+      expect.objectContaining({ id: 'visual-editor:update:1' }),
+    )
+    expect(registerDroppable).toHaveBeenCalledWith(
+      expect.any(HTMLElement),
+      expect.objectContaining({ id: 'visual-editor:gap:1:2' }),
+    )
+    expect(registerDroppable).toHaveBeenCalledWith(
+      expect.any(HTMLElement),
+      expect.objectContaining({ id: 'visual-editor:tail' }),
+    )
+
+    const updateConfig = registerDroppable.mock.calls.find(([, config]) =>
+      config.id === 'visual-editor:update:1',
+    )?.[1]
+    const payload = {
+      source: 'file-viewer',
+      type: 'file-system-item',
+      path: '/games/demo/game/scene/chapter2.txt',
+      isDir: false,
+    } as const
+
+    await updateConfig.onDrop(payload, document.createElement('div'))
+
+    expect(handleFileDropMock).toHaveBeenCalledWith(payload, {
+      placement: 'update',
+      insertIndex: 0,
+      statementId: 1,
+    })
+
+    const gapConfig = registerDroppable.mock.calls.find(([, config]) =>
+      config.id === 'visual-editor:gap:1:2',
+    )?.[1]
+
+    await gapConfig.onDrop(payload, document.createElement('div'))
+
+    expect(handleFileDropMock).toHaveBeenCalledWith(payload, {
+      placement: 'gap',
+      insertIndex: 1,
+    })
+
+    const headConfig = registerDroppable.mock.calls.find(([, config]) =>
+      config.id === 'visual-editor:head',
+    )?.[1]
+
+    await headConfig.onDrop(payload, document.createElement('div'))
+
+    expect(handleFileDropMock).toHaveBeenCalledWith(payload, {
+      placement: 'head',
+      insertIndex: 0,
+    })
+  })
+
+  it('文件投放成功后会恢复可视化编辑器焦点', async () => {
+    const registerDroppable = vi.fn()
+    handleFileDropMock.mockReturnValue(true)
+    useDroppableRegistryMock.mockReturnValue({
+      clearHover: vi.fn(),
+      drop: vi.fn(),
+      getMatchAt: vi.fn(),
+      hoveredTarget: shallowRef(),
+      isDropAllowed: shallowRef(false),
+      registerDroppable,
+      unregisterDroppable: vi.fn(),
+      updateHover: vi.fn(),
+    })
+
+    renderInBrowser(VisualEditorScene, {
+      props: { state: createSceneState() },
+      global: {
+        plugins: [createPinia()],
+        stubs: globalStubs,
+      },
+    })
+    await nextTick()
+
+    const headConfig = registerDroppable.mock.calls.find(([, config]) =>
+      config.id === 'visual-editor:head',
+    )?.[1]
+    const payload = {
+      source: 'file-viewer',
+      type: 'file-system-item',
+      path: '/games/demo/game/background/room.png',
+      isDir: false,
+    } as const
+
+    await headConfig.onDrop(payload, document.createElement('div'))
+
+    expect(document.activeElement).toHaveAttribute('tabindex', '-1')
+    expect(useShortcutContextRegistry().resolveContext().panelFocus).toBe('editor')
+  })
+
+  it('拖过插入区时会显示语义化插入指示器', async () => {
+    const registerDroppable = vi.fn()
+    useDroppableRegistryMock.mockReturnValue({
+      clearHover: vi.fn(),
+      drop: vi.fn(),
+      getMatchAt: vi.fn(),
+      hoveredTarget: shallowRef(),
+      isDropAllowed: shallowRef(false),
+      registerDroppable,
+      unregisterDroppable: vi.fn(),
+      updateHover: vi.fn(),
+    })
+
+    const result = renderInBrowser(VisualEditorScene, {
+      props: { state: createSceneState() },
+      global: {
+        plugins: [createPinia()],
+        stubs: globalStubs,
+      },
+    })
+    await nextTick()
+
+    const gapConfig = registerDroppable.mock.calls.find(([, config]) =>
+      config.id === 'visual-editor:gap:1:2',
+    )?.[1]
+    const payload = {
+      source: 'file-viewer',
+      type: 'file-system-item',
+      path: '/games/demo/game/background/room.png',
+      isDir: false,
+    } as const
+
+    gapConfig.onDragEnter(payload)
+    await nextTick()
+
+    const insertIndicator = result.container.querySelector('[data-visual-drop-indicator="insert"]')
+    expect(insertIndicator).not.toBeNull()
+    expect(insertIndicator!.className).toContain('drop-insert-indicator-before')
+    expect((insertIndicator as HTMLElement).style.top).toBe('-0.125rem')
+    expect(result.container.querySelector('[data-visual-drop-indicator="update"]')).toBeNull()
+  })
+
+  it('拖过更新区时会显示语义化更新指示器', async () => {
+    const registerDroppable = vi.fn()
+    useDroppableRegistryMock.mockReturnValue({
+      clearHover: vi.fn(),
+      drop: vi.fn(),
+      getMatchAt: vi.fn(),
+      hoveredTarget: shallowRef(),
+      isDropAllowed: shallowRef(false),
+      registerDroppable,
+      unregisterDroppable: vi.fn(),
+      updateHover: vi.fn(),
+    })
+
+    const result = renderInBrowser(VisualEditorScene, {
+      props: { state: createSceneState() },
+      global: {
+        plugins: [createPinia()],
+        stubs: globalStubs,
+      },
+    })
+    await nextTick()
+
+    const updateConfig = registerDroppable.mock.calls.find(([, config]) =>
+      config.id === 'visual-editor:update:1',
+    )?.[1]
+    const payload = {
+      source: 'file-viewer',
+      type: 'file-system-item',
+      path: '/games/demo/game/scene/chapter2.txt',
+      isDir: false,
+    } as const
+
+    updateConfig.onDragEnter(payload)
+    await nextTick()
+
+    expect(result.container.querySelector('[data-visual-drop-indicator="update"]')).not.toBeNull()
+    expect(result.container.querySelector('[data-visual-drop-indicator="insert"]')).toBeNull()
+  })
+
+  it('切换到更短场景且虚拟行尚未同步时会跳过越界行', async () => {
+    const state = createSceneState()
+    state.statements = [createStatementEntry(1, 'say:only')]
+
+    expect(() => renderInBrowser(VisualEditorScene, {
+      props: { state },
+      global: {
+        plugins: [createPinia()],
+        stubs: globalStubs,
+      },
+    })).not.toThrow()
+
+    await nextTick()
+    await expect.element(page.getByText('say:only')).toBeVisible()
+    await expect.element(page.getByText('say:world')).not.toBeInTheDocument()
   })
 
   it('拖拽语句手柄会提交语句重排', async () => {

--- a/src/components/editor/VisualEditorScene.vue
+++ b/src/components/editor/VisualEditorScene.vue
@@ -1,22 +1,39 @@
 <script setup lang="ts">
 import { useDragSort } from '~/composables/useDragSort'
+import { useDroppableRegistry } from '~/composables/useDroppableRegistry'
 import { useShortcutContext } from '~/features/editor/shortcut/useShortcutContext'
 import { useVisualEditorFocusRequest } from '~/features/editor/visual-editor/useVisualEditorFocusRequest'
 import { useVisualEditorSceneRuntime } from '~/features/editor/visual-editor/useVisualEditorSceneRuntime'
+import { INSERT_BAND_SIZE_PX } from '~/features/editor/visual-editor/visual-editor-file-drop'
 import { findSelectedVisualEditorStatementCard } from '~/features/editor/visual-editor/visual-editor-focus'
 import { useEditSettingsStore } from '~/stores/edit-settings'
 import { SceneVisualProjectionState } from '~/stores/editor'
 import { usePreferenceStore } from '~/stores/preference'
 
+import type { ComponentPublicInstance } from 'vue'
 import type { ScrollArea } from '~/components/ui/scroll-area'
+import type { StatementEntry } from '~/domain/script/sentence'
+import type { VisualEditorFileDropTarget } from '~/features/editor/visual-editor/useVisualEditorSceneRuntime'
 
 interface Props {
   state: SceneVisualProjectionState
 }
 
+interface RenderedVisualStatementRow {
+  insertDropKey: string
+  insertDropSlot: string
+  insertDropTarget: VisualEditorFileDropTarget
+  index: number
+  key: string | number
+  start: number
+  statement: StatementEntry
+  updateDropTarget: VisualEditorFileDropTarget
+}
+
 const props = defineProps<Props>()
 
 const editSettings = useEditSettingsStore()
+const dropRegistry = useDroppableRegistry()
 const editorSurfaceRef = useTemplateRef<HTMLDivElement>('editorSurfaceRef')
 const preferenceStore = usePreferenceStore()
 const scrollAreaRef = useTemplateRef<InstanceType<typeof ScrollArea>>('scrollAreaRef')
@@ -46,6 +63,41 @@ const {
 const statements = computed(() => props.state.statements)
 const scrollViewportRef = shallowRef<HTMLElement>()
 const statementReadonly = $computed(() => preferenceStore.showSidebar && editSettings.collapseStatementsOnSidebarOpen)
+const renderedStatementRows = computed<RenderedVisualStatementRow[]>(() => {
+  const rows: RenderedVisualStatementRow[] = []
+
+  for (const row of unref(virtualRows)) {
+    const statement = props.state.statements[row.index]
+    if (!statement) {
+      continue
+    }
+
+    const previousStatement = row.index === 0 ? undefined : props.state.statements[row.index - 1]
+    if (row.index > 0 && !previousStatement) {
+      continue
+    }
+
+    rows.push({
+      insertDropKey: previousStatement ? `gap:${previousStatement.id}:${statement.id}` : 'head',
+      insertDropSlot: previousStatement ? `gap-${previousStatement.id}-${statement.id}` : 'head',
+      insertDropTarget: {
+        insertIndex: row.index,
+        placement: previousStatement ? 'gap' : 'head',
+      },
+      index: row.index,
+      key: row.key as string | number,
+      start: row.start,
+      statement,
+      updateDropTarget: {
+        insertIndex: row.index,
+        placement: 'update',
+        statementId: statement.id,
+      },
+    })
+  }
+
+  return rows
+})
 const statementSort = useDragSort({
   direction: 'vertical',
   getKey: statement => String(statement.id),
@@ -73,10 +125,106 @@ const statementOverlayPreviousSpeaker = computed(() => {
   const overlayIndex = statementOverlayIndex.value
   return overlayIndex === -1 ? '' : previousSpeakers.value[overlayIndex] ?? ''
 })
+const { height: scrollViewportHeight } = useElementSize(() => scrollViewportRef.value)
+const contentMinHeight = computed(() =>
+  scrollViewportHeight.value > 0 ? `${scrollViewportHeight.value}px` : undefined,
+)
+const statementRowGapSize = computed(() =>
+  editSettings.collapseStatementsOnSidebarOpen ? '0.25rem' : '0.375rem',
+)
+const statementRowGapHalfSize = computed(() =>
+  editSettings.collapseStatementsOnSidebarOpen ? '0.125rem' : '0.1875rem',
+)
+const tailDropAreaSize = `${INSERT_BAND_SIZE_PX * 4}px`
+const tailDropAreaOffset = computed(() =>
+  `calc(-${INSERT_BAND_SIZE_PX * 2}px - ${statementRowGapSize.value})`,
+)
+const headDropTargetTopInset = `-${INSERT_BAND_SIZE_PX}px`
+const headDropIndicatorTopInset = `-${INSERT_BAND_SIZE_PX / 2}px`
+const dropElements = new Map<string, HTMLElement>()
+let activeDropIndicator = $ref<VisualEditorFileDropTarget>()
+const tailDropTarget = $computed<VisualEditorFileDropTarget>(() => ({
+  insertIndex: props.state.statements.length,
+  placement: 'tail',
+}))
 
 function handleStatementSort(fromIndex: number, toIndex: number) {
   reorderStatements(fromIndex, toIndex, { restoreSelectionPresentation: false })
   editorSurfaceRef.value?.focus({ preventScroll: true })
+}
+
+function buildInsertDropStyle(row: RenderedVisualStatementRow): Record<string, string> {
+  return {
+    height: row.index === 0
+      ? `${INSERT_BAND_SIZE_PX * 2}px`
+      : `calc(${INSERT_BAND_SIZE_PX * 2}px + ${statementRowGapSize.value})`,
+    top: row.index === 0
+      ? headDropTargetTopInset
+      : `calc(-${INSERT_BAND_SIZE_PX}px - ${statementRowGapSize.value})`,
+  }
+}
+
+function buildInsertIndicatorStyle(row: RenderedVisualStatementRow): Record<string, string> {
+  return {
+    top: row.index === 0 ? headDropIndicatorTopInset : `-${statementRowGapHalfSize.value}`,
+  }
+}
+
+function resolveHTMLElement(value: Element | ComponentPublicInstance | null): HTMLElement | undefined {
+  return value instanceof HTMLElement ? value : undefined
+}
+
+function setActiveDropIndicator(target?: VisualEditorFileDropTarget) {
+  activeDropIndicator = target
+}
+
+function registerDropTarget(
+  key: string,
+  element: HTMLElement | undefined,
+  target: VisualEditorFileDropTarget,
+) {
+  const previous = dropElements.get(key)
+  if (previous && previous !== element) {
+    dropRegistry.unregisterDroppable(previous)
+    dropElements.delete(key)
+  }
+
+  if (!element) {
+    return
+  }
+
+  dropElements.set(key, element)
+  dropRegistry.registerDroppable(element, {
+    accept: 'file-system-item',
+    canDrop(payload) {
+      return payload.type === 'file-system-item'
+        && runtime.canHandleFileDrop(payload, target)
+    },
+    id: `visual-editor:${key}`,
+    onDragEnter(payload) {
+      if (
+        payload.type !== 'file-system-item'
+        || !runtime.canHandleFileDrop(payload, target)
+      ) {
+        return
+      }
+
+      setActiveDropIndicator(target)
+    },
+    onDragLeave() {
+      setActiveDropIndicator(undefined)
+    },
+    onDrop(payload) {
+      setActiveDropIndicator(undefined)
+      if (payload.type !== 'file-system-item') {
+        return
+      }
+
+      if (runtime.handleFileDrop(payload, target)) {
+        editorSurfaceRef.value?.focus({ preventScroll: true })
+      }
+    },
+  })
 }
 
 function updateScrollViewportRef() {
@@ -114,46 +262,105 @@ useVisualEditorFocusRequest({
 onMounted(() => {
   updateStatementSortRefs()
 })
+
+tryOnUnmounted(() => {
+  for (const element of dropElements.values()) {
+    dropRegistry.unregisterDroppable(element)
+  }
+  dropElements.clear()
+})
 </script>
 
 <template>
   <div ref="editorSurfaceRef" tabindex="-1" class="outline-none h-full">
     <ScrollArea ref="scrollAreaRef" class="h-full" :style="{ opacity: isPositioning ? 0 : 1 }">
-      <div ref="statementListRef" role="listbox" :aria-label="$t('edit.visualEditor.statementList')" :style="{ height: `${totalSize}px`, width: '100%', position: 'relative' }">
+      <div
+        class="flex flex-col"
+        data-visual-editor-content
+        :style="{ minHeight: contentMinHeight }"
+      >
+        <div ref="statementListRef" role="listbox" :aria-label="$t('edit.visualEditor.statementList')" :style="{ height: `${totalSize}px`, width: '100%', position: 'relative' }">
+          <div
+            v-for="row in renderedStatementRows"
+            :key="row.key"
+            :ref="measureRowElement"
+            :data-index="row.index"
+            class="px-2"
+            :class="editSettings.collapseStatementsOnSidebarOpen ? 'pb-1' : 'pb-1.5'"
+            :style="{
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              width: '100%',
+              transform: `translateY(${row.start}px)`,
+            }"
+          >
+            <div
+              v-bind="statementSort.getItemProps(row.index)"
+              :style="statementSort.getItemStyle(row.index)"
+              class="relative"
+            >
+              <div
+                :ref="value => registerDropTarget(row.insertDropKey, resolveHTMLElement(value), row.insertDropTarget)"
+                :data-visual-drop-slot="row.insertDropSlot"
+                class="inset-x-0 absolute z-10"
+                :style="buildInsertDropStyle(row)"
+              />
+
+              <div
+                :ref="value => registerDropTarget(`update:${row.statement.id}`, resolveHTMLElement(value), row.updateDropTarget)"
+                class="relative"
+              >
+                <VisualEditorStatementCard
+                  :collapsed="isStatementCollapsed(row.statement.id)"
+                  :entry="row.statement"
+                  :index="row.index"
+                  :play-to-disabled="props.state.isDirty"
+                  :selected="row.statement.id === selectedStatementId"
+                  :readonly="statementReadonly"
+                  :previous-speaker="previousSpeakers[row.index]"
+                  @update="handleStatementUpdate"
+                  @update:collapsed="val => handleCollapsedUpdate(row.statement.id, val)"
+                  @select="handleSelect"
+                  @delete="handleStatementDelete"
+                  @play-to="handlePlayTo"
+                />
+              </div>
+
+              <div
+                v-if="(activeDropIndicator?.placement === 'head' && row.index === 0) || (activeDropIndicator?.placement === 'gap' && activeDropIndicator.insertIndex === row.index)"
+                data-visual-drop-indicator="insert"
+                aria-hidden="true"
+                :class="[$style.dropInsertIndicator, $style.dropInsertIndicatorBefore]"
+                :style="buildInsertIndicatorStyle(row)"
+              />
+              <div
+                v-if="activeDropIndicator?.placement === 'update' && activeDropIndicator.statementId === row.statement.id"
+                data-visual-drop-indicator="update"
+                aria-hidden="true"
+                :class="$style.dropUpdateIndicator"
+              />
+            </div>
+          </div>
+        </div>
+
         <div
-          v-for="row in virtualRows"
-          :key="(row.key as number)"
-          :ref="measureRowElement"
-          :data-index="row.index"
-          class="px-2"
-          :class="editSettings.collapseStatementsOnSidebarOpen ? 'pb-1' : 'pb-1.5'"
+          :ref="value => registerDropTarget('tail', resolveHTMLElement(value), tailDropTarget)"
+          data-visual-drop-slot="tail"
+          class="mx-2 flex-1 relative"
           :style="{
-            position: 'absolute',
-            top: 0,
-            left: 0,
-            width: '100%',
-            transform: `translateY(${row.start}px)`,
+            flexBasis: tailDropAreaSize,
+            minHeight: tailDropAreaSize,
+            marginTop: tailDropAreaOffset,
           }"
         >
           <div
-            v-bind="statementSort.getItemProps(row.index)"
-            :style="statementSort.getItemStyle(row.index)"
-          >
-            <VisualEditorStatementCard
-              :collapsed="isStatementCollapsed(props.state.statements[row.index].id)"
-              :entry="props.state.statements[row.index]"
-              :index="row.index"
-              :play-to-disabled="props.state.isDirty"
-              :selected="props.state.statements[row.index].id === selectedStatementId"
-              :readonly="statementReadonly"
-              :previous-speaker="previousSpeakers[row.index]"
-              @update="handleStatementUpdate"
-              @update:collapsed="val => handleCollapsedUpdate(props.state.statements[row.index].id, val)"
-              @select="handleSelect"
-              @delete="handleStatementDelete"
-              @play-to="handlePlayTo"
-            />
-          </div>
+            v-if="activeDropIndicator?.placement === 'tail'"
+            data-visual-drop-indicator="insert"
+            aria-hidden="true"
+            :class="[$style.dropInsertIndicator, $style.dropInsertIndicatorBefore]"
+            :style="{ top: '12px' }"
+          />
         </div>
       </div>
     </ScrollArea>
@@ -183,3 +390,57 @@ onMounted(() => {
     </DragOverlay>
   </div>
 </template>
+
+<style module>
+.drop-insert-indicator {
+  --drop-indicator-rgb: 14 165 233;
+
+  position: absolute;
+  right: 0.75rem;
+  left: 0.75rem;
+  z-index: 20;
+  height: 0.5rem;
+  pointer-events: none;
+  background: rgb(var(--drop-indicator-rgb) / 14%);
+  border-radius: 9999px;
+}
+
+.drop-insert-indicator::before {
+  position: absolute;
+  inset: 0.1875rem 0.5rem;
+  content: "";
+  background: rgb(var(--drop-indicator-rgb) / 86%);
+  border-radius: inherit;
+  box-shadow:
+    0 0 0 1px rgb(var(--drop-indicator-rgb) / 22%),
+    0 0 0.75rem rgb(var(--drop-indicator-rgb) / 26%);
+}
+
+.drop-insert-indicator-before {
+  top: 0;
+  transform: translateY(-50%);
+}
+
+.drop-update-indicator {
+  --drop-indicator-rgb: 14 165 233;
+
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background:
+    linear-gradient(
+      90deg,
+      rgb(var(--drop-indicator-rgb) / 10%),
+      rgb(var(--drop-indicator-rgb) / 5%)
+    );
+  border-radius: 0.5rem;
+  box-shadow:
+    inset 0 0 0 1px rgb(var(--drop-indicator-rgb) / 36%),
+    0 0 0.75rem rgb(var(--drop-indicator-rgb) / 14%);
+}
+
+:global(.dark) .drop-insert-indicator,
+:global(.dark) .drop-update-indicator {
+  --drop-indicator-rgb: 56 189 248;
+}
+</style>

--- a/src/features/editor/shared/__tests__/editor-file-drop.test.ts
+++ b/src/features/editor/shared/__tests__/editor-file-drop.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from 'vitest'
+
+import { AbsPath } from '~/domain/path'
+import {
+  buildInsertedStatementText,
+  resolveEditorDropAsset,
+  updateStatementTextForDroppedAsset,
+} from '~/features/editor/shared/editor-file-drop'
+
+import type { FileSystemDragPayload } from '~/types/drag-drop'
+
+function createPayload(path: string): FileSystemDragPayload {
+  return {
+    source: 'file-viewer',
+    type: 'file-system-item',
+    path,
+    isDir: false,
+    name: path.split('/').at(-1),
+  }
+}
+
+function createSingleItemPayload(path: string): FileSystemDragPayload {
+  return {
+    ...createPayload(path),
+    items: [{
+      isDir: false,
+      name: path.split('/').at(-1),
+      path,
+    }],
+  }
+}
+
+describe('editor-file-drop', () => {
+  it('background 资源会被识别为脚本字段路径', () => {
+    const asset = resolveEditorDropAsset({
+      gamePath: AbsPath.from('/games/demo'),
+      payload: createPayload('/games/demo/game/background/room.png'),
+    })
+
+    expect(asset).toMatchObject({
+      assetType: 'background',
+      scriptPath: 'room.png',
+    })
+  })
+
+  it('真实单文件拖拽 payload 带单项 items 时仍会识别资源', () => {
+    const asset = resolveEditorDropAsset({
+      gamePath: AbsPath.from('/games/demo'),
+      payload: createSingleItemPayload('/games/demo/game/background/room.png'),
+    })
+
+    expect(asset).toMatchObject({
+      assetType: 'background',
+      scriptPath: 'room.png',
+    })
+  })
+
+  it('animationTable.json 会被拒绝', () => {
+    const asset = resolveEditorDropAsset({
+      gamePath: AbsPath.from('/games/demo'),
+      payload: createPayload('/games/demo/game/animation/animationTable.json'),
+    })
+
+    expect(asset).toBeUndefined()
+  })
+
+  it('animation 资源写入脚本字段时只去掉 .json 后缀', () => {
+    const asset = resolveEditorDropAsset({
+      gamePath: AbsPath.from('/games/demo'),
+      payload: createPayload('/games/demo/game/animation/fade/in.json'),
+    })!
+
+    expect(asset).toMatchObject({
+      assetType: 'animation',
+      scriptPath: 'fade/in',
+    })
+    expect(buildInsertedStatementText(asset)).toBe('setAnimation:fade/in;')
+    expect(updateStatementTextForDroppedAsset('setAnimation:old;', asset)).toBe('setAnimation:fade/in;')
+  })
+
+  it('animation 非 json 文件会被拒绝', () => {
+    const asset = resolveEditorDropAsset({
+      gamePath: AbsPath.from('/games/demo'),
+      payload: createPayload('/games/demo/game/animation/fade/in.png'),
+    })
+
+    expect(asset).toBeUndefined()
+  })
+
+  it('game 根外资源会被拒绝而不是抛出异常', () => {
+    expect(() => resolveEditorDropAsset({
+      gamePath: AbsPath.from('/games/demo'),
+      payload: createPayload('/downloads/room.png'),
+    })).not.toThrow()
+
+    expect(resolveEditorDropAsset({
+      gamePath: AbsPath.from('/games/demo'),
+      payload: createPayload('/downloads/room.png'),
+    })).toBeUndefined()
+  })
+
+  it('scene 非 txt 会被拒绝', () => {
+    const asset = resolveEditorDropAsset({
+      gamePath: AbsPath.from('/games/demo'),
+      payload: createPayload('/games/demo/game/scene/chapter2.json'),
+    })
+
+    expect(asset).toBeUndefined()
+  })
+
+  it('video 资源会生成 playVideo 语句', () => {
+    const asset = resolveEditorDropAsset({
+      gamePath: AbsPath.from('/games/demo'),
+      payload: createPayload('/games/demo/game/video/opening.webm'),
+    })!
+
+    expect(buildInsertedStatementText(asset)).toBe('playVideo:opening.webm;')
+  })
+
+  it('say 行投放 vocal 会更新 vocal 参数', () => {
+    const asset = resolveEditorDropAsset({
+      gamePath: AbsPath.from('/games/demo'),
+      payload: createPayload('/games/demo/game/vocal/line-1.ogg'),
+    })!
+
+    const nextRawText = updateStatementTextForDroppedAsset('say:你好 -speaker=Alice;', asset)
+    expect(nextRawText).toBe('say:你好 -speaker=Alice -line-1.ogg;')
+  })
+
+  it('choose 行投放 scene 会追加 file 而不是覆盖 content', () => {
+    const asset = resolveEditorDropAsset({
+      gamePath: AbsPath.from('/games/demo'),
+      payload: createPayload('/games/demo/game/scene/chapter2.txt'),
+    })!
+
+    const nextRawText = updateStatementTextForDroppedAsset('choose::a.txt;', asset)
+    expect(nextRawText).toBe('choose::a.txt|:chapter2.txt;')
+  })
+
+  it('choose 行投放 scene 会优先补全末尾空 file 选项', () => {
+    const asset = resolveEditorDropAsset({
+      gamePath: AbsPath.from('/games/demo'),
+      payload: createPayload('/games/demo/game/scene/good.txt'),
+    })!
+
+    const nextRawText = updateStatementTextForDroppedAsset('choose:拒绝:bad.txt|同意:;', asset)
+    expect(nextRawText).toBe('choose:拒绝:bad.txt|同意:good.txt;')
+  })
+
+  it('choose 行只有中间选项 file 为空时仍追加 scene', () => {
+    const asset = resolveEditorDropAsset({
+      gamePath: AbsPath.from('/games/demo'),
+      payload: createPayload('/games/demo/game/scene/good.txt'),
+    })!
+
+    const nextRawText = updateStatementTextForDroppedAsset('choose:同意:|拒绝:bad.txt;', asset)
+    expect(nextRawText).toBe('choose:同意:|拒绝:bad.txt|:good.txt;')
+  })
+
+  it('非兼容语句返回 undefined，供上层显示禁止态或走路径插入', () => {
+    const asset = resolveEditorDropAsset({
+      gamePath: AbsPath.from('/games/demo'),
+      payload: createPayload('/games/demo/game/bgm/theme.ogg'),
+    })!
+
+    expect(updateStatementTextForDroppedAsset('changeBg:room.png;', asset)).toBeUndefined()
+  })
+})

--- a/src/features/editor/shared/editor-file-drop.ts
+++ b/src/features/editor/shared/editor-file-drop.ts
@@ -1,0 +1,225 @@
+import { commandType } from 'webgal-parser/src/interface/sceneInterface'
+
+import { AbsPath } from '~/domain/path'
+import { parseCommandNode, serializeCommandNode } from '~/domain/script/codec'
+import { parseSentence } from '~/domain/script/parser'
+import { serializeSentence } from '~/domain/script/serialize'
+import { updateCommandNodeContent, updateCommandNodeParam } from '~/domain/script/update'
+import { gameAssetDir, gameSceneDir } from '~/services/platform/app-paths'
+
+import type { ISentence } from 'webgal-parser/src/interface/sceneInterface'
+import type { CommandParamDescriptor } from '~/domain/script/params'
+import type { CommandNode } from '~/domain/script/types'
+import type { FileSystemDragPayload } from '~/types/drag-drop'
+
+export type EditorDropAssetType =
+  | 'background'
+  | 'figure'
+  | 'bgm'
+  | 'vocal'
+  | 'video'
+  | 'animation'
+  | 'scene'
+
+export interface EditorDropAsset {
+  assetType: EditorDropAssetType
+  scriptPath: string
+}
+
+interface AssetRootCandidate {
+  assetType: EditorDropAssetType
+  rootPath: AbsPath
+}
+
+interface DroppedFileItem {
+  isDir: boolean
+  path: string
+}
+
+const SAY_VOCAL_PARAM: CommandParamDescriptor = { key: 'vocal', type: 'file' }
+const INTRO_BACKGROUND_PARAM: CommandParamDescriptor = { key: 'backgroundImage', type: 'file' }
+const ANIMATION_TABLE_FILE_NAME = 'animationTable.json'
+const JSON_FILE_SUFFIX = '.json'
+const TXT_FILE_SUFFIX = '.txt'
+
+const INSERTED_STATEMENT_COMMANDS: Record<EditorDropAssetType, {
+  command: commandType
+  commandRaw: string
+}> = {
+  animation: { command: commandType.setAnimation, commandRaw: 'setAnimation' },
+  background: { command: commandType.changeBg, commandRaw: 'changeBg' },
+  bgm: { command: commandType.bgm, commandRaw: 'bgm' },
+  figure: { command: commandType.changeFigure, commandRaw: 'changeFigure' },
+  scene: { command: commandType.changeScene, commandRaw: 'changeScene' },
+  video: { command: commandType.video, commandRaw: 'playVideo' },
+  vocal: { command: commandType.playEffect, commandRaw: 'playEffect' },
+}
+
+const CONTENT_UPDATE_COMMANDS: Record<EditorDropAssetType, readonly commandType[]> = {
+  animation: [commandType.setAnimation],
+  background: [commandType.changeBg, commandType.unlockCg],
+  bgm: [commandType.bgm, commandType.unlockBgm],
+  figure: [commandType.changeFigure, commandType.miniAvatar],
+  scene: [commandType.changeScene, commandType.callScene],
+  video: [commandType.video],
+  vocal: [commandType.playEffect],
+}
+
+function createSentence(command: commandType, commandRaw: string, content: string): ISentence {
+  return {
+    command,
+    commandRaw,
+    content,
+    args: [],
+    inlineComment: '',
+    sentenceAssets: [],
+    subScene: [],
+  }
+}
+
+function createAssetRootCandidates(gamePath: AbsPath): AssetRootCandidate[] {
+  return [
+    { assetType: 'background', rootPath: gameAssetDir(gamePath, 'background') },
+    { assetType: 'figure', rootPath: gameAssetDir(gamePath, 'figure') },
+    { assetType: 'bgm', rootPath: gameAssetDir(gamePath, 'bgm') },
+    { assetType: 'vocal', rootPath: gameAssetDir(gamePath, 'vocal') },
+    { assetType: 'video', rootPath: gameAssetDir(gamePath, 'video') },
+    { assetType: 'animation', rootPath: gameAssetDir(gamePath, 'animation') },
+    { assetType: 'scene', rootPath: gameSceneDir(gamePath) },
+  ]
+}
+
+function resolveAnimationScriptPath(scriptPath: string): string | undefined {
+  const normalizedScriptPath = scriptPath.toLowerCase()
+  if (!normalizedScriptPath.endsWith(JSON_FILE_SUFFIX)) {
+    return undefined
+  }
+  if (normalizedScriptPath === ANIMATION_TABLE_FILE_NAME.toLowerCase()) {
+    return undefined
+  }
+
+  return scriptPath.slice(0, -JSON_FILE_SUFFIX.length)
+}
+
+function resolveScriptPath(assetType: EditorDropAssetType, scriptPath: string): string | undefined {
+  if (assetType === 'animation') {
+    return resolveAnimationScriptPath(scriptPath)
+  }
+
+  if (assetType === 'scene' && !scriptPath.toLowerCase().endsWith(TXT_FILE_SUFFIX)) {
+    return undefined
+  }
+
+  return scriptPath
+}
+
+function resolveSingleDroppedFile(payload: FileSystemDragPayload): DroppedFileItem | undefined {
+  if (payload.items && payload.items.length > 1) {
+    return undefined
+  }
+
+  const item = payload.items?.[0] ?? payload
+  return item.isDir ? undefined : item
+}
+
+export function resolveEditorDropAsset(options: {
+  gamePath: AbsPath
+  payload: FileSystemDragPayload
+}): EditorDropAsset | undefined {
+  const { gamePath, payload } = options
+  const item = resolveSingleDroppedFile(payload)
+  if (!item) {
+    return undefined
+  }
+
+  let sourcePath: AbsPath
+  try {
+    sourcePath = AbsPath.from(item.path)
+  } catch {
+    return undefined
+  }
+
+  for (const { assetType, rootPath } of createAssetRootCandidates(gamePath)) {
+    try {
+      const scriptPath = AbsPath.relativize(sourcePath, rootPath)
+      const normalizedScriptPath = resolveScriptPath(assetType, scriptPath)
+      if (!normalizedScriptPath) {
+        return undefined
+      }
+      return {
+        assetType,
+        scriptPath: normalizedScriptPath,
+      }
+    } catch {
+      // 不是当前资源目录，继续尝试下一个候选目录。
+      continue
+    }
+  }
+
+  return undefined
+}
+
+export function buildInsertedStatementText(asset: EditorDropAsset): string {
+  const { command, commandRaw } = INSERTED_STATEMENT_COMMANDS[asset.assetType]
+  return serializeSentence(createSentence(command, commandRaw, asset.scriptPath))
+}
+
+function supportsContentUpdate(asset: EditorDropAsset, type: commandType): boolean {
+  return CONTENT_UPDATE_COMMANDS[asset.assetType].includes(type)
+}
+
+function upsertChooseSceneChoice(node: Extract<CommandNode, { type: commandType.choose }>, file: string): CommandNode {
+  const lastChoice = node.choices.at(-1)
+  if (!lastChoice || lastChoice.file.trim().length > 0) {
+    return {
+      ...node,
+      choices: [...node.choices, { name: '', file }],
+    }
+  }
+
+  return {
+    ...node,
+    choices: [
+      ...node.choices.slice(0, -1),
+      { ...lastChoice, file },
+    ],
+  }
+}
+
+export function updateStatementTextForDroppedAsset(rawText: string, asset: EditorDropAsset): string | undefined {
+  const sentence = parseSentence(rawText)
+  if (!sentence) {
+    return undefined
+  }
+
+  const node = parseCommandNode(sentence)
+
+  if (asset.assetType === 'scene' && node.type === commandType.choose) {
+    return serializeSentence(serializeCommandNode(upsertChooseSceneChoice(node, asset.scriptPath)))
+  }
+
+  if (asset.assetType === 'background' && node.type === commandType.intro) {
+    const updated = updateCommandNodeParam(node, INTRO_BACKGROUND_PARAM, asset.scriptPath)
+    return updated ? serializeSentence(serializeCommandNode(updated)) : undefined
+  }
+
+  if (asset.assetType === 'vocal' && node.type === commandType.say) {
+    const updated = updateCommandNodeParam(node, SAY_VOCAL_PARAM, asset.scriptPath)
+    if (!updated) {
+      return undefined
+    }
+
+    const serialized = serializeCommandNode(updated)
+    return serializeSentence(sentence.commandRaw === 'say'
+      ? { ...serialized, commandRaw: 'say' }
+      : serialized)
+  }
+
+  if (!supportsContentUpdate(asset, node.type)) {
+    return undefined
+  }
+
+  return serializeSentence(serializeCommandNode(
+    updateCommandNodeContent(node, asset.scriptPath),
+  ))
+}

--- a/src/features/editor/text-editor/__tests__/text-editor-file-drop.test.ts
+++ b/src/features/editor/text-editor/__tests__/text-editor-file-drop.test.ts
@@ -1,0 +1,192 @@
+import * as monaco from 'monaco-editor'
+import { describe, expect, it, vi } from 'vitest'
+
+import { AbsPath } from '~/domain/path'
+import { resolveTextEditorFileDropAction } from '~/features/editor/text-editor/text-editor-file-drop'
+
+import type { FileSystemDragPayload } from '~/types/drag-drop'
+
+vi.mock('monaco-editor', async () => {
+  const { createMonacoMockModule } = await import('~/__tests__/mocks/monaco')
+  return createMonacoMockModule()
+})
+
+function createPayload(path: string): FileSystemDragPayload {
+  return {
+    source: 'file-viewer',
+    type: 'file-system-item',
+    path,
+    isDir: false,
+    name: path.split('/').at(-1),
+  }
+}
+
+function createMouseTarget(lineNumber: number, column: number): monaco.editor.IMouseTargetContentText {
+  const position = new monaco.Position(lineNumber, column)
+  const range = new monaco.Range(lineNumber, column, lineNumber, column)
+  return {
+    detail: {
+      mightBeForeignElement: false,
+    },
+    // Monaco 的 IMouseTarget 契约显式用 null 表示没有关联 DOM 元素。
+    // eslint-disable-next-line unicorn/no-null
+    element: null,
+    mouseColumn: column,
+    position,
+    range,
+    type: monaco.editor.MouseTargetType.CONTENT_TEXT,
+  }
+}
+
+function createEmptyMouseTarget(lineNumber: number, column: number): monaco.editor.IMouseTargetContentEmpty {
+  const position = new monaco.Position(lineNumber, column)
+  const range = new monaco.Range(lineNumber, column, lineNumber, column)
+  return {
+    detail: {
+      isAfterLines: false,
+    },
+    // Monaco 的 IMouseTarget 契约显式用 null 表示没有关联 DOM 元素。
+    // eslint-disable-next-line unicorn/no-null
+    element: null,
+    mouseColumn: column,
+    position,
+    range,
+    type: monaco.editor.MouseTargetType.CONTENT_EMPTY,
+  }
+}
+
+function createEditorDouble(lines: string[]) {
+  const model = {
+    getLineContent(lineNumber: number) {
+      return lines[lineNumber - 1] ?? ''
+    },
+    getLineCount() {
+      return lines.length
+    },
+    getLineMaxColumn(lineNumber: number) {
+      return (lines[lineNumber - 1] ?? '').length + 1
+    },
+  }
+
+  return {
+    getModel: () => model,
+    getSelections: () => [{ startLineNumber: 2, endLineNumber: 2 }],
+    getTargetAtClientPoint: vi.fn(() => createMouseTarget(2, 1)),
+  } as unknown as monaco.editor.IStandaloneCodeEditor
+}
+
+describe('text-editor-file-drop', () => {
+  it('空行投放 background 会生成完整语句行插入动作', () => {
+    const editor = createEditorDouble(['say:hello;', ''])
+
+    const action = resolveTextEditorFileDropAction({
+      editor,
+      gamePath: AbsPath.from('/games/demo'),
+      payload: createPayload('/games/demo/game/background/room.png'),
+      position: { x: 100, y: 40 },
+    })
+
+    expect(action).toMatchObject({
+      kind: 'insert-statement-line',
+      text: 'changeBg:room.png;',
+      range: { startLineNumber: 2, startColumn: 1, endLineNumber: 2, endColumn: 1 },
+    })
+  })
+
+  it('非空行行首投放 background 会生成上一行插入动作', () => {
+    const editor = createEditorDouble(['say:hello;', 'changeBg:old.png;'])
+    editor.getTargetAtClientPoint = vi.fn(() => createMouseTarget(2, 1))
+
+    const action = resolveTextEditorFileDropAction({
+      editor,
+      gamePath: AbsPath.from('/games/demo'),
+      payload: createPayload('/games/demo/game/background/room.png'),
+      position: { x: 20, y: 40 },
+    })
+
+    expect(action).toMatchObject({
+      kind: 'insert-statement-line',
+      text: 'changeBg:room.png;\n',
+      range: { startLineNumber: 2, startColumn: 1, endLineNumber: 2, endColumn: 1 },
+    })
+  })
+
+  it('兼容的 say 行投放 vocal 会生成语句更新动作', () => {
+    const editor = createEditorDouble(['say:hello;', 'say:world -speaker=Bob;'])
+    editor.getTargetAtClientPoint = vi.fn(() => createMouseTarget(2, 10))
+
+    const action = resolveTextEditorFileDropAction({
+      editor,
+      gamePath: AbsPath.from('/games/demo'),
+      payload: createPayload('/games/demo/game/vocal/line-2.ogg'),
+      position: { x: 80, y: 40 },
+    })
+
+    expect(action).toMatchObject({
+      kind: 'update-statement',
+      caretRange: { startLineNumber: 2, startColumn: 10, endLineNumber: 2, endColumn: 10 },
+      payload: {
+        rawText: 'say:world -speaker=Bob -line-2.ogg;',
+      },
+    })
+  })
+
+  it('非兼容行会退化为资源目录内路径插入', () => {
+    const editor = createEditorDouble(['say:hello;', 'say:world;'])
+    editor.getTargetAtClientPoint = vi.fn(() => createMouseTarget(2, 5))
+
+    const action = resolveTextEditorFileDropAction({
+      editor,
+      gamePath: AbsPath.from('/games/demo'),
+      payload: createPayload('/games/demo/game/background/room.png'),
+      position: { x: 80, y: 40 },
+    })
+
+    expect(action).toMatchObject({
+      kind: 'insert-text',
+      text: 'room.png',
+      range: { startLineNumber: 2, startColumn: 5, endLineNumber: 2, endColumn: 5 },
+    })
+  })
+
+  it('内容空白区命中仍会按 Monaco 返回位置生成插入动作', () => {
+    const editor = createEditorDouble(['say:hello;', 'plain text'])
+    editor.getTargetAtClientPoint = vi.fn(() => createEmptyMouseTarget(2, 11))
+
+    const action = resolveTextEditorFileDropAction({
+      editor,
+      gamePath: AbsPath.from('/games/demo'),
+      payload: createPayload('/games/demo/game/background/room.png'),
+      position: { x: 240, y: 40 },
+    })
+
+    expect(action).toMatchObject({
+      kind: 'insert-text',
+      range: { startLineNumber: 2, startColumn: 11, endLineNumber: 2, endColumn: 11 },
+    })
+  })
+
+  it('scene 非 txt 会被拒绝，不产生 drop action', () => {
+    const editor = createEditorDouble(['', ''])
+    const action = resolveTextEditorFileDropAction({
+      editor,
+      gamePath: AbsPath.from('/games/demo'),
+      payload: createPayload('/games/demo/game/scene/chapter2.json'),
+      position: { x: 40, y: 20 },
+    })
+
+    expect(action).toBeUndefined()
+  })
+
+  it('animationTable.json 不会在文本编辑器中产生 drop action', () => {
+    const editor = createEditorDouble(['', ''])
+    const action = resolveTextEditorFileDropAction({
+      editor,
+      gamePath: AbsPath.from('/games/demo'),
+      payload: createPayload('/games/demo/game/animation/animationTable.json'),
+      position: { x: 40, y: 20 },
+    })
+
+    expect(action).toBeUndefined()
+  })
+})

--- a/src/features/editor/text-editor/__tests__/useTextEditorBindings.test.ts
+++ b/src/features/editor/text-editor/__tests__/useTextEditorBindings.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { createSSRApp, defineComponent, h, nextTick, ref, shallowRef } from 'vue'
 import { renderToString } from 'vue/server-renderer'
+import { commandType } from 'webgal-parser/src/interface/sceneInterface'
 
 const {
   getSceneSelectionMock,
@@ -30,11 +31,23 @@ import { AbsPath } from '~/domain/path'
 import { useCommandPanelBridgeProvider, useSidebarPanelProvider } from '~/features/editor/shared/useEditorPanelBindings'
 import { useTextEditorBindings } from '~/features/editor/text-editor/useTextEditorBindings'
 
-import type { SidebarPanelBinding } from '~/features/editor/shared/useEditorPanelBindings'
+import type { CommandPanelHandler, SidebarPanelBinding } from '~/features/editor/shared/useEditorPanelBindings'
 import type { TextProjectionState } from '~/stores/editor'
 
 interface Harness {
   bindings: ReturnType<typeof useTextEditorBindings>
+  editor: {
+    executeEdits: ReturnType<typeof vi.fn>
+    focus: ReturnType<typeof vi.fn>
+    getModel: ReturnType<typeof vi.fn>
+    getPosition: ReturnType<typeof vi.fn>
+    revealPositionInCenterIfOutsideViewport: ReturnType<typeof vi.fn>
+    setPosition: ReturnType<typeof vi.fn>
+  }
+  formPanel: {
+    handleFormUpdate: ReturnType<typeof vi.fn>
+  }
+  readCommandPanelHandler: () => CommandPanelHandler | undefined
   readSidebarBinding: () => SidebarPanelBinding | undefined
 }
 
@@ -52,18 +65,37 @@ function createTextState(textContent: string): TextProjectionState {
 
 async function mountHarness(textContent: string): Promise<Harness> {
   const state = ref(createTextState(textContent))
+  const editor = {
+    executeEdits: vi.fn(),
+    focus: vi.fn(),
+    getModel: vi.fn(),
+    getPosition: vi.fn(),
+    revealPositionInCenterIfOutsideViewport: vi.fn(),
+    setPosition: vi.fn(),
+  }
+  const model = {
+    getLineContent: vi.fn((lineNumber: number) => textContent.split('\n')[lineNumber - 1] ?? ''),
+    getLineCount: vi.fn(() => textContent.split('\n').length),
+    getLineMaxColumn: vi.fn((lineNumber: number) => (textContent.split('\n')[lineNumber - 1] ?? '').length + 1),
+    getValueInRange: vi.fn(() => ''),
+  }
+  editor.getModel.mockReturnValue(model)
+  editor.getPosition.mockReturnValue({ lineNumber: 2, column: 3 })
+
   let readSidebarBinding = () => undefined as SidebarPanelBinding | undefined
+  let readCommandPanelHandler = () => undefined as CommandPanelHandler | undefined
   let bindings = undefined as ReturnType<typeof useTextEditorBindings> | undefined
+  const formPanel = {
+    handleFormUpdate: vi.fn(() => false),
+  }
 
   const BindingConsumer = defineComponent({
     setup() {
       bindings = useTextEditorBindings({
-        editorRef: shallowRef(),
+        editorRef: shallowRef(editor as never),
         getState: () => state.value,
         isCurrentTextProjectionActive: () => true,
-        formPanel: {
-          handleFormUpdate: vi.fn(() => false),
-        },
+        formPanel,
         textEditorHistory: {
           captureBeforeContentChange: vi.fn(),
           handleRedo: vi.fn(),
@@ -78,17 +110,22 @@ async function mountHarness(textContent: string): Promise<Harness> {
   const app = createSSRApp(defineComponent({
     setup() {
       const sidebarPanel = useSidebarPanelProvider()
-      useCommandPanelBridgeProvider()
+      const commandPanel = useCommandPanelBridgeProvider()
 
       readSidebarBinding = () => sidebarPanel.activeBinding.value
+      readCommandPanelHandler = () => commandPanel.activeBinding.value
       return () => h(BindingConsumer)
     },
   }))
 
   await renderToString(app)
+  await nextTick()
 
   const harness: Harness = {
     bindings: bindings!,
+    editor,
+    formPanel,
+    readCommandPanelHandler,
     readSidebarBinding,
   }
 
@@ -232,5 +269,91 @@ describe('useTextEditorBindings', () => {
     expect(binding?.getEntry()).toBeDefined()
     expect(binding?.getUpdateTarget?.()).toBeDefined()
     expect(binding?.getEmptyState?.()).not.toBe('multiple-edit-targets')
+  })
+
+  it('命令面板插入单条命令后会把光标移动到插入文本末尾', async () => {
+    getSceneSelectionMock.mockReturnValue(undefined)
+    useEditSettingsStoreMock.mockReturnValue({
+      commandInsertPosition: 'cursor',
+    })
+    useCommandPanelStoreMock.mockReturnValue({
+      getInsertText: vi.fn(() => 'changeBg:room.png;'),
+    })
+
+    const harness = await mountHarness('say:hello;\nold line')
+    await flushBindingUpdates()
+
+    harness.readCommandPanelHandler()?.insertCommand(commandType.say)
+
+    expect(harness.editor.executeEdits).toHaveBeenCalledWith('command-panel', [{
+      range: {
+        startLineNumber: 2,
+        startColumn: 9,
+        endLineNumber: 2,
+        endColumn: 9,
+      },
+      text: '\nchangeBg:room.png;',
+      forceMoveMarkers: true,
+    }])
+    expect(harness.editor.setPosition).toHaveBeenCalledWith({ lineNumber: 3, column: 19 })
+    expect(harness.editor.revealPositionInCenterIfOutsideViewport).toHaveBeenCalledWith({ lineNumber: 3, column: 19 })
+  })
+
+  it('插入命令组后会把光标移动到最后一行末尾', async () => {
+    getSceneSelectionMock.mockReturnValue(undefined)
+    useEditSettingsStoreMock.mockReturnValue({
+      commandInsertPosition: 'cursor',
+    })
+    useCommandPanelStoreMock.mockReturnValue({
+      getInsertText: vi.fn(),
+    })
+
+    const harness = await mountHarness('say:hello;\nold line')
+    await flushBindingUpdates()
+
+    harness.readCommandPanelHandler()?.insertGroup({
+      id: 'group-1',
+      name: 'scene setup',
+      rawTexts: ['changeBg:room.png;', 'playBgm:bgm.ogg;'],
+      createdAt: 1,
+    })
+
+    expect(harness.editor.executeEdits).toHaveBeenCalledWith('command-panel', [{
+      range: {
+        startLineNumber: 2,
+        startColumn: 9,
+        endLineNumber: 2,
+        endColumn: 9,
+      },
+      text: '\nchangeBg:room.png;\nplayBgm:bgm.ogg;',
+      forceMoveMarkers: true,
+    }])
+    expect(harness.editor.setPosition).toHaveBeenCalledWith({ lineNumber: 4, column: 17 })
+    expect(harness.editor.revealPositionInCenterIfOutsideViewport).toHaveBeenCalledWith({ lineNumber: 4, column: 17 })
+  })
+
+  it('程序化语句更新会保留指定事务来源', async () => {
+    getSceneSelectionMock.mockReturnValue(undefined)
+    useEditSettingsStoreMock.mockReturnValue({
+      commandInsertPosition: 'cursor',
+    })
+    useCommandPanelStoreMock.mockReturnValue({
+      getInsertText: vi.fn(),
+    })
+
+    const harness = await mountHarness('say:hello;')
+    await flushBindingUpdates()
+
+    harness.formPanel.handleFormUpdate.mockReturnValue(true)
+    expect(harness.bindings.applyProgrammaticStatementUpdate({
+      target: {
+        kind: 'line',
+        lineNumber: 1,
+      },
+      rawText: 'say:world;',
+      parsed: {} as never,
+    }, 'external')).toBe(true)
+
+    expect(harness.bindings.consumePendingTextTransactionSource()).toBe('external')
   })
 })

--- a/src/features/editor/text-editor/__tests__/useTextEditorRuntime-preview-sync.test.ts
+++ b/src/features/editor/text-editor/__tests__/useTextEditorRuntime-preview-sync.test.ts
@@ -3,6 +3,7 @@ import { effectScope, nextTick, reactive, shallowRef } from 'vue'
 
 import { useTextEditorRuntime } from '~/features/editor/text-editor/useTextEditorRuntime'
 
+import type * as monaco from 'monaco-editor'
 import type { TextProjectionState } from '~/stores/editor'
 
 const {
@@ -14,6 +15,8 @@ const {
   resolveScenePreviewLineMock,
   useEditorStoreMock,
   useTabsStoreMock,
+  useTextEditorBindingsMock,
+  useWorkspaceStoreMock,
 } = vi.hoisted(() => ({
   applySceneCursorTargetMock: vi.fn(),
   didResumeSingleEditTargetMock: vi.fn(() => false),
@@ -32,6 +35,8 @@ const {
   })),
   useEditorStoreMock: vi.fn(),
   useTabsStoreMock: vi.fn(),
+  useTextEditorBindingsMock: vi.fn(),
+  useWorkspaceStoreMock: vi.fn(),
 }))
 
 vi.mock('monaco-editor', () => ({
@@ -69,10 +74,7 @@ vi.mock('~/features/editor/text-editor/text-editor-selection', () => ({
 }))
 
 vi.mock('~/features/editor/text-editor/useTextEditorBindings', () => ({
-  useTextEditorBindings: vi.fn(() => ({
-    consumePendingTextTransactionSource: vi.fn(),
-    handleCursorSelectionChange: vi.fn(),
-  })),
+  useTextEditorBindings: useTextEditorBindingsMock,
 }))
 
 vi.mock('~/features/editor/text-editor/useTextEditorContentSync', () => ({
@@ -117,6 +119,10 @@ vi.mock('~/stores/tabs', () => ({
   useTabsStore: useTabsStoreMock,
 }))
 
+vi.mock('~/stores/workspace', () => ({
+  useWorkspaceStore: useWorkspaceStoreMock,
+}))
+
 function createState(path: string): TextProjectionState {
   return reactive({
     isDirty: false,
@@ -128,8 +134,17 @@ function createState(path: string): TextProjectionState {
   }) as TextProjectionState
 }
 
-function createEditor() {
+interface EditorDouble {
+  deltaDecorations: ReturnType<typeof vi.fn>
+  getModel: ReturnType<typeof vi.fn<() => Pick<monaco.editor.ITextModel, 'getLineContent' | 'getLineCount' | 'getLineMaxColumn'>>>
+  getPosition: ReturnType<typeof vi.fn>
+}
+
+function createEditor(): EditorDouble {
   return {
+    deltaDecorations: vi.fn((_: string[], decorations: unknown[]) =>
+      decorations.map((__, index) => `decoration-${index + 1}`),
+    ),
     getModel: vi.fn(() => ({
       getLineContent: vi.fn((lineNumber: number) => lineNumber === 2 ? 'beta' : 'alpha'),
       getLineCount: vi.fn(() => 2),
@@ -140,6 +155,42 @@ function createEditor() {
       lineNumber: 2,
     })),
   }
+}
+
+function createEditableEditorStore(path: string) {
+  return reactive({
+    currentState: {
+      kind: 'scene',
+      path,
+      projection: 'text' as const,
+    },
+    getSceneSelection: vi.fn(() => ({
+      lastLineNumber: 2,
+      selectedStatementId: 1,
+    })),
+    getState: vi.fn(),
+    redoDocument: vi.fn(),
+    registerSaveHook: vi.fn(),
+    replaceTextDocumentContent: vi.fn(),
+    scheduleAutoSaveIfEnabled: vi.fn(),
+    consumePendingSceneProjectionActivation: vi.fn(() => false),
+    setTextProjectionDraft: vi.fn(),
+    syncScenePreview: vi.fn(),
+    syncSceneSelectionFromTextLine: vi.fn(),
+    undoDocument: vi.fn(),
+    unregisterSaveHook: vi.fn(),
+  })
+}
+
+function createTabsStore(path: string) {
+  return reactive({
+    activeTab: {
+      isPreview: false,
+      path,
+    },
+    shouldFocusEditor: false,
+    tabs: [{ path }],
+  })
 }
 
 function flushRuntimeWatchers() {
@@ -156,9 +207,22 @@ describe('useTextEditorRuntime', () => {
     resolveScenePreviewLineMock.mockClear()
     useEditorStoreMock.mockReset()
     useTabsStoreMock.mockReset()
+    useTextEditorBindingsMock.mockReset()
+    useWorkspaceStoreMock.mockReset()
 
     didResumeSingleEditTargetMock.mockReturnValue(false)
     readEditorHasMultipleEditTargetsMock.mockReturnValue(false)
+    useWorkspaceStoreMock.mockReturnValue({
+      currentGame: {
+        path: '/games/demo',
+      },
+    })
+    useTextEditorBindingsMock.mockReturnValue({
+      applyProgrammaticInsert: vi.fn(() => true),
+      applyProgrammaticStatementUpdate: vi.fn(() => true),
+      consumePendingTextTransactionSource: vi.fn(),
+      handleCursorSelectionChange: vi.fn(),
+    })
 
     vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
       callback(0)
@@ -292,6 +356,57 @@ describe('useTextEditorRuntime', () => {
 
     expect(editorStore.syncSceneSelectionFromTextLine).not.toHaveBeenCalled()
     expect(editorStore.syncScenePreview).not.toHaveBeenCalled()
+  })
+
+  it('文件投放更新语句时会保留 external 事务来源', () => {
+    const path = '/project/scene-file-drop-update.txt'
+    const state = createState(path)
+    const editor = {
+      ...createEditor(),
+      getTargetAtClientPoint: vi.fn(() => ({
+        position: {
+          column: 10,
+          lineNumber: 1,
+        },
+      })),
+    }
+    editor.getModel.mockReturnValue({
+      getLineContent: vi.fn(() => 'changeBg:old.png;'),
+      getLineCount: vi.fn(() => 1),
+      getLineMaxColumn: vi.fn(() => 18),
+    })
+    const applyProgrammaticStatementUpdate = vi.fn(() => true)
+
+    useEditorStoreMock.mockReturnValue(createEditableEditorStore(path))
+    useTabsStoreMock.mockReturnValue(createTabsStore(path))
+    useTextEditorBindingsMock.mockReturnValue({
+      applyProgrammaticInsert: vi.fn(() => false),
+      applyProgrammaticStatementUpdate,
+      consumePendingTextTransactionSource: vi.fn(),
+      handleCursorSelectionChange: vi.fn(),
+    })
+
+    const runtime = useTextEditorRuntime({
+      editorRef: shallowRef(editor) as never,
+      getState: () => state,
+    })
+
+    expect(runtime.handleFileDrop({
+      source: 'file-viewer',
+      type: 'file-system-item',
+      path: '/games/demo/game/background/room.png',
+      isDir: false,
+    }, {
+      x: 100,
+      y: 40,
+    })).toBe(true)
+
+    expect(applyProgrammaticStatementUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        rawText: 'changeBg:room.png;',
+      }),
+      'external',
+    )
   })
 
   it('跨行移动光标时会同步预览到新的关注行', () => {

--- a/src/features/editor/text-editor/text-editor-file-drop.ts
+++ b/src/features/editor/text-editor/text-editor-file-drop.ts
@@ -1,0 +1,204 @@
+import * as monaco from 'monaco-editor'
+
+import { parseSentence } from '~/domain/script/parser'
+import {
+  buildInsertedStatementText,
+  resolveEditorDropAsset,
+  updateStatementTextForDroppedAsset,
+} from '~/features/editor/shared/editor-file-drop'
+import { createTextLineTarget } from '~/features/editor/statement-editor/useStatementEditor'
+
+import type { AbsPath } from '~/domain/path'
+import type { StatementUpdatePayload } from '~/features/editor/statement-editor/useStatementEditor'
+import type { DragPosition, FileSystemDragPayload } from '~/types/drag-drop'
+
+export interface TextEditorInsertTextDropAction {
+  kind: 'insert-text'
+  range: monaco.IRange
+  text: string
+}
+
+export interface TextEditorInsertStatementLineDropAction {
+  kind: 'insert-statement-line'
+  range: monaco.IRange
+  text: string
+}
+
+export interface TextEditorUpdateStatementDropAction {
+  caretRange: monaco.IRange
+  kind: 'update-statement'
+  payload: StatementUpdatePayload
+}
+
+export type TextEditorDropAction =
+  | TextEditorInsertTextDropAction
+  | TextEditorInsertStatementLineDropAction
+  | TextEditorUpdateStatementDropAction
+
+function resolveHitPosition(
+  editor: monaco.editor.IStandaloneCodeEditor,
+  position: DragPosition,
+): monaco.IPosition | undefined {
+  const target = editor.getTargetAtClientPoint(position.x, position.y)
+  if (!target?.position) {
+    return undefined
+  }
+
+  return target.position
+}
+
+function getFirstNonWhitespaceColumn(lineText: string): number {
+  const index = lineText.search(/\S/)
+  return index === -1 ? 1 : index + 1
+}
+
+function isWebgalCommentColumn(lineText: string, column: number): boolean {
+  for (let index = 0; index < lineText.length; index++) {
+    if (lineText[index] === ';' && lineText[index - 1] !== '\\') {
+      return column > index + 1
+    }
+  }
+
+  return false
+}
+
+function createCollapsedRange(position: monaco.IPosition): monaco.IRange {
+  return {
+    startLineNumber: position.lineNumber,
+    startColumn: position.column,
+    endLineNumber: position.lineNumber,
+    endColumn: position.column,
+  }
+}
+
+function createStatementLineDropAction(options: {
+  hit: monaco.IPosition
+  insertedStatementText: string
+  lineMaxColumn: number
+  lineText: string
+}): TextEditorInsertStatementLineDropAction | undefined {
+  const { hit, insertedStatementText, lineMaxColumn, lineText } = options
+  if (lineText.trim().length === 0) {
+    return {
+      kind: 'insert-statement-line',
+      text: insertedStatementText,
+      range: {
+        startLineNumber: hit.lineNumber,
+        startColumn: 1,
+        endLineNumber: hit.lineNumber,
+        endColumn: 1,
+      },
+    }
+  }
+
+  if (hit.column <= getFirstNonWhitespaceColumn(lineText)) {
+    return {
+      kind: 'insert-statement-line',
+      text: `${insertedStatementText}\n`,
+      range: {
+        startLineNumber: hit.lineNumber,
+        startColumn: 1,
+        endLineNumber: hit.lineNumber,
+        endColumn: 1,
+      },
+    }
+  }
+
+  if (isWebgalCommentColumn(lineText, hit.column) && hit.column >= lineMaxColumn) {
+    return {
+      kind: 'insert-statement-line',
+      text: `\n${insertedStatementText}`,
+      range: {
+        startLineNumber: hit.lineNumber,
+        startColumn: lineMaxColumn,
+        endLineNumber: hit.lineNumber,
+        endColumn: lineMaxColumn,
+      },
+    }
+  }
+}
+
+export function resolveTextEditorFileDropAction(options: {
+  editor: monaco.editor.IStandaloneCodeEditor
+  gamePath: AbsPath
+  payload: FileSystemDragPayload
+  position: DragPosition
+}): TextEditorDropAction | undefined {
+  const asset = resolveEditorDropAsset({
+    gamePath: options.gamePath,
+    payload: options.payload,
+  })
+  if (!asset) {
+    return undefined
+  }
+
+  const model = options.editor.getModel()
+  const hit = resolveHitPosition(options.editor, options.position)
+  if (!model || !hit) {
+    return undefined
+  }
+
+  const lineText = model.getLineContent(hit.lineNumber)
+  const lineMaxColumn = model.getLineMaxColumn(hit.lineNumber)
+  const statementLineAction = createStatementLineDropAction({
+    hit,
+    insertedStatementText: buildInsertedStatementText(asset),
+    lineMaxColumn,
+    lineText,
+  })
+  if (statementLineAction) {
+    return statementLineAction
+  }
+
+  if (!isWebgalCommentColumn(lineText, hit.column)) {
+    const nextRawText = updateStatementTextForDroppedAsset(lineText, asset)
+    const parsed = nextRawText ? parseSentence(nextRawText) : undefined
+    if (nextRawText && parsed) {
+      return {
+        caretRange: createCollapsedRange(hit),
+        kind: 'update-statement',
+        payload: {
+          target: createTextLineTarget(hit.lineNumber),
+          rawText: nextRawText,
+          parsed,
+        },
+      }
+    }
+  }
+
+  return {
+    kind: 'insert-text',
+    text: asset.scriptPath,
+    range: {
+      startLineNumber: hit.lineNumber,
+      startColumn: hit.column,
+      endLineNumber: hit.lineNumber,
+      endColumn: hit.column,
+    },
+  }
+}
+
+export function buildTextEditorDropDecorations(options: {
+  action?: TextEditorDropAction
+}): monaco.editor.IModelDeltaDecoration[] {
+  const { action } = options
+  if (!action) {
+    return []
+  }
+
+  const caretRange = action.kind === 'update-statement' ? action.caretRange : action.range
+  const decorations: monaco.editor.IModelDeltaDecoration[] = [{
+    range: new monaco.Range(
+      caretRange.startLineNumber,
+      caretRange.startColumn,
+      caretRange.endLineNumber,
+      caretRange.endColumn,
+    ),
+    options: {
+      className: 'text-editor-drop-caret',
+      stickiness: monaco.editor.TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges,
+    },
+  }]
+
+  return decorations
+}

--- a/src/features/editor/text-editor/useTextEditorBindings.ts
+++ b/src/features/editor/text-editor/useTextEditorBindings.ts
@@ -19,12 +19,35 @@ interface TextEditorSidebarPanelBindings {
 
 type TextEditorHistoryCoordinator = ReturnType<typeof useTextEditorHistory>
 
+interface ProgrammaticTextEdit {
+  range: monaco.IRange
+  text: string
+}
+
+type MonacoEditSource = 'command-panel' | 'file-drop'
+
 interface UseTextEditorBindingsOptions {
   editorRef: ShallowRef<monaco.editor.IStandaloneCodeEditor | undefined>
   getState: () => TextProjectionState
   isCurrentTextProjectionActive: () => boolean
   formPanel: TextEditorSidebarPanelBindings
   textEditorHistory: TextEditorHistoryCoordinator
+}
+
+function resolveInsertedTextEndPosition(range: monaco.IRange, text: string): monaco.IPosition {
+  const segments = text.split('\n')
+  if (segments.length === 1) {
+    return {
+      lineNumber: range.startLineNumber,
+      column: range.startColumn + text.length,
+    }
+  }
+
+  const lastSegment = segments.at(-1) ?? ''
+  return {
+    lineNumber: range.startLineNumber + segments.length - 1,
+    column: lastSegment.length + 1,
+  }
 }
 
 export function useTextEditorBindings(options: UseTextEditorBindingsOptions) {
@@ -38,6 +61,24 @@ export function useTextEditorBindings(options: UseTextEditorBindingsOptions) {
 
   function readEditor(): monaco.editor.IStandaloneCodeEditor | undefined {
     return options.editorRef.value
+  }
+
+  function applyEditorEdit(
+    editor: monaco.editor.IStandaloneCodeEditor,
+    edit: ProgrammaticTextEdit,
+    editSource: MonacoEditSource,
+  ) {
+    options.textEditorHistory.captureBeforeContentChange()
+    editor.executeEdits(editSource, [{
+      range: edit.range,
+      text: edit.text,
+      forceMoveMarkers: true,
+    }])
+
+    const endPosition = resolveInsertedTextEndPosition(edit.range, edit.text)
+    editor.setPosition(endPosition)
+    editor.revealPositionInCenterIfOutsideViewport(endPosition)
+    editor.focus()
   }
 
   const sidebarSnapshot = computed(() => {
@@ -69,7 +110,7 @@ export function useTextEditorBindings(options: UseTextEditorBindingsOptions) {
     getEntry: () => sidebarSnapshot.value.entry,
     getEmptyState: () => isSingleStatementEditingSuspended ? 'multiple-edit-targets' : undefined,
     getUpdateTarget: () => {
-      const lineNumber = sidebarSnapshot.value.lineNumber
+      const { lineNumber } = sidebarSnapshot.value
       if (lineNumber === undefined) {
         return
       }
@@ -107,18 +148,10 @@ export function useTextEditorBindings(options: UseTextEditorBindingsOptions) {
       endLineNumber: targetLine,
       endColumn: lineLength,
     }
-    options.textEditorHistory.captureBeforeContentChange()
-
-    editor.executeEdits('command-panel', [{
+    applyEditorEdit(editor, {
       range,
       text: textToInsert,
-      forceMoveMarkers: true,
-    }])
-
-    const newLineNumber = targetLine + rawTexts.length - (needsNewline ? 0 : 1)
-    editor.setPosition({ lineNumber: newLineNumber, column: 1 })
-    editor.revealPositionInCenterIfOutsideViewport({ lineNumber: newLineNumber, column: 1 })
-    editor.focus()
+    }, 'command-panel')
   }
 
   useCommandPanelBridgeBinding({
@@ -137,11 +170,49 @@ export function useTextEditorBindings(options: UseTextEditorBindingsOptions) {
     return source
   }
 
+  function applyProgrammaticInsert(
+    edit: ProgrammaticTextEdit,
+    source: TransactionSource = 'external',
+  ): boolean {
+    const editor = readEditor()
+    if (!editor) {
+      return false
+    }
+
+    const model = editor.getModel()
+    if (!model) {
+      return false
+    }
+
+    if (model.getValueInRange(edit.range) === edit.text) {
+      return false
+    }
+
+    pendingTextTransactionSource = source
+    applyEditorEdit(editor, edit, 'file-drop')
+    return true
+  }
+
+  function applyProgrammaticStatementUpdate(
+    payload: StatementUpdatePayload,
+    source: TransactionSource = 'external',
+  ): boolean {
+    pendingTextTransactionSource = source
+    if (!options.formPanel.handleFormUpdate(payload)) {
+      pendingTextTransactionSource = undefined
+      return false
+    }
+
+    return true
+  }
+
   function handleCursorSelectionChange(event: monaco.editor.ICursorSelectionChangedEvent): void {
     isSingleStatementEditingSuspended = hasMultipleEditTargets(event)
   }
 
   return {
+    applyProgrammaticInsert,
+    applyProgrammaticStatementUpdate,
     consumePendingTextTransactionSource,
     handleCursorSelectionChange,
   }

--- a/src/features/editor/text-editor/useTextEditorRuntime.ts
+++ b/src/features/editor/text-editor/useTextEditorRuntime.ts
@@ -1,12 +1,14 @@
 import * as monaco from 'monaco-editor'
 
 import { isAnimationDocumentTextValid } from '~/domain/document/animation-document-codec'
+import { buildTextEditorDropDecorations, resolveTextEditorFileDropAction } from '~/features/editor/text-editor/text-editor-file-drop'
 import { resolveTextEditorLanguage } from '~/features/editor/text-editor/text-editor-language'
 import { applySceneCursorTarget, prepareSceneCursorTarget } from '~/features/editor/text-editor/text-editor-scene-restore'
 import { resolveSceneCursorTarget, resolveScenePreviewLine } from '~/features/editor/text-editor/text-editor-scene-sync'
 import { didResumeSingleEditTarget, readEditorHasMultipleEditTargets } from '~/features/editor/text-editor/text-editor-selection'
 import { isEditableEditor, useEditorStore } from '~/stores/editor'
 import { useTabsStore } from '~/stores/tabs'
+import { useWorkspaceStore } from '~/stores/workspace'
 
 import { useTextEditorBindings } from './useTextEditorBindings'
 import { useTextEditorContentSync } from './useTextEditorContentSync'
@@ -14,8 +16,10 @@ import { useTextEditorHistory } from './useTextEditorHistory'
 import { useTextEditorPanel } from './useTextEditorPanel'
 import { useTextEditorWorkspace } from './useTextEditorWorkspace'
 
+import type { TextEditorDropAction } from './text-editor-file-drop'
 import type { AbsPath } from '~/domain/path'
 import type { TextProjectionState } from '~/stores/editor'
+import type { DragPosition, FileSystemDragPayload } from '~/types/drag-drop'
 
 interface UseTextEditorRuntimeOptions {
   editorRef: ShallowRef<monaco.editor.IStandaloneCodeEditor | undefined>
@@ -25,16 +29,77 @@ interface UseTextEditorRuntimeOptions {
 export function useTextEditorRuntime(options: UseTextEditorRuntimeOptions) {
   const editorStore = useEditorStore()
   const tabsStore = useTabsStore()
+  const workspaceStore = useWorkspaceStore()
 
   const state = computed(() => options.getState())
   const activeProjection = computed(() => {
-    const currentState = editorStore.currentState
+    const { currentState } = editorStore
     return currentState && isEditableEditor(currentState) ? currentState.projection : undefined
   })
   let isComposing = $ref(false)
+  let fileDropDecorationIds: string[] = []
 
   function readEditor(): monaco.editor.IStandaloneCodeEditor | undefined {
     return options.editorRef.value
+  }
+
+  function setFileDropDecorations(action?: TextEditorDropAction) {
+    const editor = readEditor()
+    if (!editor) {
+      return
+    }
+
+    fileDropDecorationIds = editor.deltaDecorations(
+      fileDropDecorationIds,
+      buildTextEditorDropDecorations({ action }),
+    )
+  }
+
+  function clearFileDropHover(): void {
+    setFileDropDecorations(undefined)
+  }
+
+  function resolveFileDropAction(payload: FileSystemDragPayload, position: DragPosition): TextEditorDropAction | undefined {
+    const gamePath = workspaceStore.currentGame?.path
+    const editor = readEditor()
+    if (state.value.kind !== 'scene' || !gamePath || !editor) {
+      return undefined
+    }
+
+    return resolveTextEditorFileDropAction({
+      editor,
+      gamePath,
+      payload,
+      position,
+    })
+  }
+
+  function syncFileDropHover(payload: FileSystemDragPayload, position: DragPosition | null): void {
+    if (!position) {
+      clearFileDropHover()
+      return
+    }
+
+    setFileDropDecorations(resolveFileDropAction(payload, position))
+  }
+
+  function canHandleFileDrop(payload: FileSystemDragPayload, position: DragPosition | null): boolean {
+    return position ? resolveFileDropAction(payload, position) !== undefined : false
+  }
+
+  function handleFileDrop(payload: FileSystemDragPayload, position: DragPosition): boolean {
+    const action = resolveFileDropAction(payload, position)
+    if (!action) {
+      clearFileDropHover()
+      return false
+    }
+
+    const applied = action.kind === 'update-statement'
+      ? textEditorBindings.applyProgrammaticStatementUpdate(action.payload, 'external')
+      : textEditorBindings.applyProgrammaticInsert(action, 'external')
+
+    clearFileDropHover()
+    return applied
   }
 
   function syncViewStateForSave(path: AbsPath) {
@@ -413,6 +478,8 @@ export function useTextEditorRuntime(options: UseTextEditorRuntimeOptions) {
   )
 
   return {
+    canHandleFileDrop,
+    clearFileDropHover,
     currentEditorLanguage,
     ensureModel,
     handleBeforeUnmount,
@@ -421,6 +488,8 @@ export function useTextEditorRuntime(options: UseTextEditorRuntimeOptions) {
     handleCursorSelectionChange,
     handleEditorClick,
     handleEditorCreated,
+    handleFileDrop,
     handleScrollChange,
+    syncFileDropHover,
   }
 }

--- a/src/features/editor/visual-editor/__tests__/useVisualEditorSceneRuntime.test.ts
+++ b/src/features/editor/visual-editor/__tests__/useVisualEditorSceneRuntime.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { computed, effectScope, nextTick, reactive } from 'vue'
 
 import { computeLineNumberFromStatementId } from '~/domain/document/scene-selection'
+import { buildStatements } from '~/domain/script/sentence'
 
 import { useVisualEditorSceneRuntime } from '../useVisualEditorSceneRuntime'
 
@@ -141,6 +142,12 @@ describe('useVisualEditorSceneRuntime', () => {
     useTabsStoreMock.mockReset()
     useVisualEditorSceneViewportMock.mockReset()
     useWorkspaceStoreMock.mockReset()
+    vi.mocked(buildStatements).mockImplementation((rawText: string) => [{
+      id: 99,
+      parseError: false,
+      parsed: undefined,
+      rawText,
+    }])
 
     useCommandPanelStoreMock.mockReturnValue({
       getInsertText: vi.fn(() => 'say:test'),
@@ -521,11 +528,64 @@ describe('useVisualEditorSceneRuntime', () => {
     })
 
     expect(applied).toBe(true)
-    expect(applySceneStatementInsert).toHaveBeenCalledWith('/project/scene.txt', [{
+    expect(applySceneStatementInsert).toHaveBeenCalledWith('/project/scene.txt', [expect.objectContaining({
       id: 99,
       rawText: 'changeBg:room.png;',
-    }], 0)
+    })], 0)
     expect(scheduleAutoSaveIfEnabled).toHaveBeenCalledWith('/project/scene.txt')
+
+    scope.stop()
+  })
+
+  it('文件投放到插入区但未生成有效语句时会拒绝处理', () => {
+    const scope = effectScope()
+    const state = createState()
+    const applySceneStatementInsert = vi.fn()
+    const scheduleAutoSaveIfEnabled = vi.fn()
+
+    vi.mocked(buildStatements).mockReturnValue([])
+    useEditorStoreMock.mockReturnValue(reactive({
+      applySceneStatementDelete: vi.fn(),
+      applySceneStatementInsert,
+      applySceneStatementReorder: vi.fn(),
+      applySceneStatementUpdate: vi.fn(),
+      consumePendingSceneProjectionActivation: vi.fn(() => false),
+      currentState: {
+        kind: 'scene',
+        path: '/project/scene.txt',
+        projection: 'visual',
+      },
+      getSceneSelection: vi.fn(() => ({
+        lastEditedStatementId: 1,
+        lastLineNumber: 1,
+        selectedStatementId: 1,
+      })),
+      isSceneStatementCollapsed: vi.fn(() => false),
+      scheduleAutoSaveIfEnabled,
+      setSceneStatementCollapsed: vi.fn(),
+      syncScenePreview: vi.fn(),
+      syncSceneSelectionFromStatement: vi.fn(),
+    }))
+
+    const runtime = scope.run(() => useVisualEditorSceneRuntime({
+      getScrollArea: () => undefined,
+      getState: () => state,
+    }))
+
+    const applied = runtime?.handleFileDrop({
+      source: 'file-viewer',
+      type: 'file-system-item',
+      path: '/games/demo/game/background/room.png',
+      isDir: false,
+    }, {
+      placement: 'head',
+      insertIndex: 0,
+    })
+
+    expect(applied).toBe(false)
+    expect(applySceneStatementInsert).not.toHaveBeenCalled()
+    expect(scrollToSelectedStatementMock).not.toHaveBeenCalled()
+    expect(scheduleAutoSaveIfEnabled).not.toHaveBeenCalled()
 
     scope.stop()
   })

--- a/src/features/editor/visual-editor/__tests__/useVisualEditorSceneRuntime.test.ts
+++ b/src/features/editor/visual-editor/__tests__/useVisualEditorSceneRuntime.test.ts
@@ -20,6 +20,7 @@ const {
   useSidebarPanelBindingMock,
   useTabsStoreMock,
   useVisualEditorSceneViewportMock,
+  useWorkspaceStoreMock,
 } = vi.hoisted(() => ({
   restoreSelectionAndScrollMock: vi.fn(async () => undefined),
   scrollToSelectedStatementMock: vi.fn(async () => undefined),
@@ -33,6 +34,7 @@ const {
   useSidebarPanelBindingMock: vi.fn(),
   useTabsStoreMock: vi.fn(),
   useVisualEditorSceneViewportMock: vi.fn(),
+  useWorkspaceStoreMock: vi.fn(),
 }))
 
 vi.mock('~/domain/document/scene-selection', () => ({
@@ -94,6 +96,10 @@ vi.mock('~/stores/tabs', () => ({
   useTabsStore: useTabsStoreMock,
 }))
 
+vi.mock('~/stores/workspace', () => ({
+  useWorkspaceStore: useWorkspaceStoreMock,
+}))
+
 function createState(
   statements: {
     id: number
@@ -134,6 +140,7 @@ describe('useVisualEditorSceneRuntime', () => {
     useSidebarPanelBindingMock.mockReset()
     useTabsStoreMock.mockReset()
     useVisualEditorSceneViewportMock.mockReset()
+    useWorkspaceStoreMock.mockReset()
 
     useCommandPanelStoreMock.mockReturnValue({
       getInsertText: vi.fn(() => 'say:test'),
@@ -174,6 +181,11 @@ describe('useVisualEditorSceneRuntime', () => {
     useTabsStoreMock.mockReturnValue(reactive({
       activeTab: {
         path: '/project/scene.txt',
+      },
+    }))
+    useWorkspaceStoreMock.mockReturnValue(reactive({
+      currentGame: {
+        path: '/games/demo',
       },
     }))
     useVisualEditorSceneViewportMock.mockReturnValue({
@@ -460,6 +472,183 @@ describe('useVisualEditorSceneRuntime', () => {
     expect(applySceneStatementReorder).toHaveBeenCalledWith('/project/scene.txt', 0, 1)
     expect(scheduleAutoSaveIfEnabled).toHaveBeenCalledWith('/project/scene.txt')
     expect(scrollToSelectedStatementMock).not.toHaveBeenCalled()
+
+    scope.stop()
+  })
+
+  it('文件投放到插入区会插入生成的语句并触发自动保存', () => {
+    const scope = effectScope()
+    const state = createState()
+    const applySceneStatementInsert = vi.fn()
+    const scheduleAutoSaveIfEnabled = vi.fn()
+
+    useEditorStoreMock.mockReturnValue(reactive({
+      applySceneStatementDelete: vi.fn(),
+      applySceneStatementInsert,
+      applySceneStatementReorder: vi.fn(),
+      applySceneStatementUpdate: vi.fn(),
+      consumePendingSceneProjectionActivation: vi.fn(() => false),
+      currentState: {
+        kind: 'scene',
+        path: '/project/scene.txt',
+        projection: 'visual',
+      },
+      getSceneSelection: vi.fn(() => ({
+        lastEditedStatementId: 1,
+        lastLineNumber: 1,
+        selectedStatementId: 1,
+      })),
+      isSceneStatementCollapsed: vi.fn(() => false),
+      scheduleAutoSaveIfEnabled,
+      setSceneStatementCollapsed: vi.fn(),
+      syncScenePreview: vi.fn(),
+      syncSceneSelectionFromStatement: vi.fn(),
+    }))
+
+    const runtime = scope.run(() => useVisualEditorSceneRuntime({
+      getScrollArea: () => undefined,
+      getState: () => state,
+    }))
+
+    const applied = runtime?.handleFileDrop({
+      source: 'file-viewer',
+      type: 'file-system-item',
+      path: '/games/demo/game/background/room.png',
+      isDir: false,
+    }, {
+      placement: 'head',
+      insertIndex: 0,
+    })
+
+    expect(applied).toBe(true)
+    expect(applySceneStatementInsert).toHaveBeenCalledWith('/project/scene.txt', [{
+      id: 99,
+      rawText: 'changeBg:room.png;',
+    }], 0)
+    expect(scheduleAutoSaveIfEnabled).toHaveBeenCalledWith('/project/scene.txt')
+
+    scope.stop()
+  })
+
+  it('文件投放到兼容更新区会更新原语句而不是插入', () => {
+    const scope = effectScope()
+    const state = createState([{
+      id: 1,
+      parseError: false,
+      parsed: undefined,
+      rawText: 'choose::a.txt;',
+    }])
+    const applySceneStatementInsert = vi.fn()
+    const applySceneStatementUpdate = vi.fn()
+    const scheduleAutoSaveIfEnabled = vi.fn()
+
+    useEditorStoreMock.mockReturnValue(reactive({
+      applySceneStatementDelete: vi.fn(),
+      applySceneStatementInsert,
+      applySceneStatementReorder: vi.fn(),
+      applySceneStatementUpdate,
+      consumePendingSceneProjectionActivation: vi.fn(() => false),
+      currentState: {
+        kind: 'scene',
+        path: '/project/scene.txt',
+        projection: 'visual',
+      },
+      getSceneSelection: vi.fn(() => ({
+        lastEditedStatementId: 1,
+        lastLineNumber: 1,
+        selectedStatementId: 1,
+      })),
+      isSceneStatementCollapsed: vi.fn(() => false),
+      scheduleAutoSaveIfEnabled,
+      setSceneStatementCollapsed: vi.fn(),
+      syncScenePreview: vi.fn(),
+      syncSceneSelectionFromStatement: vi.fn(),
+    }))
+
+    const runtime = scope.run(() => useVisualEditorSceneRuntime({
+      getScrollArea: () => undefined,
+      getState: () => state,
+    }))
+
+    const applied = runtime?.handleFileDrop({
+      source: 'file-viewer',
+      type: 'file-system-item',
+      path: '/games/demo/game/scene/chapter2.txt',
+      isDir: false,
+    }, {
+      placement: 'update',
+      insertIndex: 0,
+      statementId: 1,
+    })
+
+    expect(applied).toBe(true)
+    expect(applySceneStatementUpdate).toHaveBeenCalledWith(
+      '/project/scene.txt',
+      1,
+      'choose::a.txt|:chapter2.txt;',
+      'visual',
+    )
+    expect(applySceneStatementInsert).not.toHaveBeenCalled()
+    expect(scheduleAutoSaveIfEnabled).toHaveBeenCalledWith('/project/scene.txt')
+
+    scope.stop()
+  })
+
+  it('文件投放到不兼容更新区会拒绝且不会降级为插入', () => {
+    const scope = effectScope()
+    const state = createState([{
+      id: 1,
+      parseError: false,
+      parsed: undefined,
+      rawText: 'changeBg:room.png;',
+    }])
+    const applySceneStatementInsert = vi.fn()
+    const applySceneStatementUpdate = vi.fn()
+
+    useEditorStoreMock.mockReturnValue(reactive({
+      applySceneStatementDelete: vi.fn(),
+      applySceneStatementInsert,
+      applySceneStatementReorder: vi.fn(),
+      applySceneStatementUpdate,
+      consumePendingSceneProjectionActivation: vi.fn(() => false),
+      currentState: {
+        kind: 'scene',
+        path: '/project/scene.txt',
+        projection: 'visual',
+      },
+      getSceneSelection: vi.fn(() => ({
+        lastEditedStatementId: 1,
+        lastLineNumber: 1,
+        selectedStatementId: 1,
+      })),
+      isSceneStatementCollapsed: vi.fn(() => false),
+      scheduleAutoSaveIfEnabled: vi.fn(),
+      setSceneStatementCollapsed: vi.fn(),
+      syncScenePreview: vi.fn(),
+      syncSceneSelectionFromStatement: vi.fn(),
+    }))
+
+    const runtime = scope.run(() => useVisualEditorSceneRuntime({
+      getScrollArea: () => undefined,
+      getState: () => state,
+    }))
+
+    const target = {
+      placement: 'update' as const,
+      insertIndex: 0,
+      statementId: 1,
+    }
+    const payload = {
+      source: 'file-viewer' as const,
+      type: 'file-system-item' as const,
+      path: '/games/demo/game/bgm/theme.ogg',
+      isDir: false,
+    }
+
+    expect(runtime?.canHandleFileDrop(payload, target)).toBe(false)
+    expect(runtime?.handleFileDrop(payload, target)).toBe(false)
+    expect(applySceneStatementUpdate).not.toHaveBeenCalled()
+    expect(applySceneStatementInsert).not.toHaveBeenCalled()
 
     scope.stop()
   })

--- a/src/features/editor/visual-editor/__tests__/visual-editor-file-drop.test.ts
+++ b/src/features/editor/visual-editor/__tests__/visual-editor-file-drop.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest'
+
+import { AbsPath } from '~/domain/path'
+import {
+  resolveVisualEditorDropAction,
+} from '~/features/editor/visual-editor/visual-editor-file-drop'
+
+import type { FileSystemDragPayload } from '~/types/drag-drop'
+
+function createPayload(path: string): FileSystemDragPayload {
+  return {
+    source: 'file-viewer',
+    type: 'file-system-item',
+    path,
+    isDir: false,
+    name: path.split('/').at(-1),
+  }
+}
+
+describe('visual-editor-file-drop', () => {
+  it('scene 投放到 choose 更新区时会追加选项文件', () => {
+    const action = resolveVisualEditorDropAction({
+      gamePath: AbsPath.from('/games/demo'),
+      payload: createPayload('/games/demo/game/scene/chapter2.txt'),
+      placement: 'update',
+      rawText: 'choose::a.txt;',
+      insertIndex: 3,
+      statementId: 12,
+    })
+
+    expect(action).toMatchObject({
+      kind: 'update-statement',
+      statementId: 12,
+      rawText: 'choose::a.txt|:chapter2.txt;',
+    })
+  })
+
+  it('background 投放到 gap 区时会返回 changeBg 插入动作', () => {
+    const action = resolveVisualEditorDropAction({
+      gamePath: AbsPath.from('/games/demo'),
+      payload: createPayload('/games/demo/game/background/room.png'),
+      placement: 'gap',
+      insertIndex: 2,
+    })
+
+    expect(action).toMatchObject({
+      kind: 'insert-statements',
+      insertIndex: 2,
+      rawTexts: ['changeBg:room.png;'],
+    })
+  })
+
+  it('background 投放到 head 区时会返回列表头部插入动作', () => {
+    const action = resolveVisualEditorDropAction({
+      gamePath: AbsPath.from('/games/demo'),
+      payload: createPayload('/games/demo/game/background/room.png'),
+      placement: 'head',
+      insertIndex: 0,
+    })
+
+    expect(action).toMatchObject({
+      kind: 'insert-statements',
+      insertIndex: 0,
+      rawTexts: ['changeBg:room.png;'],
+    })
+  })
+
+  it('tail 区投放会在最后一条语句后插入', () => {
+    const action = resolveVisualEditorDropAction({
+      gamePath: AbsPath.from('/games/demo'),
+      payload: createPayload('/games/demo/game/scene/finale.txt'),
+      placement: 'tail',
+      insertIndex: 5,
+    })
+
+    expect(action).toMatchObject({
+      kind: 'insert-statements',
+      insertIndex: 5,
+      rawTexts: ['changeScene:finale.txt;'],
+    })
+  })
+
+  it('不兼容的 update 目标会返回 undefined', () => {
+    const action = resolveVisualEditorDropAction({
+      gamePath: AbsPath.from('/games/demo'),
+      payload: createPayload('/games/demo/game/bgm/theme.ogg'),
+      placement: 'update',
+      rawText: 'changeBg:room.png;',
+      insertIndex: 1,
+      statementId: 1,
+    })
+
+    expect(action).toBeUndefined()
+  })
+
+  it('非 txt scene 资源会被拒绝', () => {
+    const action = resolveVisualEditorDropAction({
+      gamePath: AbsPath.from('/games/demo'),
+      payload: createPayload('/games/demo/game/scene/chapter2.json'),
+      placement: 'gap',
+      insertIndex: 0,
+    })
+
+    expect(action).toBeUndefined()
+  })
+})

--- a/src/features/editor/visual-editor/__tests__/visual-editor-file-drop.test.ts
+++ b/src/features/editor/visual-editor/__tests__/visual-editor-file-drop.test.ts
@@ -1,11 +1,23 @@
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { AbsPath } from '~/domain/path'
 import {
   resolveVisualEditorDropAction,
 } from '~/features/editor/visual-editor/visual-editor-file-drop'
 
+import type { EditorDropAsset } from '~/features/editor/shared/editor-file-drop'
 import type { FileSystemDragPayload } from '~/types/drag-drop'
+
+const updateStatementTextForDroppedAssetMock = vi.hoisted(() => vi.fn())
+
+vi.mock('~/features/editor/shared/editor-file-drop', async (importOriginal) => {
+  const original = await importOriginal<typeof import('~/features/editor/shared/editor-file-drop')>()
+
+  return {
+    ...original,
+    updateStatementTextForDroppedAsset: updateStatementTextForDroppedAssetMock,
+  }
+})
 
 function createPayload(path: string): FileSystemDragPayload {
   return {
@@ -18,6 +30,13 @@ function createPayload(path: string): FileSystemDragPayload {
 }
 
 describe('visual-editor-file-drop', () => {
+  beforeEach(async () => {
+    const { updateStatementTextForDroppedAsset } = await vi.importActual<typeof import('~/features/editor/shared/editor-file-drop')>('~/features/editor/shared/editor-file-drop')
+
+    updateStatementTextForDroppedAssetMock.mockReset()
+    updateStatementTextForDroppedAssetMock.mockImplementation((rawText: string, asset: EditorDropAsset) => updateStatementTextForDroppedAsset(rawText, asset))
+  })
+
   it('scene 投放到 choose 更新区时会追加选项文件', () => {
     const action = resolveVisualEditorDropAction({
       gamePath: AbsPath.from('/games/demo'),
@@ -78,6 +97,22 @@ describe('visual-editor-file-drop', () => {
       insertIndex: 5,
       rawTexts: ['changeScene:finale.txt;'],
     })
+  })
+
+  it('空字符串语句投放到 update 区时会进入内容更新判断', () => {
+    resolveVisualEditorDropAction({
+      gamePath: AbsPath.from('/games/demo'),
+      payload: createPayload('/games/demo/game/bgm/theme.ogg'),
+      placement: 'update',
+      rawText: '',
+      insertIndex: 1,
+      statementId: 1,
+    })
+
+    expect(updateStatementTextForDroppedAssetMock).toHaveBeenCalledWith('', expect.objectContaining({
+      assetType: 'bgm',
+      scriptPath: 'theme.ogg',
+    }))
   })
 
   it('不兼容的 update 目标会返回 undefined', () => {

--- a/src/features/editor/visual-editor/useVisualEditorSceneRuntime.ts
+++ b/src/features/editor/visual-editor/useVisualEditorSceneRuntime.ts
@@ -4,6 +4,7 @@ import { useCommandPanelBridgeBinding, useSidebarPanelBinding } from '~/features
 import { useShortcut } from '~/features/editor/shortcut/useShortcut'
 import { createStatementIdTarget, StatementUpdatePayload } from '~/features/editor/statement-editor/useStatementEditor'
 import { useVisualEditorSceneViewport } from '~/features/editor/visual-editor/useVisualEditorSceneViewport'
+import { resolveVisualEditorDropAction } from '~/features/editor/visual-editor/visual-editor-file-drop'
 import { canRestoreVisualEditorCardFocus, findSelectedVisualEditorStatementCard } from '~/features/editor/visual-editor/visual-editor-focus'
 import { useCommandPanelStore } from '~/stores/command-panel'
 import { useEditSettingsStore } from '~/stores/edit-settings'
@@ -11,7 +12,17 @@ import { isEditableEditor, SceneVisualProjectionState, useEditorStore } from '~/
 import { useEditorViewStateStore } from '~/stores/editor-view-state'
 import { usePreferenceStore } from '~/stores/preference'
 import { useTabsStore } from '~/stores/tabs'
+import { useWorkspaceStore } from '~/stores/workspace'
 import { buildPreviousSpeakers } from '~/utils/speaker'
+
+import type { VisualEditorDropPlacement } from '~/features/editor/visual-editor/visual-editor-file-drop'
+import type { FileSystemDragPayload } from '~/types/drag-drop'
+
+export interface VisualEditorFileDropTarget {
+  insertIndex: number
+  placement: VisualEditorDropPlacement
+  statementId?: number
+}
 
 interface UseVisualEditorSceneRuntimeOptions {
   getScrollArea: () => InstanceType<typeof ScrollArea> | null | undefined
@@ -29,6 +40,7 @@ export function useVisualEditorSceneRuntime(options: UseVisualEditorSceneRuntime
   const editSettings = useEditSettingsStore()
   const preferenceStore = usePreferenceStore()
   const commandPanelStore = useCommandPanelStore()
+  const workspaceStore = useWorkspaceStore()
 
   let statementClipboard: string | undefined
   const state = computed(() => options.getState())
@@ -300,6 +312,54 @@ export function useVisualEditorSceneRuntime(options: UseVisualEditorSceneRuntime
       focus: true,
     })
     requestAutoSave()
+  }
+
+  function resolveFileDropAction(payload: FileSystemDragPayload, target: VisualEditorFileDropTarget) {
+    const gamePath = workspaceStore.currentGame?.path
+    if (!gamePath) {
+      return
+    }
+
+    const statementEntry = target.statementId === undefined
+      ? undefined
+      : state.value.statements.find(entry => entry.id === target.statementId)
+
+    return resolveVisualEditorDropAction({
+      gamePath,
+      payload,
+      placement: target.placement,
+      insertIndex: target.insertIndex,
+      rawText: statementEntry?.rawText,
+      statementId: target.statementId,
+    })
+  }
+
+  function canHandleFileDrop(payload: FileSystemDragPayload, target: VisualEditorFileDropTarget): boolean {
+    return resolveFileDropAction(payload, target) !== undefined
+  }
+
+  function handleFileDrop(payload: FileSystemDragPayload, target: VisualEditorFileDropTarget): boolean {
+    const action = resolveFileDropAction(payload, target)
+    if (!action) {
+      return false
+    }
+
+    if (action.kind === 'insert-statements') {
+      const newEntries = action.rawTexts.flatMap(text => buildStatements(text))
+      editorStore.applySceneStatementInsert(state.value.path, newEntries, action.insertIndex)
+      void restoreSelectedStatementPresentation({ align: 'auto' })
+      requestAutoSave()
+      return true
+    }
+
+    editorStore.applySceneStatementUpdate(
+      state.value.path,
+      action.statementId,
+      action.rawText,
+      'visual',
+    )
+    requestAutoSave()
+    return true
   }
 
   function cutStatement() {
@@ -578,7 +638,9 @@ export function useVisualEditorSceneRuntime(options: UseVisualEditorSceneRuntime
   })
 
   return {
+    canHandleFileDrop,
     handleCollapsedUpdate,
+    handleFileDrop,
     handlePlayTo,
     handleSelect,
     handleStatementDelete,

--- a/src/features/editor/visual-editor/useVisualEditorSceneRuntime.ts
+++ b/src/features/editor/visual-editor/useVisualEditorSceneRuntime.ts
@@ -346,6 +346,10 @@ export function useVisualEditorSceneRuntime(options: UseVisualEditorSceneRuntime
 
     if (action.kind === 'insert-statements') {
       const newEntries = action.rawTexts.flatMap(text => buildStatements(text))
+      if (newEntries.length === 0) {
+        return false
+      }
+
       editorStore.applySceneStatementInsert(state.value.path, newEntries, action.insertIndex)
       void restoreSelectedStatementPresentation({ align: 'auto' })
       requestAutoSave()

--- a/src/features/editor/visual-editor/useVisualEditorSceneViewport.ts
+++ b/src/features/editor/visual-editor/useVisualEditorSceneViewport.ts
@@ -1,5 +1,6 @@
 import { useVirtualizer } from '@tanstack/vue-virtual'
 
+import { INSERT_BAND_SIZE_PX } from '~/features/editor/visual-editor/visual-editor-file-drop'
 import { SceneVisualProjectionState } from '~/stores/editor'
 
 import type { DragSortVirtualAdapter } from '~/composables/useDragSort'
@@ -23,8 +24,8 @@ export function useVisualEditorSceneViewport(options: UseVisualEditorSceneViewpo
       getScrollElement: () => options.getScrollArea()?.viewport?.viewportElement ?? null,
       estimateSize: () => ESTIMATED_STATEMENT_ROW_SIZE,
       overscan: 5,
-      paddingStart: 8,
-      paddingEnd: 8,
+      paddingStart: INSERT_BAND_SIZE_PX,
+      paddingEnd: INSERT_BAND_SIZE_PX,
       getItemKey: (index: number) => state.value.statements[index]?.id ?? index,
     })),
   )

--- a/src/features/editor/visual-editor/visual-editor-file-drop.ts
+++ b/src/features/editor/visual-editor/visual-editor-file-drop.ts
@@ -45,7 +45,7 @@ export function resolveVisualEditorDropAction(options: {
     }
   }
 
-  if (options.statementId === undefined || !options.rawText) {
+  if (options.statementId === undefined || options.rawText === undefined) {
     return undefined
   }
 

--- a/src/features/editor/visual-editor/visual-editor-file-drop.ts
+++ b/src/features/editor/visual-editor/visual-editor-file-drop.ts
@@ -1,0 +1,62 @@
+import {
+  buildInsertedStatementText,
+  resolveEditorDropAsset,
+  updateStatementTextForDroppedAsset,
+} from '~/features/editor/shared/editor-file-drop'
+
+import type { AbsPath } from '~/domain/path'
+import type { FileSystemDragPayload } from '~/types/drag-drop'
+
+export const INSERT_BAND_SIZE_PX = 8
+
+export type VisualEditorDropPlacement = 'head' | 'gap' | 'update' | 'tail'
+
+export type VisualEditorDropAction =
+  | { kind: 'insert-statements', insertIndex: number, rawTexts: string[] }
+  | { kind: 'update-statement', rawText: string, statementId: number }
+
+function isInsertPlacement(placement: VisualEditorDropPlacement): boolean {
+  return placement === 'head'
+    || placement === 'gap'
+    || placement === 'tail'
+}
+
+export function resolveVisualEditorDropAction(options: {
+  gamePath: AbsPath
+  insertIndex: number
+  payload: FileSystemDragPayload
+  placement: VisualEditorDropPlacement
+  rawText?: string
+  statementId?: number
+}): VisualEditorDropAction | undefined {
+  const asset = resolveEditorDropAsset({
+    gamePath: options.gamePath,
+    payload: options.payload,
+  })
+  if (!asset) {
+    return undefined
+  }
+
+  if (isInsertPlacement(options.placement)) {
+    return {
+      kind: 'insert-statements',
+      insertIndex: options.insertIndex,
+      rawTexts: [buildInsertedStatementText(asset)],
+    }
+  }
+
+  if (options.statementId === undefined || !options.rawText) {
+    return undefined
+  }
+
+  const rawText = updateStatementTextForDroppedAsset(options.rawText, asset)
+  if (!rawText) {
+    return undefined
+  }
+
+  return {
+    kind: 'update-statement',
+    statementId: options.statementId,
+    rawText,
+  }
+}


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [ ] 错误修复
- [x] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [x] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

- 新增 `editor-file-drop` 共享逻辑，把文件拖拽 payload 解析为编辑器可消费的资源类型，并统一生成插入语句或兼容语句更新结果。
- `TextEditor` 现在可以接收文件拖拽：会根据落点位置决定插入完整语句、更新当前行语句，或直接插入相对路径；同时增加拖拽 caret 反馈，并在投放成功后恢复编辑器焦点。
- `VisualEditorScene` 现在提供 `head / gap / update / tail` 四类投放目标：插入区生成新语句，更新区仅在语句兼容时更新现有内容，不兼容时直接拒绝。
- 可视化编辑器投放补齐了 `choose` 追加 scene 选项、`intro.backgroundImage`、`say.vocal` 等特化更新规则，并在投放成功后触发自动保存。
- 补充了共享投放解析、文本编辑器投放、可视化编辑器投放、runtime 与组件交互测试。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

- 现有应用内拖拽已经覆盖了标签页排序、文件树转移和资源浏览器转移，但编辑器侧还缺少稳定的文件投放入口。
- 这次改动把资源拖拽到编辑器后的处理语义补齐到文本编辑器和可视化编辑器，减少手动拷贝路径和来回切换编辑方式的成本。
- 共享资源解析与语句更新逻辑也避免了两种编辑器各自维护一套拖拽投放规则。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
