### PR TITLE
🐛 修复引擎和模板拖拽区高亮未生效

### DIFF
--- a/src/components/home/engines-tab/EnginesTabCollectionSection.vue
+++ b/src/components/home/engines-tab/EnginesTabCollectionSection.vue
@@ -63,8 +63,11 @@ function getGroupProgress(group: EngineGroupCollectionItem): number | undefined 
       ref="dropZoneGridRef"
       type="button"
       :aria-label="$t('home.engines.installEngine')"
-      class="p-4 border-1 border-gray-300 rounded-lg border-dashed bg-gray-50 flex gap-4 cursor-pointer shadow-none transition-colors items-center justify-center overflow-hidden dark:border-gray-700 hover:border-primary/40 dark:bg-gray-900 dark:hover:border-primary/60"
-      :class="{ 'border-primary/40 bg-primary/5': isOverDropZoneGrid }"
+      class="p-4 border-1 rounded-lg border-dashed flex gap-4 cursor-pointer shadow-none transition-colors items-center justify-center overflow-hidden hover:border-primary/40 dark:hover:border-primary/60"
+      :class="{
+        'border-primary/40 bg-primary/5': isOverDropZoneGrid,
+        'border-gray-300 bg-gray-50 dark:border-gray-700 dark:bg-gray-900': !isOverDropZoneGrid,
+      }"
       @click="emit('importClick')"
     >
       <div class="p-3 rounded-full bg-primary/10">
@@ -98,8 +101,11 @@ function getGroupProgress(group: EngineGroupCollectionItem): number | undefined 
       ref="dropZoneListRef"
       type="button"
       :aria-label="$t('home.engines.installEngine')"
-      class="p-3 bg-gray-50/50 flex w-full cursor-pointer transition-colors items-center justify-between dark:bg-gray-800/10 hover:bg-gray-100 dark:hover:bg-gray-800/20"
-      :class="{ 'bg-primary/5': isOverDropZoneList }"
+      class="p-3 flex w-full cursor-pointer transition-colors items-center justify-between hover:bg-gray-100 dark:hover:bg-gray-800/20"
+      :class="{
+        'bg-primary/5': isOverDropZoneList,
+        'bg-gray-50/50 dark:bg-gray-800/10': !isOverDropZoneList,
+      }"
       @click="emit('importClick')"
     >
       <div class="flex gap-3 items-center">

--- a/src/components/home/templates-tab/TemplatesTabCollectionSection.vue
+++ b/src/components/home/templates-tab/TemplatesTabCollectionSection.vue
@@ -93,8 +93,11 @@ function getMenuItems(item: TemplateCollectionItem): MenuItem[] {
         ref="dropZoneGridRef"
         type="button"
         :aria-label="$t('home.templates.importTemplate')"
-        class="p-3 border-1 border-gray-300 rounded-lg border-dashed bg-gray-50 flex gap-4 cursor-pointer shadow-none transition-colors items-center justify-center overflow-hidden dark:border-gray-700 hover:border-primary/40 dark:bg-gray-900 dark:hover:border-primary/60"
-        :class="{ 'border-primary/40 bg-primary/5': isOverDropZoneGrid }"
+        class="p-3 border-1 rounded-lg border-dashed flex gap-4 cursor-pointer shadow-none transition-colors items-center justify-center overflow-hidden hover:border-primary/40 dark:hover:border-primary/60"
+        :class="{
+          'border-primary/40 bg-primary/5': isOverDropZoneGrid,
+          'border-gray-300 bg-gray-50 dark:border-gray-700 dark:bg-gray-900': !isOverDropZoneGrid,
+        }"
         @click="emit('importClick')"
       >
         <div class="p-3 rounded-full bg-primary/10">
@@ -127,8 +130,11 @@ function getMenuItems(item: TemplateCollectionItem): MenuItem[] {
         ref="dropZoneListRef"
         type="button"
         :aria-label="$t('home.templates.importTemplate')"
-        class="p-3 bg-gray-50/50 flex w-full cursor-pointer transition-colors items-center justify-between dark:bg-gray-800/10 hover:bg-gray-100 dark:hover:bg-gray-800/20"
-        :class="{ 'bg-primary/5': isOverDropZoneList }"
+        class="p-3 flex w-full cursor-pointer transition-colors items-center justify-between hover:bg-gray-100 dark:hover:bg-gray-800/20"
+        :class="{
+          'bg-primary/5': isOverDropZoneList,
+          'bg-gray-50/50 dark:bg-gray-800/10': !isOverDropZoneList,
+        }"
         @click="emit('importClick')"
       >
         <div class="flex gap-3 items-center">


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [x] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [ ] 测试用例
- [ ] 性能优化
- [x] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

修复首页中“引擎”和“模板”导入区域在拖拽悬停时高亮不稳定或不生效的问题。

具体调整如下：

- 将拖拽区默认的边框和背景样式从静态 `class` 中移出
- 改为通过 `:class` 根据拖拽悬停状态显式切换默认样式和高亮样式
- 同步覆盖引擎与模板两个入口中的网格视图和列表视图

这样可以避免默认样式与高亮样式同时存在时发生覆盖冲突，确保拖拽进入时视觉反馈稳定一致。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

当前拖拽区的默认背景和边框样式写在静态 `class` 中，而高亮样式通过条件类追加。由于样式优先级和类合并后的覆盖关系，高亮状态下可能仍然被默认样式抵消，导致拖拽反馈不明显。

这次修改通过把“默认态”和“高亮态”改为互斥的条件样式，直接消除样式冲突，使拖拽反馈行为更可预期，也让引擎和模板区域的交互表现保持一致。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [ ] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
