### PR TITLE
🌐 清理状态栏遗留多语言键并规范英文文案引号

### DIFF
--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -525,7 +525,7 @@ modals:
     restore: Restore
     restoreSuccess: Restored successfully
     restoreConfirmTitle: Restore this version?
-    restoreConfirmContent: "Restore the version saved at {time}? The current content will be backed up first as a \"restore\" entry."
+    restoreConfirmContent: 'Restore the version saved at {time}? The current content will be backed up first as a "restore" entry.'
     sourceKind:
       manualSave: Manual save
       autoSave: Auto save
@@ -689,10 +689,8 @@ edit:
   statusBar:
     frames: "{count} frames"
     statements: "{count} statements"
-    engine: Engine
     engineMissing: Engine unavailable
     selectEngine: Select Engine
-    template: Template
     templateMissing: Template unavailable
     selectTemplate: Select Template
   fileTree:
@@ -1160,9 +1158,9 @@ game:
   selectTemplatePlaceholder: Select an available template
   importDependencyResolutionTitle: Select Resources for Import
   importDependencyResolutionDescription: This project references an unavailable engine or template. Select resources available on this device; the app will update the project config and continue importing.
-  importDependencyResolutionDescriptionWithName: "\"{name}\" references an unavailable engine or template. Select resources available on this device; the app will update the project config and continue importing."
+  importDependencyResolutionDescriptionWithName: '"{name}" references an unavailable engine or template. Select resources available on this device; the app will update the project config and continue importing.'
   importDependencyResolutionLegacyDescription: This legacy project folder does not include its own engine. Select an available engine; the app will create a project config and continue importing.
-  importDependencyResolutionLegacyDescriptionWithName: "\"{name}\" is a legacy project and its folder does not include its own engine. Select an available engine; the app will create a project config and continue importing."
+  importDependencyResolutionLegacyDescriptionWithName: '"{name}" is a legacy project and its folder does not include its own engine. Select an available engine; the app will create a project config and continue importing.'
   importDependencyResolutionEngineTitle: Bind Engine
   importDependencyResolutionTemplateTitle: Bind Template
   importDependencyResolutionEngineIssue: Select an available engine. The imported project will use it for opening and previewing.

--- a/src/locales/ja.yml
+++ b/src/locales/ja.yml
@@ -689,10 +689,8 @@ edit:
   statusBar:
     frames: "{count} フレーム"
     statements: "{count} ステートメント"
-    engine: エンジン
     engineMissing: エンジンが利用できません
     selectEngine: エンジンを選択
-    template: テンプレート
     templateMissing: テンプレートが利用できません
     selectTemplate: テンプレートを選択
   fileTree:

--- a/src/locales/zh-Hans.yml
+++ b/src/locales/zh-Hans.yml
@@ -689,10 +689,8 @@ edit:
   statusBar:
     frames: "{count} 帧"
     statements: "{count} 条语句"
-    engine: 引擎
     engineMissing: 引擎不可用
     selectEngine: 选择引擎
-    template: 模板
     templateMissing: 模板不可用
     selectTemplate: 选择模板
   fileTree:

--- a/src/locales/zh-Hant.yml
+++ b/src/locales/zh-Hant.yml
@@ -689,10 +689,8 @@ edit:
   statusBar:
     frames: "{count} 幀"
     statements: "{count} 條語句"
-    engine: 引擎
     engineMissing: 引擎不可用
     selectEngine: 選擇引擎
-    template: 模板
     templateMissing: 模板不可用
     selectTemplate: 選擇模板
   fileTree:


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [ ] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [x] 代码格式
- [ ] 代码重构
- [ ] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [x] 其他，请描述: 国际化文案

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

- 移除 `edit.statusBar.engine` 和 `edit.statusBar.template` 在四个语言包中的遗留键。
- 统一 `src/locales/en.yml` 中几处包含引号文案的 YAML 写法，减少转义噪音并提升可读性。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

状态栏当前只使用 `engineMissing`、`selectEngine`、`templateMissing` 和 `selectTemplate` 相关文案，`engine` 与 `template` 两个键已经没有实际引用。继续保留这些键会让语言包内容与真实界面状态脱节，并增加后续维护成本。

同时，`en.yml` 中部分文案通过转义双引号表达字符串，可读性较差。改为更直接的 YAML 引号写法后，文案语义不变，但维护和审阅成本更低。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [ ] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
