### PR TITLE
🐛 修复导入项目时的引擎选择上下文

### DIFF
--- a/src/components/modals/EngineSelectionModal.spec.ts
+++ b/src/components/modals/EngineSelectionModal.spec.ts
@@ -39,18 +39,30 @@ const globalStubs = {
   EngineSelector: defineComponent({
     name: 'StubEngineSelector',
     props: {
+      modelValue: {
+        type: String,
+        default: undefined,
+      },
       preferredEngineId: {
         type: String,
         default: undefined,
       },
     },
-    setup(props) {
+    emits: ['update:modelValue'],
+    setup(props, { emit }) {
       return () => h('div', {
         'data-testid': 'engine-selector',
+        'data-model-value': props.modelValue ?? '',
         'data-preferred-engine-id': props.preferredEngineId ?? '',
-      })
+      }, [
+        h('button', {
+          type: 'button',
+          onClick: () => emit('update:modelValue', 'engine-selected'),
+        }, 'select-engine'),
+      ])
     },
   }),
+  Label: createBrowserContainerStub('StubLabel', 'label'),
 }
 
 describe('EngineSelectionModal', () => {
@@ -104,5 +116,30 @@ describe('EngineSelectionModal', () => {
     const selector = await page.getByTestId('engine-selector').element()
 
     expect(selector.dataset.preferredEngineId).toBe('open-webgal.webgal')
+  })
+
+  it('选择引擎后确认会返回选中的 engineId', async () => {
+    const onConfirm = vi.fn()
+    const updateOpen = vi.fn()
+
+    renderInBrowser(EngineSelectionModal, {
+      browser: {
+        i18nMode: 'lite',
+      },
+      props: {
+        'open': true,
+        onConfirm,
+        'onUpdate:open': updateOpen,
+      },
+      global: {
+        stubs: globalStubs,
+      },
+    })
+
+    await page.getByRole('button', { name: 'select-engine' }).click()
+    await page.getByRole('button', { name: 'common.confirm' }).click()
+
+    expect(onConfirm).toHaveBeenCalledWith('engine-selected')
+    expect(updateOpen).toHaveBeenCalledWith(false)
   })
 })

--- a/src/components/modals/EngineSelectionModal.vue
+++ b/src/components/modals/EngineSelectionModal.vue
@@ -1,16 +1,31 @@
 <script setup lang="ts">
+import { usePreferenceStore } from '~/stores/preference'
+
 import type { EngineRef } from '~/types/project-config'
 
 let open = $(defineModel<boolean>('open'))
 
 const props = defineProps<{
+  gameName?: string
   hint?: EngineRef
   onCancel?: () => void
   onConfirm?: (engineId: string) => void
 }>()
 
+const { t } = useI18n()
+const preferenceStore = usePreferenceStore()
+
 let selectedEngineId = $ref<string>()
 let settled = $ref(false)
