### PR TITLE
✨ 调整文件树新建文件夹的默认输入交互

### DIFF
--- a/src/components/editor/FileTree.vue
+++ b/src/components/editor/FileTree.vue
@@ -118,7 +118,6 @@ const {
     extension: '.txt',
     stem: t('edit.fileTree.defaultFileStem'),
   }),
-  defaultFolderName: () => t('edit.fileTree.defaultFolderName'),
   fileTreeContainerRef,
   getKey,
   inputRef,

--- a/src/features/editor/file-tree/__tests__/file-tree.test.ts
+++ b/src/features/editor/file-tree/__tests__/file-tree.test.ts
@@ -230,7 +230,6 @@ describe('fileTree', () => {
         extension: '.txt',
         stem: 'new-scene',
       },
-      defaultFolderName: 'new-folder',
       getKey: item => item.path,
       items,
       parentPath: '/project/chapter',
@@ -252,7 +251,6 @@ describe('fileTree', () => {
         extension: '.txt',
         stem: '',
       },
-      defaultFolderName: '新建文件夹',
       getKey: item => item.path,
       items: [] as TestTreeItem[],
       parentPath: '/project',
@@ -263,7 +261,7 @@ describe('fileTree', () => {
     })
   })
 
-  it('开始创建文件夹时会全选默认文件夹名', () => {
+  it('开始创建文件夹时会返回空名称', () => {
     const items: TestTreeItem[] = [
       {
         name: 'scene.txt',
@@ -280,24 +278,22 @@ describe('fileTree', () => {
         extension: '.txt',
         stem: 'new-scene',
       },
-      defaultFolderName: '新建文件夹',
       getKey: item => item.path,
       items,
       parentPath: '/project',
       type: 'folder',
     })).toEqual({
-      selectionEnd: 5,
-      value: '新建文件夹',
+      selectionEnd: 0,
+      value: '',
     })
   })
 
-  it('创建 blur 时默认名或空值会取消创建', () => {
+  it('创建 blur 时文件默认名或空值会取消创建', () => {
     expect(resolveFileTreeCreateBlurAction({
       defaultFileNameParts: {
         extension: '.txt',
         stem: 'new-scene',
       },
-      defaultFolderName: '新建文件夹',
       isStarting: false,
       parentPath: '/project',
       type: 'file',
@@ -309,7 +305,6 @@ describe('fileTree', () => {
         extension: '.txt',
         stem: 'new-scene',
       },
-      defaultFolderName: '新建文件夹',
       isStarting: false,
       parentPath: '/project',
       type: 'folder',
@@ -323,11 +318,21 @@ describe('fileTree', () => {
         extension: '.txt',
         stem: 'new-scene',
       },
-      defaultFolderName: '新建文件夹',
       isStarting: false,
       parentPath: '/project',
       type: 'file',
       value: 'branch.txt',
+    })).toBe<FileTreeBlurAction>('submit')
+
+    expect(resolveFileTreeCreateBlurAction({
+      defaultFileNameParts: {
+        extension: '.txt',
+        stem: 'new-scene',
+      },
+      isStarting: false,
+      parentPath: '/project',
+      type: 'folder',
+      value: '新建文件夹',
     })).toBe<FileTreeBlurAction>('submit')
   })
 

--- a/src/features/editor/file-tree/__tests__/useFileTreeController.test.ts
+++ b/src/features/editor/file-tree/__tests__/useFileTreeController.test.ts
@@ -207,7 +207,6 @@ function createFixture(options: {
       extension: '.txt',
       stem: 'untitled',
     }),
-    defaultFolderName: () => 'untitled-folder',
     fileTreeContainerRef: ref(),
     getKey: item => item.path,
     inputRef: ref(),

--- a/src/features/editor/file-tree/file-tree.ts
+++ b/src/features/editor/file-tree/file-tree.ts
@@ -43,7 +43,6 @@ export interface ResolveFileTreeRenameBlurActionOptions {
 export interface ResolveFileTreeCreateStartOptions<T> {
   accessor: Pick<FileTreeItemAccessor<T>, 'getChildren' | 'getPath'>
   defaultFileNameParts: FileTreeDefaultFileNameParts
-  defaultFolderName: string
   getKey: (item: T) => string
   items: T[]
   parentPath: string
@@ -58,7 +57,6 @@ export interface FileTreeCreateStartResult {
 
 export interface ResolveFileTreeCreateBlurActionOptions {
   defaultFileNameParts: FileTreeDefaultFileNameParts
-  defaultFolderName: string
   isStarting: boolean
   parentPath?: string
   type?: 'file' | 'folder'
@@ -185,12 +183,8 @@ export function resolveFileTreeCreateStart<T>(
   options: ResolveFileTreeCreateStartOptions<T>,
 ): FileTreeCreateStartResult {
   const fileDraft = resolveFileTreeDefaultFileDraft(options.defaultFileNameParts)
-  const value = options.type === 'file'
-    ? fileDraft.value
-    : options.defaultFolderName
-  const selectionEnd = options.type === 'file'
-    ? fileDraft.selectionEnd
-    : value.length
+  const value = options.type === 'file' ? fileDraft.value : ''
+  const selectionEnd = options.type === 'file' ? fileDraft.selectionEnd : 0
 
   const parentItem = findFileTreeItemByPath(options.items, options.parentPath, options.accessor)
 
@@ -209,11 +203,11 @@ export function resolveFileTreeCreateBlurAction(
   }
 
   const trimmedValue = options.value.trim()
-  const defaultName = options.type === 'file'
-    ? resolveFileTreeDefaultFileDraft(options.defaultFileNameParts).value
-    : options.defaultFolderName
+  if (!trimmedValue) {
+    return 'cancel'
+  }
 
-  if (!trimmedValue || trimmedValue === defaultName) {
+  if (options.type === 'file' && trimmedValue === resolveFileTreeDefaultFileDraft(options.defaultFileNameParts).value) {
     return 'cancel'
   }
 

--- a/src/features/editor/file-tree/file-tree.ts
+++ b/src/features/editor/file-tree/file-tree.ts
@@ -182,9 +182,14 @@ export function findFileTreeItemByPath<T>(
 export function resolveFileTreeCreateStart<T>(
   options: ResolveFileTreeCreateStartOptions<T>,
 ): FileTreeCreateStartResult {
-  const fileDraft = resolveFileTreeDefaultFileDraft(options.defaultFileNameParts)
-  const value = options.type === 'file' ? fileDraft.value : ''
-  const selectionEnd = options.type === 'file' ? fileDraft.selectionEnd : 0
+  let value = ''
+  let selectionEnd = 0
+
+  if (options.type === 'file') {
+    const fileDraft = resolveFileTreeDefaultFileDraft(options.defaultFileNameParts)
+    value = fileDraft.value
+    selectionEnd = fileDraft.selectionEnd
+  }
 
   const parentItem = findFileTreeItemByPath(options.items, options.parentPath, options.accessor)
 

--- a/src/features/editor/file-tree/useFileTreeController.ts
+++ b/src/features/editor/file-tree/useFileTreeController.ts
@@ -58,7 +58,6 @@ interface UseFileTreeControllerOptions<T extends object> {
   defaultExpanded: () => string[]
   defaultFileNameParts?: FileTreeDefaultFileNameParts | (() => FileTreeDefaultFileNameParts)
   defaultFileNamePartsFallback: () => FileTreeDefaultFileNameParts
-  defaultFolderName: () => string
   fileTreeContainerRef: ReadonlyRefLike<HTMLElement | null | undefined>
   getKey: (item: T) => string
   inputRef: ReadonlyRefLike<unknown>
@@ -472,7 +471,6 @@ export function useFileTreeController<T extends object>(options: UseFileTreeCont
     const createStart = resolveFileTreeCreateStart({
       accessor: fileTreeItemAccessor,
       defaultFileNameParts: getDefaultFileNameParts(),
-      defaultFolderName: options.defaultFolderName(),
       getKey: options.getKey,
       items: options.items(),
       parentPath,
@@ -534,7 +532,6 @@ export function useFileTreeController<T extends object>(options: UseFileTreeCont
   function handleCreateBlur(): void {
     const action = resolveFileTreeCreateBlurAction({
       defaultFileNameParts: getDefaultFileNameParts(),
-      defaultFolderName: options.defaultFolderName(),
       isStarting: createState.value.isStarting,
       parentPath: createState.value.parentPath,
       type: createState.value.type,


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [ ] 错误修复
- [x] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [x] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

这个 PR 调整了编辑器文件树中新建文件夹时的默认输入交互：

- 新建文件夹时不再预填默认名称，而是以空输入开始
- 新建文件时仍保持现有默认文件名草稿行为不变
- 创建 blur 逻辑同步收敛，文件夹创建仅在空输入时取消
- 移除了 `defaultFolderName` 相关参数传递，并同步更新了相关测试

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

新建文件夹时默认应为空输入，而不是预填一个本地化默认名称。这样可以减少一次额外删除默认名的操作，让用户直接输入目标名称，也让文件和文件夹在创建交互上的差异更符合各自使用场景。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
