### PR TITLE
♻️ 调整 VFS 元数据目录位置

### DIFF
--- a/src-tauri/src/vfs.rs
+++ b/src-tauri/src/vfs.rs
@@ -15,7 +15,8 @@ use crate::commands::{AppError, AppResult};
 
 const PROJECT_CONFIG_FILE: &str = "project.wgcp";
 const CURRENT_SCHEMA_VERSION: u32 = 1;
-const VFS_METADATA_DIR: &str = ".wgc-vfs";
+const APP_METADATA_DIR: &str = ".webgalcraft";
+const VFS_METADATA_DIR: &str = "vfs";
 const WHITEOUTS_DIR: &str = "whiteouts";
 
 pub fn to_posix_string(path: &Path) -> String {
@@ -199,7 +200,7 @@ impl OverlayFs {
 
     /// 使用已缓存的 canonical 路径构造 OverlayFs，跳过 canonicalize 系统调用
     pub fn from_cached(cached: &CachedCanonicals) -> Self {
-        let whiteout_root = cached.upper.join(VFS_METADATA_DIR).join(WHITEOUTS_DIR);
+        let whiteout_root = whiteout_root_path(&cached.upper);
         Self {
             upper: cached.upper.clone(),
             upper_canonical: cached.upper_canonical.clone(),
@@ -870,10 +871,7 @@ struct TemplatePaths {
 }
 
 fn template_paths(project_path: &Path) -> TemplatePaths {
-    let whiteout_base = project_path
-        .join(VFS_METADATA_DIR)
-        .join(WHITEOUTS_DIR)
-        .join("game");
+    let whiteout_base = whiteout_root_path(project_path).join("game");
 
     TemplatePaths {
         upper: project_path.join("game").join("template"),
@@ -886,7 +884,7 @@ fn template_paths(project_path: &Path) -> TemplatePaths {
 ///
 /// 脏状态命中条件：
 /// 1. `game/template/` 下存在任何 upper 文件或目录
-/// 2. `.wgc-vfs/whiteouts/` 下存在 `game/template/**` 相关 whiteout
+/// 2. `.webgalcraft/vfs/whiteouts/` 下存在 `game/template/**` 相关 whiteout
 pub fn is_template_dirty(project_path: &Path) -> Result<bool, VfsError> {
     let paths = template_paths(project_path);
 
@@ -998,8 +996,15 @@ fn is_internal_metadata_path(path: &Path) -> bool {
     matches!(
         path.components().next(),
         Some(Component::Normal(first))
-            if matches!(first.to_str(), Some(VFS_METADATA_DIR | PROJECT_CONFIG_FILE))
+            if matches!(first.to_str(), Some(APP_METADATA_DIR | PROJECT_CONFIG_FILE))
     )
+}
+
+fn whiteout_root_path(project_path: &Path) -> PathBuf {
+    project_path
+        .join(APP_METADATA_DIR)
+        .join(VFS_METADATA_DIR)
+        .join(WHITEOUTS_DIR)
 }
 
 fn validate_physical_path(physical_path: &Path, root_canonical: &Path) -> Result<(), VfsError> {
@@ -1178,6 +1183,14 @@ mod tests {
         assert!(sanitize_logical_path("icons\\favicon.ico").is_err());
         assert!(sanitize_logical_path("CON").is_err());
         assert!(sanitize_logical_path("assets:evil").is_err());
+        assert!(matches!(
+            sanitize_logical_path(".webgalcraft"),
+            Err(VfsError::PathDenied)
+        ));
+        assert!(matches!(
+            sanitize_logical_path(".webgalcraft/vfs/whiteouts/game/.wh.scene"),
+            Err(VfsError::PathDenied)
+        ));
     }
 
     #[test]
@@ -1585,7 +1598,7 @@ mod tests {
             "lower scene",
         )
         .expect("scene file should be written");
-        create_dir_link(&escape, &upper.join(".wgc-vfs"));
+        create_dir_link(&escape, &upper.join(".webgalcraft"));
 
         let overlay = OverlayFs::new(
             upper,
@@ -1601,6 +1614,7 @@ mod tests {
         assert!(matches!(error, VfsError::PathDenied));
         assert!(
             !escape
+                .join("vfs")
                 .join("whiteouts")
                 .join("game")
                 .join("scene")


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [ ] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [x] 代码重构
- [ ] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

- 将 VFS 内部元数据目录从 `.wgc-vfs` 调整为 `.webgalcraft/vfs`，统一应用级内部目录结构。
- 提取 `whiteout_root_path`，统一 whiteout 根路径的构造方式，避免内部路径拼接分散在多个位置。
- 收紧内部路径判定，禁止通过逻辑路径访问 `.webgalcraft` 及其 whiteout 子路径。
- 更新并补充测试，覆盖内部元数据路径拒绝，以及 linked metadata directory 下的 whiteout 写入保护。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

- 现有 `.wgc-vfs` 命名偏实现细节，不适合作为长期使用的应用内部目录。
- whiteout 路径构造此前分散在不同位置，不利于后续维护和演进。
- 这次调整把内部元数据布局和访问边界一起收拢，减少后续继续扩散路径规则的风险。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
