### PR TITLE
🐛 修复 toast 通知样式异常

### DIFF
--- a/src/components/app/Toaster.vue
+++ b/src/components/app/Toaster.vue
@@ -41,7 +41,7 @@ const props = defineProps<ToasterProps>()
 </template>
 
 <style>
-@import "vue-sonner/style.css" layer(vue-sonner);
+@import "vue-sonner/style.css";
 
 .toaster[data-sonner-toaster] {
   --width: 20rem !important;


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [x] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [ ] 测试用例
- [ ] 性能优化
- [x] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

移除了 `src/components/app/Toaster.vue` 中对 `vue-sonner/style.css` 的 `layer(...)` 导入方式，改为直接导入样式文件。

这次修改修复了 toast 通知的样式错误，避免第三方基础样式因层级处理方式不符合当前样式组织而未按预期生效。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

当前 toast 通知存在样式异常。问题集中在 `vue-sonner` 样式的导入方式上：将其放入 CSS layer 后，样式优先级和生效顺序与当前应用不匹配，导致通知组件显示异常。

本 PR 仅调整样式导入方式，修复范围收敛在通知组件本身，不涉及通知调用逻辑、状态管理或其他业务流程。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [ ] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
