### PR TITLE
🐛 修复预览面板地址栏光标样式

### DIFF
--- a/src/components/editor/PreviewPanel.vue
+++ b/src/components/editor/PreviewPanel.vue
@@ -111,7 +111,7 @@ watch(
     <div class="px-2 py-1 flex flex-shrink-0 gap-2 items-center justify-between">
       <div class="text-muted-foreground px-2 py-0.25 border border-border/50 rounded-md bg-muted/50 flex flex-1 gap-1.5 items-center overflow-hidden">
         <Link class="shrink-0 size-3" />
-        <span class="text-sm font-mono select-text truncate">{{ previewUrl }}</span>
+        <span class="text-sm font-mono cursor-default select-text truncate">{{ previewUrl }}</span>
       </div>
       <TooltipProvider>
         <div class="text-muted-foreground flex flex-shrink-0 gap-1">


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [x] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [ ] 测试用例
- [ ] 性能优化
- [x] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

将预览面板中地址栏展示文本的光标调整为默认样式，避免只读地址看起来像可输入区域。

具体改动如下：

- 在 `src/components/editor/PreviewPanel.vue` 的预览地址文本上添加 `cursor-default`
- 保留 `select-text`，用户仍然可以选中并复制预览地址

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

当前预览面板中的地址栏仅用于展示预览地址，并不支持直接输入。
由于该区域允许文本选择，鼠标悬停时容易呈现出接近输入框的交互暗示，可能让用户误以为这里可以编辑。

这次改动只修正交互反馈，不涉及预览逻辑、状态管理或接口行为变更。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [ ] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
