### PR TITLE
🐛 避免效果编辑器无操作时标记为已修改

### DIFF
--- a/src/features/editor/effect-editor/__tests__/useEffectColorControl.test.ts
+++ b/src/features/editor/effect-editor/__tests__/useEffectColorControl.test.ts
@@ -155,6 +155,33 @@ describe('useEffectColorControl', () => {
     })
   })
 
+  it('颜色选择器打开时回传当前默认颜色不会写入缺失字段', () => {
+    const { deps, emitTransform, fields } = createDeps()
+    const control = useEffectColorControl(deps)
+    const field = createColorField({
+      colorDefaults: [255, 255, 255],
+    })
+
+    control.handleColorPickerChange(field, { rgba: { r: 255, g: 255, b: 255 } })
+
+    expect(fields).toEqual({})
+    expect(emitTransform).not.toHaveBeenCalled()
+  })
+
+  it('颜色触发按钮仅 pointerdown/up 时不会写入缺失字段', () => {
+    const { deps, emitTransform, fields } = createDeps()
+    const control = useEffectColorControl(deps)
+    const field = createColorField({
+      colorDefaults: [255, 255, 255],
+    })
+
+    control.handleColorPickerPointerDown(createPointerEvent(), field)
+    control.colorDrag.stop?.(createPointerEvent())
+
+    expect(fields).toEqual({})
+    expect(emitTransform).not.toHaveBeenCalled()
+  })
+
   it('拖拽期间只做 deferred preview，结束时才 flush 最终颜色', () => {
     const { deps, emitTransform, fields } = createDeps()
     const control = useEffectColorControl(deps)

--- a/src/features/editor/effect-editor/__tests__/useEffectContinuousControls.test.ts
+++ b/src/features/editor/effect-editor/__tests__/useEffectContinuousControls.test.ts
@@ -129,6 +129,53 @@ describe('useEffectContinuousControls', () => {
     expect(fields.scaleY).toBe('12')
   })
 
+  it('滑条输入框仅提交展示用默认值时不会写入缺失字段', () => {
+    const { deps, emitTransform, fields } = createDeps()
+    const controls = useEffectContinuousControls(deps)
+
+    controls.flushSliderField(createNumberField({
+      key: 'alpha',
+      defaultValue: 1,
+      min: 0,
+      max: 1,
+    }))
+
+    expect(fields.alpha).toBeUndefined()
+    expect(emitTransform).not.toHaveBeenCalled()
+  })
+
+  it('滑条仅回传当前默认值时不会写入缺失字段', () => {
+    const { deps, emitTransform, fields } = createDeps()
+    const controls = useEffectContinuousControls(deps)
+
+    controls.updateSliderField(createNumberField({
+      key: 'alpha',
+      defaultValue: 1,
+      min: 0,
+      max: 1,
+    }), 1, { fromSlider: true, flush: true })
+
+    expect(fields.alpha).toBeUndefined()
+    expect(emitTransform).not.toHaveBeenCalled()
+  })
+
+  it('linked-slider 仅提交默认展示值时不会写入缺失字段', () => {
+    const { deps, emitTransform, fields } = createDeps()
+    const controls = useEffectContinuousControls(deps)
+    const linkedField = createLinkedNumberField({
+      defaultValue: 1,
+      min: 0,
+      max: 2,
+    })
+
+    controls.flushLinkedSliderField(linkedField, 0)
+    controls.updateLinkedSliderField(linkedField, 0, 1, { fromSlider: true, flush: true })
+
+    expect(fields.scaleX).toBeUndefined()
+    expect(fields.scaleY).toBeUndefined()
+    expect(emitTransform).not.toHaveBeenCalled()
+  })
+
   it('锁定快照主轴为 0 时，linked-slider 会回退为双轴同步', () => {
     const { deps, fields } = createDeps({
       scaleX: '0',
@@ -160,5 +207,16 @@ describe('useEffectContinuousControls', () => {
     controls.updateDialField(dialField, 90, { flush: true })
     expect(Number(fields.rotate)).toBeCloseTo(1.5708)
     expect(controls.getDialInputValue(dialField)).toBe('90')
+  })
+
+  it('dial 提交已有值时不会把弧度存储值当成角度重复转换', () => {
+    const { deps, fields } = createDeps({
+      rotate: String(Math.PI / 2),
+    })
+    const controls = useEffectContinuousControls(deps)
+
+    controls.flushDialField(createDialField())
+
+    expect(Number(fields.rotate)).toBeCloseTo(Math.PI / 2)
   })
 })

--- a/src/features/editor/effect-editor/useEffectColorControl.ts
+++ b/src/features/editor/effect-editor/useEffectColorControl.ts
@@ -12,6 +12,10 @@ export function useEffectColorControl(deps: EffectControlDeps) {
   // 拖拽期间仅做 deferred 预览，拖拽结束时（onEnd）才用暂存值执行一次 flush
   let pendingColorFlushValue = $ref<[number, number, number]>()
 
+  function isColorEqual(left: [number, number, number], right: [number, number, number]): boolean {
+    return left[0] === right[0] && left[1] === right[1] && left[2] === right[2]
+  }
+
   function getColorValue(param: EffectColorField): [number, number, number] {
     const red = normalizeColorChannel(deps.getNumberValue(param.colorPaths[0], param.colorDefaults[0]), param.colorDefaults[0])
     const green = normalizeColorChannel(deps.getNumberValue(param.colorPaths[1], param.colorDefaults[1]), param.colorDefaults[1])
@@ -42,11 +46,15 @@ export function useEffectColorControl(deps: EffectControlDeps) {
     Record<string, never>
   >({
     onStart() {
+      pendingColorFlushValue = undefined
       return {}
     },
     onMove() { /* noop */ },
     onEnd(_event, state) {
-      const targetColor = pendingColorFlushValue ?? getColorValue(state.param)
+      if (!pendingColorFlushValue) {
+        return
+      }
+      const targetColor = pendingColorFlushValue
       pendingColorFlushValue = undefined
       updateColorField(state.param, targetColor, {
         flush: true,
@@ -58,6 +66,10 @@ export function useEffectColorControl(deps: EffectControlDeps) {
   function handleColorPickerChange(param: EffectColorField, rawValue: unknown) {
     const parsed = extractRgbColor(rawValue)
     if (!parsed) {
+      return
+    }
+
+    if (isColorEqual(parsed, getColorValue(param))) {
       return
     }
 

--- a/src/features/editor/effect-editor/useEffectContinuousControls.ts
+++ b/src/features/editor/effect-editor/useEffectContinuousControls.ts
@@ -145,6 +145,15 @@ export function useEffectContinuousControls(deps: EffectControlDeps) {
     return [clamp(raw, param.min, param.max)]
   }
 
+  function getStoredFieldValue(path: string): string | undefined {
+    const value = deps.getFieldValue(path)
+    return value === '' ? undefined : value
+  }
+
+  function isImplicitDefaultWrite(path: string, value: number, defaultValue?: number): boolean {
+    return defaultValue !== undefined && value === defaultValue && getStoredFieldValue(path) === undefined
+  }
+
   function updateSliderField(
     param: NumberField,
     rawValue: string | number,
@@ -157,12 +166,19 @@ export function useEffectContinuousControls(deps: EffectControlDeps) {
     const normalized = options.fromSlider
       ? applySliderCenterSnap(clamp(result.value, param.min ?? 0, param.max ?? 0), param.center ?? 0, param.min ?? 0, param.max ?? 0)
       : result.value
+    if (options.fromSlider && isImplicitDefaultWrite(param.key, normalized, param.defaultValue)) {
+      return
+    }
     deps.setNumericField(result.fields, param.key, normalized)
     deps.emitTransform(result.fields, { schedule: 'continuous', flush: options.flush, deferAutoApply: !options.flush })
   }
 
   function flushSliderField(param: NumberField) {
-    updateSliderField(param, getSliderInputValue(param), { flush: true })
+    const storedValue = getStoredFieldValue(param.key)
+    if (storedValue === undefined) {
+      return
+    }
+    updateSliderField(param, storedValue, { flush: true })
   }
 
   // ═══════════════════════════════════════
@@ -249,6 +265,14 @@ export function useEffectContinuousControls(deps: EffectControlDeps) {
       ? applySliderCenterSnap(clamp(result.value, param.min ?? 0, param.max ?? 0), param.center ?? 0, param.min ?? 0, param.max ?? 0)
       : result.value
 
+    if (
+      options.fromSlider
+      && isImplicitDefaultWrite(activePath, normalizedActive, param.defaultValue)
+      && (!isLinkedSliderLocked(param) || getStoredFieldValue(passivePath) === undefined)
+    ) {
+      return
+    }
+
     deps.setNumericField(result.fields, activePath, normalizedActive)
 
     if (isLinkedSliderLocked(param)) {
@@ -268,7 +292,12 @@ export function useEffectContinuousControls(deps: EffectControlDeps) {
   }
 
   function flushLinkedSliderField(param: LinkedNumberField, index: 0 | 1) {
-    updateLinkedSliderField(param, index, getLinkedSliderInputValue(param, index), { flush: true })
+    const path = index === 0 ? param.key : param.linkedPairKey
+    const storedValue = getStoredFieldValue(path)
+    if (storedValue === undefined) {
+      return
+    }
+    updateLinkedSliderField(param, index, storedValue, { flush: true })
   }
 
   // ═══════════════════════════════════════
@@ -320,6 +349,9 @@ export function useEffectContinuousControls(deps: EffectControlDeps) {
   }
 
   function flushDialField(param: DialField) {
+    if (getStoredFieldValue(param.key) === undefined) {
+      return
+    }
     updateDialField(param, getDialInputValue(param), { flush: true })
   }
 


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [x] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [x] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

修复效果编辑器在没有实际编辑时误判为已修改的问题。

具体包括：

- 滑条输入框仅 blur / enter 提交展示默认值时，不再写入缺失字段。
- Slider 仅回传当前默认值时，不再把默认值写成显式 transform 字段。
- linked-slider 同样避免无操作默认值写回。
- 颜色选择器打开时，如果 picker 初始化回传当前默认颜色，不再写回颜色字段。
- 颜色触发按钮仅 pointerdown/up 时，不再触发颜色 flush。
- 保留用户显式写入默认值的能力，不修改 provider 的 dirty 语义。
- 补充连续控件与颜色控件的回归测试。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

效果编辑器中的部分字段在脚本中缺失时会使用展示默认值，例如 `alpha = 1`、颜色默认值 `255/255/255`。此前控件提交逻辑会把这些展示默认值当作真实编辑值写回 draft，导致用户只是点击滑条输入框或打开颜色选择器，也会看到字段被标记为已修改。

这个 PR 将“展示用默认值”和“真实存储值”分开处理，只在用户产生实际值变化时更新 draft。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
