### PR TITLE
♻️ 迁移 Monaco 装饰集合 API

### DIFF
--- a/src/__tests__/mocks/monaco.test.ts
+++ b/src/__tests__/mocks/monaco.test.ts
@@ -62,9 +62,10 @@ describe('monacoMock', () => {
     expect(monaco.editor.MouseTargetType.GUTTER_GLYPH_MARGIN).toBe(2)
   })
 
-  it('deltaDecorations 会为每个 decoration 返回可回传的不透明 id', () => {
-    const firstIds = monacoMockState.editorInstance.deltaDecorations([], [{}, {}])
-    const secondIds = monacoMockState.editorInstance.deltaDecorations(firstIds, [{}])
+  it('createDecorationsCollection 会维护可替换的 decoration id 集合', () => {
+    const collection = monacoMockState.editorInstance.createDecorationsCollection([{}, {}])
+    const firstIds = collection.getIds()
+    const secondIds = collection.set([{}])
 
     expect(firstIds).toHaveLength(2)
     expect(firstIds.every(id => typeof id === 'string' && id.length > 0)).toBe(true)
@@ -73,8 +74,11 @@ describe('monacoMock', () => {
     expect(secondIds[0]).not.toBe(firstIds[0])
     expect(secondIds[0]).not.toBe(firstIds[1])
 
+    collection.clear()
+    expect(collection.getIds()).toHaveLength(0)
+
     resetMonacoMockState()
 
-    expect(monacoMockState.editorInstance.deltaDecorations([], [{}])).toHaveLength(1)
+    expect(monacoMockState.editorInstance.createDecorationsCollection([{}]).getIds()).toHaveLength(1)
   })
 })

--- a/src/__tests__/mocks/monaco.ts
+++ b/src/__tests__/mocks/monaco.ts
@@ -31,6 +31,13 @@ interface MonacoDisposableMock {
   dispose: Mock<() => void>
 }
 
+export interface MonacoDecorationsCollectionMock {
+  append: Mock<(newDecorations: readonly unknown[]) => string[]>
+  clear: Mock<() => void>
+  getIds: () => string[]
+  set: Mock<(newDecorations: readonly unknown[]) => string[]>
+}
+
 interface MonacoActionMock {
   id: string
   label: string
@@ -44,7 +51,7 @@ interface MonacoDomNodeMock {
 
 export interface MonacoEditorInstanceMock {
   addCommand: MonacoCommandMock
-  deltaDecorations: Mock<(oldDecorations: string[], newDecorations: unknown[]) => string[]>
+  createDecorationsCollection: Mock<(decorations?: readonly unknown[]) => MonacoDecorationsCollectionMock>
   dispose: Mock<() => void>
   focus: Mock<() => void>
   getAction: Mock<(actionId: string) => MonacoActionMock | undefined>
@@ -79,6 +86,26 @@ function createDecorationIds(nextDecorations: unknown[]) {
   return nextDecorations.map(() => `decoration-${++decorationIdCounter}`)
 }
 
+function createDecorationsCollectionMock(initialDecorations: readonly unknown[] = []): MonacoDecorationsCollectionMock {
+  let decorationIds = createDecorationIds([...initialDecorations])
+
+  return {
+    append: vi.fn<(newDecorations: readonly unknown[]) => string[]>((newDecorations) => {
+      const nextIds = createDecorationIds([...newDecorations])
+      decorationIds = [...decorationIds, ...nextIds]
+      return nextIds
+    }),
+    clear: vi.fn<() => void>(() => {
+      decorationIds = []
+    }),
+    getIds: () => [...decorationIds],
+    set: vi.fn<(newDecorations: readonly unknown[]) => string[]>((newDecorations) => {
+      decorationIds = createDecorationIds([...newDecorations])
+      return decorationIds
+    }),
+  }
+}
+
 function createDisposable(): MonacoDisposableMock {
   return {
     dispose: vi.fn<() => void>(),
@@ -99,9 +126,7 @@ function createDomNodeMock(): MonacoDomNodeMock {
 function applyEditorInstanceMockDefaults(editorInstance: MonacoEditorInstanceMock) {
   const domNode = createDomNodeMock()
 
-  editorInstance.deltaDecorations.mockImplementation((_: string[], nextDecorations: unknown[]) =>
-    createDecorationIds(nextDecorations),
-  )
+  editorInstance.createDecorationsCollection.mockImplementation(createDecorationsCollectionMock)
   editorInstance.getAction.mockImplementation((actionId: string) => ({
     id: actionId,
     label: actionId,
@@ -119,7 +144,7 @@ function applyEditorInstanceMockDefaults(editorInstance: MonacoEditorInstanceMoc
 function createEditorInstanceMock(): MonacoEditorInstanceMock {
   const editorInstance: MonacoEditorInstanceMock = {
     addCommand: vi.fn<(keybinding: number, handler: MonacoCommandHandler) => unknown>(),
-    deltaDecorations: vi.fn<(oldDecorations: string[], newDecorations: unknown[]) => string[]>(),
+    createDecorationsCollection: vi.fn<(decorations?: readonly unknown[]) => MonacoDecorationsCollectionMock>(),
     dispose: vi.fn<() => void>(),
     focus: vi.fn<() => void>(),
     getAction: vi.fn<(actionId: string) => MonacoActionMock | undefined>(),

--- a/src/components/editor/TextEditor.spec.ts
+++ b/src/components/editor/TextEditor.spec.ts
@@ -176,6 +176,15 @@ function renderTextEditor(state: TextProjectionState) {
   })
 }
 
+function readPlayToLineDecorations() {
+  const collection = monacoMockState.editorInstance.createDecorationsCollection.mock.results[0]?.value
+  if (!collection) {
+    throw new Error('预期 TextEditor 创建播放按钮装饰集合')
+  }
+
+  return collection
+}
+
 function createHarness(path: string = '/project/scene-1.txt') {
   const editSettingsStore = reactive<EditSettingsStoreMock>({
     fontFamily: 'Fira Code',
@@ -556,7 +565,8 @@ describe('TextEditor', () => {
 
     await nextTick()
 
-    expect(monacoMockState.editorInstance.deltaDecorations).not.toHaveBeenCalled()
+    const decorations = readPlayToLineDecorations()
+    expect(decorations.set).not.toHaveBeenCalled()
 
     const handleContentChange = monacoMockState.editorInstance.onDidChangeModelContent.mock.calls[0]?.[0]
 
@@ -570,7 +580,7 @@ describe('TextEditor', () => {
     await nextTick()
 
     expect(runtimeReturnValue.handleContentChange).toHaveBeenCalledTimes(1)
-    expect(monacoMockState.editorInstance.deltaDecorations).toHaveBeenCalledTimes(1)
+    expect(decorations.set).toHaveBeenCalledTimes(1)
   })
 
   it('换行导致光标行延后更新时，播放按钮会跟随最终光标行', async () => {
@@ -583,7 +593,8 @@ describe('TextEditor', () => {
     renderTextEditor(state)
 
     await nextTick()
-    monacoMockState.editorInstance.deltaDecorations.mockClear()
+    const decorations = readPlayToLineDecorations()
+    decorations.set.mockClear()
 
     const handleContentChange = monacoMockState.editorInstance.onDidChangeModelContent.mock.calls[0]?.[0]
 
@@ -597,8 +608,8 @@ describe('TextEditor', () => {
     await Promise.resolve()
     await nextTick()
 
-    expect(monacoMockState.editorInstance.deltaDecorations).toHaveBeenCalledTimes(1)
-    const [, nextDecorations] = monacoMockState.editorInstance.deltaDecorations.mock.calls[0] ?? []
+    expect(decorations.set).toHaveBeenCalledTimes(1)
+    const [nextDecorations] = decorations.set.mock.calls[0] ?? []
 
     expect(nextDecorations).toEqual([
       expect.objectContaining({
@@ -677,16 +688,17 @@ describe('TextEditor', () => {
 
     await nextTick()
 
-    const [, decorations = []] = monacoMockState.editorInstance.deltaDecorations.mock.calls.at(-1) ?? []
-    expect(decorations).toHaveLength(1)
-    expect(decorations).toEqual([
+    const decorations = readPlayToLineDecorations()
+    const [latestDecorations = []] = decorations.set.mock.calls.at(-1) ?? []
+    expect(latestDecorations).toHaveLength(1)
+    expect(latestDecorations).toEqual([
       expect.objectContaining({
         options: expect.objectContaining({
           glyphMarginClassName: expect.stringContaining(PLAY_TO_LINE_GLYPH_CLASS_NAME),
         }),
       }),
     ])
-    expect(decorations).toEqual([
+    expect(latestDecorations).toEqual([
       expect.objectContaining({
         options: expect.objectContaining({
           glyphMarginClassName: expect.stringContaining(PLAY_TO_LINE_DISABLED_GLYPH_CLASS_NAME),

--- a/src/features/editor/text-editor/__tests__/text-editor-play-to-line.test.ts
+++ b/src/features/editor/text-editor/__tests__/text-editor-play-to-line.test.ts
@@ -23,14 +23,21 @@ function createModel(lines: string[]): EditorModelMock {
   }
 }
 
+function createDecorationsCollectionMock() {
+  return {
+    clear: vi.fn(),
+    set: vi.fn((decorations: readonly unknown[]) =>
+      decorations.map((_, index) => `glyph-${index + 1}`),
+    ),
+  }
+}
+
 describe('createTextEditorPlayToLineController', () => {
   it('光标进入可播放行时会创建 glyph margin 装饰，并在无效行时清除', () => {
-    const deltaDecorations = vi.fn()
-      .mockReturnValueOnce(['glyph-1'])
-      .mockReturnValueOnce([])
+    const decorations = createDecorationsCollectionMock()
     const controller = createTextEditorPlayToLineController({
       editor: {
-        deltaDecorations,
+        createDecorationsCollection: () => decorations,
         getModel: () => createModel(['say:hello', '; comment']),
         getPosition: () => ({ lineNumber: 1 }),
       },
@@ -45,7 +52,7 @@ describe('createTextEditorPlayToLineController', () => {
     controller.syncFromEditorPosition()
     controller.syncDecorationsForLine(2)
 
-    expect(deltaDecorations).toHaveBeenNthCalledWith(1, [], [
+    expect(decorations.set).toHaveBeenCalledWith([
       {
         range: {
           endColumn: 1,
@@ -61,14 +68,14 @@ describe('createTextEditorPlayToLineController', () => {
         },
       },
     ])
-    expect(deltaDecorations).toHaveBeenNthCalledWith(2, ['glyph-1'], [])
+    expect(decorations.clear).toHaveBeenCalledTimes(1)
   })
 
   it('点击 glyph margin 的可播放行时会强制同步场景预览', () => {
     const syncScenePreview = vi.fn()
     const controller = createTextEditorPlayToLineController({
       editor: {
-        deltaDecorations: vi.fn(),
+        createDecorationsCollection: () => createDecorationsCollectionMock(),
         getModel: () => createModel(['say:hello', '  ']),
         getPosition: () => ({ lineNumber: 1 }),
       },
@@ -112,7 +119,7 @@ describe('createTextEditorPlayToLineController', () => {
     const syncScenePreview = vi.fn()
     const controller = createTextEditorPlayToLineController({
       editor: {
-        deltaDecorations: vi.fn().mockReturnValue(['glyph-1']),
+        createDecorationsCollection: () => createDecorationsCollectionMock(),
         getModel: () => createModel(['say:hello', 'say:world']),
         getPosition: () => ({ lineNumber: 1 }),
       },
@@ -144,7 +151,7 @@ describe('createTextEditorPlayToLineController', () => {
     const syncScenePreview = vi.fn()
     const controller = createTextEditorPlayToLineController({
       editor: {
-        deltaDecorations: vi.fn(),
+        createDecorationsCollection: () => createDecorationsCollectionMock(),
         getModel: () => createModel(['say:hello']),
         getPosition: () => ({ lineNumber: 1 }),
       },
@@ -174,14 +181,12 @@ describe('createTextEditorPlayToLineController', () => {
   })
 
   it('禁用时会清空装饰且忽略点击', () => {
-    const deltaDecorations = vi.fn()
-      .mockReturnValueOnce(['glyph-1'])
-      .mockReturnValueOnce([])
+    const decorations = createDecorationsCollectionMock()
     const syncScenePreview = vi.fn()
     let enabled = true
     const controller = createTextEditorPlayToLineController({
       editor: {
-        deltaDecorations,
+        createDecorationsCollection: () => decorations,
         getModel: () => createModel(['say:hello']),
         getPosition: () => ({ lineNumber: 1 }),
       },
@@ -208,16 +213,16 @@ describe('createTextEditorPlayToLineController', () => {
       },
     })
 
-    expect(deltaDecorations).toHaveBeenNthCalledWith(2, ['glyph-1'], [])
+    expect(decorations.clear).toHaveBeenCalledTimes(1)
     expect(syncScenePreview).not.toHaveBeenCalled()
   })
 
   it('dirty 状态会使用禁用样式并忽略点击', () => {
-    const deltaDecorations = vi.fn().mockReturnValue(['glyph-1'])
+    const decorations = createDecorationsCollectionMock()
     const syncScenePreview = vi.fn()
     const controller = createTextEditorPlayToLineController({
       editor: {
-        deltaDecorations,
+        createDecorationsCollection: () => decorations,
         getModel: () => createModel(['say:hello']),
         getPosition: () => ({ lineNumber: 1 }),
       },
@@ -242,7 +247,7 @@ describe('createTextEditorPlayToLineController', () => {
       },
     })
 
-    expect(deltaDecorations).toHaveBeenCalledWith([], [
+    expect(decorations.set).toHaveBeenCalledWith([
       expect.objectContaining({
         options: expect.objectContaining({
           glyphMarginClassName: `${PLAY_TO_LINE_GLYPH_CLASS_NAME} ${PLAY_TO_LINE_DISABLED_GLYPH_CLASS_NAME}`,

--- a/src/features/editor/text-editor/__tests__/useTextEditorRuntime-preview-sync.test.ts
+++ b/src/features/editor/text-editor/__tests__/useTextEditorRuntime-preview-sync.test.ts
@@ -135,16 +135,19 @@ function createState(path: string): TextProjectionState {
 }
 
 interface EditorDouble {
-  deltaDecorations: ReturnType<typeof vi.fn>
+  createDecorationsCollection: ReturnType<typeof vi.fn>
   getModel: ReturnType<typeof vi.fn<() => Pick<monaco.editor.ITextModel, 'getLineContent' | 'getLineCount' | 'getLineMaxColumn'>>>
   getPosition: ReturnType<typeof vi.fn>
 }
 
 function createEditor(): EditorDouble {
   return {
-    deltaDecorations: vi.fn((_: string[], decorations: unknown[]) =>
-      decorations.map((__, index) => `decoration-${index + 1}`),
-    ),
+    createDecorationsCollection: vi.fn(() => ({
+      clear: vi.fn(),
+      set: vi.fn((decorations: readonly unknown[]) =>
+        decorations.map((_, index) => `decoration-${index + 1}`),
+      ),
+    })),
     getModel: vi.fn(() => ({
       getLineContent: vi.fn((lineNumber: number) => lineNumber === 2 ? 'beta' : 'alpha'),
       getLineCount: vi.fn(() => 2),

--- a/src/features/editor/text-editor/text-editor-play-to-line.ts
+++ b/src/features/editor/text-editor/text-editor-play-to-line.ts
@@ -7,12 +7,16 @@ export const PLAY_TO_LINE_GLYPH_CLASS_NAME = 'play-to-line-glyph'
 export const PLAY_TO_LINE_DISABLED_GLYPH_CLASS_NAME = 'play-to-line-glyph-disabled'
 
 export interface TextEditorPlayToLineEditor {
-  deltaDecorations: (
-    oldDecorations: string[],
-    newDecorations: TextEditorPlayToLineDecoration[],
-  ) => string[]
+  createDecorationsCollection: (
+    decorations?: TextEditorPlayToLineDecoration[],
+  ) => TextEditorPlayToLineDecorationsCollection
   getModel: () => TextEditorLineReader | null | undefined
   getPosition: () => { lineNumber: number } | null | undefined
+}
+
+export interface TextEditorPlayToLineDecorationsCollection {
+  clear: () => void
+  set: (newDecorations: readonly TextEditorPlayToLineDecoration[]) => string[]
 }
 
 export interface TextEditorPlayToLineDecoration {
@@ -76,17 +80,16 @@ function createPlayToLineDecoration(
 }
 
 export function createTextEditorPlayToLineController(options: CreateTextEditorPlayToLineControllerOptions) {
-  let decorationIds: string[] = []
+  const decorations = options.editor.createDecorationsCollection()
   let decoratedLineNumber: number | undefined
 
   function clearDecorations() {
-    decoratedLineNumber = undefined
-
-    if (decorationIds.length === 0) {
+    if (decoratedLineNumber === undefined) {
       return
     }
 
-    decorationIds = options.editor.deltaDecorations(decorationIds, [])
+    decoratedLineNumber = undefined
+    decorations.clear()
   }
 
   function syncDecorationsForLine(lineNumber: number | undefined) {
@@ -107,7 +110,7 @@ export function createTextEditorPlayToLineController(options: CreateTextEditorPl
       return
     }
 
-    decorationIds = options.editor.deltaDecorations(decorationIds, [
+    decorations.set([
       createPlayToLineDecoration(previewLine.lineNumber, options.getHoverMessage(), options.isDisabled()),
     ])
     decoratedLineNumber = previewLine.lineNumber

--- a/src/features/editor/text-editor/useTextEditorRuntime.ts
+++ b/src/features/editor/text-editor/useTextEditorRuntime.ts
@@ -39,10 +39,15 @@ export function useTextEditorRuntime(options: UseTextEditorRuntimeOptions) {
     return currentState && isEditableEditor(currentState) ? currentState.projection : undefined
   })
   let isComposing = $ref(false)
-  let dropDecorationIds: string[] = []
+  let dropDecorations: monaco.editor.IEditorDecorationsCollection | undefined
 
   function readEditor(): monaco.editor.IStandaloneCodeEditor | undefined {
     return options.editorRef.value
+  }
+
+  function getDropDecorations(editor: monaco.editor.IStandaloneCodeEditor) {
+    dropDecorations ??= editor.createDecorationsCollection()
+    return dropDecorations
   }
 
   function setDropDecorations(action?: TextEditorDropAction) {
@@ -51,10 +56,13 @@ export function useTextEditorRuntime(options: UseTextEditorRuntimeOptions) {
       return
     }
 
-    dropDecorationIds = editor.deltaDecorations(
-      dropDecorationIds,
-      buildTextEditorDropDecorations({ action }),
-    )
+    const decorations = buildTextEditorDropDecorations({ action })
+    if (decorations.length === 0) {
+      dropDecorations?.clear()
+      return
+    }
+
+    getDropDecorations(editor).set(decorations)
   }
 
   function clearDropHover(): void {


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [ ] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [x] 代码重构
- [x] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

将文本编辑器中 Monaco 已废弃的 `editor.deltaDecorations` 调用迁移为 `editor.createDecorationsCollection`。

主要改动：

- 播放到当前行的 glyph margin 装饰改为通过 decoration collection 管理。
- 文件投放 hover 装饰改为懒创建 collection，并使用 `set` / `clear` 更新。
- 更新 Monaco 测试 mock，支持 `createDecorationsCollection` 的 `set`、`clear`、`append` 和 id 集合行为。
- 更新相关 unit/browser 测试断言，避免测试继续绑定已废弃 API。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

Monaco 已将 `ICodeEditor.deltaDecorations` 标记为 deprecated，并建议使用 `createDecorationsCollection`。

这次迁移可以减少后续升级 Monaco 时的兼容风险，同时让装饰生命周期更贴近 Monaco 当前推荐的 API 语义。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
