### PR TITLE
🐛 打开效果编辑器前选中目标语句

### DIFF
--- a/src/components/editor/VisualEditorStatementCard.spec.ts
+++ b/src/components/editor/VisualEditorStatementCard.spec.ts
@@ -1,0 +1,155 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { page } from 'vitest/browser'
+import { computed, defineComponent, h } from 'vue'
+import { commandType } from 'webgal-parser/src/interface/sceneInterface'
+
+import { createBrowserClickStub, createBrowserContainerStub, renderInBrowser } from '~/__tests__/browser-render'
+
+import VisualEditorStatementCard from './VisualEditorStatementCard.vue'
+
+import type { StatementEntry } from '~/domain/script/sentence'
+
+const {
+  openAnimationEditorMock,
+  openEffectEditorMock,
+  provideStatementMetaMock,
+  useStatementAnimationEditorBridgeMock,
+  useStatementEffectEditorBridgeMock,
+} = vi.hoisted(() => ({
+  openAnimationEditorMock: vi.fn(),
+  openEffectEditorMock: vi.fn(),
+  provideStatementMetaMock: vi.fn(),
+  useStatementAnimationEditorBridgeMock: vi.fn(),
+  useStatementEffectEditorBridgeMock: vi.fn(),
+}))
+
+vi.mock('~/features/editor/animation/useStatementAnimationEditorBridge', () => ({
+  useStatementAnimationEditorBridge: useStatementAnimationEditorBridgeMock,
+}))
+
+vi.mock('~/features/editor/effect-editor/useStatementEffectEditorBridge', () => ({
+  useStatementEffectEditorBridge: useStatementEffectEditorBridgeMock,
+}))
+
+vi.mock('~/features/editor/statement-editor/preview', () => ({
+  buildStatementPreviewParams: vi.fn(() => []),
+}))
+
+vi.mock('~/features/editor/statement-editor/useStatementEditor', () => ({
+  createStatementIdTarget: (statementId: number) => ({
+    kind: 'statement',
+    statementId,
+  }),
+  isStatementInteractiveTarget: () => false,
+  useStatementEditor: vi.fn(),
+}))
+
+vi.mock('~/features/editor/statement-editor/useStatementFileMissing', () => ({
+  useStatementFileMissing: () => ({
+    fileMissingKeys: computed(() => new Set<string>()),
+  }),
+}))
+
+vi.mock('~/features/editor/statement-editor/useStatementMeta', () => ({
+  provideStatementMeta: provideStatementMetaMock,
+}))
+
+function createStatementEntry(id: number, rawText: string): StatementEntry {
+  return {
+    id,
+    rawText,
+    parsed: {
+      command: commandType.changeBg,
+      commandRaw: 'changeBg',
+      content: 'bg.jpg',
+      args: [],
+      sentenceAssets: [],
+      subScene: [],
+      inlineComment: '',
+    },
+    parseError: false,
+  }
+}
+
+function createStatementMeta() {
+  return {
+    parsed: computed(() => createStatementEntry(7, 'changeBg:bg.jpg').parsed),
+    config: computed(() => ({
+      icon: 'i-lucide-image',
+      locked: false,
+    })),
+    contentField: computed(() => undefined),
+    argFields: computed(() => []),
+    theme: computed(() => ({
+      bg: 'bg-muted',
+      gradient: 'from-muted to-muted',
+      text: 'text-muted-foreground',
+    })),
+    statementType: computed(() => 'command'),
+    commandLabel: computed(() => 'changeBg'),
+  }
+}
+
+const globalStubs = {
+  Button: createBrowserClickStub('StubButton'),
+  Collapsible: createBrowserContainerStub('StubCollapsible'),
+  CollapsibleContent: createBrowserContainerStub('StubCollapsibleContent'),
+  Separator: createBrowserContainerStub('StubSeparator'),
+  StatementEditorInline: defineComponent({
+    name: 'StubStatementEditorInline',
+    emits: ['openAnimationEditor', 'openEffectEditor', 'update'],
+    setup(_, { emit }) {
+      return () => h('button', {
+        type: 'button',
+        onClick: () => emit('openEffectEditor'),
+      }, 'Effect Editor')
+    },
+  }),
+}
+
+describe('VisualEditorStatementCard', () => {
+  beforeEach(() => {
+    openAnimationEditorMock.mockReset()
+    openEffectEditorMock.mockReset()
+    provideStatementMetaMock.mockReset()
+    useStatementAnimationEditorBridgeMock.mockReset()
+    useStatementEffectEditorBridgeMock.mockReset()
+
+    provideStatementMetaMock.mockReturnValue(createStatementMeta())
+    useStatementAnimationEditorBridgeMock.mockReturnValue({
+      openAnimationEditor: openAnimationEditorMock,
+    })
+    useStatementEffectEditorBridgeMock.mockReturnValue({
+      openEffectEditor: openEffectEditorMock,
+    })
+  })
+
+  it('打开效果编辑器前会先选中当前语句', async () => {
+    const events: string[] = []
+    const entry = createStatementEntry(7, 'changeBg:bg.jpg')
+    const onSelect = vi.fn(() => {
+      events.push('select')
+    })
+    openEffectEditorMock.mockImplementation(() => {
+      events.push('openEffectEditor')
+    })
+
+    renderInBrowser(VisualEditorStatementCard, {
+      props: {
+        collapsed: false,
+        entry,
+        index: 0,
+        selected: false,
+        onSelect,
+      },
+      global: {
+        stubs: globalStubs,
+      },
+    })
+
+    await page.getByRole('button', { name: 'Effect Editor' }).click()
+
+    expect(events.slice(0, 2)).toEqual(['select', 'openEffectEditor'])
+    expect(onSelect).toHaveBeenCalledWith(7)
+  })
+})

--- a/src/components/editor/VisualEditorStatementCard.vue
+++ b/src/components/editor/VisualEditorStatementCard.vue
@@ -85,6 +85,11 @@ const { openEffectEditor } = useStatementEffectEditorBridge({
   emitUpdate: payload => emit('update', payload),
 })
 
+function handleOpenEffectEditor() {
+  emit('select', props.entry.id)
+  openEffectEditor()
+}
+
 const { openAnimationEditor } = useStatementAnimationEditorBridge({
   updateTarget: () => createStatementIdTarget(props.entry.id),
   parsed: () => parsed.value,
@@ -221,7 +226,7 @@ function paramBadgeClass(param: StatementCardPreviewParam): string {
             ::show-inline-comment="showInlineComment"
             @update="emit('update', $event)"
             @open-animation-editor="openAnimationEditor"
-            @open-effect-editor="openEffectEditor"
+            @open-effect-editor="handleOpenEffectEditor"
           />
         </CollapsibleContent>
       </Collapsible>


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [x] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [x] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

修复在视觉编辑器中点击非选中语句的行内效果编辑器按钮时，效果编辑器目标与当前选中语句上下文不一致的问题。

现在打开效果编辑器前会先选中对应语句，然后再打开效果编辑器。此改动不改变 dirty 状态下打开效果编辑器的能力，预览是否同步仍沿用现有逻辑。

同时新增 `VisualEditorStatementCard` 浏览器回归测试，覆盖打开效果编辑器前先选中当前语句的事件顺序。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

此前行内效果编辑器按钮的点击不会同步触发语句选中：如果用户直接点击非选中行的效果编辑器按钮，效果编辑器会以该行语句为编辑目标打开，但当前选中语句仍可能停留在另一行，导致编辑器目标、侧栏上下文和预览上下文不一致。

该改动让“打开某行的效果编辑器”显式包含“选中该行”这一步，使交互状态来源保持一致。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
