### PR TITLE
🐛 分离场景保存与预览资源刷新

### DIFF
--- a/src/services/__tests__/game-fs.test.ts
+++ b/src/services/__tests__/game-fs.test.ts
@@ -22,10 +22,11 @@ const {
   fsRenameFileMock,
   vfsRenamePathMock,
   readFileMock,
+  refreshCurrentGamePreviewAssetsMock,
   resolveFilePathMock,
+  touchCurrentGameLastModifiedMock,
   useFileStoreMock,
   useWorkspaceStoreMock,
-  updateCurrentGameLastModifiedMock,
   writeBinaryFileMock,
   writeTextFileMock,
 } = vi.hoisted(() => ({
@@ -47,9 +48,10 @@ const {
   fsRenameFileMock: vi.fn(),
   vfsRenamePathMock: vi.fn(),
   readFileMock: vi.fn(),
+  refreshCurrentGamePreviewAssetsMock: vi.fn(),
   resolveFilePathMock: vi.fn(),
+  touchCurrentGameLastModifiedMock: vi.fn(),
   useFileStoreMock: vi.fn(),
-  updateCurrentGameLastModifiedMock: vi.fn(),
   writeBinaryFileMock: vi.fn(),
   useWorkspaceStoreMock: vi.fn(),
   writeTextFileMock: vi.fn(),
@@ -64,7 +66,8 @@ vi.mock('@tauri-apps/plugin-fs', () => ({
 
 vi.mock('~/services/game-manager', () => ({
   gameManager: {
-    updateCurrentGameLastModified: updateCurrentGameLastModifiedMock,
+    refreshCurrentGamePreviewAssets: refreshCurrentGamePreviewAssetsMock,
+    touchCurrentGameLastModified: touchCurrentGameLastModifiedMock,
     getGameEnginePath: getGameEnginePathMock,
     resolvePreviewSite: resolvePreviewSiteMock,
   },
@@ -123,9 +126,10 @@ describe('gameFs', () => {
     fsRenameFileMock.mockReset()
     vfsRenamePathMock.mockReset()
     resolveFilePathMock.mockReset()
+    refreshCurrentGamePreviewAssetsMock.mockReset()
+    touchCurrentGameLastModifiedMock.mockReset()
     useFileStoreMock.mockReset()
     useWorkspaceStoreMock.mockReset()
-    updateCurrentGameLastModifiedMock.mockReset()
     writeBinaryFileMock.mockReset()
     writeTextFileMock.mockReset()
 
@@ -171,7 +175,7 @@ describe('gameFs', () => {
       .mockResolvedValueOnce('/game/.overlay/image.bin')
 
     await gameFs.writeFile(AbsPath.from('/game/readme.txt'), 'hello')
-    expect(updateCurrentGameLastModifiedMock).toHaveBeenCalledTimes(1)
+    expect(touchCurrentGameLastModifiedMock).toHaveBeenCalledTimes(1)
     await gameFs.writeDocumentFile(AbsPath.from('/game/image.bin'), new Uint8Array([1, 2, 3]))
 
     expect(ensureWritableMock).toHaveBeenNthCalledWith(1, '/game/readme.txt')
@@ -183,7 +187,8 @@ describe('gameFs', () => {
       physicalPath: '/game/image.bin',
       id: 1,
     })
-    expect(updateCurrentGameLastModifiedMock).toHaveBeenCalledTimes(1)
+    expect(touchCurrentGameLastModifiedMock).toHaveBeenCalledTimes(1)
+    expect(refreshCurrentGamePreviewAssetsMock).not.toHaveBeenCalled()
   })
 
   it('文档写入失败时会回滚已登记的回响写入', async () => {
@@ -210,7 +215,8 @@ describe('gameFs', () => {
     expect(registerPendingFileWriteMock).toHaveBeenCalledWith('/game/.overlay/image.bin', new Uint8Array([1, 2, 3]))
     expect(commitPendingFileWriteMock).not.toHaveBeenCalled()
     expect(rollbackPendingFileWriteMock).toHaveBeenCalledWith(handle)
-    expect(updateCurrentGameLastModifiedMock).not.toHaveBeenCalled()
+    expect(touchCurrentGameLastModifiedMock).not.toHaveBeenCalled()
+    expect(refreshCurrentGamePreviewAssetsMock).not.toHaveBeenCalled()
   })
 
   it('VFS 模式下读取文档文件会先解析实际文件路径', async () => {
@@ -252,7 +258,8 @@ describe('gameFs', () => {
 
     expect(deleteFileMock).toHaveBeenCalledWith('/game/deleted.txt', true)
     expect(mkdirMock).not.toHaveBeenCalled()
-    expect(updateCurrentGameLastModifiedMock).toHaveBeenCalledTimes(4)
+    expect(refreshCurrentGamePreviewAssetsMock).toHaveBeenCalledTimes(4)
+    expect(touchCurrentGameLastModifiedMock).not.toHaveBeenCalled()
   })
 
   it('VFS 项目中的普通路径 rename 或 move 仍走 native adapter', async () => {

--- a/src/services/__tests__/game-manager.test.ts
+++ b/src/services/__tests__/game-manager.test.ts
@@ -16,6 +16,7 @@ const {
   dbGameGetMock,
   dbGamesToArrayMock,
   dbGameUpdateMock,
+  dbTransactionMock,
   dbGameWhereEqualsMock,
   dbGameWhereFirstMock,
   dbGameWhereMock,
@@ -43,6 +44,7 @@ const {
   dbGameGetMock: vi.fn(),
   dbGamesToArrayMock: vi.fn(),
   dbGameUpdateMock: vi.fn(),
+  dbTransactionMock: vi.fn(),
   dbGameWhereEqualsMock: vi.fn(),
   dbGameWhereFirstMock: vi.fn(),
   dbGameWhereMock: vi.fn(),
@@ -130,6 +132,7 @@ vi.mock('~/database/db', () => ({
       update: dbGameUpdateMock,
       where: dbGameWhereMock,
     },
+    transaction: dbTransactionMock,
   },
 }))
 
@@ -183,6 +186,19 @@ function createGameConfig(entries: { key: string, value: string }[]) {
   }
 }
 
+interface Deferred<T> {
+  promise: Promise<T>
+  resolve(value: T): void
+}
+
+function createDeferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((resolve_) => {
+    resolve = resolve_
+  })
+  return { promise, resolve }
+}
+
 const importedProjectEngineRef = {
   id: 'default-publisher.default-engine',
   version: '4.5.0',
@@ -206,6 +222,7 @@ describe('gameManager', () => {
     dbGameGetMock.mockReset()
     dbGamesToArrayMock.mockReset()
     dbGameUpdateMock.mockReset()
+    dbTransactionMock.mockReset()
     dbGameWhereEqualsMock.mockReset()
     dbGameWhereFirstMock.mockReset()
     dbGameWhereMock.mockReset()
@@ -238,6 +255,7 @@ describe('gameManager', () => {
     dbGameAddMock.mockResolvedValue('game-1')
     dbGameDeleteMock.mockResolvedValue(undefined)
     dbGamesToArrayMock.mockResolvedValue([])
+    dbTransactionMock.mockImplementation(async (_mode: string, _table: unknown, scope: () => unknown) => scope())
 
     gameConfigPathMock.mockImplementation((gamePath: string) => `${gamePath}/game/config.txt`)
     projectConfigPathMock.mockImplementation((gamePath: string) => `${gamePath}/project.wgcp`)
@@ -1035,7 +1053,63 @@ describe('gameManager', () => {
     )
   })
 
-  it('updateGameLastModified 会刷新预览资源快照与缓存版本', async () => {
+  it('touchGameLastModified 只更新时间戳，不刷新预览资源快照', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-03-28T10:00:00.000Z'))
+    const game = createTestGame({
+      id: 'game-1',
+      path: AbsPath.from('/games/demo'),
+      metadata: {
+        name: 'Demo',
+      },
+      previewAssets: {
+        icon: {
+          path: 'icons/current.ico',
+          cacheVersion: 111,
+        },
+        cover: {
+          path: 'game/background/current-cover.png',
+          cacheVersion: 222,
+        },
+      },
+    })
+    dbGameGetMock.mockResolvedValue(game)
+    workspaceStoreState.currentGame = game
+
+    await gameManager.touchGameLastModified('game-1')
+
+    expect(gameCmdsGetGameConfigMock).not.toHaveBeenCalled()
+    expect(dbGameUpdateMock).toHaveBeenCalledWith('game-1', {
+      lastModified: new Date('2026-03-28T10:00:00.000Z').getTime(),
+    })
+    expect(workspaceStoreState.currentGame).toEqual({
+      id: 'game-1',
+      path: '/games/demo',
+      pathLookupKey: '/games/demo',
+      createdAt: 0,
+      lastModified: new Date('2026-03-28T10:00:00.000Z').getTime(),
+      status: 'created',
+      availability: 'available',
+      metadata: {
+        name: 'Demo',
+        titleImg: 'cover.png',
+      },
+      previewAssets: {
+        icon: {
+          path: 'icons/current.ico',
+          cacheVersion: 111,
+        },
+        cover: {
+          path: 'game/background/current-cover.png',
+          cacheVersion: 222,
+        },
+      },
+    })
+
+    vi.useRealTimers()
+  })
+
+  it('refreshGamePreviewAssets 会刷新预览资源快照与缓存版本', async () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-03-28T10:00:00.000Z'))
     workspaceStoreState.currentGame = createTestGame({
@@ -1077,7 +1151,7 @@ describe('gameManager', () => {
       { key: 'Title_img', value: 'cover-next.png' },
     ]))
 
-    await gameManager.updateGameLastModified('game-1')
+    await gameManager.refreshGamePreviewAssets('game-1')
 
     expect(dbGameUpdateMock).toHaveBeenCalledWith('game-1', {
       lastModified: new Date('2026-03-28T10:00:00.000Z').getTime(),
@@ -1119,16 +1193,102 @@ describe('gameManager', () => {
     vi.useRealTimers()
   })
 
-  it('updateGameLastModified 在游戏记录不存在时不会继续更新数据库或当前工作区状态', async () => {
+  it('refreshGamePreviewAssets 等待资源解析完成后再生成修改时间，避免覆盖更新的 touch', async () => {
+    vi.useFakeTimers()
+    const refreshStartTime = new Date('2026-03-28T10:00:00.000Z').getTime()
+    const touchTime = refreshStartTime + 10
+    const refreshCommitTime = refreshStartTime + 20
+    vi.setSystemTime(refreshStartTime)
+    const configDeferred = createDeferred<ReturnType<typeof createGameConfig>>()
+
+    let storedGame = createTestGame({
+      id: 'game-1',
+      path: AbsPath.from('/games/demo'),
+      lastModified: 0,
+      previewAssets: {
+        icon: {
+          path: 'icons/current.ico',
+          cacheVersion: 111,
+        },
+        cover: {
+          path: 'game/background/current-cover.png',
+          cacheVersion: 222,
+        },
+      },
+    })
+    dbGameGetMock.mockImplementation(async () => storedGame)
+    dbGameUpdateMock.mockImplementation(async (_gameId: string, patch: Partial<typeof storedGame>) => {
+      storedGame = {
+        ...storedGame,
+        ...patch,
+        metadata: { ...storedGame.metadata, ...patch.metadata },
+        previewAssets: { ...storedGame.previewAssets, ...patch.previewAssets },
+      }
+      return 1
+    })
+    workspaceStoreState.currentGame = createTestGame({
+      id: 'game-1',
+      path: AbsPath.from('/games/demo'),
+      lastModified: 0,
+      previewAssets: {
+        icon: {
+          path: 'icons/current.ico',
+          cacheVersion: 111,
+        },
+        cover: {
+          path: 'game/background/current-cover.png',
+          cacheVersion: 222,
+        },
+      },
+    })
+    gameCmdsGetGameConfigMock.mockReturnValue(configDeferred.promise)
+
+    const refreshPromise = gameManager.refreshGamePreviewAssets('game-1')
+    await vi.waitFor(() => {
+      expect(gameCmdsGetGameConfigMock).toHaveBeenCalled()
+    })
+
+    vi.setSystemTime(touchTime)
+    await gameManager.touchGameLastModified('game-1')
+
+    vi.setSystemTime(refreshCommitTime)
+    configDeferred.resolve(createGameConfig([
+      { key: 'Game_name', value: 'Changed Name' },
+      { key: 'Title_img', value: 'cover-next.png' },
+    ]))
+    await refreshPromise
+
+    expect(dbGameUpdateMock).toHaveBeenNthCalledWith(1, 'game-1', {
+      lastModified: touchTime,
+    })
+    expect(dbGameUpdateMock).toHaveBeenNthCalledWith(2, 'game-1', {
+      lastModified: refreshCommitTime,
+      previewAssets: {
+        icon: {
+          path: 'icons/favicon.ico',
+          cacheVersion: refreshCommitTime,
+        },
+        cover: {
+          path: 'game/background/cover-next.png',
+          cacheVersion: refreshCommitTime,
+        },
+      },
+    })
+    expect(workspaceStoreState.currentGame?.lastModified).toBe(refreshCommitTime)
+
+    vi.useRealTimers()
+  })
+
+  it('refreshGamePreviewAssets 在游戏记录不存在时不会继续更新数据库或当前工作区状态', async () => {
     dbGameGetMock.mockResolvedValue(undefined)
 
-    await gameManager.updateGameLastModified('game-1')
+    await gameManager.refreshGamePreviewAssets('game-1')
 
     expect(dbGameUpdateMock).not.toHaveBeenCalled()
     expect(workspaceStoreState.currentGame).toBeUndefined()
   })
 
-  it('updateGameLastModified 在预览资源解析失败时仍会推进预览缓存版本', async () => {
+  it('refreshGamePreviewAssets 在预览资源解析失败时仍会推进预览缓存版本', async () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-03-28T10:00:00.000Z'))
     dbGameGetMock.mockResolvedValue(createTestGame({
@@ -1161,7 +1321,7 @@ describe('gameManager', () => {
     })
     gameCmdsGetGameConfigMock.mockRejectedValue(new Error('config missing'))
 
-    await gameManager.updateGameLastModified('game-1')
+    await gameManager.refreshGamePreviewAssets('game-1')
 
     expect(dbGameUpdateMock).toHaveBeenCalledWith('game-1', {
       lastModified: new Date('2026-03-28T10:00:00.000Z').getTime(),
@@ -1181,7 +1341,7 @@ describe('gameManager', () => {
     vi.useRealTimers()
   })
 
-  it('updateCurrentGameLastModified 会按 500ms 防抖更新当前游戏', async () => {
+  it('touchCurrentGameLastModified 会按 500ms 防抖更新当前游戏', async () => {
     vi.useFakeTimers()
     workspaceStoreState.currentGame = createTestGame({
       id: 'game-1',
@@ -1192,8 +1352,8 @@ describe('gameManager', () => {
       path: AbsPath.from('/games/demo'),
     }))
 
-    gameManager.updateCurrentGameLastModified()
-    gameManager.updateCurrentGameLastModified()
+    gameManager.touchCurrentGameLastModified()
+    gameManager.touchCurrentGameLastModified()
 
     expect(dbGameUpdateMock).not.toHaveBeenCalled()
 

--- a/src/services/__tests__/path-operation.test.ts
+++ b/src/services/__tests__/path-operation.test.ts
@@ -83,7 +83,6 @@ function createDeps(overrides: DeepPartial<PathOperationDeps> = {}): PathOperati
     },
     gameManager: {
       refreshRegisteredGameSnapshot: vi.fn(),
-      updateCurrentGameLastModified: vi.fn(),
     },
     getGamePath: vi.fn(() => AbsPath.from('/project')),
     history: {
@@ -180,7 +179,6 @@ describe('pathOperation', () => {
       newPath: '/project/game/background/renamed.jpg',
       source: 'system-refactor',
     })
-    expect(deps.gameManager.updateCurrentGameLastModified).toHaveBeenCalledTimes(1)
     expect(deps.gameManager.refreshRegisteredGameSnapshot).toHaveBeenCalledWith('/project')
     expect(deps.pathOperationRegistry.updateChannel).toHaveBeenCalledWith(1, {
       echoMode: 'watcher',
@@ -645,7 +643,6 @@ describe('pathOperation', () => {
       },
       gameManager: {
         refreshRegisteredGameSnapshot,
-        updateCurrentGameLastModified: vi.fn(),
       },
       history: {
         migrateSceneHistory,

--- a/src/services/game-fs.ts
+++ b/src/services/game-fs.ts
@@ -25,7 +25,7 @@ async function resolveWritablePath(path: AbsPath): Promise<AbsPath> {
 
 async function writeFile(path: AbsPath, content: string): Promise<void> {
   await writeTextFile(await resolveWritablePath(path), content)
-  gameManager.updateCurrentGameLastModified()
+  gameManager.touchCurrentGameLastModified()
 }
 
 async function writeDocumentFile(path: AbsPath, content: Uint8Array): Promise<void> {
@@ -201,12 +201,12 @@ async function renameFile(oldPath: AbsPath, newName: string): Promise<PathMutati
 async function deleteFile(path: AbsPath, permanent?: boolean): Promise<void> {
   const fileStore = useFileStore()
   if (fileStore.isVfs && await fileStore.deleteEntry(path)) {
-    gameManager.updateCurrentGameLastModified()
+    gameManager.refreshCurrentGamePreviewAssets()
     return
   }
 
   await fsCmds.deleteFile(path, permanent)
-  gameManager.updateCurrentGameLastModified()
+  gameManager.refreshCurrentGamePreviewAssets()
 }
 
 async function resolveVfsCreatePath(
@@ -228,13 +228,13 @@ async function createFile(targetPath: AbsPath, fileName: string): Promise<AbsPat
   const fileStore = useFileStore()
   if (!fileStore.isVfs) {
     const result = await fsCmds.createFile(targetPath, fileName)
-    gameManager.updateCurrentGameLastModified()
+    gameManager.refreshCurrentGamePreviewAssets()
     return result
   }
 
   const writablePath = await resolveVfsCreatePath(targetPath, fileName, false)
   await writeTextFile(writablePath, '')
-  gameManager.updateCurrentGameLastModified()
+  gameManager.refreshCurrentGamePreviewAssets()
   return writablePath
 }
 
@@ -242,13 +242,13 @@ async function createFolder(targetPath: AbsPath, folderName: string): Promise<Ab
   const fileStore = useFileStore()
   if (!fileStore.isVfs) {
     const result = await fsCmds.createFolder(targetPath, folderName)
-    gameManager.updateCurrentGameLastModified()
+    gameManager.refreshCurrentGamePreviewAssets()
     return result
   }
 
   const writablePath = await resolveVfsCreatePath(targetPath, folderName, true)
   await mkdir(writablePath, { recursive: true })
-  gameManager.updateCurrentGameLastModified()
+  gameManager.refreshCurrentGamePreviewAssets()
   return writablePath
 }
 
@@ -257,7 +257,7 @@ async function copyFile(sourcePath: AbsPath, targetPath: AbsPath): Promise<AbsPa
   if (fileStore.isVfs) {
     const copiedPath = await fileStore.copyEntry(sourcePath, targetPath)
     if (copiedPath) {
-      gameManager.updateCurrentGameLastModified()
+      gameManager.refreshCurrentGamePreviewAssets()
       return copiedPath
     }
   }
@@ -267,7 +267,7 @@ async function copyFile(sourcePath: AbsPath, targetPath: AbsPath): Promise<AbsPa
     : sourcePath
   const writableTargetPath = await resolveWritablePath(targetPath)
   const result = await fsCmds.copyFile(resolvedSourcePath, writableTargetPath)
-  gameManager.updateCurrentGameLastModified()
+  gameManager.refreshCurrentGamePreviewAssets()
   return result
 }
 

--- a/src/services/game-manager.ts
+++ b/src/services/game-manager.ts
@@ -196,11 +196,43 @@ function applyCurrentGamePatch(
   }
 
   const current = workspaceStore.currentGame
+  const lastModified = patch.lastModified === undefined
+    ? current.lastModified
+    : Math.max(current.lastModified, patch.lastModified)
   workspaceStore.currentGame = {
     ...current,
     ...patch,
+    lastModified,
     metadata: { ...current.metadata, ...patch.metadata },
     previewAssets: { ...current.previewAssets, ...patch.previewAssets },
+  }
+}
+
+async function updateGameMonotonicLastModified(
+  gameId: string,
+  patch: Partial<Pick<Game, 'previewAssets'>> & { lastModified: number },
+): Promise<void> {
+  const appliedPatch = await db.transaction('rw', db.games, async () => {
+    const game = await db.games.get(gameId)
+    if (!game) {
+      return
+    }
+
+    const lastModified = Math.max(game.lastModified, patch.lastModified)
+    const nextPatch: Partial<Pick<Game, 'lastModified' | 'previewAssets'>> = {
+      ...patch,
+      lastModified,
+    }
+    if (nextPatch.previewAssets) {
+      nextPatch.previewAssets = withGamePreviewCacheVersion(nextPatch.previewAssets, lastModified)
+    }
+
+    await db.games.update(gameId, nextPatch)
+    return nextPatch
+  })
+
+  if (appliedPatch) {
+    applyCurrentGamePatch(gameId, appliedPatch)
   }
 }
 
@@ -790,49 +822,73 @@ async function resolvePreviewSite(game: Pick<Game, 'engineId' | 'path'>): Promis
   }
 }
 
-async function updateGameLastModified(gameId: string): Promise<void> {
-  const cacheVersion = Date.now()
-  const patch: Partial<Pick<Game, 'lastModified' | 'previewAssets'>> = {
-    lastModified: cacheVersion,
-  }
+async function touchGameLastModified(gameId: string): Promise<void> {
+  const lastModified = Date.now()
+  await updateGameMonotonicLastModified(gameId, { lastModified })
+}
 
+async function refreshGamePreviewAssets(gameId: string): Promise<void> {
   const game = await db.games.get(gameId)
   if (!game) {
     return
   }
 
+  let previewAssets: GamePreviewAssets | undefined
   try {
-    patch.previewAssets = withGamePreviewCacheVersion(
-      await getGamePreviewAssets(game.path),
-      cacheVersion,
-    )
+    previewAssets = await getGamePreviewAssets(game.path)
   } catch (error) {
     if (game.previewAssets) {
-      patch.previewAssets = withGamePreviewCacheVersion(game.previewAssets, cacheVersion)
+      previewAssets = game.previewAssets
     }
     logger.warn(`刷新游戏预览资源快照失败: ${error}`)
   }
 
-  await db.games.update(gameId, patch)
-  applyCurrentGamePatch(gameId, patch)
+  const cacheVersion = Date.now()
+  const patch: Partial<Pick<Game, 'previewAssets'>> & { lastModified: number } = {
+    lastModified: cacheVersion,
+  }
+  if (previewAssets) {
+    patch.previewAssets = previewAssets
+  }
+
+  await updateGameMonotonicLastModified(gameId, patch)
 }
 
-let lastModifiedTimer: ReturnType<typeof setTimeout> | undefined
+let touchLastModifiedTimer: ReturnType<typeof setTimeout> | undefined
+let refreshPreviewAssetsTimer: ReturnType<typeof setTimeout> | undefined
 
 /** 防抖更新当前游戏的 lastModified 字段（500ms） */
-function updateCurrentGameLastModified(): void {
+function touchCurrentGameLastModified(): void {
   const workspaceStore = useWorkspaceStore()
   const gameId = workspaceStore.currentGame?.id
   if (!gameId) {
     return
   }
 
-  clearTimeout(lastModifiedTimer)
-  lastModifiedTimer = setTimeout(async () => {
+  clearTimeout(touchLastModifiedTimer)
+  touchLastModifiedTimer = setTimeout(async () => {
     try {
-      await updateGameLastModified(gameId)
+      await touchGameLastModified(gameId)
     } catch (error) {
       logger.error(`更新游戏 lastModified 失败: ${error}`)
+    }
+  }, 500)
+}
+
+/** 防抖刷新当前游戏的预览资源快照（500ms） */
+function refreshCurrentGamePreviewAssets(): void {
+  const workspaceStore = useWorkspaceStore()
+  const gameId = workspaceStore.currentGame?.id
+  if (!gameId) {
+    return
+  }
+
+  clearTimeout(refreshPreviewAssetsTimer)
+  refreshPreviewAssetsTimer = setTimeout(async () => {
+    try {
+      await refreshGamePreviewAssets(gameId)
+    } catch (error) {
+      logger.error(`刷新游戏预览资源快照失败: ${error}`)
     }
   }, 500)
 }
@@ -852,7 +908,9 @@ export const gameManager = {
   importGame,
   getGameEnginePath,
   resolvePreviewSite,
-  updateGameLastModified,
-  updateCurrentGameLastModified,
+  touchGameLastModified,
+  refreshGamePreviewAssets,
+  touchCurrentGameLastModified,
+  refreshCurrentGamePreviewAssets,
   identityKeyOf,
 }

--- a/src/services/path-operation.ts
+++ b/src/services/path-operation.ts
@@ -135,7 +135,6 @@ export interface PathOperationDeps {
   }
   gameManager: {
     refreshRegisteredGameSnapshot(gamePath: AbsPath): Promise<void>
-    updateCurrentGameLastModified(): void
   }
   getGamePath(): AbsPath | undefined
   history: {
@@ -1291,7 +1290,6 @@ export function createPathOperationService(deps: PathOperationDeps) {
       if (gamePath) {
         await deps.gameManager.refreshRegisteredGameSnapshot(gamePath)
       }
-      deps.gameManager.updateCurrentGameLastModified()
       emitPathOperationEvent(deps, plan, fsResult.newPath, isDir)
       emitRewriteEvents(deps, plan.rewrites)
 

--- a/src/stores/internal/__tests__/editor-document-save.test.ts
+++ b/src/stores/internal/__tests__/editor-document-save.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { AbsPath } from '~/domain/path'
+import { saveEditorDocument } from '~/stores/internal/editor-document-save'
+import { createDocumentState, createLoadedDocumentState } from '~/stores/internal/editor-document-state'
+import { AppError } from '~/types/errors'
+
+import type { EditorDocumentSaveContext } from '~/stores/internal/editor-document-save'
+import type { DocumentState } from '~/stores/internal/editor-document-state'
+import type { EditableEditorState, TextProjectionState } from '~/stores/internal/editor-session'
+
+const {
+  touchCurrentGameLastModifiedMock,
+  refreshCurrentGamePreviewAssetsMock,
+  writeDocumentFileMock,
+} = vi.hoisted(() => ({
+  touchCurrentGameLastModifiedMock: vi.fn(),
+  refreshCurrentGamePreviewAssetsMock: vi.fn(),
+  writeDocumentFileMock: vi.fn(),
+}))
+
+vi.mock('~/services/game-fs', () => ({
+  gameFs: {
+    writeDocumentFile: writeDocumentFileMock,
+  },
+}))
+
+vi.mock('~/services/game-manager', () => ({
+  gameManager: {
+    touchCurrentGameLastModified: touchCurrentGameLastModifiedMock,
+    refreshCurrentGamePreviewAssets: refreshCurrentGamePreviewAssetsMock,
+  },
+}))
+
+function createSaveContext(document: DocumentState): EditorDocumentSaveContext {
+  const state = {
+    isDirty: true,
+    kind: document.model.kind,
+    lastSavedTime: undefined,
+    projection: 'text',
+  } as EditableEditorState
+  const textState = {
+    isDirty: true,
+    lastSavedTime: undefined,
+    projection: 'text',
+    syncError: undefined,
+    textContent: document.savedTextContent,
+    textSource: 'draft',
+  } as TextProjectionState
+
+  return {
+    createEditorError: message => new AppError('EDITOR_ERROR', message),
+    getDocumentState: () => document,
+    getEditableState: () => state,
+    getSceneSelection: vi.fn(),
+    getTextProjectionState: () => textState,
+    getVisualProjectionState: () => undefined,
+    patchSceneSelection: vi.fn(),
+    syncStateFromDocument: vi.fn(),
+  }
+}
+
+describe('saveEditorDocument', () => {
+  beforeEach(() => {
+    touchCurrentGameLastModifiedMock.mockReset()
+    refreshCurrentGamePreviewAssetsMock.mockReset()
+    writeDocumentFileMock.mockReset()
+    writeDocumentFileMock.mockResolvedValue(undefined)
+  })
+
+  it('保存场景文档后只更新游戏修改时间，不刷新预览资源快照', async () => {
+    const loadedState = createLoadedDocumentState('scene', 'say:hello;')
+    const document = createDocumentState(loadedState.model, loadedState.savedTextContent)
+    const context = createSaveContext(document)
+
+    await saveEditorDocument(context, AbsPath.from('/project/game/scene/start.txt'))
+
+    expect(writeDocumentFileMock).toHaveBeenCalledOnce()
+    expect(touchCurrentGameLastModifiedMock).toHaveBeenCalledOnce()
+    expect(refreshCurrentGamePreviewAssetsMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/stores/internal/editor-document-save.ts
+++ b/src/stores/internal/editor-document-save.ts
@@ -101,6 +101,6 @@ export async function saveEditorDocument(
 
   await gameFs.writeDocumentFile(path, finalBytes)
   finalizeSavedDocument(context, path, saveSnapshot, finalContent, new Date())
-  gameManager.updateCurrentGameLastModified()
+  gameManager.touchCurrentGameLastModified()
   return finalContent
 }


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [x] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [x] 代码重构
- [x] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

- 将游戏保存链路拆分为两类操作：
  - 场景/脚本保存只更新 `lastModified`
  - 真正影响图标、封面等预览资源的文件操作才刷新 `previewAssets`
- 为游戏修改时间更新增加单调合并，避免异步预览资源刷新覆盖较新的保存时间
- 补充 `gameManager`、`gameFs` 和 `saveEditorDocument` 相关测试，覆盖场景保存、预览资源刷新和竞态场景

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

此前场景保存会复用同一条“当前游戏快照失效”逻辑，在保存成功后同时刷新 `previewAssets` 的缓存版本。即使本次保存只改动了 scene/script 文本内容，也会导致编辑器头部的游戏图标重新生成 URL，并触发额外的图标请求。

另外，预览资源刷新依赖异步读取配置；如果刷新过程中又发生新的保存，旧刷新有机会覆盖更新的修改时间。这次调整把两类职责拆开，并确保 `lastModified` 只会单调前进，减少无意义重载和竞态覆盖。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->

资源创建、复制、删除等真正影响预览资源的操作仍会刷新游戏预览快照

### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
