### PR TITLE
🐛 修复预览资源缓存失效粒度与合并逻辑

### DIFF
--- a/src/components/modals/game-config/IconEditorDialog.spec.ts
+++ b/src/components/modals/game-config/IconEditorDialog.spec.ts
@@ -667,7 +667,7 @@ describe('IconEditorDialog', () => {
           relativePath: RelPath.from('icons/favicon.ico'),
         },
       ])
-      expect(refreshRegisteredGameSnapshotMock).toHaveBeenCalledWith('/games/demo')
+      expect(refreshRegisteredGameSnapshotMock).toHaveBeenCalledWith('/games/demo', { invalidate: 'icon' })
       expect(updateOpen).toHaveBeenCalledWith(false)
     })
   })

--- a/src/features/modals/game-config/icon-editor/useIconEditorSession.ts
+++ b/src/features/modals/game-config/icon-editor/useIconEditorSession.ts
@@ -381,7 +381,7 @@ export function useIconEditorSession(options: UseIconEditorSessionOptions) {
     try {
       const outputs = await buildIconExportOutputs(state.value)
       await saveIconEditorOutputs(gamePath, outputs)
-      await gameManager.refreshRegisteredGameSnapshot(gamePath)
+      await gameManager.refreshRegisteredGameSnapshot(gamePath, { invalidate: 'icon' })
       options.open.value = false
     } catch (error) {
       handleError(error, { context: options.t('modals.gameConfig.iconEditor.generateFailed') })

--- a/src/services/__tests__/engine-switch.test.ts
+++ b/src/services/__tests__/engine-switch.test.ts
@@ -171,6 +171,7 @@ describe('engineSwitch.switchEngine', () => {
     expect(dbGameUpdateMock).toHaveBeenCalledWith('game-1', { engineId: 'engine-new' })
     expect(updateSiteEngineMock).toHaveBeenCalledWith('/games/demo', '/engines/new')
     expect(updateSiteTemplateMock).toHaveBeenCalledWith('/games/demo', '/engines/new/game/template')
+    expect(refreshRegisteredGameSnapshotMock).toHaveBeenCalledWith('/games/demo', { invalidate: 'all' })
     expect(cleanTemplateUpperMock).not.toHaveBeenCalled()
     expect(refreshIfCurrentGameMock).not.toHaveBeenCalled()
     expect(syncIfCurrentGameMock).toHaveBeenCalledWith({

--- a/src/services/__tests__/game-fs.test.ts
+++ b/src/services/__tests__/game-fs.test.ts
@@ -143,7 +143,13 @@ describe('gameFs', () => {
     resolveFilePathMock.mockImplementation(async (path: string) => path)
     useWorkspaceStoreMock.mockReturnValue({
       CWD: '/project',
-      currentGame: { path: '/project' },
+      currentGame: {
+        path: '/project',
+        previewAssets: {
+          icon: { path: 'icons/favicon.ico' },
+          cover: { path: 'game/background/cover.png' },
+        },
+      },
     })
     resolvePreviewSiteMock.mockResolvedValue({
       projectPath: '/project',
@@ -258,7 +264,24 @@ describe('gameFs', () => {
 
     expect(deleteFileMock).toHaveBeenCalledWith('/game/deleted.txt', true)
     expect(mkdirMock).not.toHaveBeenCalled()
-    expect(refreshCurrentGamePreviewAssetsMock).toHaveBeenCalledTimes(4)
+    expect(refreshCurrentGamePreviewAssetsMock).not.toHaveBeenCalled()
+    expect(touchCurrentGameLastModifiedMock).toHaveBeenCalledTimes(4)
+  })
+
+  it('创建当前图标文件时只刷新图标预览资源', async () => {
+    createFileMock.mockResolvedValue('/project/icons/favicon.ico')
+
+    await expect(gameFs.createFile(AbsPath.from('/project/icons'), 'favicon.ico')).resolves.toBe('/project/icons/favicon.ico')
+
+    expect(refreshCurrentGamePreviewAssetsMock).toHaveBeenCalledWith({ invalidate: 'icon' })
+    expect(touchCurrentGameLastModifiedMock).not.toHaveBeenCalled()
+  })
+
+  it('删除当前封面文件时只刷新封面预览资源', async () => {
+    await gameFs.deleteFile(AbsPath.from('/project/game/background/cover.png'), true)
+
+    expect(deleteFileMock).toHaveBeenCalledWith('/project/game/background/cover.png', true)
+    expect(refreshCurrentGamePreviewAssetsMock).toHaveBeenCalledWith({ invalidate: 'cover' })
     expect(touchCurrentGameLastModifiedMock).not.toHaveBeenCalled()
   })
 

--- a/src/services/__tests__/game-manager.test.ts
+++ b/src/services/__tests__/game-manager.test.ts
@@ -1552,6 +1552,65 @@ describe('gameManager', () => {
     vi.useRealTimers()
   })
 
+  it('refreshRegisteredGameSnapshot 写入前会基于最新游戏记录合并预览缓存版本', async () => {
+    vi.useFakeTimers()
+    try {
+      vi.setSystemTime(new Date('2026-03-28T10:00:00.000Z'))
+      const staleGame = createTestGame({
+        id: 'game-1',
+        path: AbsPath.from('/games/demo'),
+        previewAssets: {
+          icon: {
+            path: 'icons/favicon.ico',
+            cacheVersion: 111,
+          },
+          cover: {
+            path: 'game/background/cover.png',
+            cacheVersion: 222,
+          },
+        },
+      })
+      const latestGame = createTestGame({
+        id: 'game-1',
+        path: AbsPath.from('/games/demo'),
+        previewAssets: {
+          icon: {
+            path: 'icons/favicon.ico',
+            cacheVersion: 333,
+          },
+          cover: {
+            path: 'game/background/cover.png',
+            cacheVersion: 444,
+          },
+        },
+      })
+      dbGameWhereFirstMock
+        .mockResolvedValueOnce(staleGame)
+        .mockResolvedValueOnce(latestGame)
+      gameCmdsGetGameConfigMock.mockResolvedValue(createGameConfig([
+        { key: 'Game_name', value: 'Renamed Game' },
+        { key: 'Title_img', value: 'cover.png' },
+      ]))
+
+      await gameManager.refreshRegisteredGameSnapshot(AbsPath.from('/games/demo'))
+
+      expect(dbGameUpdateMock).toHaveBeenCalledWith('game-1', expect.objectContaining({
+        previewAssets: {
+          icon: {
+            path: 'icons/favicon.ico',
+            cacheVersion: 333,
+          },
+          cover: {
+            path: 'game/background/cover.png',
+            cacheVersion: 444,
+          },
+        },
+      }))
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('refreshRegisteredGameSnapshot 支持显式只刷新图标缓存版本', async () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-03-28T10:00:00.000Z'))
@@ -1739,6 +1798,65 @@ describe('gameManager', () => {
     })
 
     vi.useRealTimers()
+  })
+
+  it('refreshGamePreviewAssets 写入前会基于最新游戏记录合并预览缓存版本', async () => {
+    vi.useFakeTimers()
+    try {
+      vi.setSystemTime(new Date('2026-03-28T10:00:00.000Z'))
+      const staleGame = createTestGame({
+        id: 'game-1',
+        path: AbsPath.from('/games/demo'),
+        previewAssets: {
+          icon: {
+            path: 'icons/favicon.ico',
+            cacheVersion: 111,
+          },
+          cover: {
+            path: 'game/background/cover.png',
+            cacheVersion: 222,
+          },
+        },
+      })
+      const latestGame = createTestGame({
+        id: 'game-1',
+        path: AbsPath.from('/games/demo'),
+        previewAssets: {
+          icon: {
+            path: 'icons/favicon.ico',
+            cacheVersion: 333,
+          },
+          cover: {
+            path: 'game/background/cover.png',
+            cacheVersion: 444,
+          },
+        },
+      })
+      dbGameGetMock
+        .mockResolvedValueOnce(staleGame)
+        .mockResolvedValueOnce(latestGame)
+      gameCmdsGetGameConfigMock.mockResolvedValue(createGameConfig([
+        { key: 'Game_name', value: 'Renamed Game' },
+        { key: 'Title_img', value: 'cover.png' },
+      ]))
+
+      await gameManager.refreshGamePreviewAssets('game-1')
+
+      expect(dbGameUpdateMock).toHaveBeenCalledWith('game-1', expect.objectContaining({
+        previewAssets: {
+          icon: {
+            path: 'icons/favicon.ico',
+            cacheVersion: 333,
+          },
+          cover: {
+            path: 'game/background/cover.png',
+            cacheVersion: 444,
+          },
+        },
+      }))
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('refreshGamePreviewAssets 等待资源解析完成后再生成修改时间，避免覆盖更新的 touch', async () => {

--- a/src/services/__tests__/game-manager.test.ts
+++ b/src/services/__tests__/game-manager.test.ts
@@ -1419,7 +1419,7 @@ describe('gameManager', () => {
     })
   })
 
-  it('refreshRegisteredGameSnapshot 会按路径刷新数据库快照，并同步当前工作区游戏', async () => {
+  it('refreshRegisteredGameSnapshot 会按路径刷新数据库快照，并只刷新变化资源的缓存版本', async () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-03-28T10:00:00.000Z'))
     dbGameWhereFirstMock.mockResolvedValue(createTestGame({
@@ -1472,7 +1472,7 @@ describe('gameManager', () => {
       previewAssets: {
         icon: {
           path: 'icons/favicon.ico',
-          cacheVersion: new Date('2026-03-28T10:00:00.000Z').getTime(),
+          cacheVersion: 111,
         },
         cover: {
           path: 'game/background/cover-next.png',
@@ -1490,7 +1490,7 @@ describe('gameManager', () => {
       previewAssets: {
         icon: {
           path: 'icons/favicon.ico',
-          cacheVersion: new Date('2026-03-28T10:00:00.000Z').getTime(),
+          cacheVersion: 111,
         },
         cover: {
           path: 'game/background/cover-next.png',
@@ -1499,6 +1499,91 @@ describe('gameManager', () => {
       },
       lastModified: new Date('2026-03-28T10:00:00.000Z').getTime(),
     })
+
+    vi.useRealTimers()
+  })
+
+  it('refreshRegisteredGameSnapshot 在语义元数据变化但预览路径不变时保留资源缓存版本', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-03-28T10:00:00.000Z'))
+    dbGameWhereFirstMock.mockResolvedValue(createTestGame({
+      id: 'game-1',
+      path: AbsPath.from('/games/demo'),
+      metadata: {
+        name: 'Old Name',
+        titleImg: 'cover.png',
+      },
+      previewAssets: {
+        icon: {
+          path: 'icons/favicon.ico',
+          cacheVersion: 111,
+        },
+        cover: {
+          path: 'game/background/cover.png',
+          cacheVersion: 222,
+        },
+      },
+    }))
+    gameCmdsGetGameConfigMock.mockResolvedValue(createGameConfig([
+      { key: 'Game_name', value: 'Renamed Game' },
+      { key: 'Title_img', value: 'cover.png' },
+    ]))
+
+    await gameManager.refreshRegisteredGameSnapshot(AbsPath.from('/games/demo'))
+
+    expect(dbGameUpdateMock).toHaveBeenCalledWith('game-1', {
+      lastModified: new Date('2026-03-28T10:00:00.000Z').getTime(),
+      metadata: {
+        name: 'Renamed Game',
+        titleImg: 'cover.png',
+      },
+      previewAssets: {
+        icon: {
+          path: 'icons/favicon.ico',
+          cacheVersion: 111,
+        },
+        cover: {
+          path: 'game/background/cover.png',
+          cacheVersion: 222,
+        },
+      },
+    })
+
+    vi.useRealTimers()
+  })
+
+  it('refreshRegisteredGameSnapshot 支持显式只刷新图标缓存版本', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-03-28T10:00:00.000Z'))
+    dbGameWhereFirstMock.mockResolvedValue(createTestGame({
+      id: 'game-1',
+      path: AbsPath.from('/games/demo'),
+      previewAssets: {
+        icon: {
+          path: 'icons/favicon.ico',
+          cacheVersion: 111,
+        },
+        cover: {
+          path: 'game/background/cover.png',
+          cacheVersion: 222,
+        },
+      },
+    }))
+
+    await gameManager.refreshRegisteredGameSnapshot(AbsPath.from('/games/demo'), { invalidate: 'icon' })
+
+    expect(dbGameUpdateMock).toHaveBeenCalledWith('game-1', expect.objectContaining({
+      previewAssets: {
+        icon: {
+          path: 'icons/favicon.ico',
+          cacheVersion: new Date('2026-03-28T10:00:00.000Z').getTime(),
+        },
+        cover: {
+          path: 'game/background/cover.png',
+          cacheVersion: 222,
+        },
+      },
+    }))
 
     vi.useRealTimers()
   })
@@ -1527,7 +1612,7 @@ describe('gameManager', () => {
       },
       previewAssets: {
         icon: {
-          path: 'icons/current.ico',
+          path: 'icons/favicon.ico',
           cacheVersion: 111,
         },
         cover: {
@@ -1559,7 +1644,7 @@ describe('gameManager', () => {
       },
       previewAssets: {
         icon: {
-          path: 'icons/current.ico',
+          path: 'icons/favicon.ico',
           cacheVersion: 111,
         },
         cover: {
@@ -1572,7 +1657,7 @@ describe('gameManager', () => {
     vi.useRealTimers()
   })
 
-  it('refreshGamePreviewAssets 会刷新预览资源快照与缓存版本', async () => {
+  it('refreshGamePreviewAssets 会刷新预览资源快照，并只刷新变化资源的缓存版本', async () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-03-28T10:00:00.000Z'))
     workspaceStoreState.currentGame = createTestGame({
@@ -1583,7 +1668,7 @@ describe('gameManager', () => {
       },
       previewAssets: {
         icon: {
-          path: 'icons/current.ico',
+          path: 'icons/favicon.ico',
           cacheVersion: 111,
         },
         cover: {
@@ -1600,7 +1685,7 @@ describe('gameManager', () => {
       },
       previewAssets: {
         icon: {
-          path: 'icons/current.ico',
+          path: 'icons/favicon.ico',
           cacheVersion: 111,
         },
         cover: {
@@ -1621,7 +1706,7 @@ describe('gameManager', () => {
       previewAssets: {
         icon: {
           path: 'icons/favicon.ico',
-          cacheVersion: new Date('2026-03-28T10:00:00.000Z').getTime(),
+          cacheVersion: 111,
         },
         cover: {
           path: 'game/background/cover-next.png',
@@ -1644,7 +1729,7 @@ describe('gameManager', () => {
       previewAssets: {
         icon: {
           path: 'icons/favicon.ico',
-          cacheVersion: new Date('2026-03-28T10:00:00.000Z').getTime(),
+          cacheVersion: 111,
         },
         cover: {
           path: 'game/background/cover-next.png',
@@ -1670,7 +1755,7 @@ describe('gameManager', () => {
       lastModified: 0,
       previewAssets: {
         icon: {
-          path: 'icons/current.ico',
+          path: 'icons/favicon.ico',
           cacheVersion: 111,
         },
         cover: {
@@ -1695,7 +1780,7 @@ describe('gameManager', () => {
       lastModified: 0,
       previewAssets: {
         icon: {
-          path: 'icons/current.ico',
+          path: 'icons/favicon.ico',
           cacheVersion: 111,
         },
         cover: {
@@ -1729,7 +1814,7 @@ describe('gameManager', () => {
       previewAssets: {
         icon: {
           path: 'icons/favicon.ico',
-          cacheVersion: refreshCommitTime,
+          cacheVersion: 111,
         },
         cover: {
           path: 'game/background/cover-next.png',
@@ -1751,7 +1836,7 @@ describe('gameManager', () => {
     expect(workspaceStoreState.currentGame).toBeUndefined()
   })
 
-  it('refreshGamePreviewAssets 在预览资源解析失败时仍会推进预览缓存版本', async () => {
+  it('refreshGamePreviewAssets 在预览资源解析失败时只推进修改时间', async () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-03-28T10:00:00.000Z'))
     dbGameGetMock.mockResolvedValue(createTestGame({
@@ -1788,16 +1873,6 @@ describe('gameManager', () => {
 
     expect(dbGameUpdateMock).toHaveBeenCalledWith('game-1', {
       lastModified: new Date('2026-03-28T10:00:00.000Z').getTime(),
-      previewAssets: {
-        icon: {
-          path: 'icons/current.ico',
-          cacheVersion: new Date('2026-03-28T10:00:00.000Z').getTime(),
-        },
-        cover: {
-          path: 'game/background/current-cover.png',
-          cacheVersion: new Date('2026-03-28T10:00:00.000Z').getTime(),
-        },
-      },
     })
     expect(warnMock).toHaveBeenCalledWith('刷新游戏预览资源快照失败: Error: config missing')
 
@@ -1825,6 +1900,62 @@ describe('gameManager', () => {
     expect(dbGameUpdateMock).toHaveBeenCalledTimes(1)
     expect(dbGameUpdateMock).toHaveBeenCalledWith('game-1', expect.objectContaining({
       lastModified: expect.any(Number),
+    }))
+
+    vi.useRealTimers()
+  })
+
+  it('refreshCurrentGamePreviewAssets 会合并防抖窗口内的资源失效范围', async () => {
+    vi.useFakeTimers()
+    const refreshRequestTime = new Date('2026-03-28T10:00:00.000Z').getTime()
+    const refreshCommitTime = refreshRequestTime + 500
+    vi.setSystemTime(refreshRequestTime)
+    workspaceStoreState.currentGame = createTestGame({
+      id: 'game-1',
+      path: AbsPath.from('/games/demo'),
+      previewAssets: {
+        icon: {
+          path: 'icons/favicon.ico',
+          cacheVersion: 111,
+        },
+        cover: {
+          path: 'game/background/cover.png',
+          cacheVersion: 222,
+        },
+      },
+    })
+    dbGameGetMock.mockResolvedValue(createTestGame({
+      id: 'game-1',
+      path: AbsPath.from('/games/demo'),
+      previewAssets: {
+        icon: {
+          path: 'icons/favicon.ico',
+          cacheVersion: 111,
+        },
+        cover: {
+          path: 'game/background/cover.png',
+          cacheVersion: 222,
+        },
+      },
+    }))
+
+    gameManager.refreshCurrentGamePreviewAssets({ invalidate: 'icon' })
+    gameManager.refreshCurrentGamePreviewAssets({ invalidate: 'cover' })
+
+    await vi.advanceTimersByTimeAsync(500)
+
+    expect(dbGameUpdateMock).toHaveBeenCalledTimes(1)
+    expect(dbGameUpdateMock).toHaveBeenCalledWith('game-1', expect.objectContaining({
+      previewAssets: {
+        icon: {
+          path: 'icons/favicon.ico',
+          cacheVersion: refreshCommitTime,
+        },
+        cover: {
+          path: 'game/background/cover.png',
+          cacheVersion: refreshCommitTime,
+        },
+      },
     }))
 
     vi.useRealTimers()

--- a/src/services/__tests__/game-manager.test.ts
+++ b/src/services/__tests__/game-manager.test.ts
@@ -2078,4 +2078,86 @@ describe('gameManager', () => {
 
     vi.useRealTimers()
   })
+
+  it('refreshCurrentGamePreviewAssets 会按游戏隔离防抖状态和资源失效范围', async () => {
+    vi.useFakeTimers()
+    try {
+      const refreshRequestTime = new Date('2026-03-28T10:00:00.000Z').getTime()
+      const refreshCommitTime = refreshRequestTime + 500
+      vi.setSystemTime(refreshRequestTime)
+
+      const gameOne = createTestGame({
+        id: 'game-1',
+        path: AbsPath.from('/games/one'),
+        previewAssets: {
+          icon: {
+            path: 'icons/favicon.ico',
+            cacheVersion: 111,
+          },
+          cover: {
+            path: 'game/background/cover.png',
+            cacheVersion: 222,
+          },
+        },
+      })
+      const gameTwo = createTestGame({
+        id: 'game-2',
+        path: AbsPath.from('/games/two'),
+        previewAssets: {
+          icon: {
+            path: 'icons/favicon.ico',
+            cacheVersion: 333,
+          },
+          cover: {
+            path: 'game/background/cover.png',
+            cacheVersion: 444,
+          },
+        },
+      })
+      dbGameGetMock.mockImplementation(async (gameId: string) => {
+        if (gameId === 'game-1') {
+          return gameOne
+        }
+
+        if (gameId === 'game-2') {
+          return gameTwo
+        }
+      })
+
+      workspaceStoreState.currentGame = gameOne
+      gameManager.refreshCurrentGamePreviewAssets({ invalidate: 'icon' })
+      workspaceStoreState.currentGame = gameTwo
+      gameManager.refreshCurrentGamePreviewAssets({ invalidate: 'cover' })
+
+      await vi.advanceTimersByTimeAsync(500)
+
+      expect(dbGameUpdateMock).toHaveBeenCalledTimes(2)
+      expect(dbGameUpdateMock).toHaveBeenCalledWith('game-1', expect.objectContaining({
+        previewAssets: {
+          icon: {
+            path: 'icons/favicon.ico',
+            cacheVersion: refreshCommitTime,
+          },
+          cover: {
+            path: 'game/background/cover.png',
+            cacheVersion: 222,
+          },
+        },
+      }))
+      expect(dbGameUpdateMock).toHaveBeenCalledWith('game-2', expect.objectContaining({
+        previewAssets: {
+          icon: {
+            path: 'icons/favicon.ico',
+            cacheVersion: 333,
+          },
+          cover: {
+            path: 'game/background/cover.png',
+            cacheVersion: refreshCommitTime,
+          },
+        },
+      }))
+    } finally {
+      vi.useRealTimers()
+    }
+  })
 })

--- a/src/services/engine-switch.ts
+++ b/src/services/engine-switch.ts
@@ -137,7 +137,7 @@ async function switchEngine(
 
     // 收尾：刷新 DB 与 workspace 快照，更新 previewAssets.cacheVersion，
     // 让首页卡片与编辑器头部都能拉到新引擎图标，避免浏览器命中旧缓存
-    await runFinalizer(() => gameManager.refreshRegisteredGameSnapshot(game.path), '刷新游戏快照失败')
+    await runFinalizer(() => gameManager.refreshRegisteredGameSnapshot(game.path, { invalidate: 'all' }), '刷新游戏快照失败')
 
     // 收尾：关闭打开的模板文档、刷新文件树、通知预览拉取新模板
     // 显式传入 newEngine.path 与 newTemplatePath：此时 workspaceStore.currentGame

--- a/src/services/game-fs.ts
+++ b/src/services/game-fs.ts
@@ -14,6 +14,7 @@ import { useWorkspaceStore } from '~/stores/workspace'
 import { AppError } from '~/types/errors'
 import { buildUniqueEntryName } from '~/utils/entry-name'
 
+import type { GamePreviewInvalidation } from '~/services/game-manager'
 import type { PathMutationResult } from '~/services/path-mutation'
 
 async function resolveWritablePath(path: AbsPath): Promise<AbsPath> {
@@ -61,6 +62,59 @@ function isPathWithinOrEqual(path: AbsPath, root: AbsPath): boolean {
   } catch {
     return false
   }
+}
+
+function resolvePreviewAssetPath(assetPath: string | undefined): AbsPath | undefined {
+  const workspaceStore = useWorkspaceStore()
+  const gamePath = workspaceStore.currentGame?.path
+  if (!gamePath || !assetPath) {
+    return undefined
+  }
+
+  return AbsPath.join(gamePath, RelPath.from(assetPath))
+}
+
+function doesChangedPathAffectAsset(
+  changedPath: AbsPath,
+  assetPath: AbsPath,
+  includeChildren: boolean,
+): boolean {
+  return includeChildren
+    ? isPathWithinOrEqual(assetPath, changedPath)
+    : AbsPath.equals(changedPath, assetPath)
+}
+
+function resolvePreviewInvalidation(changedPath: AbsPath, includeChildren = false): GamePreviewInvalidation | undefined {
+  const workspaceStore = useWorkspaceStore()
+  const previewAssets = workspaceStore.currentGame?.previewAssets
+  if (!previewAssets) {
+    return undefined
+  }
+
+  const iconPath = resolvePreviewAssetPath(previewAssets.icon.path)
+  const coverPath = resolvePreviewAssetPath(previewAssets.cover.path)
+  const affectsIcon = !!iconPath && doesChangedPathAffectAsset(changedPath, iconPath, includeChildren)
+  const affectsCover = !!coverPath && doesChangedPathAffectAsset(changedPath, coverPath, includeChildren)
+
+  if (affectsIcon && affectsCover) {
+    return 'all'
+  }
+
+  if (affectsIcon) {
+    return 'icon'
+  }
+
+  return affectsCover ? 'cover' : undefined
+}
+
+function markPathChanged(path: AbsPath, options: { includeChildren?: boolean } = {}): void {
+  const invalidation = resolvePreviewInvalidation(path, options.includeChildren)
+  if (invalidation) {
+    gameManager.refreshCurrentGamePreviewAssets({ invalidate: invalidation })
+    return
+  }
+
+  gameManager.touchCurrentGameLastModified()
 }
 
 function usesTemplateOverlayPath(path: AbsPath): boolean {
@@ -201,12 +255,12 @@ async function renameFile(oldPath: AbsPath, newName: string): Promise<PathMutati
 async function deleteFile(path: AbsPath, permanent?: boolean): Promise<void> {
   const fileStore = useFileStore()
   if (fileStore.isVfs && await fileStore.deleteEntry(path)) {
-    gameManager.refreshCurrentGamePreviewAssets()
+    markPathChanged(path, { includeChildren: true })
     return
   }
 
   await fsCmds.deleteFile(path, permanent)
-  gameManager.refreshCurrentGamePreviewAssets()
+  markPathChanged(path, { includeChildren: true })
 }
 
 async function resolveVfsCreatePath(
@@ -228,13 +282,13 @@ async function createFile(targetPath: AbsPath, fileName: string): Promise<AbsPat
   const fileStore = useFileStore()
   if (!fileStore.isVfs) {
     const result = await fsCmds.createFile(targetPath, fileName)
-    gameManager.refreshCurrentGamePreviewAssets()
+    markPathChanged(result)
     return result
   }
 
   const writablePath = await resolveVfsCreatePath(targetPath, fileName, false)
   await writeTextFile(writablePath, '')
-  gameManager.refreshCurrentGamePreviewAssets()
+  markPathChanged(writablePath)
   return writablePath
 }
 
@@ -242,13 +296,13 @@ async function createFolder(targetPath: AbsPath, folderName: string): Promise<Ab
   const fileStore = useFileStore()
   if (!fileStore.isVfs) {
     const result = await fsCmds.createFolder(targetPath, folderName)
-    gameManager.refreshCurrentGamePreviewAssets()
+    gameManager.touchCurrentGameLastModified()
     return result
   }
 
   const writablePath = await resolveVfsCreatePath(targetPath, folderName, true)
   await mkdir(writablePath, { recursive: true })
-  gameManager.refreshCurrentGamePreviewAssets()
+  gameManager.touchCurrentGameLastModified()
   return writablePath
 }
 
@@ -257,7 +311,7 @@ async function copyFile(sourcePath: AbsPath, targetPath: AbsPath): Promise<AbsPa
   if (fileStore.isVfs) {
     const copiedPath = await fileStore.copyEntry(sourcePath, targetPath)
     if (copiedPath) {
-      gameManager.refreshCurrentGamePreviewAssets()
+      markPathChanged(copiedPath)
       return copiedPath
     }
   }
@@ -267,7 +321,7 @@ async function copyFile(sourcePath: AbsPath, targetPath: AbsPath): Promise<AbsPa
     : sourcePath
   const writableTargetPath = await resolveWritablePath(targetPath)
   const result = await fsCmds.copyFile(resolvedSourcePath, writableTargetPath)
-  gameManager.refreshCurrentGamePreviewAssets()
+  markPathChanged(result)
   return result
 }
 

--- a/src/services/game-manager.ts
+++ b/src/services/game-manager.ts
@@ -18,7 +18,6 @@ import {
 } from '~/services/resource-health'
 import { toLookupPathKey } from '~/services/resource-path/lookup'
 import { templateSwitch } from '~/services/template-switch'
-import { GameMetadata, GamePreviewAssets } from '~/services/types'
 import { useResourceStore } from '~/stores/resource'
 import { useWorkspaceStore } from '~/stores/workspace'
 import { AppError } from '~/types/errors'
@@ -27,6 +26,7 @@ import type { GameConfigEntry } from '~/commands/game'
 import type { Engine, Game, Template } from '~/database/model'
 import type { GameIconPathExistsContext } from '~/services/project-icon-assets'
 import type { LookupPathKey } from '~/services/resource-path/lookup'
+import type { GameMetadata, GamePreviewAssets, PreviewAsset } from '~/services/types'
 import type {
   ImportDependencyResolutionContext,
   ImportDependencyResolutionResult,
@@ -45,6 +45,13 @@ interface RegisterGameOptions {
 
 interface ImportGameOptions {
   resolveDependencies?: ResolveImportDependencies
+}
+
+export type GamePreviewAssetKey = keyof GamePreviewAssets
+export type GamePreviewInvalidation = GamePreviewAssetKey | 'all'
+
+export interface GamePreviewRefreshOptions {
+  invalidate?: GamePreviewInvalidation
 }
 
 export interface GameInspectionPayload {
@@ -194,6 +201,70 @@ function withGamePreviewCacheVersion(
   }
 }
 
+function isPreviewAssetInvalidated(key: GamePreviewAssetKey, invalidation: GamePreviewInvalidation | undefined): boolean {
+  return invalidation === 'all' || invalidation === key
+}
+
+function mergeGamePreviewInvalidation(
+  current: GamePreviewInvalidation | undefined,
+  next: GamePreviewInvalidation | undefined,
+): GamePreviewInvalidation | undefined {
+  if (!current) {
+    return next
+  }
+
+  if (!next) {
+    return current
+  }
+
+  if (current === next) {
+    return current
+  }
+
+  return 'all'
+}
+
+function mergePreviewAsset(
+  previous: PreviewAsset,
+  next: PreviewAsset,
+  invalidated: boolean,
+  cacheVersion: number,
+): PreviewAsset {
+  if (invalidated || previous.path !== next.path) {
+    return {
+      ...next,
+      cacheVersion,
+    }
+  }
+
+  return {
+    ...next,
+    cacheVersion: previous.cacheVersion,
+  }
+}
+
+function mergeGamePreviewAssets(
+  previous: GamePreviewAssets,
+  next: GamePreviewAssets,
+  options: GamePreviewRefreshOptions | undefined,
+  cacheVersion: number,
+): GamePreviewAssets {
+  return {
+    icon: mergePreviewAsset(
+      previous.icon,
+      next.icon,
+      isPreviewAssetInvalidated('icon', options?.invalidate),
+      cacheVersion,
+    ),
+    cover: mergePreviewAsset(
+      previous.cover,
+      next.cover,
+      isPreviewAssetInvalidated('cover', options?.invalidate),
+      cacheVersion,
+    ),
+  }
+}
+
 async function getGamePreviewAssets(gamePath: AbsPath): Promise<GamePreviewAssets> {
   const [metadata, iconLookup] = await Promise.all([
     getGameMetadata(gamePath),
@@ -255,10 +326,6 @@ async function updateGameMonotonicLastModified(
       ...patch,
       lastModified,
     }
-    if (nextPatch.previewAssets) {
-      nextPatch.previewAssets = withGamePreviewCacheVersion(nextPatch.previewAssets, lastModified)
-    }
-
     await db.games.update(gameId, nextPatch)
     return nextPatch
   })
@@ -268,19 +335,19 @@ async function updateGameMonotonicLastModified(
   }
 }
 
-async function refreshRegisteredGameSnapshot(gamePath: AbsPath): Promise<void> {
+async function refreshRegisteredGameSnapshot(gamePath: AbsPath, options?: GamePreviewRefreshOptions): Promise<void> {
   const game = await db.games.where('pathLookupKey').equals(toLookupPathKey(gamePath)).first()
   if (!game) {
     return
   }
 
   const snapshot = await getGameSnapshot(gamePath)
-  const snapshotVersion = snapshot.previewAssets.icon.cacheVersion
-    ?? snapshot.previewAssets.cover.cacheVersion
-    ?? Date.now()
+  const snapshotVersion = Date.now()
+  const previewAssets = mergeGamePreviewAssets(game.previewAssets, snapshot.previewAssets, options, snapshotVersion)
   const patch: Partial<Pick<Game, 'lastModified' | 'metadata' | 'previewAssets'>> = {
     lastModified: snapshotVersion,
-    ...snapshot,
+    metadata: snapshot.metadata,
+    previewAssets,
   }
 
   await db.games.update(game.id, patch)
@@ -1001,7 +1068,7 @@ async function touchGameLastModified(gameId: string): Promise<void> {
   await updateGameMonotonicLastModified(gameId, { lastModified })
 }
 
-async function refreshGamePreviewAssets(gameId: string): Promise<void> {
+async function refreshGamePreviewAssets(gameId: string, options?: GamePreviewRefreshOptions): Promise<void> {
   const game = await db.games.get(gameId)
   if (!game) {
     return
@@ -1011,9 +1078,6 @@ async function refreshGamePreviewAssets(gameId: string): Promise<void> {
   try {
     previewAssets = await getGamePreviewAssets(game.path)
   } catch (error) {
-    if (game.previewAssets) {
-      previewAssets = game.previewAssets
-    }
     logger.warn(`刷新游戏预览资源快照失败: ${error}`)
   }
 
@@ -1022,7 +1086,7 @@ async function refreshGamePreviewAssets(gameId: string): Promise<void> {
     lastModified: cacheVersion,
   }
   if (previewAssets) {
-    patch.previewAssets = previewAssets
+    patch.previewAssets = mergeGamePreviewAssets(game.previewAssets, previewAssets, options, cacheVersion)
   }
 
   await updateGameMonotonicLastModified(gameId, patch)
@@ -1030,6 +1094,7 @@ async function refreshGamePreviewAssets(gameId: string): Promise<void> {
 
 let touchLastModifiedTimer: ReturnType<typeof setTimeout> | undefined
 let refreshPreviewAssetsTimer: ReturnType<typeof setTimeout> | undefined
+let pendingPreviewInvalidation: GamePreviewInvalidation | undefined
 
 /** 防抖更新当前游戏的 lastModified 字段（500ms） */
 function touchCurrentGameLastModified(): void {
@@ -1050,17 +1115,20 @@ function touchCurrentGameLastModified(): void {
 }
 
 /** 防抖刷新当前游戏的预览资源快照（500ms） */
-function refreshCurrentGamePreviewAssets(): void {
+function refreshCurrentGamePreviewAssets(options?: GamePreviewRefreshOptions): void {
   const workspaceStore = useWorkspaceStore()
   const gameId = workspaceStore.currentGame?.id
   if (!gameId) {
     return
   }
 
+  pendingPreviewInvalidation = mergeGamePreviewInvalidation(pendingPreviewInvalidation, options?.invalidate)
   clearTimeout(refreshPreviewAssetsTimer)
   refreshPreviewAssetsTimer = setTimeout(async () => {
+    const invalidate = pendingPreviewInvalidation
+    pendingPreviewInvalidation = undefined
     try {
-      await refreshGamePreviewAssets(gameId)
+      await refreshGamePreviewAssets(gameId, { invalidate })
     } catch (error) {
       logger.error(`刷新游戏预览资源快照失败: ${error}`)
     }

--- a/src/services/game-manager.ts
+++ b/src/services/game-manager.ts
@@ -59,6 +59,9 @@ export interface GameInspectionPayload {
   previewAssets: GamePreviewAssets
 }
 
+type MonotonicGamePatch = Partial<Pick<Game, 'previewAssets'>> & { lastModified: number }
+type MonotonicGamePatchSource = MonotonicGamePatch | ((game: Game) => MonotonicGamePatch)
+
 const GAME_NAME_RAW_KEY = 'Game_name'
 const GAME_KEY_RAW_KEY = 'Game_key'
 const TITLE_IMAGE_RAW_KEY = 'Title_img'
@@ -313,7 +316,7 @@ function applyCurrentGamePatch(
 
 async function updateGameMonotonicLastModified(
   gameId: string,
-  patch: Partial<Pick<Game, 'previewAssets'>> & { lastModified: number },
+  patch: MonotonicGamePatchSource,
 ): Promise<void> {
   const appliedPatch = await db.transaction('rw', db.games, async () => {
     const game = await db.games.get(gameId)
@@ -321,9 +324,10 @@ async function updateGameMonotonicLastModified(
       return
     }
 
-    const lastModified = Math.max(game.lastModified, patch.lastModified)
+    const rawPatch = typeof patch === 'function' ? patch(game) : patch
+    const lastModified = Math.max(game.lastModified, rawPatch.lastModified)
     const nextPatch: Partial<Pick<Game, 'lastModified' | 'previewAssets'>> = {
-      ...patch,
+      ...rawPatch,
       lastModified,
     }
     await db.games.update(gameId, nextPatch)
@@ -335,6 +339,36 @@ async function updateGameMonotonicLastModified(
   }
 }
 
+async function updateRegisteredGameSnapshot(
+  gamePath: AbsPath,
+  snapshot: Pick<Game, 'metadata' | 'previewAssets'>,
+  options: GamePreviewRefreshOptions | undefined,
+  snapshotVersion: number,
+): Promise<void> {
+  const pathLookupKey = toLookupPathKey(gamePath)
+  const appliedUpdate = await db.transaction('rw', db.games, async () => {
+    const game = await db.games.where('pathLookupKey').equals(pathLookupKey).first()
+    if (!game) {
+      return
+    }
+
+    const patch: Partial<Pick<Game, 'lastModified' | 'metadata' | 'previewAssets'>> = {
+      lastModified: Math.max(game.lastModified, snapshotVersion),
+      metadata: snapshot.metadata,
+      previewAssets: mergeGamePreviewAssets(game.previewAssets, snapshot.previewAssets, options, snapshotVersion),
+    }
+    await db.games.update(game.id, patch)
+    return {
+      gameId: game.id,
+      patch,
+    }
+  })
+
+  if (appliedUpdate) {
+    applyCurrentGamePatch(appliedUpdate.gameId, appliedUpdate.patch)
+  }
+}
+
 async function refreshRegisteredGameSnapshot(gamePath: AbsPath, options?: GamePreviewRefreshOptions): Promise<void> {
   const game = await db.games.where('pathLookupKey').equals(toLookupPathKey(gamePath)).first()
   if (!game) {
@@ -343,15 +377,7 @@ async function refreshRegisteredGameSnapshot(gamePath: AbsPath, options?: GamePr
 
   const snapshot = await getGameSnapshot(gamePath)
   const snapshotVersion = Date.now()
-  const previewAssets = mergeGamePreviewAssets(game.previewAssets, snapshot.previewAssets, options, snapshotVersion)
-  const patch: Partial<Pick<Game, 'lastModified' | 'metadata' | 'previewAssets'>> = {
-    lastModified: snapshotVersion,
-    metadata: snapshot.metadata,
-    previewAssets,
-  }
-
-  await db.games.update(game.id, patch)
-  applyCurrentGamePatch(game.id, patch)
+  await updateRegisteredGameSnapshot(gamePath, snapshot, options, snapshotVersion)
 }
 
 async function registerGame(
@@ -1082,14 +1108,15 @@ async function refreshGamePreviewAssets(gameId: string, options?: GamePreviewRef
   }
 
   const cacheVersion = Date.now()
-  const patch: Partial<Pick<Game, 'previewAssets'>> & { lastModified: number } = {
-    lastModified: cacheVersion,
-  }
-  if (previewAssets) {
-    patch.previewAssets = mergeGamePreviewAssets(game.previewAssets, previewAssets, options, cacheVersion)
-  }
-
-  await updateGameMonotonicLastModified(gameId, patch)
+  await updateGameMonotonicLastModified(gameId, (latestGame) => {
+    const patch: MonotonicGamePatch = {
+      lastModified: cacheVersion,
+    }
+    if (previewAssets) {
+      patch.previewAssets = mergeGamePreviewAssets(latestGame.previewAssets, previewAssets, options, cacheVersion)
+    }
+    return patch
+  })
 }
 
 let touchLastModifiedTimer: ReturnType<typeof setTimeout> | undefined

--- a/src/services/game-manager.ts
+++ b/src/services/game-manager.ts
@@ -1120,8 +1120,8 @@ async function refreshGamePreviewAssets(gameId: string, options?: GamePreviewRef
 }
 
 let touchLastModifiedTimer: ReturnType<typeof setTimeout> | undefined
-let refreshPreviewAssetsTimer: ReturnType<typeof setTimeout> | undefined
-let pendingPreviewInvalidation: GamePreviewInvalidation | undefined
+const refreshPreviewAssetsTimers = new Map<string, ReturnType<typeof setTimeout>>()
+const pendingPreviewInvalidations = new Map<string, GamePreviewInvalidation | undefined>()
 
 /** 防抖更新当前游戏的 lastModified 字段（500ms） */
 function touchCurrentGameLastModified(): void {
@@ -1149,17 +1149,23 @@ function refreshCurrentGamePreviewAssets(options?: GamePreviewRefreshOptions): v
     return
   }
 
-  pendingPreviewInvalidation = mergeGamePreviewInvalidation(pendingPreviewInvalidation, options?.invalidate)
-  clearTimeout(refreshPreviewAssetsTimer)
-  refreshPreviewAssetsTimer = setTimeout(async () => {
-    const invalidate = pendingPreviewInvalidation
-    pendingPreviewInvalidation = undefined
+  pendingPreviewInvalidations.set(
+    gameId,
+    mergeGamePreviewInvalidation(pendingPreviewInvalidations.get(gameId), options?.invalidate),
+  )
+  clearTimeout(refreshPreviewAssetsTimers.get(gameId))
+
+  const refreshPreviewAssetsTimer = setTimeout(async () => {
+    const invalidate = pendingPreviewInvalidations.get(gameId)
+    pendingPreviewInvalidations.delete(gameId)
+    refreshPreviewAssetsTimers.delete(gameId)
     try {
       await refreshGamePreviewAssets(gameId, { invalidate })
     } catch (error) {
       logger.error(`刷新游戏预览资源快照失败: ${error}`)
     }
   }, 500)
+  refreshPreviewAssetsTimers.set(gameId, refreshPreviewAssetsTimer)
 }
 
 export const gameManager = {


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [x] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [x] 代码重构
- [x] 测试用例
- [x] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

本次修改为游戏预览资源引入了更细粒度的失效控制，避免在无关变更时无差别推进图标和封面的缓存版本。

具体包括：

- 为 `gameManager` 增加预览资源失效范围（`icon` / `cover` / `all`）；
- 调整 `refreshRegisteredGameSnapshot` 和 `refreshCurrentGamePreviewAssets`，只在对应资源路径变化或显式失效时刷新 `cacheVersion`；
- 修正文件创建、删除、复制后的预览刷新行为，无关路径变更只更新 `lastModified`；
- 调整图标编辑器和引擎切换后的快照刷新参数，分别触发局部失效和全量失效；
- 补充并更新相关单元测试，覆盖局部失效、全量失效、防抖合并和异常分支。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

当前实现会在刷新游戏快照时统一推进 `previewAssets.cacheVersion`，导致以下问题：

- 仅修改游戏元数据时，也会强制首页和编辑器重新拉取图标或封面；
- 创建、删除无关文件时，也会触发不必要的预览缓存失效；
- 防抖窗口内的多次预览刷新请求无法正确合并失效范围；
- 显式需要全量失效的场景和只应局部失效的场景边界不清晰。

这次修改的目标，是让“路径变化”和“缓存版本推进”解耦，按真实影响范围刷新预览资源，减少无意义的缓存抖动和额外请求。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
