### PR TITLE
🐛 修复首页项目网格中导入按钮高度和布局

### DIFF
--- a/src/components/home/games-tab/GamesTabCollectionSection.vue
+++ b/src/components/home/games-tab/GamesTabCollectionSection.vue
@@ -140,7 +140,7 @@ const LIST_COVER_THUMBNAIL: AssetThumbnailOptions = {
         ref="dropZoneGridRef"
         type="button"
         :aria-label="$t('home.games.importGame')"
-        class="p-4 border-1 border-gray-300 rounded-lg border-dashed bg-gray-50 flex flex-col gap-3 h-full w-full cursor-pointer shadow-none transition-colors items-center justify-center text-center overflow-hidden dark:border-gray-700 hover:border-purple-300 dark:bg-gray-900 dark:hover:border-purple-700"
+        class="p-4 text-center border-1 border-gray-300 rounded-lg border-dashed bg-gray-50 flex flex-col gap-3 h-full w-full cursor-pointer shadow-none transition-colors items-center justify-center overflow-hidden dark:border-gray-700 hover:border-purple-300 dark:bg-gray-900 dark:hover:border-purple-700"
         :class="{ 'border-purple-300 bg-purple-50': isOverDropZoneGrid }"
         @click="emit('importClick')"
       >

--- a/src/components/home/games-tab/GamesTabCollectionSection.vue
+++ b/src/components/home/games-tab/GamesTabCollectionSection.vue
@@ -57,13 +57,13 @@ const LIST_COVER_THUMBNAIL: AssetThumbnailOptions = {
 
 <template>
   <ScrollArea class="h-full min-h-0">
-    <div v-if="viewMode === 'grid'" class="gap-4 grid grid-cols-1 lg:grid-cols-4 md:grid-cols-3 sm:grid-cols-2">
+    <div v-if="viewMode === 'grid'" class="gap-4 grid auto-rows-fr grid-cols-1 lg:grid-cols-4 md:grid-cols-3 sm:grid-cols-2">
       <ContextMenu v-for="item in items" :key="item.game.id">
         <ContextMenuTrigger as-child>
           <Card
             :data-testid="`game-card-${item.game.id}`"
             :data-availability="item.game.availability"
-            class="group rounded-lg cursor-pointer shadow-sm transition-all duration-300 relative overflow-hidden hover:shadow"
+            class="group rounded-lg h-full cursor-pointer shadow-sm transition-all duration-300 relative overflow-hidden hover:shadow"
             :class="{
               'cursor-wait': hasGameProgress(item.game),
               'opacity-90 ring-1 ring-destructive/40 border-destructive/30 bg-destructive/[0.03]': item.game.availability !== 'available',
@@ -140,19 +140,21 @@ const LIST_COVER_THUMBNAIL: AssetThumbnailOptions = {
         ref="dropZoneGridRef"
         type="button"
         :aria-label="$t('home.games.importGame')"
-        class="p-4 border-1 border-gray-300 rounded-lg border-dashed bg-gray-50 flex flex-col w-full cursor-pointer shadow-none transition-colors items-center justify-center overflow-hidden dark:border-gray-700 hover:border-purple-300 dark:bg-gray-900 dark:hover:border-purple-700"
-        :class="{'border-purple-300 bg-purple-50': isOverDropZoneGrid}"
+        class="p-4 border-1 border-gray-300 rounded-lg border-dashed bg-gray-50 flex flex-col gap-3 h-full w-full cursor-pointer shadow-none transition-colors items-center justify-center text-center overflow-hidden dark:border-gray-700 hover:border-purple-300 dark:bg-gray-900 dark:hover:border-purple-700"
+        :class="{ 'border-purple-300 bg-purple-50': isOverDropZoneGrid }"
         @click="emit('importClick')"
       >
-        <div class="mb-3 p-3 rounded-full bg-purple-100 dark:bg-purple-900/20">
+        <div class="p-3 rounded-full bg-purple-100 dark:bg-purple-900/20">
           <Scroll class="text-purple-600 h-6 w-6 dark:text-purple-400" />
         </div>
-        <p class="text-sm font-medium">
-          {{ $t('home.games.importGame') }}
-        </p>
-        <p class="text-xs text-muted-foreground mt-1">
-          {{ $t('home.games.importGameHint') }}
-        </p>
+        <div class="px-4 min-w-0">
+          <p class="text-sm font-medium">
+            {{ $t('home.games.importGame') }}
+          </p>
+          <p class="text-xs text-muted-foreground mt-1">
+            {{ $t('home.games.importGameHint') }}
+          </p>
+        </div>
       </button>
     </div>
     <div v-else class="border rounded-lg overflow-hidden divide-y">


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [x] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [ ] 测试用例
- [ ] 性能优化
- [x] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

修复首页项目网格中导入按钮卡片的高度和内部布局，使其在网格视图下与项目卡片保持一致的视觉节奏。

这次调整主要包括：

- 为网格容器补充 `auto-rows-fr`，让同一行卡片高度按网格统一拉伸
- 为项目卡片和导入按钮卡片补充 `h-full`，避免导入按钮高度低于相邻项目卡片
- 调整导入按钮内部布局，统一图标、标题和说明文案的间距与对齐方式
- 为文案容器补充 `text-center`、`min-w-0` 和内边距，改善不同宽度下的排版稳定性

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

首页项目网格中的导入按钮在部分布局下高度不足，且内部内容分布与普通项目卡片不一致，导致网格节奏被打断，视觉上显得不整齐。

这个 PR 通过统一网格行高策略和卡片自身拉伸行为，修复导入按钮与项目卡片之间的高度差，同时优化按钮内部排版，使首页项目网格在不同列数下都更稳定一致。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [ ] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
