### PR TITLE
♻️ 移除游戏配置弹窗中的引擎与模板切换入口

### DIFF
--- a/src/components/modals/GameConfigModal.vue
+++ b/src/components/modals/GameConfigModal.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ArrowRightLeft, Info } from '@lucide/vue'
+import { Info } from '@lucide/vue'
 import { useForm } from 'vee-validate'
 
 import {
@@ -26,7 +26,6 @@ interface Props {
   serveUrl?: string
   unmanagedLineCount: number
   game?: Game
-  engineLabel?: string
 }
 
 const props = defineProps<Props>()
@@ -145,19 +144,6 @@ async function handleSave() {
 
   await submitConfig()
 }
-
-function openSwitchEngine() {
-  if (props.game) {
-    modalStore.open('SwitchEngineModal', { game: props.game })
-  }
-}
-
-function openSwitchTemplate() {
-  if (props.game) {
-    modalStore.open('SwitchTemplateModal', { game: props.game })
-  }
-}
-
 </script>
 
 <template>
@@ -244,44 +230,6 @@ function openSwitchTemplate() {
           :serve-url="props.serveUrl"
           class="mx-2"
         />
-
-        <!-- 引擎与模板配置 -->
-        <div v-if="props.game?.engineId" class="mx-2 mt-4 pt-4 border-t flex flex-col gap-3">
-          <div class="flex items-center justify-between">
-            <div>
-              <div class="text-sm font-medium">
-                {{ $t('edit.statusBar.engine') }}
-              </div>
-              <div class="text-xs text-muted-foreground">
-                {{ props.engineLabel ?? $t('common.unknown') }}
-              </div>
-            </div>
-            <Button
-              variant="outline"
-              size="sm"
-              @click="openSwitchEngine"
-            >
-              <ArrowRightLeft class="mr-1 size-3.5" />
-              {{ $t('modals.switchEngine.title') }}
-            </Button>
-          </div>
-
-          <div class="flex items-center justify-between">
-            <div>
-              <div class="text-sm font-medium">
-                {{ $t('edit.statusBar.template') }}
-              </div>
-            </div>
-            <Button
-              variant="outline"
-              size="sm"
-              @click="openSwitchTemplate"
-            >
-              <ArrowRightLeft class="mr-1 size-3.5" />
-              {{ $t('modals.switchTemplate.title') }}
-            </Button>
-          </div>
-        </div>
       </ScrollArea>
 
       <IconEditorDialog


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [ ] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [x] 代码重构
- [ ] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

- 移除 `GameConfigModal` 中的引擎切换和模板切换区块
- 删除与该区块对应的 `engineLabel` prop
- 删除 `openSwitchEngine` 与 `openSwitchTemplate` 相关逻辑
- 保留游戏基础配置与图标编辑能力，使弹窗职责更聚焦

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

当前编辑器状态栏已经提供了引擎与模板切换入口，游戏配置弹窗中继续保留同类操作会形成重复入口，也会让配置弹窗承担额外的导航职责。

这次调整的目标是收敛交互入口，减少界面噪音，同时清理不再需要的 props 与事件处理逻辑。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [ ] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
