### PR TITLE
🐛 修复首页引擎列表的导入中状态与整组删除判定

### DIFF
--- a/src/components/home/engines-tab/EngineGroupCard.spec.ts
+++ b/src/components/home/engines-tab/EngineGroupCard.spec.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { page } from 'vitest/browser'
+import { defineComponent, h } from 'vue'
 
 import {
   createBrowserClickStub,
@@ -12,6 +13,25 @@ import { AbsPath } from '~/domain/path'
 import EngineGroupCard from './EngineGroupCard.vue'
 
 import type { EngineGroupCollectionItem } from '~/features/home/home-collection-items'
+
+function createProgressStub() {
+  return defineComponent({
+    name: 'StubProgress',
+    props: {
+      modelValue: {
+        type: Number,
+        default: 0,
+      },
+    },
+    setup(props, { attrs }) {
+      return () => h('progress', {
+        ...attrs,
+        max: 100,
+        value: props.modelValue,
+      })
+    },
+  })
+}
 
 const globalStubs = {
   AssetImage: createBrowserContainerStub('StubAssetImage', 'img'),
@@ -28,6 +48,7 @@ const globalStubs = {
   Popover: createBrowserContainerStub('StubPopover'),
   PopoverContent: createBrowserContainerStub('StubPopoverContent'),
   PopoverTrigger: createBrowserContainerStub('StubPopoverTrigger', 'button'),
+  Progress: createProgressStub(),
 }
 
 function createGroup(): EngineGroupCollectionItem {
@@ -61,6 +82,8 @@ function createGroup(): EngineGroupCollectionItem {
       },
     ],
     hasAvailableVersion: true,
+    isImporting: false,
+    isUnavailable: false,
     isDefault: true,
     latestVersionLabel: '4.5.0',
     name: 'WebGAL',
@@ -71,6 +94,37 @@ function createGroup(): EngineGroupCollectionItem {
     summary: 'Stable release',
     unavailableCount: 1,
     versionCount: 2,
+  }
+}
+
+function createImportingGroup(): EngineGroupCollectionItem {
+  const importingEngine = createTestEngine({
+    id: 'importing',
+    name: 'WebGAL',
+    path: AbsPath.from('/engines/WebGAL/4.7.0'),
+    status: 'creating',
+    version: '4.7.0',
+  })
+
+  return {
+    ...createGroup(),
+    engines: [
+      {
+        engine: importingEngine,
+        serveUrl: 'serve://importing',
+      },
+    ],
+    hasAvailableVersion: false,
+    isImporting: true,
+    isUnavailable: false,
+    isDefault: false,
+    latestVersionLabel: undefined,
+    representativeItem: {
+      engine: importingEngine,
+      serveUrl: 'serve://importing',
+    },
+    unavailableCount: 0,
+    versionCount: 1,
   }
 }
 
@@ -139,6 +193,8 @@ describe('EngineGroupCard', () => {
         group: {
           ...createGroup(),
           hasAvailableVersion: false,
+          isImporting: false,
+          isUnavailable: true,
           latestVersionLabel: undefined,
         },
         viewMode: 'list',
@@ -152,5 +208,48 @@ describe('EngineGroupCard', () => {
     })
 
     await expect.element(page.getByRole('button', { name: 'engine.unsetDefaultEngine' }).first()).not.toBeDisabled()
+  })
+
+  it('导入中的引擎组不会显示失效徽标', async () => {
+    renderInBrowser(EngineGroupCard, {
+      props: {
+        group: createImportingGroup(),
+        progress: 42,
+        viewMode: 'grid',
+      },
+      browser: {
+        i18nMode: 'lite',
+      },
+      global: {
+        stubs: globalStubs,
+      },
+    })
+
+    await expect.element(page.getByText('home.unavailableBadge')).not.toBeInTheDocument()
+    await expect.element(page.getByText('home.engines.importing')).toBeVisible()
+    await expect.element(page.getByText('engine.noAvailableVersionSummary')).not.toBeInTheDocument()
+    await expect.element(page.getByRole('button', { name: 'engine.uninstallAllVersions' })).not.toBeInTheDocument()
+    await expect.element(page.getByRole('button', { name: 'engine.deleteVersion' })).not.toBeInTheDocument()
+    const progress = await page.getByRole('progressbar').element() as HTMLProgressElement
+    expect(progress.value).toBe(42)
+  })
+
+  it('导入进度尚未开始时也会显示导入中状态', async () => {
+    renderInBrowser(EngineGroupCard, {
+      props: {
+        group: createImportingGroup(),
+        viewMode: 'list',
+      },
+      browser: {
+        i18nMode: 'lite',
+      },
+      global: {
+        stubs: globalStubs,
+      },
+    })
+
+    await expect.element(page.getByText('home.engines.importing')).toBeVisible()
+    await expect.element(page.getByText('engine.noAvailableVersionSummary')).not.toBeInTheDocument()
+    await expect.element(page.getByRole('progressbar')).not.toBeInTheDocument()
   })
 })

