### PR TITLE
🐛 修复空标签页下辅助侧栏显示不一致

### DIFF
--- a/src/components/editor/EditorPanel.spec.ts
+++ b/src/components/editor/EditorPanel.spec.ts
@@ -382,6 +382,21 @@ describe('EditorPanel', () => {
     await expect.element(page.getByRole('button', { name: 'insert-command' })).not.toBeInTheDocument()
   })
 
+  it('空标签页不会挂载辅助侧栏布局', async () => {
+    useEditorStoreMock.mockReturnValue(reactive({
+      currentState: undefined,
+      isCurrentSceneFile: false,
+    }))
+    usePreferenceStoreMock.mockReturnValue(reactive({
+      showSidebar: true,
+    }))
+
+    renderEditorPanel()
+
+    await expect.element(page.getByText('File Editor')).toBeVisible()
+    await expect.element(page.getByTestId('sidebar-slot')).not.toBeInTheDocument()
+  })
+
   it('存在侧栏绑定但未选中语句时会显示文本模式空状态文案', async () => {
     useEditorStoreMock.mockReturnValue(reactive({
       currentState: {

--- a/src/components/editor/EditorPanel.vue
+++ b/src/components/editor/EditorPanel.vue
@@ -81,10 +81,10 @@ defineExpose({ toggleCommandPanel })
       <EditorToolbar />
     </div>
     <div ref="editorPanel" class="flex-1 min-h-0 relative overflow-hidden">
-      <EditorSidebarLayout ::show="effectiveShowSidebar" class="h-full">
+      <EditorSidebarLayout v-if="isCurrentSceneFile" ::show="effectiveShowSidebar" class="h-full">
         <div class="flex flex-col h-full relative overflow-hidden">
           <!-- 场景文件：编辑器 + 命令面板纵向分割 -->
-          <ResizablePanelGroup v-if="isCurrentSceneFile" auto-save-id="editor-vertical" direction="vertical" class="flex-1 min-h-0">
+          <ResizablePanelGroup auto-save-id="editor-vertical" direction="vertical" class="flex-1 min-h-0">
             <ResizablePanel size-unit="px" :min-size="200">
               <FileEditor />
             </ResizablePanel>
@@ -102,11 +102,9 @@ defineExpose({ toggleCommandPanel })
               />
             </ResizablePanel>
           </ResizablePanelGroup>
-          <!-- 非场景文件：编辑器占满 -->
-          <FileEditor v-else class="flex-1 min-h-0" />
           <!-- 命令面板折叠态：底部居中小标签 -->
           <button
-            v-if="isCurrentSceneFile && isCommandPanelCollapsed"
+            v-if="isCommandPanelCollapsed"
             class="text-xs text-muted-foreground px-3 py-0.5 border border-b-0 rounded-t bg-muted flex gap-1 transition-colors items-center bottom-0 left-1/2 justify-center absolute hover:text-foreground hover:bg-accent -translate-x-1/2"
             @click="toggleCommandPanel"
           >
@@ -132,6 +130,9 @@ defineExpose({ toggleCommandPanel })
           </div>
         </template>
       </EditorSidebarLayout>
+      <div v-else class="flex flex-col h-full relative overflow-hidden">
+        <FileEditor class="flex-1 min-h-0" />
+      </div>
 
       <Sheet :open="effectEditorProvider.isOpen" :modal="false" @update:open="handleEffectEditorSheetOpenChange">
         <div


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [x] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [x] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

修复编辑器空标签页状态下辅助侧栏显示不一致的问题。

此前新项目进入编辑器时，即使没有打开任何标签页，也可能挂载辅助侧栏布局并显示空白区域；而打开并关闭标签页后，同样处于空标签页状态时辅助侧栏会消失。

本次更改将 `EditorSidebarLayout` 限定为仅在当前文件是场景文件时挂载。空标签页和非场景文件统一走单栏编辑区布局，`showSidebar` 仍保留为用户偏好，只在场景文件上下文中生效。

同时新增浏览器组件测试，覆盖 `showSidebar=true` 但当前没有标签页时不应挂载辅助侧栏布局的回归场景。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

空标签页没有 active file、scene projection 或 selected statement，辅助侧栏没有可编辑目标。统一隐藏辅助侧栏可以避免新项目空态和关闭最后一个标签页后的空态表现不一致。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
