### PR TITLE
🐛 修复文件树右键菜单在资源管理器中的定位行为

### DIFF
--- a/src/components/editor/FileTreeContextMenuContent.vue
+++ b/src/components/editor/FileTreeContextMenuContent.vue
@@ -10,7 +10,7 @@ import {
   Scissors,
   Trash2,
 } from '@lucide/vue'
-import { openPath } from '@tauri-apps/plugin-opener'
+import { openPath, revealItemInDir } from '@tauri-apps/plugin-opener'
 
 import { usePathOperationFeedback } from '~/composables/usePathOperationFeedback'
 import { AbsPath, RelPath } from '~/domain/path'
@@ -175,8 +175,12 @@ function handleViewHistory(): void {
 
 async function handleRevealInExplorer(): Promise<void> {
   try {
-    const pathToOpen = item.isDir ? item.path : AbsPath.parent(AbsPath.from(item.path))
-    await openPath(pathToOpen)
+    if (isRoot) {
+      await openPath(item.path)
+      return
+    }
+
+    await revealItemInDir(item.path)
   } catch (error) {
     logger.error(`打开文件管理器失败: ${error}`)
   }


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [x] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [ ] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

修复文件树右键菜单“在资源管理器中显示”的行为。

本次调整后：
- 根节点仍然直接打开对应目录
- 非根节点改为调用 `revealItemInDir`，在系统文件管理器中直接定位到当前文件或目录，而不是仅打开父目录

这使菜单行为与用户对“显示/定位到当前项”的预期保持一致，减少在外部文件管理器中继续手动查找目标项的成本。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

此前该操作对非根节点的处理方式是打开父目录：
- 目录节点会直接打开该目录
- 文件节点会打开其父目录

这会导致用户在执行“在资源管理器中显示”时，无法直接看到目标项被定位或选中，交互语义偏向“打开目录”而不是“显示当前项”。

本次修改将非根节点统一为“定位到当前项”，仅对根节点保留“直接打开目录”的行为，以匹配不同层级节点的实际语义。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [ ] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
