### PR TITLE
♻️ 重构效果编辑器 set-effect 重置语义

### DIFF
--- a/src/components/editor/StatementEditorPanel.vue
+++ b/src/components/editor/StatementEditorPanel.vue
@@ -89,7 +89,6 @@ const showCommandFieldsSection = $computed(() => {
 
 const { openEffectEditor } = useStatementEffectEditorBridge({
   updateTarget: () => props.updateTarget,
-  rawText: () => props.entry.rawText,
   parsed: () => parsed.value,
   emitUpdate,
 })

--- a/src/components/editor/VisualEditorStatementCard.vue
+++ b/src/components/editor/VisualEditorStatementCard.vue
@@ -81,7 +81,6 @@ function handleCardDblClick() {
 
 const { openEffectEditor } = useStatementEffectEditorBridge({
   updateTarget: () => createStatementIdTarget(props.entry.id),
-  rawText: () => props.entry.rawText,
   parsed: () => parsed.value,
   emitUpdate: payload => emit('update', payload),
 })

--- a/src/features/editor/effect-editor/__tests__/useEffectEditorProvider-queue.test.ts
+++ b/src/features/editor/effect-editor/__tests__/useEffectEditorProvider-queue.test.ts
@@ -4,14 +4,12 @@ import '~/__tests__/mocks/modal-store'
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import { commandType } from 'webgal-parser/src/interface/sceneInterface'
 
-import { serializeSentence } from '~/domain/script/serialize'
 import {
   fieldsToTransform,
   parseTransformJson,
   serializeTransform,
   transformToFields,
 } from '~/features/editor/effect-editor/effect-editor-config'
-import { applyEffectEditorResultToSentence } from '~/features/editor/effect-editor/effect-editor-result'
 import { createEffectEditorProvider } from '~/features/editor/effect-editor/useEffectEditorProvider'
 import { useEditSettingsStore } from '~/stores/edit-settings'
 
@@ -161,13 +159,7 @@ describe('useEffectEditorProvider', () => {
     const provider = createEffectEditorProvider()
 
     await provider.open({
-      entryId: 1,
-      scenePath: 'scene/001.txt',
       baseSentence: createBaseSentence(),
-      baseLineNumber: 1,
-      baseLineText: 'changeFigure: figure.png;',
-      previewContextLineNumber: 0,
-      previewContextLineText: '',
       effectTarget: 'fig-center',
       onApply(result) {
         applyCalls.push(cloneDraft(result))
@@ -185,20 +177,13 @@ describe('useEffectEditorProvider', () => {
     expect(applyCalls[0]?.transform.blur).toBe(0)
   })
 
-  it('实时预览在字段被清除后会回到当前句前文，并执行修改后的当前命令', async () => {
+  it('实时预览在字段被清除后直接发送缺失该字段的 setEffect', async () => {
     useEditSettingsStore().autoApplyEffectEditorChanges = false
 
-    const baseSentence = createBaseSentence('{"alpha":0.5,"blur":8}')
     const provider = createEffectEditorProvider()
 
     await provider.open({
-      entryId: 1,
-      scenePath: 'scene/001.txt',
-      baseSentence,
-      baseLineNumber: 3,
-      baseLineText: 'changeFigure: figure.png -transform={"alpha":0.5,"blur":8};',
-      previewContextLineNumber: 2,
-      previewContextLineText: 'say:previous;',
+      baseSentence: createBaseSentence('{"alpha":0.5,"blur":8}'),
       effectTarget: 'fig-center',
       onApply() { /* no-op */ },
     })
@@ -206,40 +191,23 @@ describe('useEffectEditorProvider', () => {
     provider.updateDraft({ transform: { alpha: 0.5 } })
     provider.requestPreview({ schedule: 'immediate' })
     await vi.waitFor(() => {
-      expect(debugCommanderMock.syncScene).toHaveBeenCalledTimes(1)
-      expect(debugCommanderMock.executeCommand).toHaveBeenCalledTimes(1)
+      expect(debugCommanderMock.setEffect).toHaveBeenCalledTimes(1)
     })
 
-    expect(debugCommanderMock.syncScene).toHaveBeenCalledWith(
-      'scene/001.txt',
-      2,
-      'say:previous;',
-      true,
-    )
-    expect(debugCommanderMock.setEffect).not.toHaveBeenCalled()
-    expect(debugCommanderMock.executeCommand).toHaveBeenCalledWith(serializeSentence(
-      applyEffectEditorResultToSentence(baseSentence, {
-        transform: { alpha: 0.5 },
-        duration: '',
-        ease: '',
-      }),
-    ))
+    expect(debugCommanderMock.syncScene).not.toHaveBeenCalled()
+    expect(debugCommanderMock.executeCommand).not.toHaveBeenCalled()
+    expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', {
+      alpha: 0.5,
+    })
   })
 
-  it('实时预览在最后一个显式字段被清除后会执行去掉 transform 的当前命令', async () => {
+  it('实时预览在最后一个显式字段被清除后发送空 transform', async () => {
     useEditSettingsStore().autoApplyEffectEditorChanges = false
 
-    const baseSentence = createBaseSentence('{"blur":8}')
     const provider = createEffectEditorProvider()
 
     await provider.open({
-      entryId: 1,
-      scenePath: 'scene/001.txt',
-      baseSentence,
-      baseLineNumber: 1,
-      baseLineText: 'changeFigure: figure.png -transform={"blur":8};',
-      previewContextLineNumber: 0,
-      previewContextLineText: '',
+      baseSentence: createBaseSentence('{"blur":8}'),
       effectTarget: 'fig-center',
       onApply() { /* no-op */ },
     })
@@ -247,39 +215,21 @@ describe('useEffectEditorProvider', () => {
     provider.updateDraft({ transform: {} })
     provider.requestPreview({ schedule: 'immediate' })
     await vi.waitFor(() => {
-      expect(debugCommanderMock.syncScene).toHaveBeenCalledTimes(1)
-      expect(debugCommanderMock.executeCommand).toHaveBeenCalledTimes(1)
+      expect(debugCommanderMock.setEffect).toHaveBeenCalledTimes(1)
     })
 
-    expect(debugCommanderMock.syncScene).toHaveBeenCalledWith(
-      'scene/001.txt',
-      0,
-      '',
-      true,
-    )
-    expect(debugCommanderMock.setEffect).not.toHaveBeenCalled()
-    expect(debugCommanderMock.executeCommand).toHaveBeenCalledWith(serializeSentence(
-      applyEffectEditorResultToSentence(baseSentence, {
-        transform: {},
-        duration: '',
-        ease: '',
-      }),
-    ))
+    expect(debugCommanderMock.syncScene).not.toHaveBeenCalled()
+    expect(debugCommanderMock.executeCommand).not.toHaveBeenCalled()
+    expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', {})
   })
 
-  it('非删除型实时预览仍直接发送 setEffect', async () => {
+  it('实时预览在字段更新时直接发送 setEffect', async () => {
     useEditSettingsStore().autoApplyEffectEditorChanges = false
 
     const provider = createEffectEditorProvider()
 
     await provider.open({
-      entryId: 1,
-      scenePath: 'scene/001.txt',
       baseSentence: createBaseSentence('{"blur":8}'),
-      baseLineNumber: 1,
-      baseLineText: 'changeFigure: figure.png -transform={"blur":8};',
-      previewContextLineNumber: 0,
-      previewContextLineText: '',
       effectTarget: 'fig-center',
       onApply() { /* no-op */ },
     })
@@ -303,13 +253,7 @@ describe('useEffectEditorProvider', () => {
     const provider = createEffectEditorProvider()
 
     await provider.open({
-      entryId: 1,
-      scenePath: 'scene/001.txt',
       baseSentence: createBaseSentence('{"blur":8}'),
-      baseLineNumber: 1,
-      baseLineText: 'changeFigure: figure.png -transform={"blur":8};',
-      previewContextLineNumber: 0,
-      previewContextLineText: '',
       effectTarget: 'fig-center',
       onApply() { /* no-op */ },
     })
@@ -328,19 +272,13 @@ describe('useEffectEditorProvider', () => {
     })
   })
 
-  it('重置草稿时会回滚场景预览到初始基线', async () => {
+  it('重置草稿时通过空 setEffect 回到效果预览基线', async () => {
     useEditSettingsStore().autoApplyEffectEditorChanges = false
 
     const provider = createEffectEditorProvider()
 
     await provider.open({
-      entryId: 1,
-      scenePath: 'scene/001.txt',
       baseSentence: createBaseSentence('{"blur":8}'),
-      baseLineNumber: 3,
-      baseLineText: 'changeFigure: figure.png -transform={"blur":8};',
-      previewContextLineNumber: 2,
-      previewContextLineText: 'say:previous;',
       effectTarget: 'fig-center',
       onApply() { /* no-op */ },
     })
@@ -349,21 +287,24 @@ describe('useEffectEditorProvider', () => {
       duration: '300',
       transform: { blur: 12 },
     })
+    provider.requestPreview({ schedule: 'immediate' })
+    await vi.waitFor(() => {
+      expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', {
+        blur: 12,
+      })
+    })
+
+    debugCommanderMock.setEffect.mockClear()
 
     provider.resetToInitialDraft()
 
     await vi.waitFor(() => {
-      expect(debugCommanderMock.syncScene).toHaveBeenCalledTimes(1)
+      expect(debugCommanderMock.setEffect).toHaveBeenCalledTimes(1)
     })
 
-    expect(debugCommanderMock.syncScene).toHaveBeenCalledWith(
-      'scene/001.txt',
-      3,
-      'changeFigure: figure.png -transform={"blur":8};',
-      true,
-    )
+    expect(debugCommanderMock.syncScene).not.toHaveBeenCalled()
     expect(debugCommanderMock.executeCommand).not.toHaveBeenCalled()
-    expect(debugCommanderMock.setEffect).not.toHaveBeenCalled()
+    expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', {})
     expect(provider.session?.draft).toEqual({
       duration: '',
       ease: '',
@@ -373,19 +314,87 @@ describe('useEffectEditorProvider', () => {
     expect(provider.canReset).toBe(false)
   })
 
+  it('重置仅修改时长的草稿不会发送效果预览重置', async () => {
+    useEditSettingsStore().autoApplyEffectEditorChanges = false
+
+    const provider = createEffectEditorProvider()
+
+    await provider.open({
+      baseSentence: createBaseSentence('{"blur":8}'),
+      effectTarget: 'fig-center',
+      onApply() { /* no-op */ },
+    })
+
+    provider.updateDraft({ duration: '300' })
+    provider.resetToInitialDraft()
+
+    expect(debugCommanderMock.syncScene).not.toHaveBeenCalled()
+    expect(debugCommanderMock.executeCommand).not.toHaveBeenCalled()
+    expect(debugCommanderMock.setEffect).not.toHaveBeenCalled()
+    expect(provider.session?.draft).toEqual({
+      duration: '',
+      ease: '',
+      transform: { blur: 8 },
+    })
+  })
+
+  it('关闭并丢弃未应用变更时通过空 setEffect 重置预览', async () => {
+    useEditSettingsStore().autoApplyEffectEditorChanges = false
+
+    const provider = createEffectEditorProvider()
+
+    await provider.open({
+      baseSentence: createBaseSentence('{"blur":8}'),
+      effectTarget: 'fig-center',
+      onApply() { /* no-op */ },
+    })
+
+    provider.updateDraft({ transform: { blur: 12 } })
+    provider.requestPreview({ schedule: 'immediate' })
+    await vi.waitFor(() => {
+      expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', {
+        blur: 12,
+      })
+    })
+
+    debugCommanderMock.setEffect.mockClear()
+
+    const closed = await provider.close({ forceDiscard: true })
+
+    expect(closed).toBe(true)
+    expect(debugCommanderMock.syncScene).not.toHaveBeenCalled()
+    expect(debugCommanderMock.executeCommand).not.toHaveBeenCalled()
+    expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', {})
+  })
+
+  it('关闭并丢弃仅修改时长的草稿不会发送效果预览重置', async () => {
+    useEditSettingsStore().autoApplyEffectEditorChanges = false
+
+    const provider = createEffectEditorProvider()
+
+    await provider.open({
+      baseSentence: createBaseSentence('{"blur":8}'),
+      effectTarget: 'fig-center',
+      onApply() { /* no-op */ },
+    })
+
+    provider.updateDraft({ duration: '300' })
+
+    const closed = await provider.close({ forceDiscard: true })
+
+    expect(closed).toBe(true)
+    expect(debugCommanderMock.syncScene).not.toHaveBeenCalled()
+    expect(debugCommanderMock.executeCommand).not.toHaveBeenCalled()
+    expect(debugCommanderMock.setEffect).not.toHaveBeenCalled()
+  })
+
   it('autoApplyQueued 在提交未完成时可串行消费后续草稿', async () => {
     const applyCalls: EffectEditorDraft[] = []
     const resolvers: (() => void)[] = []
     const provider = createEffectEditorProvider()
 
     await provider.open({
-      entryId: 1,
-      scenePath: 'scene/001.txt',
       baseSentence: createBaseSentence(),
-      baseLineNumber: 1,
-      baseLineText: 'changeFigure: figure.png;',
-      previewContextLineNumber: 0,
-      previewContextLineText: '',
       effectTarget: 'fig-center',
       onApply(result) {
         applyCalls.push(cloneDraft(result))
@@ -429,13 +438,7 @@ describe('useEffectEditorProvider', () => {
     })
 
     await provider.open({
-      entryId: 1,
-      scenePath: 'scene/001.txt',
       baseSentence: createBaseSentence(),
-      baseLineNumber: 1,
-      baseLineText: 'changeFigure: figure.png;',
-      previewContextLineNumber: 0,
-      previewContextLineText: '',
       effectTarget: 'fig-center',
       onApply(result) {
         applyCalls.push(cloneDraft(result))

--- a/src/features/editor/effect-editor/useEffectEditorProvider.ts
+++ b/src/features/editor/effect-editor/useEffectEditorProvider.ts
@@ -1,10 +1,8 @@
 import { commandType } from 'webgal-parser/src/interface/sceneInterface'
 
 import { readSentenceArgString } from '~/domain/script/sentence'
-import { serializeSentence } from '~/domain/script/serialize'
 import { Transform } from '~/domain/stage/types'
 import { fieldsToTransform, isTransformEqual, parseTransformJson, transformToFields } from '~/features/editor/effect-editor/effect-editor-config'
-import { applyEffectEditorResultToSentence } from '~/features/editor/effect-editor/effect-editor-result'
 import { EmitTransformOptions } from '~/features/editor/effect-editor/types'
 import { debugCommander } from '~/services/debug-commander'
 import { useEditSettingsStore } from '~/stores/edit-settings'
@@ -33,26 +31,13 @@ export interface EffectEditorDraft {
 }
 
 export interface EffectEditorOpenTarget {
-  entryId: number
-  scenePath: string
   baseSentence: ISentence
-  baseLineNumber: number
-  baseLineText: string
-  previewContextLineNumber: number
-  previewContextLineText: string
   effectTarget?: string
   onApply: (result: EffectEditorDraft) => void | Promise<void>
 }
 
 export interface EffectEditorSession {
   sessionId: number
-  entryId: number
-  scenePath: string
-  baseSentence: ISentence
-  baseLineNumber: number
-  baseLineText: string
-  previewContextLineNumber: number
-  previewContextLineText: string
   effectTarget: string
   draft: EffectEditorDraft
   /** 打开编辑器时的初始草稿快照，用于"重置"操作的目标 */
@@ -136,18 +121,6 @@ function isDraftEqual(left: EffectEditorDraft, right: EffectEditorDraft): boolea
     && isTransformEqual(left.transform, right.transform)
 }
 
-function hasRemovedTransformPaths(
-  previousFields: Record<string, string>,
-  nextFields: Record<string, string>,
-): boolean {
-  for (const path of Object.keys(previousFields)) {
-    if (nextFields[path] === undefined) {
-      return true
-    }
-  }
-  return false
-}
-
 function areTransformFieldsEqual(
   left: Record<string, string>,
   right: Record<string, string>,
@@ -161,8 +134,16 @@ function areTransformFieldsEqual(
   return leftKeys.every(key => left[key] === right[key])
 }
 
-function buildPreviewCommandText(session: EffectEditorSession): string {
-  return serializeSentence(applyEffectEditorResultToSentence(session.baseSentence, session.draft))
+function hasPreviewTransformChanged(session: EffectEditorSession): boolean {
+  return !areTransformFieldsEqual(
+    session.previewedTransformFields,
+    transformToFields(session.initialDraft.transform),
+  )
+}
+
+function needsPreviewBaselineReset(session: EffectEditorSession): boolean {
+  return hasPreviewTransformChanged(session)
+    || !isTransformEqual(session.draft.transform, session.initialDraft.transform)
 }
 
 export function createEffectEditorProvider() {
@@ -186,6 +167,13 @@ export function createEffectEditorProvider() {
 
   function canAutoApply(): boolean {
     return editSettings.autoApplyEffectEditorChanges
+  }
+
+  function warnMissingEffectTarget(currentSession: EffectEditorSession): void {
+    if (!currentSession.missingTargetWarned) {
+      logger.warn('效果编辑器缺少 target，跳过实时预览')
+    }
+    currentSession.missingTargetWarned = true
   }
 
   function cancelScheduledPreview() {
@@ -245,30 +233,13 @@ export function createEffectEditorProvider() {
 
     try {
       const nextPreviewFields = transformToFields(session.draft.transform)
-      const hasDeletion = hasRemovedTransformPaths(session.previewedTransformFields, nextPreviewFields)
 
-      if (!hasDeletion && areTransformFieldsEqual(session.previewedTransformFields, nextPreviewFields)) {
-        return
-      }
-
-      if (hasDeletion) {
-        await debugCommander.syncScene(
-          session.scenePath,
-          session.previewContextLineNumber,
-          session.previewContextLineText,
-          true,
-        )
-        await debugCommander.executeCommand(buildPreviewCommandText(session))
-        session.previewedTransformFields = nextPreviewFields
-        session.previewErrorWarned = false
+      if (areTransformFieldsEqual(session.previewedTransformFields, nextPreviewFields)) {
         return
       }
 
       if (!session.effectTarget) {
-        if (!session.missingTargetWarned) {
-          logger.warn('效果编辑器缺少 target，跳过实时预览')
-        }
-        session.missingTargetWarned = true
+        warnMissingEffectTarget(session)
         return
       }
 
@@ -355,6 +326,8 @@ export function createEffectEditorProvider() {
     }
 
     const currentSession = session
+    const shouldResetPreview = needsPreviewBaselineReset(currentSession)
+
     updateDraft({
       transform: cloneTransform(currentSession.initialDraft.transform),
       duration: currentSession.initialDraft.duration,
@@ -367,25 +340,27 @@ export function createEffectEditorProvider() {
     previewQueue.cancel()
     cancelScheduledPreview()
 
-    // 还原时直接回放场景，避免仅 setEffect 导致预览残留。
-    currentSession.previewedTransformFields = transformToFields(currentSession.initialDraft.transform)
-    void rollbackPreview(currentSession)
+    if (shouldResetPreview) {
+      void resetPreviewToBaseline(currentSession)
+    }
 
     if (canAutoApply()) {
       autoApplyQueue.enqueue()
     }
   }
 
-  async function rollbackPreview(currentSession: EffectEditorSession) {
+  async function resetPreviewToBaseline(currentSession: EffectEditorSession) {
+    if (!currentSession.effectTarget) {
+      warnMissingEffectTarget(currentSession)
+      return
+    }
+
     try {
-      await debugCommander.syncScene(
-        currentSession.scenePath,
-        currentSession.baseLineNumber,
-        currentSession.baseLineText,
-        true,
-      )
+      await debugCommander.setEffect(currentSession.effectTarget, {})
+      currentSession.previewedTransformFields = transformToFields(currentSession.initialDraft.transform)
+      currentSession.previewErrorWarned = false
     } catch (error) {
-      logger.error(`回滚效果预览失败: ${error}`)
+      logger.error(`重置效果预览失败: ${error}`)
     }
   }
 
@@ -401,7 +376,7 @@ export function createEffectEditorProvider() {
     })
   }
 
-  async function close(options: { forceDiscard?: boolean, skipRollback?: boolean } = {}): Promise<boolean> {
+  async function close(options: { forceDiscard?: boolean, skipPreviewReset?: boolean } = {}): Promise<boolean> {
     if (!session) {
       isOpen = false
       return true
@@ -430,11 +405,15 @@ export function createEffectEditorProvider() {
     const currentSession = session
 
     autoApplyQueue.cancel()
+    previewQueue.cancel()
     cancelScheduledPreview()
 
-    // 仅在存在未提交更改时回放，避免"未改动关闭也刷新预览"。
-    if (!options.skipRollback && !currentSession.hasApplied && currentSession.dirty) {
-      await rollbackPreview(currentSession)
+    if (
+      !options.skipPreviewReset
+      && !currentSession.hasApplied
+      && needsPreviewBaselineReset(currentSession)
+    ) {
+      await resetPreviewToBaseline(currentSession)
     }
 
     session = undefined
@@ -468,7 +447,7 @@ export function createEffectEditorProvider() {
       }
     }
 
-    return await close({ forceDiscard: true, skipRollback: true })
+    return await close({ forceDiscard: true, skipPreviewReset: true })
   }
 
   async function open(target: EffectEditorOpenTarget): Promise<boolean> {
@@ -490,13 +469,6 @@ export function createEffectEditorProvider() {
 
     session = {
       sessionId,
-      entryId: target.entryId,
-      scenePath: target.scenePath,
-      baseSentence,
-      baseLineNumber: target.baseLineNumber,
-      baseLineText: target.baseLineText,
-      previewContextLineNumber: target.previewContextLineNumber,
-      previewContextLineText: target.previewContextLineText,
       effectTarget,
       draft: cloneDraft(initialDraft),
       initialDraft: cloneDraft(initialDraft),

--- a/src/features/editor/effect-editor/useStatementEffectEditorBridge.ts
+++ b/src/features/editor/effect-editor/useStatementEffectEditorBridge.ts
@@ -1,20 +1,16 @@
 import { commandType } from 'webgal-parser/src/interface/sceneInterface'
 
-import { computeLineNumberFromStatementId } from '~/domain/document/scene-selection'
 import { hasSentenceTruthyFlag, readSentenceArgString } from '~/domain/script/sentence'
 import { serializeSentence } from '~/domain/script/serialize'
 import { applyEffectEditorResultToSentence, EffectEditorResult } from '~/features/editor/effect-editor/effect-editor-result'
 import { useInjectedEffectEditorProvider } from '~/features/editor/effect-editor/useEffectEditorProvider'
 import { createStatementIdTarget, StatementUpdatePayload, StatementUpdateTarget } from '~/features/editor/statement-editor/useStatementEditor'
-import { resolveSceneReplayAnchorLine } from '~/features/editor/text-editor/text-editor-scene-sync'
 import { isEditableEditor, useEditorStore } from '~/stores/editor'
 
 import type { ISentence } from 'webgal-parser/src/interface/sceneInterface'
-import type { SceneVisualProjectionState, TextProjectionState } from '~/stores/editor'
 
 interface UseStatementEffectEditorBridgeOptions {
   updateTarget?: MaybeRefOrGetter<StatementUpdateTarget | undefined>
-  rawText: MaybeRefOrGetter<string>
   parsed: MaybeRefOrGetter<ISentence | undefined>
   emitUpdate: (payload: StatementUpdatePayload) => void
 }
@@ -50,62 +46,6 @@ function resolveEffectPreviewTarget(sentence: ISentence): string {
 }
 
 /**
- * 将更新目标转换为文件中的起始行号（1-based）。
- */
-function resolveBaseLineNumber(
-  state: TextProjectionState | SceneVisualProjectionState,
-  target: StatementUpdateTarget | undefined,
-): number {
-  if (!target) {
-    return 1
-  }
-
-  if (target.kind === 'line') {
-    return target.lineNumber
-  }
-
-  if (state.projection === 'visual') {
-    return computeLineNumberFromStatementId(state.statements, target.statementId) ?? 1
-  }
-
-  return 1
-}
-
-function resolvePreviewContext(
-  textContent: string | undefined,
-  baseLineNumber: number,
-): { previewContextLineNumber: number, previewContextLineText: string } {
-  if (!textContent) {
-    return {
-      previewContextLineNumber: 0,
-      previewContextLineText: '',
-    }
-  }
-
-  const lines = textContent.split(/\r?\n/u)
-  const replayAnchor = resolveSceneReplayAnchorLine(baseLineNumber, {
-    getLineContent(lineNumber: number) {
-      return lines[lineNumber - 1] ?? ''
-    },
-    getLineCount() {
-      return lines.length
-    },
-  })
-
-  if (!replayAnchor) {
-    return {
-      previewContextLineNumber: 0,
-      previewContextLineText: '',
-    }
-  }
-
-  return {
-    previewContextLineNumber: replayAnchor.lineNumber,
-    previewContextLineText: replayAnchor.lineText,
-  }
-}
-
-/**
  * 效果编辑器打开方式的 override 函数类型。
  * 模态框通过 provide 此函数，让 bridge 在模态框上下文中
  * 使用二级 Dialog 而非 Sheet 打开效果编辑器。
@@ -120,7 +60,6 @@ export const EFFECT_EDITOR_OPEN_OVERRIDE_KEY: InjectionKey<EffectEditorOpenOverr
 
 export function useStatementEffectEditorBridge(options: UseStatementEffectEditorBridgeOptions) {
   const updateTarget = computed(() => toValue(options.updateTarget))
-  const rawText = computed(() => toValue(options.rawText))
   const parsed = computed(() => toValue(options.parsed))
   const effectEditorProvider = useInjectedEffectEditorProvider()
   const overriddenOpen = inject(EFFECT_EDITOR_OPEN_OVERRIDE_KEY, undefined)
@@ -165,21 +104,8 @@ export function useStatementEffectEditorBridge(options: UseStatementEffectEditor
       return
     }
 
-    const baseLineNumber = resolveBaseLineNumber(state, updateTarget.value)
-    const previewContext = resolvePreviewContext(
-      editorStore.currentTextProjection?.textContent,
-      baseLineNumber,
-    )
-    const entryId = resolveEffectEditorEntryId(updateTarget.value)
-
     void effectEditorProvider.open({
-      entryId,
-      scenePath: state.path,
       baseSentence: parsed.value,
-      baseLineNumber,
-      baseLineText: rawText.value,
-      previewContextLineNumber: previewContext.previewContextLineNumber,
-      previewContextLineText: previewContext.previewContextLineText,
       effectTarget: resolveEffectPreviewTarget(parsed.value),
       onApply: applyEffectEditorResult,
     })
@@ -189,16 +115,4 @@ export function useStatementEffectEditorBridge(options: UseStatementEffectEditor
     openEffectEditor,
     applyEffectEditorResult,
   }
-}
-
-function resolveEffectEditorEntryId(target: StatementUpdateTarget | undefined): number {
-  if (!target) {
-    return 0
-  }
-
-  if (target.kind === 'line') {
-    return target.lineNumber
-  }
-
-  return target.statementId
 }


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [ ] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [x] 代码重构
- [x] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

重构效果编辑器实时预览的重置逻辑，使其对齐最新 `set-effect` 通信协议：

- 字段级重置改为发送缺失对应字段的 `setEffect` payload，由预览端按原始值恢复。
- 清除最后一个 transform 字段、重置草稿、关闭并丢弃未应用预览时，通过空 transform `{}` 回到效果预览基线。
- 移除旧的 `syncScene + executeCommand` 场景回放路径。
- 清理 provider / bridge 中仅服务于旧协议的行号、上下文和 `rawText` 参数。
- 更新单元测试，覆盖字段清除、空 transform、重置/关闭丢弃，以及仅修改 duration 时不触发效果预览重置的场景。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

`set-effect` 协议已变更：未附带的字段会使用原始值，空 `transform` 可用于恢复整体基线。

因此效果编辑器不再需要通过回放当前命令来表达字段级重置。本次重构将预览重置逻辑收敛到新的协议语义，减少旧协议上下文和回放路径带来的维护成本。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
