### PR TITLE
🐛 修复空场景首条语句插入与可视化空状态

### DIFF
--- a/src/components/editor/VisualEditorScene.spec.ts
+++ b/src/components/editor/VisualEditorScene.spec.ts
@@ -284,6 +284,101 @@ describe('VisualEditorScene', () => {
     await expect.element(page.getByText('say:world')).toBeVisible()
   })
 
+  it('空场景会显示空状态而不是空语句卡片', async () => {
+    const state = createSceneState()
+    state.statements = []
+
+    renderInBrowser(VisualEditorScene, {
+      props: {
+        state,
+      },
+      global: {
+        plugins: [createPinia()],
+        stubs: globalStubs,
+      },
+    })
+
+    await expect.element(page.getByText('edit.visualEditor.emptyTitle')).toBeVisible()
+    await expect.element(page.getByText('edit.visualEditor.emptyDescription')).toBeVisible()
+    await expect.element(page.getByRole('option')).not.toBeInTheDocument()
+  })
+
+  it('空场景会把空状态区域注册为首条语句投放目标', async () => {
+    const registerDroppable = vi.fn()
+    handleCommandDropMock.mockReturnValue(true)
+    handleFileDropMock.mockReturnValue(true)
+    useDroppableRegistryMock.mockReturnValue({
+      clearHover: vi.fn(),
+      drop: vi.fn(),
+      getMatchAt: vi.fn(),
+      hoveredTarget: shallowRef(),
+      isDropAllowed: shallowRef(false),
+      registerDroppable,
+      unregisterDroppable: vi.fn(),
+      updateHover: vi.fn(),
+    })
+
+    const state = createSceneState()
+    state.statements = []
+
+    const result = renderInBrowser(VisualEditorScene, {
+      props: { state },
+      global: {
+        plugins: [createPinia()],
+        stubs: globalStubs,
+      },
+    })
+    await nextTick()
+
+    expect(registerDroppable).toHaveBeenCalledWith(
+      expect.any(HTMLElement),
+      expect.objectContaining({ id: 'visual-editor:empty' }),
+    )
+    expect(registerDroppable).not.toHaveBeenCalledWith(
+      expect.any(HTMLElement),
+      expect.objectContaining({ id: 'visual-editor:tail' }),
+    )
+
+    const emptyConfig = registerDroppable.mock.calls.find(([, config]) =>
+      config.id === 'visual-editor:empty',
+    )?.[1]
+    const commandPayload = {
+      label: 'Say',
+      rawTexts: ['say:new;'],
+      source: 'command-panel',
+      type: 'command-panel-statement',
+    } as const
+    const filePayload = {
+      source: 'file-viewer',
+      type: 'file-system-item',
+      path: '/games/demo/game/background/room.png',
+      isDir: false,
+    } as const
+
+    expect(emptyConfig.canDrop(commandPayload, document.createElement('div'))).toBe(true)
+
+    emptyConfig.onDragEnter(commandPayload)
+    await nextTick()
+
+    expect(result.container.querySelector('[data-visual-drop-indicator="empty"]')).not.toBeNull()
+    expect(result.container.querySelector('[data-visual-drop-indicator="insert"]')).toBeNull()
+
+    await emptyConfig.onDrop(commandPayload, document.createElement('div'))
+
+    expect(handleCommandDropMock).toHaveBeenCalledWith(commandPayload, {
+      placement: 'tail',
+      insertIndex: 0,
+    })
+    expect(document.activeElement).toHaveAttribute('tabindex', '-1')
+
+    await emptyConfig.onDrop(filePayload, document.createElement('div'))
+
+    expect(handleFileDropMock).toHaveBeenCalledWith(filePayload, {
+      placement: 'tail',
+      insertIndex: 0,
+    })
+  })
+
   it('卡片事件会转发到 runtime 处理函数', async () => {
     renderInBrowser(VisualEditorScene, {
       props: {

--- a/src/components/editor/VisualEditorScene.spec.ts
+++ b/src/components/editor/VisualEditorScene.spec.ts
@@ -737,6 +737,62 @@ describe('VisualEditorScene', () => {
     })
   })
 
+  it('空场景插入首条语句后会恢复语句列表拖拽排序', async () => {
+    const state = reactive({
+      ...createSceneState(),
+      statements: [],
+    }) as SceneVisualProjectionState
+    statementSortVirtualAdapterMock.getItemCount.mockReturnValue(2)
+    statementSortVirtualAdapterMock.getVisibleItems.mockReturnValue([])
+    const Harness = defineComponent({
+      name: 'EmptyToFilledSceneHarness',
+      setup() {
+        return () => h(VisualEditorScene, { state })
+      },
+    })
+
+    renderInBrowser(Harness, {
+      global: {
+        plugins: [createPinia()],
+        stubs: globalStubs,
+      },
+    })
+    await nextTick()
+
+    state.statements.push(
+      createStatementEntry(1, 'say:first'),
+      createStatementEntry(2, 'say:second'),
+    )
+    statementSortVirtualAdapterMock.getVisibleItems.mockReturnValue([
+      { index: 0, size: 48, start: 0 },
+      { index: 1, size: 48, start: 48 },
+    ])
+    await nextTick()
+    await nextTick()
+
+    const listbox = document.querySelector<HTMLElement>('[role="listbox"]')
+    const firstItem = document.querySelector<HTMLElement>('[data-drag-index="0"]')
+    const secondItem = document.querySelector<HTMLElement>('[data-drag-index="1"]')
+    const handle = firstItem?.querySelector<HTMLElement>('[data-statement-drag-handle]')
+
+    expect(listbox).not.toBeNull()
+    expect(firstItem).not.toBeNull()
+    expect(secondItem).not.toBeNull()
+    expect(handle).not.toBeNull()
+
+    setRect(listbox!, createVerticalRect(0, 96))
+    setRect(firstItem!, createVerticalRect(0))
+    setRect(secondItem!, createVerticalRect(48))
+
+    handle!.dispatchEvent(createPointerEvent('pointerdown', { clientX: 8, clientY: 8 }))
+    globalThis.dispatchEvent(createPointerEvent('pointermove', { clientX: 8, clientY: 90 }))
+    globalThis.dispatchEvent(createPointerEvent('pointerup', { clientX: 8, clientY: 90 }))
+
+    await vi.waitFor(() => {
+      expect(reorderStatementsMock).toHaveBeenCalledWith(0, 1, { restoreSelectionPresentation: false })
+    })
+  })
+
   it('拖拽语句排序后会恢复可视化编辑器快捷键焦点上下文', async () => {
     renderInBrowser(VisualEditorScene, {
       props: {

--- a/src/components/editor/VisualEditorScene.vue
+++ b/src/components/editor/VisualEditorScene.vue
@@ -293,6 +293,10 @@ onMounted(() => {
   updateStatementSortRefs()
 })
 
+watch(isSceneEmpty, () => {
+  updateStatementSortRefs()
+}, { flush: 'post' })
+
 tryOnUnmounted(() => {
   for (const element of dropElements.values()) {
     dropRegistry.unregisterDroppable(element)

--- a/src/components/editor/VisualEditorScene.vue
+++ b/src/components/editor/VisualEditorScene.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { FileText } from '@lucide/vue'
+
 import { useDragSort } from '~/composables/useDragSort'
 import { useDroppableRegistry } from '~/composables/useDroppableRegistry'
 import { useShortcutContext } from '~/features/editor/shortcut/useShortcutContext'
@@ -62,6 +64,7 @@ const {
 } = runtime
 
 const statements = computed(() => props.state.statements)
+const isSceneEmpty = computed(() => props.state.statements.length === 0)
 const scrollViewportRef = shallowRef<HTMLElement>()
 const statementReadonly = $computed(() => preferenceStore.showSidebar && editSettings.collapseStatementsOnSidebarOpen)
 const renderedStatementRows = computed<RenderedVisualStatementRow[]>(() => {
@@ -306,7 +309,34 @@ tryOnUnmounted(() => {
         data-visual-editor-content
         :style="{ minHeight: contentMinHeight }"
       >
-        <div ref="statementListRef" role="listbox" :aria-label="$t('edit.visualEditor.statementList')" :style="{ height: `${totalSize}px`, width: '100%', position: 'relative' }">
+        <div
+          v-if="isSceneEmpty"
+          :ref="value => registerDropTarget('empty', resolveHTMLElement(value), tailDropTarget)"
+          data-visual-drop-slot="empty"
+          class="flex flex-1 min-h-64 relative"
+        >
+          <Empty class="border-0 flex-1">
+            <EmptyContent>
+              <EmptyHeader>
+                <EmptyMedia variant="icon">
+                  <FileText />
+                </EmptyMedia>
+                <EmptyTitle>{{ $t('edit.visualEditor.emptyTitle') }}</EmptyTitle>
+                <EmptyDescription>
+                  {{ $t('edit.visualEditor.emptyDescription') }}
+                </EmptyDescription>
+              </EmptyHeader>
+            </EmptyContent>
+          </Empty>
+          <div
+            v-if="activeDropIndicator?.placement === 'tail'"
+            data-visual-drop-indicator="empty"
+            aria-hidden="true"
+            :class="$style.dropEmptyIndicator"
+          />
+        </div>
+
+        <div v-else ref="statementListRef" role="listbox" :aria-label="$t('edit.visualEditor.statementList')" :style="{ height: `${totalSize}px`, width: '100%', position: 'relative' }">
           <div
             v-for="row in renderedStatementRows"
             :key="row.key"
@@ -372,6 +402,7 @@ tryOnUnmounted(() => {
         </div>
 
         <div
+          v-if="!isSceneEmpty"
           :ref="value => registerDropTarget('tail', resolveHTMLElement(value), tailDropTarget)"
           data-visual-drop-slot="tail"
           class="mx-2 flex-1 relative"
@@ -466,8 +497,22 @@ tryOnUnmounted(() => {
     0 0 0.75rem rgb(var(--drop-indicator-rgb) / 14%);
 }
 
+.drop-empty-indicator {
+  --drop-indicator-rgb: 14 165 233;
+
+  position: absolute;
+  inset: 0.5rem;
+  z-index: 20;
+  pointer-events: none;
+  background: rgb(var(--drop-indicator-rgb) / 8%);
+  border: 1px dashed rgb(var(--drop-indicator-rgb) / 70%);
+  border-radius: 0.5rem;
+  box-shadow: inset 0 0 0 1px rgb(var(--drop-indicator-rgb) / 18%);
+}
+
 :global(.dark) .drop-insert-indicator,
-:global(.dark) .drop-update-indicator {
+:global(.dark) .drop-update-indicator,
+:global(.dark) .drop-empty-indicator {
   --drop-indicator-rgb: 56 189 248;
 }
 </style>

--- a/src/domain/script/__tests__/roundtrip.test.ts
+++ b/src/domain/script/__tests__/roundtrip.test.ts
@@ -128,6 +128,13 @@ describe('sentence', () => {
     expect(joinStatements(entries)).toBe(raw)
   })
 
+  it('空内容不会构造幽灵空语句', () => {
+    expect(splitStatements('')).toEqual([])
+    expect(buildStatements('')).toEqual([])
+    expect(buildSceneStatements('')).toEqual([])
+    expect(joinStatements([])).toBe('')
+  })
+
   it('createEmptySentence 序列化为规范的空 say 语句', () => {
     expect(serializeSentence(createEmptySentence())).toBe(':;')
   })

--- a/src/domain/script/sentence.ts
+++ b/src/domain/script/sentence.ts
@@ -35,6 +35,10 @@ export function createEmptySentence(): ISentence {
  * 未来支持跨行语句时，只需修改此函数。
  */
 export function splitStatements(text: string): string[] {
+  if (text === '') {
+    return []
+  }
+
   return text.split('\n')
 }
 

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -693,6 +693,8 @@ edit:
     toggleSidebar: Toggle Auxiliary Panel
   visualEditor:
     playToLine: Play to this line
+    emptyTitle: This scene is empty
+    emptyDescription: Add a statement from the command panel, or drag a resource file here to insert it.
     audioPreview:
       play: Play audio
       pause: Pause audio

--- a/src/locales/ja.yml
+++ b/src/locales/ja.yml
@@ -693,6 +693,8 @@ edit:
     toggleSidebar: 補助パネル切替
   visualEditor:
     playToLine: この行まで実行
+    emptyTitle: シーンはまだ空です
+    emptyDescription: コマンドパネルからステートメントを追加するか、リソースファイルをドラッグして直接挿入してください。
     audioPreview:
       play: 音声を再生
       pause: 音声を一時停止

--- a/src/locales/zh-Hans.yml
+++ b/src/locales/zh-Hans.yml
@@ -693,6 +693,8 @@ edit:
     toggleSidebar: 切换辅助面板
   visualEditor:
     playToLine: 执行到此句
+    emptyTitle: 场景还是空的
+    emptyDescription: 从命令面板添加语句，或拖拽资源文件直接插入。
     audioPreview:
       play: 播放音频
       pause: 暂停音频

--- a/src/locales/zh-Hant.yml
+++ b/src/locales/zh-Hant.yml
@@ -693,6 +693,8 @@ edit:
     toggleSidebar: 切換輔助面板
   visualEditor:
     playToLine: 執行到此句
+    emptyTitle: 場景還是空的
+    emptyDescription: 從命令面板加入語句，或拖曳資源檔案直接插入。
     audioPreview:
       play: 播放音訊
       pause: 暫停音訊

--- a/src/stores/internal/__tests__/editor-document-actions.test.ts
+++ b/src/stores/internal/__tests__/editor-document-actions.test.ts
@@ -7,6 +7,7 @@ import { AbsPath } from '~/domain/path'
 import {
   applyAnimationFrameInsert,
   applyAnimationFrameUpdate,
+  applySceneStatementInsert,
   applySceneStatementReorder,
   applyTextDocumentContent,
   redoDocument,
@@ -122,13 +123,22 @@ function createAnimationActionHarness() {
   }
 }
 
-function createSceneActionHarness() {
-  const scenePath = AbsPath.from('/game/scene/document.txt')
+function createSceneActionHarness(options: {
+  content?: string
+  path?: string
+  sceneSelection?: SceneSelectionState
+} = {}) {
+  const {
+    content = 'alpha\nbeta\ngamma',
+    path = '/game/scene/document.txt',
+    sceneSelection: initialSceneSelection,
+  } = options
+  const scenePath = AbsPath.from(path)
   const document: DocumentState = createDocumentState(createDocumentModel({
     kind: 'scene',
-    content: 'alpha\nbeta\ngamma',
+    content,
   }))
-  let sceneSelection: SceneSelectionState | undefined = {
+  let sceneSelection: SceneSelectionState | undefined = initialSceneSelection ?? {
     lastEditedStatementId: document.model.kind === 'scene' ? document.model.statements[1]?.id : undefined,
     lastLineNumber: 2,
     selectedStatementId: document.model.kind === 'scene' ? document.model.statements[1]?.id : undefined,
@@ -342,6 +352,28 @@ describe('编辑器文档动作回滚', () => {
       lastEditedStatementId: movedStatementId,
       lastLineNumber: 1,
       selectedStatementId: movedStatementId,
+    })
+  })
+
+  it('空场景插入第一条语句时不会保留首行空语句', () => {
+    const { context, document, readSceneSelection, scenePath, syncStateFromDocument } = createSceneActionHarness({
+      content: '',
+      path: '/game/scene/empty.txt',
+      sceneSelection: undefined,
+    })
+
+    applySceneStatementInsert(context, scenePath, [{ id: 101, rawText: 'say:hello;' }], 0)
+
+    expect(syncStateFromDocument).toHaveBeenCalledTimes(1)
+    expect(document.model.kind).toBe('scene')
+    if (document.model.kind !== 'scene') {
+      throw new TypeError('expected scene document model')
+    }
+    expect(document.model.statements.map(statement => statement.rawText)).toEqual(['say:hello;'])
+    expect(readSceneSelection()).toMatchObject({
+      lastEditedStatementId: 101,
+      lastLineNumber: 1,
+      selectedStatementId: 101,
     })
   })
 })


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [x] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [x] 测试用例
- [ ] 性能优化
- [x] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

修复空场景在脚本层和可视化编辑器中的异常表现。

主要改动包括：

- `splitStatements('')` 不再返回包含空字符串的结果，避免空内容被构造成幽灵空语句
- 为脚本 roundtrip 补充空内容用例，确保空场景序列化与反序列化行为稳定
- 为文档动作补充测试，覆盖空场景插入第一条语句时不残留首行空语句的场景
- 可视化编辑器在空场景下显示明确的空状态
- 空场景会把空状态区域注册为首条语句的投放目标，允许从命令面板或资源面板直接插入第一条内容
- 补充对应多语言文案

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

当前空场景会在领域模型中保留一条实际不存在的空语句，导致首条语句插入行为不干净，也让可视化编辑器在空场景下缺少明确反馈和投放入口。

这个 PR 统一修正了领域层与界面层对“空场景”的处理方式，使空内容、首条插入和可视化拖放的语义保持一致。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
