### PR TITLE
✨ 支持命令面板语句拖放插入编辑器

### DIFF
--- a/src/components/editor/CommandPanel.spec.ts
+++ b/src/components/editor/CommandPanel.spec.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { page } from 'vitest/browser'
+import { shallowRef } from 'vue'
 
 import {
   createBrowserActionStub,
@@ -9,13 +10,37 @@ import {
 } from '~/__tests__/browser-render'
 import { useCommandPanelStore } from '~/stores/command-panel'
 
-const { modalOpenMock, useModalStoreMock } = vi.hoisted(() => ({
+const { dragSourcePropsMock, lastDragSourceOptions, modalOpenMock, useDragSessionMock, useDragSourceMock, useModalStoreMock } = vi.hoisted(() => ({
+  dragSourcePropsMock: vi.fn(() => ({
+    onClickCapture: vi.fn(),
+    onPointerdown: vi.fn(),
+  })),
+  lastDragSourceOptions: {
+    value: undefined as undefined | {
+      getData: (element: HTMLElement) => unknown
+    },
+  },
   modalOpenMock: vi.fn(),
+  useDragSessionMock: vi.fn(),
+  useDragSourceMock: vi.fn((options) => {
+    lastDragSourceOptions.value = options
+    return {
+      sourceProps: dragSourcePropsMock,
+    }
+  }),
   useModalStoreMock: vi.fn(),
 }))
 
 vi.mock('~/stores/modal', () => ({
   useModalStore: useModalStoreMock,
+}))
+
+vi.mock('~/composables/useDragSession', () => ({
+  useDragSession: useDragSessionMock,
+}))
+
+vi.mock('~/composables/useDragTransfer', () => ({
+  useDragSource: useDragSourceMock,
 }))
 
 import CommandPanel from './CommandPanel.vue'
@@ -83,6 +108,21 @@ describe('CommandPanel', () => {
 
   beforeEach(() => {
     modalOpenMock.mockReset()
+    dragSourcePropsMock.mockClear()
+    lastDragSourceOptions.value = undefined
+    useDragSessionMock.mockReset()
+    useDragSourceMock.mockClear()
+    useDragSessionMock.mockReturnValue({
+      state: shallowRef({
+        currentDropTarget: undefined,
+        currentPosition: undefined,
+        isActive: false,
+        mode: undefined,
+        payload: undefined,
+        startPosition: undefined,
+        transferOperation: 'move',
+      }),
+    })
     useModalStoreMock.mockReturnValue({
       open: modalOpenMock,
     })
@@ -151,6 +191,47 @@ describe('CommandPanel', () => {
     await page.getByRole('button', { name: 'dialogue-command' }).click()
 
     expect(onInsertCommand).toHaveBeenCalledWith(expect.any(Number))
+  })
+
+  it('命令卡片拖拽会生成 command-panel-statement payload', () => {
+    const { pinia } = renderCommandPanel()
+    const store = useCommandPanelStore(pinia)
+    store.saveDefault(0, 'say:custom;')
+    const getData = lastDragSourceOptions.value?.getData
+
+    const element = document.createElement('div')
+    element.dataset.commandPanelDragKind = 'command'
+    element.dataset.commandPanelCommandType = '0'
+    element.dataset.commandPanelDragLabel = 'dialogue-command'
+
+    expect(getData?.(element)).toEqual({
+      label: 'dialogue-command',
+      rawTexts: ['say:custom;'],
+      source: 'command-panel',
+      type: 'command-panel-statement',
+    })
+  })
+
+  it('语句组卡片拖拽会生成语句组 payload', () => {
+    const { pinia } = renderCommandPanel()
+    const store = useCommandPanelStore(pinia)
+    const group = store.saveGroup({
+      name: 'My Group',
+      rawTexts: ['say:hello;', 'bgm:theme.ogg;'],
+    })
+    const getData = lastDragSourceOptions.value?.getData
+
+    const element = document.createElement('div')
+    element.dataset.commandPanelDragKind = 'group'
+    element.dataset.commandPanelGroupId = group.id
+    element.dataset.commandPanelDragLabel = group.name
+
+    expect(getData?.(element)).toEqual({
+      label: 'My Group',
+      rawTexts: ['say:hello;', 'bgm:theme.ogg;'],
+      source: 'command-panel',
+      type: 'command-panel-statement',
+    })
   })
 
   it('点击命令默认值按钮会打开默认值模态框', async () => {

--- a/src/components/editor/CommandPanel.vue
+++ b/src/components/editor/CommandPanel.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { useDragSession } from '~/composables/useDragSession'
+import { useDragSource } from '~/composables/useDragTransfer'
 import {
   buildCommandPanelGroupTagEntries,
   resolveCommandPanelVisibleCommands,
@@ -15,8 +17,10 @@ import { StatementGroup, useCommandPanelStore } from '~/stores/command-panel'
 import { useModalStore } from '~/stores/modal'
 import { handleWheelToHorizontalScroll } from '~/utils/wheel'
 
+import type { StyleValue } from 'vue'
 import type { commandType } from 'webgal-parser/src/interface/sceneInterface'
 import type { ScrollArea } from '~/components/ui/scroll-area'
+import type { CommandPanelStatementDragPayload } from '~/types/drag-drop'
 
 const emit = defineEmits<{
   insertCommand: [type: commandType]
@@ -26,6 +30,7 @@ const emit = defineEmits<{
 const { t } = useI18n()
 const commandPanelStore = useCommandPanelStore()
 const activeCategory = $computed(() => commandPanelStore.activeCategory)
+const dragSession = useDragSession()
 
 const isGroupsView = $computed(() => activeCategory === 'groups')
 const visibleCommands = $computed(() => resolveCommandPanelVisibleCommands(activeCategory))
@@ -63,6 +68,18 @@ function requestDeleteGroup(groupId: string): void {
 }
 
 const commandAreaRef = $(useTemplateRef('commandAreaRef'))
+const commandAreaViewport = $computed(() =>
+  commandAreaRef?.viewport?.viewportElement as HTMLElement | undefined,
+)
+const commandAreaViewportRef = computed(() => commandAreaViewport)
+const commandDragSource = useDragSource<CommandPanelStatementDragPayload>({
+  autoScroll: {
+    container: commandAreaViewportRef,
+    edgeSize: 32,
+  },
+  getData: getCommandPanelDragPayload,
+  type: 'command-panel-statement',
+})
 
 function resetScrollTop(): void {
   nextTick(() => {
@@ -89,6 +106,57 @@ const groupTagEntriesMap = $computed(() => {
 function getGroupTagEntries(groupId: string) {
   return groupTagEntriesMap.get(groupId) ?? []
 }
+
+function getCommandPanelDragPayload(element: HTMLElement): CommandPanelStatementDragPayload {
+  const { dataset } = element
+  const kind = dataset.commandPanelDragKind
+  const label = dataset.commandPanelDragLabel ?? ''
+
+  if (kind === 'group') {
+    const group = commandPanelStore.groups.find(item => item.id === dataset.commandPanelGroupId)
+    return {
+      label: group?.name ?? label,
+      rawTexts: group ? [...group.rawTexts] : [],
+      source: 'command-panel',
+      type: 'command-panel-statement',
+    }
+  }
+
+  const rawType = dataset.commandPanelCommandType
+  const type = rawType === undefined ? undefined : Number(rawType) as commandType
+  return {
+    label,
+    rawTexts: type === undefined ? [] : [commandPanelStore.getInsertText(type)],
+    source: 'command-panel',
+    type: 'command-panel-statement',
+  }
+}
+
+const activeCommandPanelPayload = $computed(() => {
+  const state = dragSession.state.value
+  if (
+    !state.isActive
+    || state.mode !== 'transfer'
+    || state.payload?.type !== 'command-panel-statement'
+    || state.payload.source !== 'command-panel'
+  ) {
+    return
+  }
+
+  return state.payload
+})
+
+const dragOverlayStyle = $computed<StyleValue | undefined>(() => {
+  const currentPosition = dragSession.state.value.currentPosition
+  if (!activeCommandPanelPayload || !currentPosition) {
+    return
+  }
+
+  return {
+    transform: `translate3d(${currentPosition.x + 6}px, ${currentPosition.y + 6}px, 0)`,
+    zIndex: '9999',
+  }
+})
 
 useShortcutContext({
   panelFocus: 'commandPanel',
@@ -151,6 +219,12 @@ useShortcutContext({
               :key="entry.type"
               :title="resolveI18n(entry.label, t)"
               :description="getCommandDescription(entry.type, t)"
+              :drag-data="{
+                kind: 'command',
+                commandType: entry.type,
+                label: resolveI18n(entry.label, t),
+              }"
+              :drag-source="commandDragSource"
               :icon="entry.icon"
               :gradient="categoryTheme[entry.category].gradient"
               :icon-bg="categoryTheme[entry.category].bg"
@@ -163,7 +237,7 @@ useShortcutContext({
                   size="sm"
                   class="p-0 opacity-60 size-6 hover:opacity-100"
                   :title="$t('edit.visualEditor.commandPanel.editDefaults')"
-                  @click.stop="openDefaultsModal(entry.type)"
+                  @click="openDefaultsModal(entry.type)"
                 >
                   <div class="i-lucide-pencil size-3" />
                 </Button>
@@ -176,6 +250,12 @@ useShortcutContext({
               v-for="group in commandPanelStore.groups"
               :key="group.id"
               :title="group.name"
+              :drag-data="{
+                kind: 'group',
+                groupId: group.id,
+                label: group.name,
+              }"
+              :drag-source="commandDragSource"
               icon="i-lucide-box"
               gradient="from-violet-500 to-fuchsia-300"
               icon-bg="bg-violet-50 dark:bg-violet-950"
@@ -206,7 +286,7 @@ useShortcutContext({
                   size="sm"
                   class="p-0 opacity-60 size-6 hover:opacity-100"
                   :title="$t('common.edit')"
-                  @click.stop="openGroupModal(group)"
+                  @click="openGroupModal(group)"
                 >
                   <div class="i-lucide-pencil size-3" />
                 </Button>
@@ -217,7 +297,7 @@ useShortcutContext({
                       size="sm"
                       class="p-0 opacity-60 size-6 hover:text-destructive hover:opacity-100"
                       :title="$t('common.delete')"
-                      @click.stop="requestDeleteGroup(group.id)"
+                      @click="requestDeleteGroup(group.id)"
                     >
                       <div class="i-lucide-trash-2 size-3" />
                     </Button>
@@ -251,5 +331,15 @@ useShortcutContext({
         </div>
       </ScrollArea>
     </TooltipProvider>
+    <DragOverlay :visible="activeCommandPanelPayload !== undefined" :overlay-style="dragOverlayStyle">
+      <div class="text-xs text-popover-foreground px-2.5 py-1.5 border rounded-md bg-popover max-w-48 min-w-28 shadow-lg">
+        <div class="font-medium truncate">
+          {{ activeCommandPanelPayload?.label }}
+        </div>
+        <div class="text-muted-foreground tabular-nums">
+          {{ $t('edit.visualEditor.commandPanel.groupCount', { count: activeCommandPanelPayload?.rawTexts.length ?? 0 }) }}
+        </div>
+      </div>
+    </DragOverlay>
   </div>
 </template>

--- a/src/components/editor/CommandPanelCard.spec.ts
+++ b/src/components/editor/CommandPanelCard.spec.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from 'vitest'
+import { page } from 'vitest/browser'
+import { h } from 'vue'
+
+import { createBrowserContainerStub, renderInBrowser } from '~/__tests__/browser-render'
+
+import CommandPanelCard from './CommandPanelCard.vue'
+
+const globalStubs = {
+  Tooltip: createBrowserContainerStub('StubTooltip'),
+  TooltipContent: createBrowserContainerStub('StubTooltipContent'),
+  TooltipTrigger: createBrowserContainerStub('StubTooltipTrigger'),
+}
+
+describe('CommandPanelCard', () => {
+  it('点击动作区按钮不会触发卡片点击', async () => {
+    const handleClick = vi.fn()
+
+    renderInBrowser(CommandPanelCard, {
+      props: {
+        onClick: handleClick,
+        title: 'Dialogue',
+      },
+      slots: {
+        actions: () => h('button', { type: 'button' }, 'edit-action'),
+      },
+      global: {
+        stubs: globalStubs,
+      },
+    })
+
+    await page.getByRole('button', { name: 'edit-action', exact: true }).click()
+
+    expect(handleClick).not.toHaveBeenCalled()
+  })
+
+  it('点击卡片主体仍会触发卡片点击', async () => {
+    const handleClick = vi.fn()
+
+    renderInBrowser(CommandPanelCard, {
+      props: {
+        onClick: handleClick,
+        title: 'Dialogue',
+      },
+      global: {
+        stubs: globalStubs,
+      },
+    })
+
+    await page.getByRole('button', { name: 'Dialogue' }).click()
+
+    expect(handleClick).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/components/editor/CommandPanelCard.vue
+++ b/src/components/editor/CommandPanelCard.vue
@@ -1,7 +1,18 @@
 <script setup lang="ts">
+import type { UseDragSourceReturn } from '~/composables/useDragTransfer'
+
+interface CommandPanelCardDragData {
+  commandType?: number
+  groupId?: string
+  kind: 'command' | 'group'
+  label: string
+}
+
 interface Props {
   title: string
   description?: string
+  dragData?: CommandPanelCardDragData
+  dragSource?: UseDragSourceReturn
   icon?: string
   gradient?: string
   iconBg?: string
@@ -12,6 +23,8 @@ interface Props {
 
 const props = withDefaults(defineProps<Props>(), {
   description: '',
+  dragData: undefined,
+  dragSource: undefined,
   icon: '',
   gradient: 'from-muted-foreground/40 to-muted-foreground/10',
   iconBg: 'bg-muted/60',
@@ -38,12 +51,37 @@ function handleKeydown(event: KeyboardEvent) {
   event.preventDefault()
   handleClick()
 }
+
+const dragSourceProps = $computed(() => props.dragSource?.sourceProps() ?? {})
+const dragDataAttrs = $computed(() => {
+  if (!props.dragData) {
+    return {}
+  }
+
+  const attrs: Record<string, number | string> = {
+    'data-command-panel-drag-kind': props.dragData.kind,
+    'data-command-panel-drag-label': props.dragData.label,
+  }
+  if (props.dragData.commandType !== undefined) {
+    attrs['data-command-panel-command-type'] = props.dragData.commandType
+  }
+  if (props.dragData.groupId !== undefined) {
+    attrs['data-command-panel-group-id'] = props.dragData.groupId
+  }
+
+  return attrs
+})
+const cardAttrs = $computed(() => ({
+  ...dragDataAttrs,
+  ...dragSourceProps,
+}))
 </script>
 
 <template>
   <Tooltip :disabled="!description && !$slots.tooltip">
     <TooltipTrigger as-child>
       <div
+        v-bind="cardAttrs"
         role="button"
         :tabindex="interactive ? 0 : -1"
         class="group text-left border rounded-lg bg-card w-full transition-[border-color,background-color,box-shadow,transform] relative overflow-hidden hover:border-primary/35 hover:bg-accent/30 hover:shadow-sm"
@@ -65,7 +103,12 @@ function handleKeydown(event: KeyboardEvent) {
           </div>
         </div>
 
-        <div class="pl-3 pr-1.5 opacity-0 flex gap-0.5 transition-opacity items-center right-0 top-1/2 absolute from-card from-65% bg-gradient-to-l group-hover:opacity-100 -translate-y-1/2">
+        <div
+          class="pl-3 pr-1.5 opacity-0 flex gap-0.5 transition-opacity items-center right-0 top-1/2 absolute from-card from-65% bg-gradient-to-l group-hover:opacity-100 -translate-y-1/2"
+          @click.stop
+          @keydown.stop
+          @pointerdown.stop
+        >
           <slot name="actions" />
         </div>
       </div>

--- a/src/components/editor/TextEditor.spec.ts
+++ b/src/components/editor/TextEditor.spec.ts
@@ -30,11 +30,13 @@ const {
   const ensureModelMock = vi.fn()
   const handleBeforeUnmountMock = vi.fn()
   const runtimeReturnValue = {
+    canHandleCommandDrop: vi.fn(() => true),
     canHandleFileDrop: vi.fn(() => true),
-    clearFileDropHover: vi.fn(),
+    clearDropHover: vi.fn(),
     currentEditorLanguage: { value: 'webgalscript' },
     ensureModel: ensureModelMock,
     handleBeforeUnmount: handleBeforeUnmountMock,
+    handleCommandDrop: vi.fn(),
     handleContentChange: vi.fn(),
     handleCursorPositionChange: vi.fn(),
     handleCursorSelectionChange: vi.fn(),
@@ -42,6 +44,7 @@ const {
     handleEditorCreated: vi.fn(),
     handleFileDrop: vi.fn(),
     handleScrollChange: vi.fn(),
+    syncCommandDropHover: vi.fn(),
     syncFileDropHover: vi.fn(),
   }
 
@@ -211,8 +214,10 @@ describe('TextEditor', () => {
     resetMonacoMockState()
     ensureModelMock.mockReset()
     handleBeforeUnmountMock.mockReset()
+    runtimeReturnValue.canHandleCommandDrop.mockReset()
     runtimeReturnValue.canHandleFileDrop.mockReset()
-    runtimeReturnValue.clearFileDropHover.mockReset()
+    runtimeReturnValue.clearDropHover.mockReset()
+    runtimeReturnValue.handleCommandDrop.mockReset()
     runtimeReturnValue.handleContentChange.mockReset()
     runtimeReturnValue.handleCursorPositionChange.mockReset()
     runtimeReturnValue.handleCursorSelectionChange.mockReset()
@@ -220,7 +225,9 @@ describe('TextEditor', () => {
     runtimeReturnValue.handleEditorCreated.mockReset()
     runtimeReturnValue.handleFileDrop.mockReset()
     runtimeReturnValue.handleScrollChange.mockReset()
+    runtimeReturnValue.syncCommandDropHover.mockReset()
     runtimeReturnValue.syncFileDropHover.mockReset()
+    runtimeReturnValue.canHandleCommandDrop.mockReturnValue(true)
     runtimeReturnValue.canHandleFileDrop.mockReturnValue(true)
     useEditSettingsStoreMock.mockReset()
     useEditorStoreMock.mockReset()
@@ -349,7 +356,7 @@ describe('TextEditor', () => {
     await nextTick()
     await result.unmount()
 
-    expect(runtimeReturnValue.clearFileDropHover).toHaveBeenCalledTimes(1)
+    expect(runtimeReturnValue.clearDropHover).toHaveBeenCalledTimes(1)
     expect(handleBeforeUnmountMock).toHaveBeenCalledTimes(1)
     expect(monacoMockState.editorInstance.dispose).toHaveBeenCalledTimes(1)
   })
@@ -404,7 +411,7 @@ describe('TextEditor', () => {
     expect(runtimeReturnValue.handleFileDrop).toHaveBeenCalledWith(payload, { x: 40, y: 20 })
 
     config.onDragLeave(payload, document.createElement('div'))
-    expect(runtimeReturnValue.clearFileDropHover).toHaveBeenCalled()
+    expect(runtimeReturnValue.clearDropHover).toHaveBeenCalled()
 
     await result.unmount()
     expect(unregisterDroppable).toHaveBeenCalledTimes(1)
@@ -439,6 +446,61 @@ describe('TextEditor', () => {
     config.onDrop(payload, document.createElement('div'))
 
     expect(monacoMockState.editorInstance.focus).toHaveBeenCalledTimes(1)
+  })
+
+  it('命令面板语句投放会把 payload 与当前位置交给 runtime', async () => {
+    const registerDroppable = vi.fn()
+    useDroppableRegistryMock.mockReturnValue({
+      clearHover: vi.fn(),
+      drop: vi.fn(),
+      getMatchAt: vi.fn(),
+      hoveredTarget: shallowRef(),
+      isDropAllowed: shallowRef(false),
+      registerDroppable,
+      unregisterDroppable: vi.fn(),
+      updateHover: vi.fn(),
+    })
+    runtimeReturnValue.handleCommandDrop.mockReturnValue(true)
+    useDragSessionMock.mockReturnValue({
+      state: shallowRef({
+        currentDropTarget: undefined,
+        currentPosition: { x: 80, y: 24 },
+        isActive: true,
+        mode: 'transfer',
+        payload: {
+          label: 'Say',
+          rawTexts: ['say:hello;'],
+          source: 'command-panel',
+          type: 'command-panel-statement',
+        },
+        startPosition: { x: 80, y: 24 },
+        transferOperation: 'copy',
+      }),
+    })
+
+    const { state } = createHarness('/project/scene-command-drop.txt')
+    renderTextEditor(state)
+    await nextTick()
+
+    const [, config] = registerDroppable.mock.calls[0]
+    const payload = {
+      label: 'Say',
+      rawTexts: ['say:hello;'],
+      source: 'command-panel',
+      type: 'command-panel-statement',
+    } as const
+
+    expect(config.canDrop(payload, document.createElement('div'))).toBe(true)
+
+    config.onDragEnter(payload, document.createElement('div'))
+    expect(runtimeReturnValue.syncCommandDropHover).toHaveBeenCalledWith(payload, { x: 80, y: 24 })
+
+    config.onDrop(payload, document.createElement('div'))
+    expect(runtimeReturnValue.handleCommandDrop).toHaveBeenCalledWith(payload, { x: 80, y: 24 })
+    expect(monacoMockState.editorInstance.focus).toHaveBeenCalledTimes(1)
+
+    config.onDragLeave(payload, document.createElement('div'))
+    expect(runtimeReturnValue.clearDropHover).toHaveBeenCalled()
   })
 
   it('animation 文本状态会拒绝脚本文件投放', async () => {

--- a/src/components/editor/TextEditor.vue
+++ b/src/components/editor/TextEditor.vue
@@ -14,7 +14,7 @@ import { isEditableEditor, useEditorStore } from '~/stores/editor'
 import { useTabsStore } from '~/stores/tabs'
 
 import type { TextProjectionState } from '~/stores/editor'
-import type { FileSystemDragPayload } from '~/types/drag-drop'
+import type { DragPayload, DragPosition } from '~/types/drag-drop'
 
 interface Props {
   state: TextProjectionState
@@ -70,9 +70,43 @@ function readCurrentDragPosition() {
   return dragSession.state.value.currentPosition
 }
 
-function readCurrentFileDragPayload(): FileSystemDragPayload | undefined {
-  const payload = dragSession.state.value.payload
-  return payload?.type === 'file-system-item' ? payload : undefined
+function readCurrentDragPayload(): DragPayload | undefined {
+  return dragSession.state.value.payload ?? undefined
+}
+
+function canHandleDropPayload(payload: DragPayload, position: DragPosition | null): boolean {
+  if (payload.type === 'file-system-item') {
+    return runtime.canHandleFileDrop(payload, position)
+  }
+
+  if (payload.type === 'command-panel-statement') {
+    return runtime.canHandleCommandDrop(payload, position)
+  }
+
+  return false
+}
+
+function syncDropHover(payload: DragPayload, position: DragPosition | null): void {
+  if (payload.type === 'file-system-item') {
+    runtime.syncFileDropHover(payload, position)
+    return
+  }
+
+  if (payload.type === 'command-panel-statement') {
+    runtime.syncCommandDropHover(payload, position)
+  }
+}
+
+function handleDropPayload(payload: DragPayload, position: DragPosition): boolean {
+  if (payload.type === 'file-system-item') {
+    return runtime.handleFileDrop(payload, position)
+  }
+
+  if (payload.type === 'command-panel-statement') {
+    return runtime.handleCommandDrop(payload, position)
+  }
+
+  return false
 }
 
 function unregisterTextDropTarget() {
@@ -97,34 +131,27 @@ function registerTextDropTarget() {
   unregisterTextDropTarget()
   textDropTargetElement = editorContainer
   dropRegistry.registerDroppable(editorContainer, {
-    accept: 'file-system-item',
+    accept: ['file-system-item', 'command-panel-statement'],
     canDrop(payload) {
-      return payload.type === 'file-system-item'
-        && runtime.canHandleFileDrop(payload, readCurrentDragPosition())
+      return canHandleDropPayload(payload, readCurrentDragPosition())
     },
     id: `text-editor:${props.state.path}`,
     onDragEnter(payload) {
-      if (payload.type === 'file-system-item') {
-        runtime.syncFileDropHover(payload, readCurrentDragPosition())
-      }
+      syncDropHover(payload, readCurrentDragPosition())
     },
     onDragLeave(payload) {
-      if (payload.type === 'file-system-item') {
-        runtime.clearFileDropHover()
+      if (payload.type === 'file-system-item' || payload.type === 'command-panel-statement') {
+        runtime.clearDropHover()
       }
     },
     onDrop(payload) {
-      if (payload.type !== 'file-system-item') {
-        return
-      }
-
       const position = readCurrentDragPosition()
       if (!position) {
-        runtime.clearFileDropHover()
+        runtime.clearDropHover()
         return
       }
 
-      if (runtime.handleFileDrop(payload, position)) {
+      if (handleDropPayload(payload, position)) {
         editor?.focus()
       }
     },
@@ -253,14 +280,14 @@ watch(() => dragSession.state.value.currentPosition, (position) => {
     return
   }
 
-  const payload = readCurrentFileDragPayload()
+  const payload = readCurrentDragPayload()
   if (payload) {
-    runtime.syncFileDropHover(payload, position)
+    syncDropHover(payload, position)
   }
 })
 
 onUnmounted(() => {
-  runtime.clearFileDropHover()
+  runtime.clearDropHover()
   unregisterTextDropTarget()
 
   if (editor) {

--- a/src/components/editor/VisualEditorScene.spec.ts
+++ b/src/components/editor/VisualEditorScene.spec.ts
@@ -60,6 +60,7 @@ const {
   handleSelectMock,
   handleStatementDeleteMock,
   handleStatementUpdateMock,
+  handleCommandDropMock,
   handleFileDropMock,
   measureRowElementMock,
   reorderStatementsMock,
@@ -76,6 +77,7 @@ const {
   handleSelectMock: vi.fn(),
   handleStatementDeleteMock: vi.fn(),
   handleStatementUpdateMock: vi.fn(),
+  handleCommandDropMock: vi.fn(),
   handleFileDropMock: vi.fn(),
   measureRowElementMock: vi.fn(),
   reorderStatementsMock: vi.fn(),
@@ -193,6 +195,7 @@ describe('VisualEditorScene', () => {
     handleSelectMock.mockReset()
     handleStatementDeleteMock.mockReset()
     handleStatementUpdateMock.mockReset()
+    handleCommandDropMock.mockReset()
     handleFileDropMock.mockReset()
     measureRowElementMock.mockReset()
     reorderStatementsMock.mockReset()
@@ -231,7 +234,9 @@ describe('VisualEditorScene', () => {
       shouldFocusEditor: false,
     }))
     useVisualEditorSceneRuntimeMock.mockReturnValue({
+      canHandleCommandDrop: vi.fn(() => true),
       canHandleFileDrop: vi.fn(() => true),
+      handleCommandDrop: handleCommandDropMock,
       handleCollapsedUpdate: handleCollapsedUpdateMock,
       handleFileDrop: handleFileDropMock,
       handlePlayTo: handlePlayToMock,
@@ -328,7 +333,9 @@ describe('VisualEditorScene', () => {
       { index: 2, size: 100, start: 200 },
     ])
     useVisualEditorSceneRuntimeMock.mockReturnValue({
+      canHandleCommandDrop: vi.fn(() => true),
       canHandleFileDrop: vi.fn(() => true),
+      handleCommandDrop: handleCommandDropMock,
       handleCollapsedUpdate: handleCollapsedUpdateMock,
       handleFileDrop: handleFileDropMock,
       handlePlayTo: handlePlayToMock,
@@ -415,6 +422,14 @@ describe('VisualEditorScene', () => {
       path: '/games/demo/game/scene/chapter2.txt',
       isDir: false,
     } as const
+    const commandPayload = {
+      label: 'Say',
+      rawTexts: ['say:new;'],
+      source: 'command-panel',
+      type: 'command-panel-statement',
+    } as const
+
+    expect(updateConfig.canDrop(commandPayload, document.createElement('div'))).toBe(false)
 
     await updateConfig.onDrop(payload, document.createElement('div'))
 
@@ -431,6 +446,14 @@ describe('VisualEditorScene', () => {
     await gapConfig.onDrop(payload, document.createElement('div'))
 
     expect(handleFileDropMock).toHaveBeenCalledWith(payload, {
+      placement: 'gap',
+      insertIndex: 1,
+    })
+
+    expect(gapConfig.canDrop(commandPayload, document.createElement('div'))).toBe(true)
+    await gapConfig.onDrop(commandPayload, document.createElement('div'))
+
+    expect(handleCommandDropMock).toHaveBeenCalledWith(commandPayload, {
       placement: 'gap',
       insertIndex: 1,
     })

--- a/src/components/editor/VisualEditorScene.vue
+++ b/src/components/editor/VisualEditorScene.vue
@@ -4,7 +4,7 @@ import { useDroppableRegistry } from '~/composables/useDroppableRegistry'
 import { useShortcutContext } from '~/features/editor/shortcut/useShortcutContext'
 import { useVisualEditorFocusRequest } from '~/features/editor/visual-editor/useVisualEditorFocusRequest'
 import { useVisualEditorSceneRuntime } from '~/features/editor/visual-editor/useVisualEditorSceneRuntime'
-import { INSERT_BAND_SIZE_PX } from '~/features/editor/visual-editor/visual-editor-file-drop'
+import { INSERT_BAND_SIZE_PX, isVisualEditorInsertDropPlacement } from '~/features/editor/visual-editor/visual-editor-drop'
 import { findSelectedVisualEditorStatementCard } from '~/features/editor/visual-editor/visual-editor-focus'
 import { useEditSettingsStore } from '~/stores/edit-settings'
 import { SceneVisualProjectionState } from '~/stores/editor'
@@ -14,6 +14,7 @@ import type { ComponentPublicInstance } from 'vue'
 import type { ScrollArea } from '~/components/ui/scroll-area'
 import type { StatementEntry } from '~/domain/script/sentence'
 import type { VisualEditorFileDropTarget } from '~/features/editor/visual-editor/useVisualEditorSceneRuntime'
+import type { DragPayload } from '~/types/drag-drop'
 
 interface Props {
   state: SceneVisualProjectionState
@@ -178,6 +179,33 @@ function setActiveDropIndicator(target?: VisualEditorFileDropTarget) {
   activeDropIndicator = target
 }
 
+function canHandleDropPayload(payload: DragPayload, target: VisualEditorFileDropTarget): boolean {
+  if (payload.type === 'file-system-item') {
+    return runtime.canHandleFileDrop(payload, target)
+  }
+
+  if (payload.type === 'command-panel-statement') {
+    if (!isVisualEditorInsertDropPlacement(target.placement)) {
+      return false
+    }
+    return runtime.canHandleCommandDrop(payload, target)
+  }
+
+  return false
+}
+
+function handleDropPayload(payload: DragPayload, target: VisualEditorFileDropTarget): boolean {
+  if (payload.type === 'file-system-item') {
+    return runtime.handleFileDrop(payload, target)
+  }
+
+  if (payload.type === 'command-panel-statement') {
+    return runtime.handleCommandDrop(payload, target)
+  }
+
+  return false
+}
+
 function registerDropTarget(
   key: string,
   element: HTMLElement | undefined,
@@ -195,17 +223,19 @@ function registerDropTarget(
 
   dropElements.set(key, element)
   dropRegistry.registerDroppable(element, {
-    accept: 'file-system-item',
+    accept: target.placement === 'update'
+      ? 'file-system-item'
+      : ['file-system-item', 'command-panel-statement'],
     canDrop(payload) {
-      return payload.type === 'file-system-item'
-        && runtime.canHandleFileDrop(payload, target)
+      return canHandleDropPayload(payload, target)
     },
     id: `visual-editor:${key}`,
     onDragEnter(payload) {
-      if (
-        payload.type !== 'file-system-item'
-        || !runtime.canHandleFileDrop(payload, target)
-      ) {
+      if (payload.type === 'command-panel-statement' && !isVisualEditorInsertDropPlacement(target.placement)) {
+        return
+      }
+
+      if (!canHandleDropPayload(payload, target)) {
         return
       }
 
@@ -216,11 +246,8 @@ function registerDropTarget(
     },
     onDrop(payload) {
       setActiveDropIndicator(undefined)
-      if (payload.type !== 'file-system-item') {
-        return
-      }
 
-      if (runtime.handleFileDrop(payload, target)) {
+      if (handleDropPayload(payload, target)) {
         editorSurfaceRef.value?.focus({ preventScroll: true })
       }
     },

--- a/src/features/editor/text-editor/__tests__/text-editor-command-drop.test.ts
+++ b/src/features/editor/text-editor/__tests__/text-editor-command-drop.test.ts
@@ -1,0 +1,122 @@
+import * as monaco from 'monaco-editor'
+import { describe, expect, it, vi } from 'vitest'
+
+import { resolveTextEditorCommandDropAction } from '~/features/editor/text-editor/text-editor-command-drop'
+
+import type { CommandPanelStatementDragPayload } from '~/types/drag-drop'
+
+vi.mock('monaco-editor', async () => {
+  const { createMonacoMockModule } = await import('~/__tests__/mocks/monaco')
+  return createMonacoMockModule()
+})
+
+function createPayload(rawTexts: string[]): CommandPanelStatementDragPayload {
+  return {
+    label: 'Say',
+    rawTexts,
+    source: 'command-panel',
+    type: 'command-panel-statement',
+  }
+}
+
+function createMouseTarget(lineNumber: number, column: number): monaco.editor.IMouseTargetContentText {
+  const position = new monaco.Position(lineNumber, column)
+  const range = new monaco.Range(lineNumber, column, lineNumber, column)
+  return {
+    detail: {
+      mightBeForeignElement: false,
+    },
+    // Monaco 的 IMouseTarget 契约显式用 null 表示没有关联 DOM 元素。
+    // eslint-disable-next-line unicorn/no-null
+    element: null,
+    mouseColumn: column,
+    position,
+    range,
+    type: monaco.editor.MouseTargetType.CONTENT_TEXT,
+  }
+}
+
+function createEditorDouble(lines: string[]) {
+  const model = {
+    getLineContent(lineNumber: number) {
+      return lines[lineNumber - 1] ?? ''
+    },
+    getLineMaxColumn(lineNumber: number) {
+      return (lines[lineNumber - 1] ?? '').length + 1
+    },
+  }
+
+  return {
+    getModel: () => model,
+    getTargetAtClientPoint: vi.fn(() => createMouseTarget(2, 1)),
+  } as unknown as monaco.editor.IStandaloneCodeEditor
+}
+
+describe('resolveTextEditorCommandDropAction', () => {
+  it('空行投放命令会在空行位置插入语句', () => {
+    const editor = createEditorDouble(['say:hello;', ''])
+
+    const action = resolveTextEditorCommandDropAction({
+      editor,
+      payload: createPayload(['changeBg:room.png;']),
+      position: { x: 100, y: 40 },
+    })
+
+    expect(action).toMatchObject({
+      kind: 'insert-statement-line',
+      text: 'changeBg:room.png;',
+      range: { startLineNumber: 2, startColumn: 1, endLineNumber: 2, endColumn: 1 },
+    })
+  })
+
+  it('非空行行首投放命令会插入到当前行之前', () => {
+    const editor = createEditorDouble(['say:hello;', 'changeBg:old.png;'])
+    editor.getTargetAtClientPoint = vi.fn(() => createMouseTarget(2, 1))
+
+    const action = resolveTextEditorCommandDropAction({
+      editor,
+      payload: createPayload(['changeBg:room.png;']),
+      position: { x: 20, y: 40 },
+    })
+
+    expect(action).toMatchObject({
+      kind: 'insert-statement-line',
+      text: 'changeBg:room.png;\n',
+      range: { startLineNumber: 2, startColumn: 1, endLineNumber: 2, endColumn: 1 },
+    })
+  })
+
+  it('语句主体中间投放命令会插入到当前行之后', () => {
+    const editor = createEditorDouble(['say:hello;', 'say:world -speaker=Bob;'])
+    editor.getTargetAtClientPoint = vi.fn(() => createMouseTarget(2, 10))
+
+    const action = resolveTextEditorCommandDropAction({
+      editor,
+      payload: createPayload(['changeBg:room.png;']),
+      position: { x: 120, y: 40 },
+    })
+
+    expect(action).toMatchObject({
+      kind: 'insert-statement-line',
+      text: '\nchangeBg:room.png;',
+      range: { startLineNumber: 2, startColumn: 24, endLineNumber: 2, endColumn: 24 },
+    })
+  })
+
+  it('语句组投放会按多行连续插入', () => {
+    const editor = createEditorDouble(['say:hello;', 'say:world;'])
+    editor.getTargetAtClientPoint = vi.fn(() => createMouseTarget(2, 5))
+
+    const action = resolveTextEditorCommandDropAction({
+      editor,
+      payload: createPayload(['changeBg:room.png;', 'bgm:theme.ogg;']),
+      position: { x: 120, y: 40 },
+    })
+
+    expect(action).toMatchObject({
+      kind: 'insert-statement-line',
+      text: '\nchangeBg:room.png;\nbgm:theme.ogg;',
+      range: { startLineNumber: 2, startColumn: 11, endLineNumber: 2, endColumn: 11 },
+    })
+  })
+})

--- a/src/features/editor/text-editor/__tests__/useTextEditorRuntime-preview-sync.test.ts
+++ b/src/features/editor/text-editor/__tests__/useTextEditorRuntime-preview-sync.test.ts
@@ -409,6 +409,58 @@ describe('useTextEditorRuntime', () => {
     )
   })
 
+  it('命令面板语句投放会通过 external 事务来源插入文本', () => {
+    const path = '/project/scene-command-drop.txt'
+    const state = createState(path)
+    const editor = {
+      ...createEditor(),
+      getTargetAtClientPoint: vi.fn(() => ({
+        position: {
+          column: 5,
+          lineNumber: 1,
+        },
+      })),
+    }
+    editor.getModel.mockReturnValue({
+      getLineContent: vi.fn(() => 'say:hello;'),
+      getLineCount: vi.fn(() => 1),
+      getLineMaxColumn: vi.fn(() => 11),
+    })
+    const applyProgrammaticInsert = vi.fn(() => true)
+
+    useEditorStoreMock.mockReturnValue(createEditableEditorStore(path))
+    useTabsStoreMock.mockReturnValue(createTabsStore(path))
+    useTextEditorBindingsMock.mockReturnValue({
+      applyProgrammaticInsert,
+      applyProgrammaticStatementUpdate: vi.fn(() => false),
+      consumePendingTextTransactionSource: vi.fn(),
+      handleCursorSelectionChange: vi.fn(),
+    })
+
+    const runtime = useTextEditorRuntime({
+      editorRef: shallowRef(editor) as never,
+      getState: () => state,
+    })
+
+    expect(runtime.handleCommandDrop({
+      label: 'Say',
+      rawTexts: ['say:new;'],
+      source: 'command-panel',
+      type: 'command-panel-statement',
+    }, {
+      x: 100,
+      y: 40,
+    })).toBe(true)
+
+    expect(applyProgrammaticInsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: 'insert-statement-line',
+        text: '\nsay:new;',
+      }),
+      'external',
+    )
+  })
+
   it('跨行移动光标时会同步预览到新的关注行', () => {
     const path = '/project/scene-cross-line.txt'
     const state = createState(path)

--- a/src/features/editor/text-editor/text-editor-command-drop.ts
+++ b/src/features/editor/text-editor/text-editor-command-drop.ts
@@ -1,0 +1,34 @@
+import {
+  createTextEditorStatementLineDropAction,
+  resolveTextEditorHitPosition,
+} from '~/features/editor/text-editor/text-editor-drop-action'
+
+import type { TextEditorInsertStatementLineDropAction } from './text-editor-drop-action'
+import type * as monaco from 'monaco-editor'
+import type { CommandPanelStatementDragPayload, DragPosition } from '~/types/drag-drop'
+
+export function resolveTextEditorCommandDropAction(options: {
+  editor: monaco.editor.IStandaloneCodeEditor
+  payload: CommandPanelStatementDragPayload
+  position: DragPosition
+}): TextEditorInsertStatementLineDropAction | undefined {
+  if (options.payload.rawTexts.length === 0) {
+    return undefined
+  }
+
+  const model = options.editor.getModel()
+  const hit = resolveTextEditorHitPosition(options.editor, options.position)
+  if (!model || !hit) {
+    return undefined
+  }
+
+  const lineText = model.getLineContent(hit.lineNumber)
+  const lineMaxColumn = model.getLineMaxColumn(hit.lineNumber)
+  return createTextEditorStatementLineDropAction({
+    hit,
+    inlinePlacement: 'after-line',
+    insertedStatementText: options.payload.rawTexts.join('\n'),
+    lineMaxColumn,
+    lineText,
+  })
+}

--- a/src/features/editor/text-editor/text-editor-drop-action.ts
+++ b/src/features/editor/text-editor/text-editor-drop-action.ts
@@ -1,0 +1,121 @@
+import * as monaco from 'monaco-editor'
+
+import type { StatementUpdatePayload } from '~/features/editor/statement-editor/useStatementEditor'
+import type { DragPosition } from '~/types/drag-drop'
+
+export interface TextEditorInsertTextDropAction {
+  kind: 'insert-text'
+  range: monaco.IRange
+  text: string
+}
+
+export interface TextEditorInsertStatementLineDropAction {
+  kind: 'insert-statement-line'
+  range: monaco.IRange
+  text: string
+}
+
+export interface TextEditorUpdateStatementDropAction {
+  caretRange: monaco.IRange
+  kind: 'update-statement'
+  payload: StatementUpdatePayload
+}
+
+export type TextEditorDropAction =
+  | TextEditorInsertTextDropAction
+  | TextEditorInsertStatementLineDropAction
+  | TextEditorUpdateStatementDropAction
+
+export type TextEditorInlineStatementPlacement = 'after-line' | 'none'
+
+export function resolveTextEditorHitPosition(
+  editor: monaco.editor.IStandaloneCodeEditor,
+  position: DragPosition,
+): monaco.IPosition | undefined {
+  return editor.getTargetAtClientPoint(position.x, position.y)?.position ?? undefined
+}
+
+export function createTextEditorCollapsedRange(position: monaco.IPosition): monaco.IRange {
+  return {
+    startLineNumber: position.lineNumber,
+    startColumn: position.column,
+    endLineNumber: position.lineNumber,
+    endColumn: position.column,
+  }
+}
+
+function getFirstNonWhitespaceColumn(lineText: string): number {
+  const index = lineText.search(/\S/)
+  return index === -1 ? 1 : index + 1
+}
+
+function createLineEdgeRange(lineNumber: number, column: number): monaco.IRange {
+  return {
+    startLineNumber: lineNumber,
+    startColumn: column,
+    endLineNumber: lineNumber,
+    endColumn: column,
+  }
+}
+
+export function createTextEditorStatementLineDropAction(options: {
+  hit: monaco.IPosition
+  inlinePlacement?: TextEditorInlineStatementPlacement
+  insertedStatementText: string
+  lineMaxColumn: number
+  lineText: string
+}): TextEditorInsertStatementLineDropAction | undefined {
+  const {
+    hit,
+    inlinePlacement = 'none',
+    insertedStatementText,
+    lineMaxColumn,
+    lineText,
+  } = options
+  if (lineText.trim().length === 0) {
+    return {
+      kind: 'insert-statement-line',
+      text: insertedStatementText,
+      range: createLineEdgeRange(hit.lineNumber, 1),
+    }
+  }
+
+  if (hit.column <= getFirstNonWhitespaceColumn(lineText)) {
+    return {
+      kind: 'insert-statement-line',
+      text: `${insertedStatementText}\n`,
+      range: createLineEdgeRange(hit.lineNumber, 1),
+    }
+  }
+
+  if (inlinePlacement === 'after-line') {
+    return {
+      kind: 'insert-statement-line',
+      text: `\n${insertedStatementText}`,
+      range: createLineEdgeRange(hit.lineNumber, lineMaxColumn),
+    }
+  }
+}
+
+export function buildTextEditorDropDecorations(options: {
+  action?: TextEditorDropAction
+}): monaco.editor.IModelDeltaDecoration[] {
+  const { action } = options
+  if (!action) {
+    return []
+  }
+
+  const caretRange = action.kind === 'update-statement' ? action.caretRange : action.range
+  return [{
+    range: new monaco.Range(
+      caretRange.startLineNumber,
+      caretRange.startColumn,
+      caretRange.endLineNumber,
+      caretRange.endColumn,
+    ),
+    options: {
+      className: 'text-editor-drop-caret',
+      stickiness: monaco.editor.TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges,
+    },
+  }]
+}

--- a/src/features/editor/text-editor/text-editor-file-drop.ts
+++ b/src/features/editor/text-editor/text-editor-file-drop.ts
@@ -1,5 +1,3 @@
-import * as monaco from 'monaco-editor'
-
 import { parseSentence } from '~/domain/script/parser'
 import {
   buildInsertedStatementText,
@@ -7,50 +5,16 @@ import {
   updateStatementTextForDroppedAsset,
 } from '~/features/editor/shared/editor-file-drop'
 import { createTextLineTarget } from '~/features/editor/statement-editor/useStatementEditor'
+import {
+  createTextEditorCollapsedRange,
+  createTextEditorStatementLineDropAction,
+  resolveTextEditorHitPosition,
+} from '~/features/editor/text-editor/text-editor-drop-action'
 
+import type * as monaco from 'monaco-editor'
 import type { AbsPath } from '~/domain/path'
-import type { StatementUpdatePayload } from '~/features/editor/statement-editor/useStatementEditor'
+import type { TextEditorDropAction } from '~/features/editor/text-editor/text-editor-drop-action'
 import type { DragPosition, FileSystemDragPayload } from '~/types/drag-drop'
-
-export interface TextEditorInsertTextDropAction {
-  kind: 'insert-text'
-  range: monaco.IRange
-  text: string
-}
-
-export interface TextEditorInsertStatementLineDropAction {
-  kind: 'insert-statement-line'
-  range: monaco.IRange
-  text: string
-}
-
-export interface TextEditorUpdateStatementDropAction {
-  caretRange: monaco.IRange
-  kind: 'update-statement'
-  payload: StatementUpdatePayload
-}
-
-export type TextEditorDropAction =
-  | TextEditorInsertTextDropAction
-  | TextEditorInsertStatementLineDropAction
-  | TextEditorUpdateStatementDropAction
-
-function resolveHitPosition(
-  editor: monaco.editor.IStandaloneCodeEditor,
-  position: DragPosition,
-): monaco.IPosition | undefined {
-  const target = editor.getTargetAtClientPoint(position.x, position.y)
-  if (!target?.position) {
-    return undefined
-  }
-
-  return target.position
-}
-
-function getFirstNonWhitespaceColumn(lineText: string): number {
-  const index = lineText.search(/\S/)
-  return index === -1 ? 1 : index + 1
-}
 
 function isWebgalCommentColumn(lineText: string, column: number): boolean {
   for (let index = 0; index < lineText.length; index++) {
@@ -60,62 +24,6 @@ function isWebgalCommentColumn(lineText: string, column: number): boolean {
   }
 
   return false
-}
-
-function createCollapsedRange(position: monaco.IPosition): monaco.IRange {
-  return {
-    startLineNumber: position.lineNumber,
-    startColumn: position.column,
-    endLineNumber: position.lineNumber,
-    endColumn: position.column,
-  }
-}
-
-function createStatementLineDropAction(options: {
-  hit: monaco.IPosition
-  insertedStatementText: string
-  lineMaxColumn: number
-  lineText: string
-}): TextEditorInsertStatementLineDropAction | undefined {
-  const { hit, insertedStatementText, lineMaxColumn, lineText } = options
-  if (lineText.trim().length === 0) {
-    return {
-      kind: 'insert-statement-line',
-      text: insertedStatementText,
-      range: {
-        startLineNumber: hit.lineNumber,
-        startColumn: 1,
-        endLineNumber: hit.lineNumber,
-        endColumn: 1,
-      },
-    }
-  }
-
-  if (hit.column <= getFirstNonWhitespaceColumn(lineText)) {
-    return {
-      kind: 'insert-statement-line',
-      text: `${insertedStatementText}\n`,
-      range: {
-        startLineNumber: hit.lineNumber,
-        startColumn: 1,
-        endLineNumber: hit.lineNumber,
-        endColumn: 1,
-      },
-    }
-  }
-
-  if (isWebgalCommentColumn(lineText, hit.column) && hit.column >= lineMaxColumn) {
-    return {
-      kind: 'insert-statement-line',
-      text: `\n${insertedStatementText}`,
-      range: {
-        startLineNumber: hit.lineNumber,
-        startColumn: lineMaxColumn,
-        endLineNumber: hit.lineNumber,
-        endColumn: lineMaxColumn,
-      },
-    }
-  }
 }
 
 export function resolveTextEditorFileDropAction(options: {
@@ -133,15 +41,18 @@ export function resolveTextEditorFileDropAction(options: {
   }
 
   const model = options.editor.getModel()
-  const hit = resolveHitPosition(options.editor, options.position)
+  const hit = resolveTextEditorHitPosition(options.editor, options.position)
   if (!model || !hit) {
     return undefined
   }
 
   const lineText = model.getLineContent(hit.lineNumber)
   const lineMaxColumn = model.getLineMaxColumn(hit.lineNumber)
-  const statementLineAction = createStatementLineDropAction({
+  const statementLineAction = createTextEditorStatementLineDropAction({
     hit,
+    inlinePlacement: isWebgalCommentColumn(lineText, hit.column) && hit.column >= lineMaxColumn
+      ? 'after-line'
+      : 'none',
     insertedStatementText: buildInsertedStatementText(asset),
     lineMaxColumn,
     lineText,
@@ -155,7 +66,7 @@ export function resolveTextEditorFileDropAction(options: {
     const parsed = nextRawText ? parseSentence(nextRawText) : undefined
     if (nextRawText && parsed) {
       return {
-        caretRange: createCollapsedRange(hit),
+        caretRange: createTextEditorCollapsedRange(hit),
         kind: 'update-statement',
         payload: {
           target: createTextLineTarget(hit.lineNumber),
@@ -169,36 +80,6 @@ export function resolveTextEditorFileDropAction(options: {
   return {
     kind: 'insert-text',
     text: asset.scriptPath,
-    range: {
-      startLineNumber: hit.lineNumber,
-      startColumn: hit.column,
-      endLineNumber: hit.lineNumber,
-      endColumn: hit.column,
-    },
+    range: createTextEditorCollapsedRange(hit),
   }
-}
-
-export function buildTextEditorDropDecorations(options: {
-  action?: TextEditorDropAction
-}): monaco.editor.IModelDeltaDecoration[] {
-  const { action } = options
-  if (!action) {
-    return []
-  }
-
-  const caretRange = action.kind === 'update-statement' ? action.caretRange : action.range
-  const decorations: monaco.editor.IModelDeltaDecoration[] = [{
-    range: new monaco.Range(
-      caretRange.startLineNumber,
-      caretRange.startColumn,
-      caretRange.endLineNumber,
-      caretRange.endColumn,
-    ),
-    options: {
-      className: 'text-editor-drop-caret',
-      stickiness: monaco.editor.TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges,
-    },
-  }]
-
-  return decorations
 }

--- a/src/features/editor/text-editor/useTextEditorRuntime.ts
+++ b/src/features/editor/text-editor/useTextEditorRuntime.ts
@@ -1,7 +1,9 @@
 import * as monaco from 'monaco-editor'
 
 import { isAnimationDocumentTextValid } from '~/domain/document/animation-document-codec'
-import { buildTextEditorDropDecorations, resolveTextEditorFileDropAction } from '~/features/editor/text-editor/text-editor-file-drop'
+import { resolveTextEditorCommandDropAction } from '~/features/editor/text-editor/text-editor-command-drop'
+import { buildTextEditorDropDecorations } from '~/features/editor/text-editor/text-editor-drop-action'
+import { resolveTextEditorFileDropAction } from '~/features/editor/text-editor/text-editor-file-drop'
 import { resolveTextEditorLanguage } from '~/features/editor/text-editor/text-editor-language'
 import { applySceneCursorTarget, prepareSceneCursorTarget } from '~/features/editor/text-editor/text-editor-scene-restore'
 import { resolveSceneCursorTarget, resolveScenePreviewLine } from '~/features/editor/text-editor/text-editor-scene-sync'
@@ -16,10 +18,10 @@ import { useTextEditorHistory } from './useTextEditorHistory'
 import { useTextEditorPanel } from './useTextEditorPanel'
 import { useTextEditorWorkspace } from './useTextEditorWorkspace'
 
-import type { TextEditorDropAction } from './text-editor-file-drop'
+import type { TextEditorDropAction, TextEditorInsertStatementLineDropAction } from './text-editor-drop-action'
 import type { AbsPath } from '~/domain/path'
 import type { TextProjectionState } from '~/stores/editor'
-import type { DragPosition, FileSystemDragPayload } from '~/types/drag-drop'
+import type { CommandPanelStatementDragPayload, DragPosition, FileSystemDragPayload } from '~/types/drag-drop'
 
 interface UseTextEditorRuntimeOptions {
   editorRef: ShallowRef<monaco.editor.IStandaloneCodeEditor | undefined>
@@ -37,26 +39,26 @@ export function useTextEditorRuntime(options: UseTextEditorRuntimeOptions) {
     return currentState && isEditableEditor(currentState) ? currentState.projection : undefined
   })
   let isComposing = $ref(false)
-  let fileDropDecorationIds: string[] = []
+  let dropDecorationIds: string[] = []
 
   function readEditor(): monaco.editor.IStandaloneCodeEditor | undefined {
     return options.editorRef.value
   }
 
-  function setFileDropDecorations(action?: TextEditorDropAction) {
+  function setDropDecorations(action?: TextEditorDropAction) {
     const editor = readEditor()
     if (!editor) {
       return
     }
 
-    fileDropDecorationIds = editor.deltaDecorations(
-      fileDropDecorationIds,
+    dropDecorationIds = editor.deltaDecorations(
+      dropDecorationIds,
       buildTextEditorDropDecorations({ action }),
     )
   }
 
-  function clearFileDropHover(): void {
-    setFileDropDecorations(undefined)
+  function clearDropHover(): void {
+    setDropDecorations(undefined)
   }
 
   function resolveFileDropAction(payload: FileSystemDragPayload, position: DragPosition): TextEditorDropAction | undefined {
@@ -74,23 +76,52 @@ export function useTextEditorRuntime(options: UseTextEditorRuntimeOptions) {
     })
   }
 
+  function resolveCommandDropAction(
+    payload: CommandPanelStatementDragPayload,
+    position: DragPosition,
+  ): TextEditorInsertStatementLineDropAction | undefined {
+    const editor = readEditor()
+    if (state.value.kind !== 'scene' || !editor) {
+      return undefined
+    }
+
+    return resolveTextEditorCommandDropAction({
+      editor,
+      payload,
+      position,
+    })
+  }
+
   function syncFileDropHover(payload: FileSystemDragPayload, position: DragPosition | null): void {
     if (!position) {
-      clearFileDropHover()
+      clearDropHover()
       return
     }
 
-    setFileDropDecorations(resolveFileDropAction(payload, position))
+    setDropDecorations(resolveFileDropAction(payload, position))
+  }
+
+  function syncCommandDropHover(payload: CommandPanelStatementDragPayload, position: DragPosition | null): void {
+    if (!position) {
+      clearDropHover()
+      return
+    }
+
+    setDropDecorations(resolveCommandDropAction(payload, position))
   }
 
   function canHandleFileDrop(payload: FileSystemDragPayload, position: DragPosition | null): boolean {
     return position ? resolveFileDropAction(payload, position) !== undefined : false
   }
 
+  function canHandleCommandDrop(payload: CommandPanelStatementDragPayload, position: DragPosition | null): boolean {
+    return position ? resolveCommandDropAction(payload, position) !== undefined : false
+  }
+
   function handleFileDrop(payload: FileSystemDragPayload, position: DragPosition): boolean {
     const action = resolveFileDropAction(payload, position)
     if (!action) {
-      clearFileDropHover()
+      clearDropHover()
       return false
     }
 
@@ -98,7 +129,20 @@ export function useTextEditorRuntime(options: UseTextEditorRuntimeOptions) {
       ? textEditorBindings.applyProgrammaticStatementUpdate(action.payload, 'external')
       : textEditorBindings.applyProgrammaticInsert(action, 'external')
 
-    clearFileDropHover()
+    clearDropHover()
+    return applied
+  }
+
+  function handleCommandDrop(payload: CommandPanelStatementDragPayload, position: DragPosition): boolean {
+    const action = resolveCommandDropAction(payload, position)
+    if (!action) {
+      clearDropHover()
+      return false
+    }
+
+    const applied = textEditorBindings.applyProgrammaticInsert(action, 'external')
+
+    clearDropHover()
     return applied
   }
 
@@ -478,10 +522,12 @@ export function useTextEditorRuntime(options: UseTextEditorRuntimeOptions) {
   )
 
   return {
+    canHandleCommandDrop,
     canHandleFileDrop,
-    clearFileDropHover,
+    clearDropHover,
     currentEditorLanguage,
     ensureModel,
+    handleCommandDrop,
     handleBeforeUnmount,
     handleContentChange,
     handleCursorPositionChange,
@@ -490,6 +536,7 @@ export function useTextEditorRuntime(options: UseTextEditorRuntimeOptions) {
     handleEditorCreated,
     handleFileDrop,
     handleScrollChange,
+    syncCommandDropHover,
     syncFileDropHover,
   }
 }

--- a/src/features/editor/visual-editor/__tests__/useVisualEditorSceneRuntime.test.ts
+++ b/src/features/editor/visual-editor/__tests__/useVisualEditorSceneRuntime.test.ts
@@ -537,6 +537,113 @@ describe('useVisualEditorSceneRuntime', () => {
     scope.stop()
   })
 
+  it('命令面板语句投放到插入区会插入 rawTexts 并触发自动保存', () => {
+    const scope = effectScope()
+    const state = createState()
+    const applySceneStatementInsert = vi.fn()
+    const scheduleAutoSaveIfEnabled = vi.fn()
+
+    useEditorStoreMock.mockReturnValue(reactive({
+      applySceneStatementDelete: vi.fn(),
+      applySceneStatementInsert,
+      applySceneStatementReorder: vi.fn(),
+      applySceneStatementUpdate: vi.fn(),
+      consumePendingSceneProjectionActivation: vi.fn(() => false),
+      currentState: {
+        kind: 'scene',
+        path: '/project/scene.txt',
+        projection: 'visual',
+      },
+      getSceneSelection: vi.fn(() => ({
+        lastEditedStatementId: 1,
+        lastLineNumber: 1,
+        selectedStatementId: 1,
+      })),
+      isSceneStatementCollapsed: vi.fn(() => false),
+      scheduleAutoSaveIfEnabled,
+      setSceneStatementCollapsed: vi.fn(),
+      syncScenePreview: vi.fn(),
+      syncSceneSelectionFromStatement: vi.fn(),
+    }))
+
+    const runtime = scope.run(() => useVisualEditorSceneRuntime({
+      getScrollArea: () => undefined,
+      getState: () => state,
+    }))
+
+    const applied = runtime?.handleCommandDrop({
+      label: 'Group',
+      rawTexts: ['changeBg:room.png;', 'bgm:theme.ogg;'],
+      source: 'command-panel',
+      type: 'command-panel-statement',
+    }, {
+      placement: 'gap',
+      insertIndex: 1,
+    })
+
+    expect(applied).toBe(true)
+    expect(applySceneStatementInsert).toHaveBeenCalledWith('/project/scene.txt', [
+      expect.objectContaining({ rawText: 'changeBg:room.png;' }),
+      expect.objectContaining({ rawText: 'bgm:theme.ogg;' }),
+    ], 1)
+    expect(scheduleAutoSaveIfEnabled).toHaveBeenCalledWith('/project/scene.txt')
+
+    scope.stop()
+  })
+
+  it('命令面板语句投放到更新区会被拒绝', () => {
+    const scope = effectScope()
+    const state = createState()
+    const applySceneStatementInsert = vi.fn()
+    const applySceneStatementUpdate = vi.fn()
+
+    useEditorStoreMock.mockReturnValue(reactive({
+      applySceneStatementDelete: vi.fn(),
+      applySceneStatementInsert,
+      applySceneStatementReorder: vi.fn(),
+      applySceneStatementUpdate,
+      consumePendingSceneProjectionActivation: vi.fn(() => false),
+      currentState: {
+        kind: 'scene',
+        path: '/project/scene.txt',
+        projection: 'visual',
+      },
+      getSceneSelection: vi.fn(() => ({
+        lastEditedStatementId: 1,
+        lastLineNumber: 1,
+        selectedStatementId: 1,
+      })),
+      isSceneStatementCollapsed: vi.fn(() => false),
+      scheduleAutoSaveIfEnabled: vi.fn(),
+      setSceneStatementCollapsed: vi.fn(),
+      syncScenePreview: vi.fn(),
+      syncSceneSelectionFromStatement: vi.fn(),
+    }))
+
+    const runtime = scope.run(() => useVisualEditorSceneRuntime({
+      getScrollArea: () => undefined,
+      getState: () => state,
+    }))
+    const payload = {
+      label: 'Say',
+      rawTexts: ['say:new;'],
+      source: 'command-panel' as const,
+      type: 'command-panel-statement' as const,
+    }
+    const target = {
+      placement: 'update' as const,
+      insertIndex: 0,
+      statementId: 1,
+    }
+
+    expect(runtime?.canHandleCommandDrop(payload, target)).toBe(false)
+    expect(runtime?.handleCommandDrop(payload, target)).toBe(false)
+    expect(applySceneStatementUpdate).not.toHaveBeenCalled()
+    expect(applySceneStatementInsert).not.toHaveBeenCalled()
+
+    scope.stop()
+  })
+
   it('文件投放到插入区但未生成有效语句时会拒绝处理', () => {
     const scope = effectScope()
     const state = createState()

--- a/src/features/editor/visual-editor/__tests__/visual-editor-command-drop.test.ts
+++ b/src/features/editor/visual-editor/__tests__/visual-editor-command-drop.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveVisualEditorCommandDropAction } from '~/features/editor/visual-editor/visual-editor-command-drop'
+
+import type { CommandPanelStatementDragPayload } from '~/types/drag-drop'
+
+function createPayload(rawTexts: string[]): CommandPanelStatementDragPayload {
+  return {
+    label: 'Say',
+    rawTexts,
+    source: 'command-panel',
+    type: 'command-panel-statement',
+  }
+}
+
+describe('resolveVisualEditorCommandDropAction', () => {
+  it('gap 区投放命令会生成指定位置的插入动作', () => {
+    const action = resolveVisualEditorCommandDropAction({
+      insertIndex: 2,
+      payload: createPayload(['changeBg:room.png;']),
+      placement: 'gap',
+    })
+
+    expect(action).toEqual({
+      kind: 'insert-statements',
+      insertIndex: 2,
+      rawTexts: ['changeBg:room.png;'],
+    })
+  })
+
+  it('语句组投放会保留多条 rawTexts', () => {
+    const action = resolveVisualEditorCommandDropAction({
+      insertIndex: 5,
+      payload: createPayload(['changeBg:room.png;', 'bgm:theme.ogg;']),
+      placement: 'tail',
+    })
+
+    expect(action).toEqual({
+      kind: 'insert-statements',
+      insertIndex: 5,
+      rawTexts: ['changeBg:room.png;', 'bgm:theme.ogg;'],
+    })
+  })
+
+  it('update 区不会接受命令面板语句投放', () => {
+    const action = resolveVisualEditorCommandDropAction({
+      insertIndex: 1,
+      payload: createPayload(['changeBg:room.png;']),
+      placement: 'update',
+    })
+
+    expect(action).toBeUndefined()
+  })
+})

--- a/src/features/editor/visual-editor/useVisualEditorSceneRuntime.ts
+++ b/src/features/editor/visual-editor/useVisualEditorSceneRuntime.ts
@@ -4,6 +4,7 @@ import { useCommandPanelBridgeBinding, useSidebarPanelBinding } from '~/features
 import { useShortcut } from '~/features/editor/shortcut/useShortcut'
 import { createStatementIdTarget, StatementUpdatePayload } from '~/features/editor/statement-editor/useStatementEditor'
 import { useVisualEditorSceneViewport } from '~/features/editor/visual-editor/useVisualEditorSceneViewport'
+import { resolveVisualEditorCommandDropAction } from '~/features/editor/visual-editor/visual-editor-command-drop'
 import { resolveVisualEditorDropAction } from '~/features/editor/visual-editor/visual-editor-file-drop'
 import { canRestoreVisualEditorCardFocus, findSelectedVisualEditorStatementCard } from '~/features/editor/visual-editor/visual-editor-focus'
 import { useCommandPanelStore } from '~/stores/command-panel'
@@ -15,8 +16,8 @@ import { useTabsStore } from '~/stores/tabs'
 import { useWorkspaceStore } from '~/stores/workspace'
 import { buildPreviousSpeakers } from '~/utils/speaker'
 
-import type { VisualEditorDropPlacement } from '~/features/editor/visual-editor/visual-editor-file-drop'
-import type { FileSystemDragPayload } from '~/types/drag-drop'
+import type { VisualEditorDropAction, VisualEditorDropPlacement } from '~/features/editor/visual-editor/visual-editor-drop'
+import type { CommandPanelStatementDragPayload, FileSystemDragPayload } from '~/types/drag-drop'
 
 export interface VisualEditorFileDropTarget {
   insertIndex: number
@@ -338,6 +339,18 @@ export function useVisualEditorSceneRuntime(options: UseVisualEditorSceneRuntime
     return resolveFileDropAction(payload, target) !== undefined
   }
 
+  function applyInsertStatementsDropAction(action: Extract<VisualEditorDropAction, { kind: 'insert-statements' }>): boolean {
+    const newEntries = action.rawTexts.flatMap(text => buildStatements(text))
+    if (newEntries.length === 0) {
+      return false
+    }
+
+    editorStore.applySceneStatementInsert(state.value.path, newEntries, action.insertIndex)
+    void restoreSelectedStatementPresentation({ align: 'auto' })
+    requestAutoSave()
+    return true
+  }
+
   function handleFileDrop(payload: FileSystemDragPayload, target: VisualEditorFileDropTarget): boolean {
     const action = resolveFileDropAction(payload, target)
     if (!action) {
@@ -345,15 +358,7 @@ export function useVisualEditorSceneRuntime(options: UseVisualEditorSceneRuntime
     }
 
     if (action.kind === 'insert-statements') {
-      const newEntries = action.rawTexts.flatMap(text => buildStatements(text))
-      if (newEntries.length === 0) {
-        return false
-      }
-
-      editorStore.applySceneStatementInsert(state.value.path, newEntries, action.insertIndex)
-      void restoreSelectedStatementPresentation({ align: 'auto' })
-      requestAutoSave()
-      return true
+      return applyInsertStatementsDropAction(action)
     }
 
     editorStore.applySceneStatementUpdate(
@@ -364,6 +369,27 @@ export function useVisualEditorSceneRuntime(options: UseVisualEditorSceneRuntime
     )
     requestAutoSave()
     return true
+  }
+
+  function resolveCommandDropAction(payload: CommandPanelStatementDragPayload, target: VisualEditorFileDropTarget) {
+    return resolveVisualEditorCommandDropAction({
+      payload,
+      placement: target.placement,
+      insertIndex: target.insertIndex,
+    })
+  }
+
+  function canHandleCommandDrop(payload: CommandPanelStatementDragPayload, target: VisualEditorFileDropTarget): boolean {
+    return resolveCommandDropAction(payload, target) !== undefined
+  }
+
+  function handleCommandDrop(payload: CommandPanelStatementDragPayload, target: VisualEditorFileDropTarget): boolean {
+    const action = resolveCommandDropAction(payload, target)
+    if (!action) {
+      return false
+    }
+
+    return applyInsertStatementsDropAction(action)
   }
 
   function cutStatement() {
@@ -642,7 +668,9 @@ export function useVisualEditorSceneRuntime(options: UseVisualEditorSceneRuntime
   })
 
   return {
+    canHandleCommandDrop,
     canHandleFileDrop,
+    handleCommandDrop,
     handleCollapsedUpdate,
     handleFileDrop,
     handlePlayTo,

--- a/src/features/editor/visual-editor/useVisualEditorSceneViewport.ts
+++ b/src/features/editor/visual-editor/useVisualEditorSceneViewport.ts
@@ -1,6 +1,6 @@
 import { useVirtualizer } from '@tanstack/vue-virtual'
 
-import { INSERT_BAND_SIZE_PX } from '~/features/editor/visual-editor/visual-editor-file-drop'
+import { INSERT_BAND_SIZE_PX } from '~/features/editor/visual-editor/visual-editor-drop'
 import { SceneVisualProjectionState } from '~/stores/editor'
 
 import type { DragSortVirtualAdapter } from '~/composables/useDragSort'

--- a/src/features/editor/visual-editor/visual-editor-command-drop.ts
+++ b/src/features/editor/visual-editor/visual-editor-command-drop.ts
@@ -1,0 +1,16 @@
+import { createVisualEditorInsertStatementsDropAction } from './visual-editor-drop'
+
+import type { VisualEditorDropPlacement } from './visual-editor-drop'
+import type { CommandPanelStatementDragPayload } from '~/types/drag-drop'
+
+export function resolveVisualEditorCommandDropAction(options: {
+  insertIndex: number
+  payload: CommandPanelStatementDragPayload
+  placement: VisualEditorDropPlacement
+}) {
+  return createVisualEditorInsertStatementsDropAction({
+    insertIndex: options.insertIndex,
+    placement: options.placement,
+    rawTexts: options.payload.rawTexts,
+  })
+}

--- a/src/features/editor/visual-editor/visual-editor-drop.ts
+++ b/src/features/editor/visual-editor/visual-editor-drop.ts
@@ -1,0 +1,31 @@
+export const INSERT_BAND_SIZE_PX = 8
+
+export type VisualEditorDropPlacement = 'head' | 'gap' | 'update' | 'tail'
+
+export type VisualEditorDropAction =
+  | { kind: 'insert-statements', insertIndex: number, rawTexts: string[] }
+  | { kind: 'update-statement', rawText: string, statementId: number }
+
+type VisualEditorInsertStatementsDropAction = Extract<VisualEditorDropAction, { kind: 'insert-statements' }>
+
+export function isVisualEditorInsertDropPlacement(placement: VisualEditorDropPlacement): boolean {
+  return placement === 'head'
+    || placement === 'gap'
+    || placement === 'tail'
+}
+
+export function createVisualEditorInsertStatementsDropAction(options: {
+  insertIndex: number
+  placement: VisualEditorDropPlacement
+  rawTexts: string[]
+}): VisualEditorInsertStatementsDropAction | undefined {
+  if (!isVisualEditorInsertDropPlacement(options.placement) || options.rawTexts.length === 0) {
+    return undefined
+  }
+
+  return {
+    kind: 'insert-statements',
+    insertIndex: options.insertIndex,
+    rawTexts: [...options.rawTexts],
+  }
+}

--- a/src/features/editor/visual-editor/visual-editor-file-drop.ts
+++ b/src/features/editor/visual-editor/visual-editor-file-drop.ts
@@ -3,23 +3,11 @@ import {
   resolveEditorDropAsset,
   updateStatementTextForDroppedAsset,
 } from '~/features/editor/shared/editor-file-drop'
+import { createVisualEditorInsertStatementsDropAction } from '~/features/editor/visual-editor/visual-editor-drop'
 
 import type { AbsPath } from '~/domain/path'
+import type { VisualEditorDropAction, VisualEditorDropPlacement } from '~/features/editor/visual-editor/visual-editor-drop'
 import type { FileSystemDragPayload } from '~/types/drag-drop'
-
-export const INSERT_BAND_SIZE_PX = 8
-
-export type VisualEditorDropPlacement = 'head' | 'gap' | 'update' | 'tail'
-
-export type VisualEditorDropAction =
-  | { kind: 'insert-statements', insertIndex: number, rawTexts: string[] }
-  | { kind: 'update-statement', rawText: string, statementId: number }
-
-function isInsertPlacement(placement: VisualEditorDropPlacement): boolean {
-  return placement === 'head'
-    || placement === 'gap'
-    || placement === 'tail'
-}
 
 export function resolveVisualEditorDropAction(options: {
   gamePath: AbsPath
@@ -37,12 +25,13 @@ export function resolveVisualEditorDropAction(options: {
     return undefined
   }
 
-  if (isInsertPlacement(options.placement)) {
-    return {
-      kind: 'insert-statements',
-      insertIndex: options.insertIndex,
-      rawTexts: [buildInsertedStatementText(asset)],
-    }
+  const insertAction = createVisualEditorInsertStatementsDropAction({
+    insertIndex: options.insertIndex,
+    rawTexts: [buildInsertedStatementText(asset)],
+    placement: options.placement,
+  })
+  if (insertAction) {
+    return insertAction
   }
 
   if (options.statementId === undefined || options.rawText === undefined) {

--- a/src/types/drag-drop.ts
+++ b/src/types/drag-drop.ts
@@ -4,11 +4,13 @@ export interface DragPosition {
 }
 
 export type DragEntityType =
+  | 'command-panel-statement'
   | 'editor-tab'
   | 'file-system-item'
   | 'scene-statement'
 
 export type DragSourceType =
+  | 'command-panel'
   | 'editor-tabs'
   | 'file-tree'
   | 'file-viewer'
@@ -48,7 +50,14 @@ export interface SceneStatementDragPayload extends DragPayloadBase {
   type: 'scene-statement'
 }
 
+export interface CommandPanelStatementDragPayload extends DragPayloadBase {
+  label: string
+  rawTexts: string[]
+  type: 'command-panel-statement'
+}
+
 export type DragPayload =
+  | CommandPanelStatementDragPayload
   | EditorTabDragPayload
   | FileSystemDragPayload
   | SceneStatementDragPayload


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [ ] 错误修复
- [x] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [x] 代码重构
- [x] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

这个 PR 为命令面板命令卡片和语句组卡片增加拖放能力，允许将命令面板中的语句直接投放到文本编辑器或可视化编辑器中。

主要更改：

- 新增 `command-panel-statement` 拖放 payload，用于承载命令或语句组的 `rawTexts`
- 命令面板卡片接入拖拽源，并增加拖拽浮层展示当前拖拽内容
- 文本编辑器支持接收命令面板语句投放，并根据落点插入到空行、行前或行后
- 可视化编辑器支持在 head / gap / tail 插入区接收命令面板语句投放，拒绝 update 区投放
- 抽离文本编辑器与可视化编辑器的 drop action 公共逻辑，减少文件投放和命令投放之间的重复
- 修正命令面板卡片动作区事件冒泡，避免点击编辑/删除按钮时触发卡片主点击行为
- 补充命令面板、文本编辑器、可视化编辑器及 drop action 的相关测试

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

命令面板已经承担了快速插入 WebGAL 语句的入口职责，但原先只能通过点击插入，无法把命令或语句组直接投放到目标位置。

这个改动让命令面板、文本编辑器和可视化编辑器共用现有拖放基础设施，使用户可以用更直接的方式把单条命令或语句组插入到当前编辑位置，同时保持文件资源投放的既有行为不变。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
