### PR TITLE
🐛 修正 Game_Logo 序列化尾部分隔符

### DIFF
--- a/src/components/modals/GameConfigModal.spec.ts
+++ b/src/components/modals/GameConfigModal.spec.ts
@@ -597,7 +597,7 @@ describe('GameConfigModal', () => {
           }),
           expect.objectContaining({
             key: 'Game_Logo',
-            value: 'enter-next.webp|logo-next.webp|',
+            value: 'enter-next.webp|logo-next.webp',
           }),
           expect.objectContaining({
             key: 'Stage_Width',

--- a/src/features/modals/game-config/__tests__/game-config-form.test.ts
+++ b/src/features/modals/game-config/__tests__/game-config-form.test.ts
@@ -64,7 +64,7 @@ describe('gameConfigForm', () => {
         },
         {
           key: 'Game_Logo',
-          value: 'opening.webp|enter.webp|',
+          value: 'opening.webp|enter.webp',
         },
         {
           key: 'Game_name',
@@ -455,7 +455,7 @@ describe('gameConfigForm', () => {
         },
         {
           key: 'Game_Logo',
-          value: 'opening.webp|enter.webp|',
+          value: 'opening.webp|enter.webp',
         },
         {
           key: 'Enable_Appreciation',

--- a/src/features/modals/game-config/game-config-images.ts
+++ b/src/features/modals/game-config/game-config-images.ts
@@ -8,9 +8,5 @@ export function parseGameLogoImages(value: string): string[] {
 }
 
 export function serializeGameLogoImages(images: string[]): string {
-  if (images.length === 0) {
-    return ''
-  }
-
-  return `${images.join('|')}|`
+  return images.join('|')
 }


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [x] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [x] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

修正 `Game_Logo` 字段的序列化逻辑，不再在末尾追加多余的 `|`。

同步更新以下测试断言，使其与新的存储格式保持一致：

- `src/features/modals/game-config/game-config-images.ts`
- `src/features/modals/game-config/__tests__/game-config-form.test.ts`
- `src/components/modals/GameConfigModal.spec.ts`

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

此前 `Game_Logo` 会被序列化为 `a|b|` 这种带尾随分隔符的格式，额外引入一个空段。
这会让配置值格式不够规范，也让测试断言依赖这个多余的尾部分隔符。

本次改动将其统一为 `a|b`，使序列化结果更直接、稳定，也更符合该字段的预期存储格式。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->

- 空数组场景仍然会序列化为 `''`
- 本次改动范围仅限 `game-config` 的 Logo 图片序列化及相关测试
- 未引入新的公共接口或持久化迁移逻辑

### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
