### PR TITLE
♻️ 统一局部属性访问的解构写法

### DIFF
--- a/src/composables/useDragSort.ts
+++ b/src/composables/useDragSort.ts
@@ -900,7 +900,7 @@ export function useDragSort<T>(options: UseDragSortOptions<T>): UseDragSortRetur
       settle(context.currentPosition)
     },
     onDragMove: (_event, context) => {
-      const currentPosition = context.currentPosition
+      const { currentPosition } = context
 
       session.updatePosition(currentPosition)
       updateDrag(currentPosition)

--- a/src/features/editor/shared/useEditorPanelBindings.ts
+++ b/src/features/editor/shared/useEditorPanelBindings.ts
@@ -35,7 +35,7 @@ function useActiveBinding<TBinding extends ActivatableBinding>(
   if (!context) {
     return
   }
-  const activeBinding = context.activeBinding
+  const { activeBinding } = context
 
   let isRegistered = false
 

--- a/src/features/editor/text-editor/text-editor-history-adapter.ts
+++ b/src/features/editor/text-editor/text-editor-history-adapter.ts
@@ -35,7 +35,7 @@ export function shouldCaptureBeforeContentChangeKeydown(event: monaco.IKeyboardE
     return false
   }
 
-  const key = event.browserEvent.key
+  const { key } = event.browserEvent
   if (key.length === 1) {
     return true
   }

--- a/src/features/editor/visual-editor/useVisualEditorFocusRequest.ts
+++ b/src/features/editor/visual-editor/useVisualEditorFocusRequest.ts
@@ -14,7 +14,7 @@ export function useVisualEditorFocusRequest(options: UseVisualEditorFocusRequest
   const path = computed(() => toValue(options.path))
   const rootElement = computed(() => toValue(options.rootElement))
   const isCurrentVisualSurfaceActive = computed(() => {
-    const currentState = editorStore.currentState
+    const { currentState } = editorStore
     return currentState !== undefined
       && isEditableEditor(currentState)
       && currentState.projection === 'visual'

--- a/src/features/editor/visual-editor/useVisualEditorSceneRuntime.ts
+++ b/src/features/editor/visual-editor/useVisualEditorSceneRuntime.ts
@@ -46,7 +46,7 @@ export function useVisualEditorSceneRuntime(options: UseVisualEditorSceneRuntime
   let statementClipboard: string | undefined
   const state = computed(() => options.getState())
   const activeProjection = computed(() => {
-    const currentState = editorStore.currentState
+    const { currentState } = editorStore
     return currentState && isEditableEditor(currentState) ? currentState.projection : undefined
   })
 
@@ -484,13 +484,13 @@ export function useVisualEditorSceneRuntime(options: UseVisualEditorSceneRuntime
   }
 
   function handleStatementUpdate(payload: StatementUpdatePayload) {
-    const target = payload.target
+    const { target } = payload
     if (target.kind !== 'statement') {
       logger.warn(`可视化场景编辑收到非语句目标更新 (${state.value.path})`)
       return
     }
 
-    const statements = state.value.statements
+    const { statements } = state.value
     const index = statements.findIndex(entry => entry.id === target.statementId)
     if (index === -1) {
       return

--- a/src/features/modals/create-game/useCreateGameForm.ts
+++ b/src/features/modals/create-game/useCreateGameForm.ts
@@ -62,7 +62,7 @@ export function useCreateGameForm(options: UseCreateGameFormOptions) {
   let isPathManuallyChanged = $ref(false)
 
   async function handleGameNameChange(event: Event): Promise<void> {
-    const value = (event.target as HTMLInputElement).value
+    const { value } = event.target as HTMLInputElement
     const gamePath = await resolveCreateGamePathSuggestion({
       gameName: value,
       gameSavePath: storageSettingsStore.gameSavePath,

--- a/src/features/modals/statement-group/useStatementGroupDraft.ts
+++ b/src/features/modals/statement-group/useStatementGroupDraft.ts
@@ -136,7 +136,7 @@ export function useStatementGroupDraft(options: UseStatementGroupDraftOptions) {
   }
 
   function handleEntryUpdate(payload: StatementUpdatePayload): void {
-    const target = payload.target
+    const { target } = payload
     if (target.kind !== 'statement') {
       return
     }

--- a/src/services/game-fs.ts
+++ b/src/services/game-fs.ts
@@ -101,7 +101,7 @@ async function resolveTemplateOverlayPathContext(): Promise<TemplateOverlayPathC
 
   try {
     const site = await gameManager.resolvePreviewSite(game)
-    const enginePath = site.enginePath
+    const { enginePath } = site
     if (!enginePath) {
       throw new AppError('FS_ERROR', '当前项目未绑定可用引擎，无法执行模板覆盖层路径操作')
     }

--- a/src/services/game-manager.ts
+++ b/src/services/game-manager.ts
@@ -447,7 +447,7 @@ async function createGame(gameName: string, gamePath: AbsPath, engineId: string,
     throw new AppError('IO_ERROR', '引擎不可用')
   }
 
-  const templateBinding = options.templateBinding
+  const { templateBinding } = options
 
   const targetExisted = await exists(gamePath)
   let gameId: string | undefined

--- a/src/services/path-operation.ts
+++ b/src/services/path-operation.ts
@@ -535,7 +535,7 @@ function rewriteSceneContent(
   const changedSentences = new Map<number, ReturnType<typeof cloneReferenceSentence>>()
 
   for (const record of records) {
-    const statementId = record.statementId
+    const { statementId } = record
     if (statementId === undefined) {
       unsupported.push(record)
       continue

--- a/src/services/resource-index/service.ts
+++ b/src/services/resource-index/service.ts
@@ -311,7 +311,7 @@ function bindResourceIndexBootstrap(): void {
     )
 
     fileSystemEvents.on('file:created', (event) => {
-      const gamePath = resourceIndexState.value.gamePath
+      const { gamePath } = resourceIndexState.value
       if (!gamePath || !isPathWithinGameRoot(gamePath, event.path)) {
         return
       }
@@ -324,7 +324,7 @@ function bindResourceIndexBootstrap(): void {
     })
 
     fileSystemEvents.on('file:removed', (event) => {
-      const gamePath = resourceIndexState.value.gamePath
+      const { gamePath } = resourceIndexState.value
       if (!gamePath || !isPathWithinGameRoot(gamePath, event.path)) {
         return
       }
@@ -337,7 +337,7 @@ function bindResourceIndexBootstrap(): void {
     })
 
     fileSystemEvents.on('file:renamed', (event) => {
-      const gamePath = resourceIndexState.value.gamePath
+      const { gamePath } = resourceIndexState.value
       if (!gamePath) {
         return
       }
@@ -359,7 +359,7 @@ function bindResourceIndexBootstrap(): void {
     })
 
     const rebuildReferenceOnFileChange = (path: AbsPath) => {
-      const gamePath = resourceIndexState.value.gamePath
+      const { gamePath } = resourceIndexState.value
       if (!gamePath || !isPathWithinGameRoot(gamePath, path)) {
         return
       }
@@ -371,7 +371,7 @@ function bindResourceIndexBootstrap(): void {
     fileSystemEvents.on('file:written', event => rebuildReferenceOnFileChange(event.path))
 
     const rebuildOnDirectoryChange = (path: AbsPath) => {
-      const gamePath = resourceIndexState.value.gamePath
+      const { gamePath } = resourceIndexState.value
       if (!gamePath) {
         return
       }

--- a/src/stores/__tests__/file.test.ts
+++ b/src/stores/__tests__/file.test.ts
@@ -796,8 +796,7 @@ describe('useFileStore', () => {
       expect(firstRead.map(item => item.path)).toEqual(['/root/scene'])
       expect(readDirectoryItemsCachedMock).toHaveBeenCalledTimes(1)
 
-      const pathToId = caches.pathToId
-      const items = caches.items
+      const { pathToId, items } = caches
       expect(pathToId).toBeDefined()
       expect(items).toBeDefined()
 
@@ -919,8 +918,7 @@ describe('useFileStore', () => {
       expect(firstRead).toHaveLength(2)
       expect(readDirectoryItemsCachedMock).toHaveBeenCalledTimes(1)
 
-      const pathToId = caches.pathToId
-      const items = caches.items
+      const { pathToId, items } = caches
       expect(pathToId).toBeDefined()
       expect(items).toBeDefined()
 
@@ -964,8 +962,7 @@ describe('useFileStore', () => {
       expect(firstRead).toHaveLength(2)
       expect(readDirectoryItemsCachedMock).toHaveBeenCalledTimes(1)
 
-      const pathToId = caches.pathToId
-      const items = caches.items
+      const { pathToId, items } = caches
       const evictedId = pathToId!.get('/root/file-a.txt')
       expect(evictedId).toBeDefined()
       items!.delete(evictedId!)
@@ -1286,8 +1283,7 @@ describe('useFileStore', () => {
     // initialize 内部已加载 game/，需要把它从 items 里移除以模拟"未加载"
     const caches = captureFileStoreCaches()
     try {
-      const pathToId = caches.pathToId
-      const items = caches.items
+      const { pathToId, items } = caches
       const gameId = pathToId?.get(AbsPath.from('/workspace/game'))
       if (gameId) {
         items?.delete(gameId)

--- a/src/stores/file.ts
+++ b/src/stores/file.ts
@@ -439,7 +439,7 @@ export const useFileStore = defineStore('file', () => {
       return
     }
 
-    const loadRevision = parent.loadRevision
+    const { loadRevision } = parent
     parent.loadingRevision = loadRevision
     const loadPromise = (async () => {
       try {

--- a/src/stores/internal/editor-document-save.ts
+++ b/src/stores/internal/editor-document-save.ts
@@ -95,7 +95,7 @@ export async function saveEditorDocument(
   path: AbsPath,
   saveSnapshot: EditorDocumentSaveSnapshot = createEditorDocumentSaveSnapshot(context, path),
 ): Promise<string> {
-  const metadata = saveSnapshot.docEntry.model.metadata
+  const { metadata } = saveSnapshot.docEntry.model
   const finalContent = normalizeTextLineEnding(saveSnapshot.content, metadata.lineEnding)
   const finalBytes = encodeTextFile(finalContent, metadata)
 

--- a/src/stores/internal/editor-session.ts
+++ b/src/stores/internal/editor-session.ts
@@ -115,7 +115,7 @@ export function createEditableSession(
   loadedState: LoadedDocumentState,
   preferredProjection: 'text' | 'visual',
 ): EditableEditorSession {
-  const model = loadedState.model
+  const { model } = loadedState
   const visualStateSnapshot = model.kind === 'scene' || model.kind === 'animation'
     ? createInitialVisualProjectionState(model)
     : undefined

--- a/src/stores/tabs.ts
+++ b/src/stores/tabs.ts
@@ -42,7 +42,7 @@ function rebrandProjectTabsMap(rawState: unknown): Record<string, ProjectTabsSta
     return {}
   }
 
-  const projectTabsMap = (rawState as { projectTabsMap?: unknown }).projectTabsMap
+  const { projectTabsMap } = rawState as { projectTabsMap?: unknown }
   if (!projectTabsMap || typeof projectTabsMap !== 'object') {
     return {}
   }

--- a/src/stores/workspace.ts
+++ b/src/stores/workspace.ts
@@ -66,7 +66,7 @@ export const useWorkspaceStore = defineStore(
         return undefined
       }
 
-      const gameId = route.params.gameId
+      const { gameId } = route.params
       return Array.isArray(gameId) ? gameId[0] : gameId
     }
 


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [ ] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [x] 代码重构
- [ ] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

本 PR 统一整理了前端 composables、editor features、services、stores 以及相关测试中的局部属性访问写法，将 `const foo = obj.foo` 这类中间属性读取改为局部解构。

这次改动的目标是与当前仓库的 TypeScript 约定保持一致，减少重复属性路径，提升局部变量命名的可读性和代码一致性。

本次改动不涉及业务逻辑、状态结构、持久化格式或对外接口调整，预期不改变运行时行为。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

当前仓库约定在访问嵌套属性时，优先对中间对象进行解构。暂存改动集中清理了这类不一致写法，覆盖 editor、service、store 和测试代码中的同类场景，避免后续维护时继续混用不同风格。

同步调整测试代码的目的也是让示例和生产代码保持一致，降低阅读切换成本。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [ ] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