--- a/src/components/home/engines-tab/EngineGroupCard.vue
+++ b/src/components/home/engines-tab/EngineGroupCard.vue
@@ -8,10 +8,15 @@ import type { MenuItem } from '~/types/menu-item'
 
 interface Props {
   group: EngineGroupCollectionItem
+  progress?: number
   viewMode: 'grid' | 'list'
 }
 
-const { group, viewMode } = defineProps<Props>()
+const {
+  group,
+  progress,
+  viewMode,
+} = defineProps<Props>()
 const { t } = useI18n()
 
 const emit = defineEmits<{
@@ -24,7 +29,13 @@ const emit = defineEmits<{
 const GRID_ICON_THUMBNAIL: AssetThumbnailOptions = { width: 120, height: 120, resizeMode: 'cover' }
 const LIST_ICON_THUMBNAIL: AssetThumbnailOptions = { width: 80, height: 80, resizeMode: 'cover' }
 
+const isActiveImporting = $computed(() => group.isImporting)
+
 const versionSummary = $computed(() => {
+  if (isActiveImporting) {
+    return t('home.engines.importing')
+  }
+
   if (!group.hasAvailableVersion || !group.latestVersionLabel) {
     return t('engine.noAvailableVersionSummary', { count: group.versionCount })
   }
@@ -35,25 +46,32 @@ const versionSummary = $computed(() => {
   })
 })
 
-const menuItems = $computed<MenuItem[]>(() => [
-  {
-    icon: Star,
-    label: group.isDefault ? t('engine.unsetDefaultEngine') : t('engine.setDefaultEngine'),
-    onClick: () => emit('setDefaultEngine', group.isDefault ? undefined : group.engineId),
-    disabled: !group.hasAvailableVersion && !group.isDefault,
-  },
-  {
-    icon: Folder,
-    label: t('common.openFolder'),
-    onClick: () => emit('openGroupFolder', group),
-  },
-  {
-    icon: Trash2,
-    label: t('engine.uninstallAllVersions'),
-    onClick: () => emit('deleteGroup', group.engineId),
-    class: 'text-destructive focus:text-destructive-foreground focus:bg-destructive',
-  },
-])
+const menuItems = $computed<MenuItem[]>(() => {
+  const items: MenuItem[] = [
+    {
+      icon: Star,
+      label: group.isDefault ? t('engine.unsetDefaultEngine') : t('engine.setDefaultEngine'),
+      onClick: () => emit('setDefaultEngine', group.isDefault ? undefined : group.engineId),
+      disabled: !group.hasAvailableVersion && !group.isDefault,
+    },
+    {
+      icon: Folder,
+      label: t('common.openFolder'),
+      onClick: () => emit('openGroupFolder', group),
+    },
+  ]
+
+  if (!isActiveImporting) {
+    items.push({
+      icon: Trash2,
+      label: t('engine.uninstallAllVersions'),
+      onClick: () => emit('deleteGroup', group.engineId),
+      class: 'text-destructive focus:text-destructive-foreground focus:bg-destructive',
+    })
+  }
+
+  return items
+})
 </script>
 
 <template>
@@ -61,9 +79,12 @@ const menuItems = $computed<MenuItem[]>(() => [
     <ContextMenuTrigger as-child>
       <Card
         v-if="viewMode === 'grid'"
-        :data-availability="group.hasAvailableVersion ? 'available' : 'unavailable'"
-        class="rounded-lg shadow-sm"
-        :class="{ 'ring-1 ring-destructive/40 border-destructive/30 bg-destructive/[0.03]': !group.hasAvailableVersion }"
+        :data-availability="group.isUnavailable ? 'unavailable' : 'available'"
+        class="rounded-lg shadow-sm relative overflow-hidden"
+        :class="{
+          'cursor-wait': isActiveImporting,
+          'ring-1 ring-destructive/40 border-destructive/30 bg-destructive/[0.03]': group.isUnavailable,
+        }"
       >
         <CardContent class="p-3 flex flex-col gap-1">
           <div class="flex gap-4 items-start justify-between">
@@ -92,7 +113,7 @@ const menuItems = $computed<MenuItem[]>(() => [
                   <Badge v-if="group.isDefault" variant="secondary">
                     {{ $t('engine.defaultEngine') }}
                   </Badge>
-                  <Badge v-if="!group.hasAvailableVersion" variant="destructive">
+                  <Badge v-if="group.isUnavailable" variant="destructive">
                     <TriangleAlert class="size-3" />
                     {{ $t('home.unavailableBadge') }}
                   </Badge>
@@ -107,7 +128,11 @@ const menuItems = $computed<MenuItem[]>(() => [
                     </Button>
                   </PopoverTrigger>
                   <PopoverContent align="start" class="px-3 py-2 w-56">
-                    <EngineVersionPopover :group="group" @delete-engine="engine => emit('deleteEngine', engine)" />
+                    <EngineVersionPopover
+                      :group="group"
+                      :can-delete="!isActiveImporting"
+                      @delete-engine="engine => emit('deleteEngine', engine)"
+                    />
                   </PopoverContent>
                 </Popover>
               </div>
@@ -138,13 +163,21 @@ const menuItems = $computed<MenuItem[]>(() => [
             {{ group.summary }}
           </p>
         </CardContent>
+        <Progress
+          v-if="progress !== undefined"
+          :model-value="progress"
+          class="rounded-none h-1 inset-x-0 bottom-0 absolute"
+        />
       </Card>
 
       <div
         v-else
-        :data-availability="group.hasAvailableVersion ? 'available' : 'unavailable'"
+        :data-availability="group.isUnavailable ? 'unavailable' : 'available'"
         class="p-3 flex transition-colors duration-200 items-center justify-between relative hover:bg-primary/5 dark:hover:bg-primary/10"
-        :class="{ 'bg-destructive/[0.04] hover:bg-destructive/[0.08] dark:hover:bg-destructive/[0.12]': !group.hasAvailableVersion }"
+        :class="{
+          'cursor-wait': isActiveImporting,
+          'bg-destructive/[0.04] hover:bg-destructive/[0.08] dark:hover:bg-destructive/[0.12]': group.isUnavailable,
+        }"
       >
         <div class="flex flex-1 gap-3 min-w-0 items-center">
           <div class="rounded-md flex shrink-0 h-10 w-10 items-center justify-center overflow-hidden">
@@ -171,7 +204,7 @@ const menuItems = $computed<MenuItem[]>(() => [
               <Badge v-if="group.isDefault" variant="secondary">
                 {{ $t('engine.defaultEngine') }}
               </Badge>
-              <Badge v-if="!group.hasAvailableVersion" variant="destructive">
+              <Badge v-if="group.isUnavailable" variant="destructive">
                 <TriangleAlert class="size-3" />
                 {{ $t('home.unavailableBadge') }}
               </Badge>
@@ -190,7 +223,11 @@ const menuItems = $computed<MenuItem[]>(() => [
               </Button>
             </PopoverTrigger>
             <PopoverContent align="end" class="p-2 w-56">
-              <EngineVersionPopover :group="group" @delete-engine="engine => emit('deleteEngine', engine)" />
+              <EngineVersionPopover
+                :group="group"
+                :can-delete="!isActiveImporting"
+                @delete-engine="engine => emit('deleteEngine', engine)"
+              />
             </PopoverContent>
           </Popover>
 
@@ -214,6 +251,11 @@ const menuItems = $computed<MenuItem[]>(() => [
             </DropdownMenuContent>
           </DropdownMenu>
         </div>
+        <Progress
+          v-if="progress !== undefined"
+          :model-value="progress"
+          class="rounded-none h-0.75 inset-x-0 bottom-0 absolute"
+        />
       </div>
     </ContextMenuTrigger>
 

--- a/src/components/home/engines-tab/EngineVersionPopover.vue
+++ b/src/components/home/engines-tab/EngineVersionPopover.vue
@@ -5,10 +5,11 @@ import type { Engine } from '~/database/model'
 import type { EngineGroupCollectionItem } from '~/features/home/home-collection-items'
 
 interface Props {
+  canDelete?: boolean
   group: EngineGroupCollectionItem
 }
 
-defineProps<Props>()
+const { canDelete = true, group } = defineProps<Props>()
 
 const emit = defineEmits<{
   deleteEngine: [engine: Engine]
@@ -38,6 +39,7 @@ const emit = defineEmits<{
       </div>
 
       <Button
+        v-if="canDelete"
         :aria-label="$t('engine.deleteVersion')"
         variant="ghost"
         size="icon"

--- a/src/components/home/engines-tab/EnginesTab.vue
+++ b/src/components/home/engines-tab/EnginesTab.vue
@@ -26,12 +26,12 @@ const engineGroupItems = computed<EngineGroupCollectionItem[]>(() =>
 )
 const controller = useEnginesTabController({
   activeProgress: resourceStore.activeProgress,
-  openDeleteEngineGroupModal: (engineId) => {
+  openDeleteEngineGroupModal: (engineId, options) => {
     const group = engineGroupItems.value.find(g => g.engineId === engineId)
     modalStore.open('DeleteEngineGroupModal', {
       engineId,
       groupName: group?.name ?? engineId,
-      allUnavailable: group ? !group.hasAvailableVersion : false,
+      allUnavailable: options.allUnavailable,
     })
   },
   openDeleteEngineModal: engine => modalStore.open('DeleteEngineModal', { engine }),
@@ -49,6 +49,7 @@ const { isOverDropZone: isOverDropZoneEmpty } = useTauriDropZone(dropZoneEmptyRe
     v-if="engineGroupItems.length > 0"
     :groups="engineGroupItems"
     :view-mode="preferenceStore.viewMode"
+    :get-engine-progress="controller.getEngineProgress"
     @delete-engine="controller.handleDelete"
     @delete-group="controller.handleDeleteGroup"
     @drop="controller.handleDrop"

--- a/src/components/home/engines-tab/EnginesTabCollectionSection.spec.ts
+++ b/src/components/home/engines-tab/EnginesTabCollectionSection.spec.ts
@@ -1,8 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { page } from 'vitest/browser'
+import { defineComponent, h } from 'vue'
 
 import {
-  createBrowserActionStub,
   createBrowserClickStub,
   renderInBrowser,
 } from '~/__tests__/browser-render'
@@ -11,6 +11,7 @@ import { AbsPath } from '~/domain/path'
 
 import EnginesTabCollectionSection from './EnginesTabCollectionSection.vue'
 
+import type { Engine } from '~/database/model'
 import type { EngineGroupCollectionItem } from '~/features/home/home-collection-items'
 
 vi.mock('~/composables/useTauriDropZone', () => ({
@@ -22,24 +23,32 @@ vi.mock('~/composables/useTauriDropZone', () => ({
 
 const globalStubs = {
   Button: createBrowserClickStub('StubButton'),
-  EngineGroupCard: createBrowserActionStub('StubEngineGroupCard', {
-    eventName: 'deleteGroup',
-    includeDefaultSlot: false,
-    namedSlots: [],
-    payload: (props: Record<string, unknown>) => String((props.group as EngineGroupCollectionItem).name),
+  EngineGroupCard: defineComponent({
+    name: 'StubEngineGroupCard',
     props: {
       group: {
         type: Object,
         required: true,
+      },
+      progress: {
+        type: Number,
       },
       viewMode: {
         type: String,
         required: true,
       },
     },
-    rootTag: 'article',
-    testId: (props: Record<string, unknown>) => `group-card-${String((props.group as EngineGroupCollectionItem).name)}`,
-    text: (props: Record<string, unknown>) => String((props.group as EngineGroupCollectionItem).name),
+    emits: ['deleteGroup'],
+    setup(props, { emit }) {
+      return () => {
+        const group = props.group as EngineGroupCollectionItem
+        return h('article', {
+          'data-progress': String(props.progress),
+          'data-testid': `group-card-${group.name}`,
+          'onClick': () => emit('deleteGroup', group.name),
+        }, group.name)
+      }
+    },
   }),
 }
 
@@ -72,6 +81,8 @@ function createGroups(): EngineGroupCollectionItem[] {
         },
       ],
       hasAvailableVersion: true,
+      isImporting: false,
+      isUnavailable: false,
       isDefault: false,
       latestVersionLabel: '4.5.0',
       representativeItem: {
@@ -95,8 +106,7 @@ describe('EnginesTabCollectionSection', () => {
       props: {
         groups: createGroups(),
         viewMode: 'grid',
-        getEngineProgress: () => 0,
-        hasEngineProgress: () => false,
+        getEngineProgress: () => undefined,
       },
       browser: {
         i18nMode: 'lite',
@@ -116,8 +126,7 @@ describe('EnginesTabCollectionSection', () => {
       props: {
         groups: createGroups(),
         viewMode: 'list',
-        getEngineProgress: () => 0,
-        hasEngineProgress: () => false,
+        getEngineProgress: () => undefined,
         onDeleteGroup,
       },
       browser: {
@@ -131,5 +140,27 @@ describe('EnginesTabCollectionSection', () => {
     await page.getByText('WebGAL').click()
 
     expect(onDeleteGroup).toHaveBeenCalledWith('WebGAL')
+  })
+
+  it('会按组内导入中的引擎透传进度', async () => {
+    const groups = createGroups()
+    const importingEngine = groups[0]!.engines[0]!.engine
+
+    renderInBrowser(EnginesTabCollectionSection, {
+      props: {
+        groups,
+        viewMode: 'grid',
+        getEngineProgress: (engine: Engine) => engine.id === importingEngine.id ? 64 : undefined,
+      },
+      browser: {
+        i18nMode: 'lite',
+      },
+      global: {
+        stubs: globalStubs,
+      },
+    })
+
+    const card = await page.getByTestId('group-card-WebGAL').element()
+    expect(card.dataset.progress).toBe('64')
   })
 })

--- a/src/components/home/engines-tab/EnginesTabCollectionSection.spec.ts
+++ b/src/components/home/engines-tab/EnginesTabCollectionSection.spec.ts
@@ -45,7 +45,7 @@ const globalStubs = {
         return h('article', {
           'data-progress': String(props.progress),
           'data-testid': `group-card-${group.name}`,
-          'onClick': () => emit('deleteGroup', group.name),
+          'onClick': () => emit('deleteGroup', group.engineId),
         }, group.name)
       }
     },
@@ -139,7 +139,7 @@ describe('EnginesTabCollectionSection', () => {
 
     await page.getByText('WebGAL').click()
 
-    expect(onDeleteGroup).toHaveBeenCalledWith('WebGAL')
+    expect(onDeleteGroup).toHaveBeenCalledWith('open-webgal.webgal')
   })
 
   it('会按组内导入中的引擎透传进度', async () => {

--- a/src/components/home/engines-tab/EnginesTabCollectionSection.vue
+++ b/src/components/home/engines-tab/EnginesTabCollectionSection.vue
@@ -8,10 +8,15 @@ import type { EngineGroupCollectionItem } from '~/features/home/home-collection-
 
 interface Props {
   groups: EngineGroupCollectionItem[]
+  getEngineProgress: (engine: Engine) => number | undefined
   viewMode: 'grid' | 'list'
 }
 
-const { groups, viewMode } = defineProps<Props>()
+const {
+  groups,
+  getEngineProgress,
+  viewMode,
+} = defineProps<Props>()
 
 const emit = defineEmits<{
   deleteEngine: [engine: Engine]
@@ -27,6 +32,17 @@ const { isOverDropZone: isOverDropZoneGrid } = useTauriDropZone(dropZoneGridRef,
 
 const dropZoneListRef = useTemplateRef<HTMLElement>('dropZoneListRef')
 const { isOverDropZone: isOverDropZoneList } = useTauriDropZone(dropZoneListRef, paths => emit('drop', paths))
+
+function getGroupProgress(group: EngineGroupCollectionItem): number | undefined {
+  for (const item of group.engines) {
+    const progress = getEngineProgress(item.engine)
+    if (progress !== undefined) {
+      return progress
+    }
+  }
+
+  return undefined
+}
 </script>
 
 <template>
@@ -35,6 +51,7 @@ const { isOverDropZone: isOverDropZoneList } = useTauriDropZone(dropZoneListRef,
       v-for="group in groups"
       :key="group.name"
       :group="group"
+      :progress="getGroupProgress(group)"
       view-mode="grid"
       @delete-engine="emit('deleteEngine', $event)"
       @delete-group="emit('deleteGroup', $event)"
@@ -69,6 +86,7 @@ const { isOverDropZone: isOverDropZoneList } = useTauriDropZone(dropZoneListRef,
       v-for="group in groups"
       :key="group.name"
       :group="group"
+      :progress="getGroupProgress(group)"
       view-mode="list"
       @delete-engine="emit('deleteEngine', $event)"
       @delete-group="emit('deleteGroup', $event)"

--- a/src/features/home/engines-tab/__tests__/engine-group-view-model.test.ts
+++ b/src/features/home/engines-tab/__tests__/engine-group-view-model.test.ts
@@ -77,10 +77,41 @@ describe('buildEngineGroupCollectionItems', () => {
 
     expect(items[0]).toMatchObject({
       hasAvailableVersion: false,
+      isImporting: false,
+      isUnavailable: true,
       latestVersionLabel: undefined,
       summary: 'legacy only',
       versionCount: 1,
     })
     expect(items[0]?.representativeItem).toBeUndefined()
+  })
+
+  it('导入中的引擎版本不会让分组显示为失效', () => {
+    const items = buildEngineGroupCollectionItems({
+      engines: [
+        createTestEngine({
+          id: 'importing',
+          name: 'WebGAL',
+          path: AbsPath.from('/engines/WebGAL/4.7.0'),
+          version: '4.7.0',
+          status: 'creating',
+          metadata: {
+            description: 'importing build',
+          },
+        }),
+      ],
+      resolveServeUrl: path => `serve://${path}`,
+    })
+
+    expect(items[0]).toMatchObject({
+      hasAvailableVersion: false,
+      isImporting: true,
+      isUnavailable: false,
+      latestVersionLabel: undefined,
+      summary: 'importing build',
+      unavailableCount: 0,
+      versionCount: 1,
+    })
+    expect(items[0]?.representativeItem?.engine.id).toBe('importing')
   })
 })

--- a/src/features/home/engines-tab/__tests__/useEnginesTabController.test.ts
+++ b/src/features/home/engines-tab/__tests__/useEnginesTabController.test.ts
@@ -149,11 +149,51 @@ describe('useEnginesTabController', () => {
     expect(setDefaultEngineIdMock).toHaveBeenCalledWith(undefined)
   })
 
-  it('会把整组删除委托给调用方', async () => {
+  it('会用最新校验结果打开整组删除弹窗', async () => {
+    const staleEngine = createTestEngine({
+      id: 'engine-stale',
+      availability: 'available',
+    })
+    const missingEngine = createTestEngine({
+      id: 'engine-missing',
+      availability: 'missing',
+    })
+    enginesWhereMock.mockReturnValue({
+      equals: vi.fn(() => ({ toArray: vi.fn().mockResolvedValue([staleEngine, missingEngine]) })),
+    })
+    reconcileEngineRecordMock
+      .mockResolvedValueOnce('missing')
+      .mockResolvedValueOnce('missing')
     const controller = createController()
 
     await controller.handleDeleteGroup('WebGAL')
 
-    expect(openDeleteEngineGroupModalMock).toHaveBeenCalledWith('WebGAL')
+    expect(openDeleteEngineGroupModalMock).toHaveBeenCalledWith('WebGAL', {
+      allUnavailable: true,
+    })
+  })
+
+  it('仍有可用版本时不会把整组删除视为只删记录', async () => {
+    const availableEngine = createTestEngine({
+      id: 'engine-available',
+      availability: 'available',
+    })
+    const missingEngine = createTestEngine({
+      id: 'engine-missing',
+      availability: 'missing',
+    })
+    enginesWhereMock.mockReturnValue({
+      equals: vi.fn(() => ({ toArray: vi.fn().mockResolvedValue([availableEngine, missingEngine]) })),
+    })
+    reconcileEngineRecordMock
+      .mockResolvedValueOnce('available')
+      .mockResolvedValueOnce('missing')
+    const controller = createController()
+
+    await controller.handleDeleteGroup('WebGAL')
+
+    expect(openDeleteEngineGroupModalMock).toHaveBeenCalledWith('WebGAL', {
+      allUnavailable: false,
+    })
   })
 })

--- a/src/features/home/engines-tab/engine-group-view-model.ts
+++ b/src/features/home/engines-tab/engine-group-view-model.ts
@@ -17,18 +17,21 @@ export function buildEngineGroupCollectionItems(
 ): EngineGroupCollectionItem[] {
   return groupEngines(options.engines).map((group) => {
     const items = group.engines.map(engine => toEngineCollectionItem(engine, options.resolveServeUrl))
-    const availableItems = items.filter(item => isEngineUsable(item.engine))
-    const latestAvailable = availableItems[0]
-    const representative = latestAvailable ?? items[0]
+    const latestAvailable = items.find(item => isEngineUsable(item.engine))
+    const latestDisplayable = items.find(({ engine }) => engine.availability === 'available' && engine.status !== 'error')
+    const representative = latestAvailable ?? latestDisplayable ?? items[0]
+    const isImporting = items.some(({ engine }) => engine.status === 'creating')
 
     return {
       engineId: group.engineId,
       name: group.name,
       engines: items,
-      hasAvailableVersion: availableItems.length > 0,
+      hasAvailableVersion: latestAvailable !== undefined,
+      isImporting,
+      isUnavailable: latestDisplayable === undefined,
       isDefault: group.engineId === options.defaultEngineId,
       latestVersionLabel: latestAvailable?.engine.version,
-      representativeItem: latestAvailable,
+      representativeItem: latestAvailable ?? latestDisplayable,
       summary: representative?.engine.metadata.description ?? '',
       unavailableCount: items.filter(item => item.engine.availability !== 'available').length,
       versionCount: items.length,

--- a/src/features/home/engines-tab/useEnginesTabController.ts
+++ b/src/features/home/engines-tab/useEnginesTabController.ts
@@ -12,7 +12,7 @@ import type { I18nT } from '~/utils/i18n-like'
 
 interface UseEnginesTabControllerOptions {
   activeProgress: ReadonlyMap<string, number>
-  openDeleteEngineGroupModal: (engineId: string) => void
+  openDeleteEngineGroupModal: (engineId: string, options: { allUnavailable: boolean }) => void
   openDeleteEngineModal: (engine: Engine) => void
   setDefaultEngineId: (engineId: string | undefined) => void
   t: I18nT
@@ -57,18 +57,22 @@ export function useEnginesTabController(options: UseEnginesTabControllerOptions)
   async function handleDeleteGroup(engineId: string) {
     // 全版本删除前对组内每个版本即时校验，让弹窗的 allUnavailable 判断基于最新结果
     const engines = await db.engines.where('engineId').equals(engineId).toArray()
-    await Promise.all(engines.map(engine => resourceReconcile.reconcileEngineRecord(engine)))
-    options.openDeleteEngineGroupModal(engineId)
+    const latestAvailability = await Promise.all(engines.map(engine => resourceReconcile.reconcileEngineRecord(engine)))
+    const allUnavailable = latestAvailability.length > 0
+      && latestAvailability.every(availability => availability !== 'available')
+
+    options.openDeleteEngineGroupModal(engineId, { allUnavailable })
   }
 
   return {
-    getEngineProgress: importActions.getProgress,
+    getEngineProgress: (engine: Engine) => importActions.hasProgress(engine)
+      ? importActions.getProgress(engine)
+      : undefined,
     handleDelete,
     handleDeleteGroup,
     handleDrop: importActions.handleDrop,
     handleOpenGroupFolder,
     handleSetDefaultEngine: options.setDefaultEngineId,
-    hasEngineProgress: importActions.hasProgress,
     selectEngineFolder: importActions.selectFolder,
   }
 }

--- a/src/features/home/home-collection-items.ts
+++ b/src/features/home/home-collection-items.ts
@@ -27,6 +27,8 @@ export interface EngineGroupCollectionItem {
   engineId: string
   engines: EngineCollectionItem[]
   hasAvailableVersion: boolean
+  isImporting: boolean
+  isUnavailable: boolean
   isDefault: boolean
   latestVersionLabel?: string
   name: string

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -126,6 +126,7 @@ home:
     importSuccess: Engine imported successfully
     importAlreadyExists: This engine already exists
     importInvalidFolder: This does not look like an engine folder. Please check its contents.
+    importing: Importing engine...
     importSchemaTooNew: This engine is too new for the current app. Please upgrade the app and try again.
     importTargetConflict: The install location is already in use. Please remove the conflicting folder and retry.
     importUnsupportedLegacyEngine: This engine is too old. Please use a newer version.

--- a/src/locales/ja.yml
+++ b/src/locales/ja.yml
@@ -126,6 +126,7 @@ home:
     importSuccess: エンジンのインポートに成功しました
     importAlreadyExists: このエンジンは既に存在します
     importInvalidFolder: エンジンフォルダのようには見えません。中身を確認してください。
+    importing: エンジンをインポート中...
     importSchemaTooNew: このエンジンは現在のアプリには新しすぎます。アプリをアップグレードしてから再度お試しください。
     importTargetConflict: インストール先が既に使用されています。競合するフォルダを削除してから再試行してください。
     importUnsupportedLegacyEngine: このエンジンは古すぎます。新しいバージョンを使用してください。

--- a/src/locales/zh-Hans.yml
+++ b/src/locales/zh-Hans.yml
@@ -126,6 +126,7 @@ home:
     importSuccess: 引擎导入成功
     importAlreadyExists: 该引擎已存在
     importInvalidFolder: 这不像是引擎文件夹，请确认目录结构
+    importing: 引擎导入中……
     importSchemaTooNew: 该引擎版本过新，请升级应用后再尝试导入
     importTargetConflict: 安装位置已被占用，请先删除冲突的文件夹后重试
     importUnsupportedLegacyEngine: 该引擎版本过旧，请改用新版本

--- a/src/locales/zh-Hant.yml
+++ b/src/locales/zh-Hant.yml
@@ -126,6 +126,7 @@ home:
     importSuccess: 引擎匯入成功
     importAlreadyExists: 該引擎已存在
     importInvalidFolder: 這不像是引擎資料夾，請確認目錄結構
+    importing: 引擎匯入中……
     importSchemaTooNew: 該引擎版本過新，請升級應用後再嘗試匯入
     importTargetConflict: 安裝位置已被佔用，請先刪除衝突的資料夾後重試
     importUnsupportedLegacyEngine: 該引擎版本過舊，請改用新版本

--- a/src/services/__tests__/engine-manager.test.ts
+++ b/src/services/__tests__/engine-manager.test.ts
@@ -249,8 +249,9 @@ describe('engineManager', () => {
       '/engines/WebGAL/4.5.0',
       expect.any(Function),
     )
-    expect(resourceStoreMock.updateProgress).toHaveBeenNthCalledWith(1, 'engine-1', 25)
-    expect(resourceStoreMock.updateProgress).toHaveBeenNthCalledWith(2, 'engine-1', 100)
+    expect(resourceStoreMock.updateProgress).toHaveBeenNthCalledWith(1, 'engine-1', 0)
+    expect(resourceStoreMock.updateProgress).toHaveBeenNthCalledWith(2, 'engine-1', 25)
+    expect(resourceStoreMock.updateProgress).toHaveBeenNthCalledWith(3, 'engine-1', 100)
     expect(resourceStoreMock.finishProgress).toHaveBeenCalledWith('engine-1')
     expect(enginesUpdateMock).toHaveBeenCalledWith('engine-1', expect.objectContaining({
       status: 'created',

--- a/src/services/engine-manager.ts
+++ b/src/services/engine-manager.ts
@@ -440,6 +440,7 @@ async function importEngine(enginePath: AbsPath): Promise<ImportEngineResult> {
     ...snapshot,
     status: 'creating',
   })
+  useResourceStore().updateProgress(engineId, 0)
 
   try {
     await copyAndFinalizeEngine(engineId, normalizedPath, targetPath)


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [x] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [x] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

修复首页引擎列表在导入过程中的状态展示与整组删除判定：

- 为新导入的引擎初始化 0% 进度，并将组内进度透传到引擎分组卡片
- 为 creating 状态的引擎组显示“导入中”文案与进度条，而不是误显示为“不可用”
- 导入期间隐藏版本删除与整组卸载入口，避免对未完成导入的引擎执行破坏性操作
- 整组删除前重新校验组内各版本的最新可用性，并将结果用于 `allUnavailable` 判定
- 补充组件、view model、controller 和 engine manager 的相关测试，并新增导入中文案

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

当前实现会把 `status = creating` 的引擎组误当成不可用版本，导致首页卡片摘要、徽标和可执行操作都不准确。

同时，整组删除弹窗依赖已有分组状态，可能与删除前最新的资源校验结果不一致。这会让“是否全部不可用”的判断滞后于实际状态。

这批改动把“导入中”和“不可用”明确区分，并让删除判定基于最新 reconcile 结果，保证首页引擎列表的状态语义一致。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
