### PR TITLE
🐛 修复效果编辑器滑块重复和无效预览请求

### DIFF
--- a/src/components/editor/effect-editor/EffectDraftCategorySection.vue
+++ b/src/components/editor/effect-editor/EffectDraftCategorySection.vue
@@ -192,7 +192,7 @@ function getClearPropertyLabel(label: Parameters<EffectDraftLabelResolver>[0]): 
               :step="item.param.step"
               :model-value="controls.getSliderTrackValue(item.param)"
               @update:model-value="$event && controls.updateSliderField(item.param, $event[0] ?? 0, { fromSlider: true })"
-              @pointerup="controls.flushSliderField(item.param)"
+              @value-commit="$event && controls.updateSliderField(item.param, $event[0] ?? 0, { fromSlider: true, flush: true })"
             />
             <Input
               :id="controls.sliderInputId(item.param.key)"
@@ -250,7 +250,7 @@ function getClearPropertyLabel(label: Parameters<EffectDraftLabelResolver>[0]): 
                 :step="item.param.step"
                 :model-value="[clamp(controls.getNumberValue(item.param.key, item.param.defaultValue ?? 0), item.param.min, item.param.max)]"
                 @update:model-value="$event && controls.updateLinkedSliderField(item.param, 0, $event[0] ?? 0, { fromSlider: true })"
-                @pointerup="controls.flushLinkedSliderField(item.param, 0)"
+                @value-commit="$event && controls.updateLinkedSliderField(item.param, 0, $event[0] ?? 0, { fromSlider: true, flush: true })"
               />
               <Input
                 type="number"
@@ -273,7 +273,7 @@ function getClearPropertyLabel(label: Parameters<EffectDraftLabelResolver>[0]): 
                 :step="item.param.step"
                 :model-value="[clamp(controls.getNumberValue(item.param.linkedPairKey, item.param.defaultValue ?? 0), item.param.min, item.param.max)]"
                 @update:model-value="$event && controls.updateLinkedSliderField(item.param, 1, $event[0] ?? 0, { fromSlider: true })"
-                @pointerup="controls.flushLinkedSliderField(item.param, 1)"
+                @value-commit="$event && controls.updateLinkedSliderField(item.param, 1, $event[0] ?? 0, { fromSlider: true, flush: true })"
               />
               <Input
                 type="number"

--- a/src/features/editor/effect-editor/__tests__/useEffectEditorProvider-queue.test.ts
+++ b/src/features/editor/effect-editor/__tests__/useEffectEditorProvider-queue.test.ts
@@ -297,6 +297,37 @@ describe('useEffectEditorProvider', () => {
     })
   })
 
+  it('实时预览跳过已经发送过的相同 transform', async () => {
+    useEditSettingsStore().autoApplyEffectEditorChanges = false
+
+    const provider = createEffectEditorProvider()
+
+    await provider.open({
+      entryId: 1,
+      scenePath: 'scene/001.txt',
+      baseSentence: createBaseSentence('{"blur":8}'),
+      baseLineNumber: 1,
+      baseLineText: 'changeFigure: figure.png -transform={"blur":8};',
+      previewContextLineNumber: 0,
+      previewContextLineText: '',
+      effectTarget: 'fig-center',
+      onApply() { /* no-op */ },
+    })
+
+    provider.updateDraft({ transform: { blur: 12 } }, { deferAutoApply: true })
+    provider.requestPreview({ schedule: 'immediate' })
+    await vi.waitFor(() => {
+      expect(debugCommanderMock.setEffect).toHaveBeenCalledTimes(1)
+    })
+
+    provider.updateDraft({ transform: { blur: 12 } }, { deferAutoApply: false })
+    provider.requestPreview({ schedule: 'continuous', flush: true })
+
+    await vi.waitFor(() => {
+      expect(debugCommanderMock.setEffect).toHaveBeenCalledTimes(1)
+    })
+  })
+
   it('重置草稿时会回滚场景预览到初始基线', async () => {
     useEditSettingsStore().autoApplyEffectEditorChanges = false
 

--- a/src/features/editor/effect-editor/useEffectEditorProvider.ts
+++ b/src/features/editor/effect-editor/useEffectEditorProvider.ts
@@ -148,6 +148,19 @@ function hasRemovedTransformPaths(
   return false
 }
 
+function areTransformFieldsEqual(
+  left: Record<string, string>,
+  right: Record<string, string>,
+): boolean {
+  const leftKeys = Object.keys(left)
+  const rightKeys = Object.keys(right)
+  if (leftKeys.length !== rightKeys.length) {
+    return false
+  }
+
+  return leftKeys.every(key => left[key] === right[key])
+}
+
 function buildPreviewCommandText(session: EffectEditorSession): string {
   return serializeSentence(applyEffectEditorResultToSentence(session.baseSentence, session.draft))
 }
@@ -233,6 +246,10 @@ export function createEffectEditorProvider() {
     try {
       const nextPreviewFields = transformToFields(session.draft.transform)
       const hasDeletion = hasRemovedTransformPaths(session.previewedTransformFields, nextPreviewFields)
+
+      if (!hasDeletion && areTransformFieldsEqual(session.previewedTransformFields, nextPreviewFields)) {
+        return
+      }
 
       if (hasDeletion) {
         await debugCommander.syncScene(


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [x] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [x] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

修复效果编辑器中滑块预览请求的两个问题：

1. 拖拽滑块结束时会重复发送相同的最终预览请求。
2. 单纯点击滑块但值未变化时，仍会发送一次预览请求。

修复方式分两层：

- 控件层：将效果编辑器滑块的“结束提交”从裸 `pointerup` 改为 Reka Slider 的 `valueCommit`，只在组件确认值发生提交时触发最终 flush。
- 预览层：在发送实时预览前比较当前 transform 与最近一次已发送的 transform；如果没有字段删除且内容完全相同，则跳过发送。

这样可以同时消除“拖拽结束重复请求”和“值未变也请求”这两个问题。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

效果编辑器当前把“交互结束”直接等同于“值发生变化”，导致：

- 最后一次 `update:model-value` 已经发送过最终值后，`pointerup` 又会再发送一次相同请求；
- 即使滑块值没有变化，只要触发 `pointerup`，也会走一次 flush 预览。

这会产生多余的 WS 通信，也让预览链路的语义变得不准确。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
