### PR TITLE
🐛 修复 setAnimation 语句动画控件值回显异常

### DIFF
--- a/src/features/editor/statement-editor/__tests__/useStatementEditorContent.test.ts
+++ b/src/features/editor/statement-editor/__tests__/useStatementEditorContent.test.ts
@@ -10,6 +10,8 @@ import { mustParse } from '~/domain/script/__tests__/utils'
 import { parseCommandNode } from '~/domain/script/codec'
 import { stringifySetVarContent } from '~/domain/script/content'
 import { createHarness, resetStatementEditorRuntime } from '~/features/editor/__tests__/statement-editor-test-utils'
+import { CUSTOM_CONTENT } from '~/features/editor/command-registry/schema'
+import { registerDynamicOptions } from '~/features/editor/dynamic-options/dynamic-options'
 import { useStatementEditorContent } from '~/features/editor/statement-editor/useStatementEditorContent'
 
 import type { ISentence } from 'webgal-parser/src/interface/sceneInterface'
@@ -61,6 +63,66 @@ describe('useStatementEditorContent', () => {
     editor.content.specialContent.handleSetVarValueChange('20')
 
     expect(updates.at(-1)?.rawText).toBe(`setVar:${stringifySetVarContent('score', '20')};`)
+  })
+
+  it('无静态选项的 content choice 会回显文本值和选择器写入值', () => {
+    const { editor, updates } = createHarness('setAnimation: bounce;')
+    const contentField = editor.contentField.value
+
+    if (!contentField) {
+      throw new TypeError('missing content field')
+    }
+
+    expect(editor.params.getFieldSelectValue(contentField)).toBe('bounce')
+
+    editor.params.handleFieldSelectChange(contentField, 'flash')
+
+    expect(updates.at(-1)?.parsed.content).toBe('flash')
+    expect(editor.params.getFieldSelectValue(contentField)).toBe('flash')
+  })
+
+  it('customizable content choice 会用动态选项区分已知值和自定义值', () => {
+    registerDynamicOptions('animationTableEntries', () => ({
+      options: [
+        { label: 'bounce', value: 'bounce' },
+        { label: 'flash', value: 'flash' },
+      ],
+      loading: false,
+    }))
+
+    const dynamicContentField = {
+      key: 'content',
+      storage: 'content',
+      field: {
+        key: 'animation',
+        type: 'choice',
+        label: 'animation',
+        customizable: true,
+        dynamicOptionsKey: 'animationTableEntries',
+        options: [],
+      },
+    } satisfies EditorField
+
+    const knownSentence = mustParse('setAnimation: flash;')
+    const knownContent = useStatementEditorContent({
+      parsed: computed(() => knownSentence),
+      commandNode: computed(() => parseCommandNode(knownSentence)),
+      contentField: computed(() => dynamicContentField),
+      argFields: computed(() => [] as ArgField[]),
+      emitUpdate: () => { /* no-op */ },
+    })
+
+    const customSentence = mustParse('setAnimation: custom-motion;')
+    const customContent = useStatementEditorContent({
+      parsed: computed(() => customSentence),
+      commandNode: computed(() => parseCommandNode(customSentence)),
+      contentField: computed(() => dynamicContentField),
+      argFields: computed(() => [] as ArgField[]),
+      emitUpdate: () => { /* no-op */ },
+    })
+
+    expect(knownContent.contentSelectValue.value).toBe('flash')
+    expect(customContent.contentSelectValue.value).toBe(CUSTOM_CONTENT)
   })
 
   it('多行 textarea 字段会被识别为 multiline', () => {

--- a/src/features/editor/statement-editor/useStatementEditorContent.ts
+++ b/src/features/editor/statement-editor/useStatementEditorContent.ts
@@ -5,8 +5,11 @@ import { ChooseContentItem, parseChooseContent, parseSetVarContent, parseStyleRu
 import { CommandNode } from '~/domain/script/types'
 import { updateCommandNodeContent } from '~/domain/script/update'
 import { ArgField, CUSTOM_CONTENT, EditorField, FieldDef, readArgFieldStorageKey, resolveI18n } from '~/features/editor/command-registry/schema'
+import { resolveDynamicOptions } from '~/features/editor/dynamic-options/dynamic-options'
+import { useWorkspaceStore } from '~/stores/workspace'
 
 import type { ISentence } from 'webgal-parser/src/interface/sceneInterface'
+import type { DynamicOptionsContext } from '~/features/editor/command-registry/schema'
 
 export interface UseStatementEditorContentOptions {
   parsed: ComputedRef<ISentence | undefined>
@@ -22,15 +25,44 @@ export interface UseStatementEditorContentOptions {
 export function useStatementEditorContent(options: UseStatementEditorContentOptions) {
   const { t } = useI18n()
 
+  function createDynamicOptionsContext(): DynamicOptionsContext {
+    const workspaceStore = useWorkspaceStore()
+    return {
+      content: options.parsed.value?.content ?? '',
+      gamePath: workspaceStore.CWD ?? '',
+    }
+  }
+
+  function getContentDynamicOptions(field: Extract<FieldDef, { type: 'choice' }>): { label: string, value: string }[] {
+    const key = field.dynamicOptionsKey
+    if (!key) {
+      return []
+    }
+    const result = resolveDynamicOptions(key, createDynamicOptionsContext())
+    return result?.options ?? []
+  }
+
+  function isKnownContentChoiceValue(field: Extract<FieldDef, { type: 'choice' }>, value: string): boolean {
+    return field.options.some(option => option.value === value)
+      || getContentDynamicOptions(field).some(option => option.value === value)
+  }
+
   const contentSelectValue = computed(() => {
     const content = options.contentField.value?.field
-    const fieldOptions = content?.type === 'choice' ? content.options : undefined
-    if (!fieldOptions?.length) {
+    if (content?.type !== 'choice') {
       return ''
     }
-    return fieldOptions.some((o: { value: string }) => o.value === options.parsed.value?.content)
-      ? (options.parsed.value?.content ?? '')
-      : CUSTOM_CONTENT
+
+    const currentValue = options.parsed.value?.content ?? ''
+    if (!currentValue) {
+      return ''
+    }
+
+    if (!content.customizable || isKnownContentChoiceValue(content, currentValue)) {
+      return currentValue
+    }
+
+    return CUSTOM_CONTENT
   })
 
   const isCustomContent = computed(() => contentSelectValue.value === CUSTOM_CONTENT)


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [x] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [x] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

修复 `setAnimation` 语句在可视化编辑器中的动画控件值回显问题。

这次改动主要调整了 `useStatementEditorContent` 对 `choice` 类型 content 字段的值解析逻辑：
- 当字段没有静态选项时，直接回显当前文本值，避免选择器显示为空；
- 当字段使用动态选项且允许自定义值时，正确区分已知动态选项和自定义内容；
- 保持选择器变更后的写回行为正确。

同时补充了对应测试，覆盖无静态选项回显、动态选项命中以及自定义值回退到 `CUSTOM_CONTENT` 的场景。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

`setAnimation` 的动画名依赖动态选项，但现有 content 选择值计算逻辑主要只检查静态 `options`。

这会导致语句已有值时，动画控件无法正确显示当前值，影响可视化编辑器中的状态回显和后续编辑体验。

这次修复将动态选项纳入已知值判断，并补齐回归测试，防止同类问题再次出现。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