+
+const preferredEngineId = $computed(() => props.hint?.id ?? preferenceStore.defaultEngineId)
+
+const description = $computed(() => {
+  const gameName = props.gameName?.trim()
+  return gameName
+    ? t('game.selectEngineDescriptionWithName', { name: gameName })
+    : t('game.selectEngineDescription')
+})
 
 function handleCancel() {
   if (settled) {
@@ -51,15 +66,23 @@ watch($$(open), (isOpen) => {
 
 <template>
   <Dialog :open="open" @update:open="handleDialogOpenChange">
-    <DialogContent class="sm:max-w-[440px]">
+    <DialogContent class="sm:max-w-[425px]">
       <DialogHeader>
         <DialogTitle>{{ $t('game.selectEngine') }}</DialogTitle>
         <DialogDescription>
-          {{ $t('game.selectEngineDescription') }}
+          {{ description }}
         </DialogDescription>
       </DialogHeader>
 
-      <EngineSelector v-model="selectedEngineId" :preferred-engine-id="hint?.id" />
+      <div class="px-2 gap-x-4 gap-y-2 grid grid-cols-[auto_1fr] items-center">
+        <Label class="text-right whitespace-nowrap">
+          {{ $t('modals.createGame.gameEngine') }}
+        </Label>
+        <EngineSelector
+          ::="selectedEngineId"
+          :preferred-engine-id="preferredEngineId"
+        />
+      </div>
 
       <DialogFooter>
         <Button variant="outline" @click="handleCancel">

--- a/src/features/home/games-tab/useGamesTabController.ts
+++ b/src/features/home/games-tab/useGamesTabController.ts
@@ -5,7 +5,7 @@ import { resourceReconcile } from '~/services/resource-reconcile'
 
 import type { EngineStatus, Game } from '~/database/model'
 import type { ResourceAvailability } from '~/services/resource-health'
-import type { EngineRef } from '~/types/project-config'
+import type { EngineSelectionContext } from '~/types/engine-selection'
 import type { I18nT } from '~/utils/i18n-like'
 
 interface EngineAvailabilityCheck {
@@ -22,19 +22,19 @@ interface UseGamesTabControllerOptions {
   openNoEngineAlertModal: (onConfirm: () => void) => void
   openRecoverGameModal: (game: Game) => void
   pushRoute: (path: string) => unknown
-  selectEngine?: (hint?: EngineRef) => Promise<string | undefined>
+  selectEngine?: (context?: EngineSelectionContext) => Promise<string | undefined>
   t: I18nT
   switchToEnginesTab: () => void
 }
 
 export function useGamesTabController(options: UseGamesTabControllerOptions) {
-  async function selectEngine(hint?: EngineRef): Promise<string | undefined> {
+  async function selectEngine(context?: EngineSelectionContext): Promise<string | undefined> {
     if (options.selectEngine) {
-      return await options.selectEngine(hint)
+      return await options.selectEngine(context)
     }
 
     const { requestEngineSelection } = await import('~/features/modals/engine-selection/request-engine-selection')
-    return await requestEngineSelection(hint)
+    return await requestEngineSelection(context)
   }
 
   const importActions = useHomeResourceImportActions<Game>({

--- a/src/features/modals/engine-selection/request-engine-selection.ts
+++ b/src/features/modals/engine-selection/request-engine-selection.ts
@@ -1,13 +1,13 @@
 import { useModalStore } from '~/stores/modal'
 
-import type { EngineRef } from '~/types/project-config'
+import type { EngineSelectionContext } from '~/types/engine-selection'
 
-export function requestEngineSelection(hint?: EngineRef): Promise<string | undefined> {
+export function requestEngineSelection(context: EngineSelectionContext = {}): Promise<string | undefined> {
   const modalStore = useModalStore()
 
   return new Promise((resolve) => {
     modalStore.open('EngineSelectionModal', {
-      hint,
+      ...context,
       onCancel: () => resolve(undefined),
       onConfirm: (engineId: string) => resolve(engineId),
     }, crypto.randomUUID())

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -1101,3 +1101,4 @@ engine:
 game:
   selectEngine: Select game engine
   selectEngineDescription: Current engine is unavailable, please select any available engine to open
+  selectEngineDescriptionWithName: The engine associated with "{name}" is unavailable. Select an available engine to continue importing.

--- a/src/locales/ja.yml
+++ b/src/locales/ja.yml
@@ -1101,3 +1101,4 @@ engine:
 game:
   selectEngine: エンジンを選択
   selectEngineDescription: 現在のエンジンが利用できません。利用可能な任意のエンジンを選択して開いてください
+  selectEngineDescriptionWithName: 「{name}」に関連付けられたエンジンは利用できません。インポートを続行するには、利用可能なエンジンを選択してください。

--- a/src/locales/zh-Hans.yml
+++ b/src/locales/zh-Hans.yml
@@ -1101,3 +1101,4 @@ engine:
 game:
   selectEngine: 选择引擎
   selectEngineDescription: 当前引擎不可用，请选择任意可用引擎打开
+  selectEngineDescriptionWithName: 「{name}」关联的引擎不可用，请选择一个可用引擎继续导入。

--- a/src/locales/zh-Hant.yml
+++ b/src/locales/zh-Hant.yml
@@ -1101,3 +1101,4 @@ engine:
 game:
   selectEngine: 選擇引擎
   selectEngineDescription: 目前引擎不可用，請選擇任意可用引擎開啟
+  selectEngineDescriptionWithName: 「{name}」關聯的引擎不可用，請選擇一個可用引擎繼續匯入。

--- a/src/services/__tests__/game-manager.test.ts
+++ b/src/services/__tests__/game-manager.test.ts
@@ -183,6 +183,21 @@ function createGameConfig(entries: { key: string, value: string }[]) {
   }
 }
 
+const importedProjectEngineRef = {
+  id: 'default-publisher.default-engine',
+  version: '4.5.0',
+}
+
+const selectedProjectEngineRef = {
+  id: 'default-publisher.default-engine',
+  version: '4.6.0',
+}
+
+const importedEngineSelectionContext = {
+  gameName: 'Demo Game',
+  hint: importedProjectEngineRef,
+}
+
 describe('gameManager', () => {
   beforeEach(() => {
     dbEngineGetMock.mockReset()
@@ -573,10 +588,7 @@ describe('gameManager', () => {
       || path === '/games/vfs/game/background/cover.png')
     readProjectConfigMock.mockResolvedValue({
       version: 1,
-      engine: {
-        id: 'default-publisher.default-engine',
-        version: '4.5.0',
-      },
+      engine: importedProjectEngineRef,
     })
     engineFindByRefMock.mockResolvedValue(createTestEngine({
       id: 'engine-1',
@@ -650,16 +662,16 @@ describe('gameManager', () => {
       status: 'created',
     }))
 
+    const selectEngine = vi.fn().mockResolvedValue('engine-2')
+
     await expect(gameManager.importGame(AbsPath.from('/games/vfs'), {
-      selectEngine: vi.fn().mockResolvedValue('engine-2'),
+      selectEngine,
     })).resolves.toEqual({ id: 'game-1', alreadyRegistered: false })
 
+    expect(selectEngine).toHaveBeenCalledWith(importedEngineSelectionContext)
     expect(writeProjectConfigMock).toHaveBeenCalledWith('/games/vfs', {
       version: 1,
-      engine: {
-        id: 'default-publisher.default-engine',
-        version: '4.6.0',
-      },
+      engine: selectedProjectEngineRef,
     })
     expect(dbGameAddMock).toHaveBeenCalledWith(expect.objectContaining({
       engineId: 'engine-2',
@@ -676,10 +688,7 @@ describe('gameManager', () => {
       || path === '/games/vfs/game/background/cover.png')
     readProjectConfigMock.mockResolvedValue({
       version: 1,
-      engine: {
-        id: 'default-publisher.default-engine',
-        version: '4.5.0',
-      },
+      engine: importedProjectEngineRef,
     })
     engineFindByRefMock.mockResolvedValue(undefined)
     dbEngineGetMock.mockResolvedValue(createTestEngine({
@@ -689,16 +698,16 @@ describe('gameManager', () => {
       status: 'created',
     }))
 
+    const selectEngine = vi.fn().mockResolvedValue('engine-2')
+
     await expect(gameManager.importGame(AbsPath.from('/games/vfs'), {
-      selectEngine: vi.fn().mockResolvedValue('engine-2'),
+      selectEngine,
     })).resolves.toEqual({ id: 'game-1', alreadyRegistered: false })
 
+    expect(selectEngine).toHaveBeenCalledWith(importedEngineSelectionContext)
     expect(writeProjectConfigMock).toHaveBeenCalledWith('/games/vfs', {
       version: 1,
-      engine: {
-        id: 'default-publisher.default-engine',
-        version: '4.6.0',
-      },
+      engine: selectedProjectEngineRef,
     })
     expect(dbGameAddMock).toHaveBeenCalledWith(expect.objectContaining({
       engineId: 'engine-2',

--- a/src/services/game-manager.ts
+++ b/src/services/game-manager.ts
@@ -26,6 +26,7 @@ import { EngineRef, ProjectConfig, TemplateBinding } from '~/types/project-confi
 
 import type { GameConfigEntry } from '~/commands/game'
 import type { LookupPathKey } from '~/services/resource-path/lookup'
+import type { EngineSelectionContext } from '~/types/engine-selection'
 import type { StaticSiteConfig } from '~/types/server'
 
 interface RegisterGameOptions {
@@ -36,7 +37,7 @@ interface RegisterGameOptions {
 }
 
 interface ImportGameOptions {
-  selectEngine?: (hint?: EngineRef) => Promise<string | undefined>
+  selectEngine?: (context?: EngineSelectionContext) => Promise<string | undefined>
 }
 
 export interface GameInspectionPayload {
@@ -296,7 +297,7 @@ async function resolveBoundEngine(
 
 async function resolveSelectableEngine(
   selectEngine: ImportGameOptions['selectEngine'],
-  hint?: EngineRef,
+  context?: EngineSelectionContext,
 ): Promise<Engine> {
   if (!selectEngine) {
     throw new AppError('IO_ERROR', '项目缺少可用引擎，请重新导入并选择引擎', {
@@ -304,7 +305,7 @@ async function resolveSelectableEngine(
     })
   }
 
-  const engineId = await selectEngine(hint)
+  const engineId = await selectEngine(context)
   if (!engineId) {
     throw new AppError('IO_ERROR', '导入已取消', {
       details: { reason: 'IMPORT_CANCELLED' },
@@ -327,6 +328,18 @@ async function resolveSelectableEngine(
   return engine
 }
 
+function buildEngineSelectionContext(
+  metadata: GameMetadata,
+  hint?: EngineRef,
+): EngineSelectionContext {
+  const gameName = metadata.name?.trim()
+
+  return {
+    ...(gameName ? { gameName } : {}),
+    ...(hint ? { hint } : {}),
+  }
+}
+
 async function importLegacyGame(
   gamePath: AbsPath,
   options: ImportGameOptions,
@@ -339,7 +352,10 @@ async function importLegacyGame(
     return registerGame(gamePath, { ...inspection })
   }
 
-  const engine = await resolveSelectableEngine(options.selectEngine)
+  const engine = await resolveSelectableEngine(
+    options.selectEngine,
+    buildEngineSelectionContext(inspection.metadata),
+  )
   await projectConfigCmds.writeProjectConfig(gamePath, {
     version: 1,
     engine: buildProjectEngineRef(engine),
@@ -404,7 +420,10 @@ async function bindSelectedEngine(
   inspection: GameInspectionPayload,
   hint?: EngineRef,
 ): Promise<string> {
-  const engine = await resolveSelectableEngine(options.selectEngine, hint)
+  const engine = await resolveSelectableEngine(
+    options.selectEngine,
+    buildEngineSelectionContext(inspection.metadata, hint),
+  )
   await projectConfigCmds.writeProjectConfig(gamePath, {
     ...config,
     engine: buildProjectEngineRef(engine),

--- a/src/types/engine-selection.ts
+++ b/src/types/engine-selection.ts
@@ -1,0 +1,6 @@
+import type { EngineRef } from './project-config'
+
+export interface EngineSelectionContext {
+  gameName?: string
+  hint?: EngineRef
+}


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [x] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [x] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

- 为引擎选择流程引入 `EngineSelectionContext`，统一传递 `gameName` 和 `hint`
- 在导入旧项目或处理失效引擎绑定时，将项目名和原引擎信息带入选择弹窗
- 调整 `EngineSelectionModal`，支持显示带项目名的描述文案，并优先使用 `hint.id` 或默认引擎作为预选项
- 补充 `EngineSelectionModal` 和 `gameManager` 的测试，同时新增对应的多语言文案

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

导入项目或修复失效引擎时，原有引擎选择流程只能传递简单的 `hint`，上下文信息不完整，导致弹窗无法准确表达当前操作对象，也不利于统一处理默认引擎偏好。

这个 PR 将引擎选择相关上下文收敛为单一结构，减少调用端分散拼装逻辑，让导入链路、重新绑定链路和弹窗行为保持一致，并补上对应测试覆盖。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
