### PR TITLE
♻️ 精简编辑设置并统一命令点击插入行为

### DIFF
--- a/src/components/editor/EditorPanel.spec.ts
+++ b/src/components/editor/EditorPanel.spec.ts
@@ -11,7 +11,6 @@ const {
   expandCommandPanelMock,
   sidebarPanelMock,
   statementAnimationDialogMock,
-  useEditSettingsStoreMock,
   useEditorStoreMock,
   usePreferenceStoreMock,
   useStatementAnimationDialogMock,
@@ -63,7 +62,6 @@ const {
     resetToDefault: vi.fn(),
     updateFrames: vi.fn(),
   },
-  useEditSettingsStoreMock: vi.fn(),
   useEditorStoreMock: vi.fn(),
   usePreferenceStoreMock: vi.fn(),
   useStatementAnimationDialogMock: vi.fn(),
@@ -81,10 +79,6 @@ vi.mock('~/stores/editor', () => ({
 
 vi.mock('~/stores/preference', () => ({
   usePreferenceStore: usePreferenceStoreMock,
-}))
-
-vi.mock('~/stores/edit-settings', () => ({
-  useEditSettingsStore: useEditSettingsStoreMock,
 }))
 
 vi.mock('~/stores/tabs', () => ({
@@ -322,7 +316,6 @@ describe('EditorPanel', () => {
     effectEditorProviderMock.isOpen = false
     effectEditorProviderMock.session = undefined
     useStatementAnimationDialogMock.mockReset()
-    useEditSettingsStoreMock.mockReset()
     useEditorStoreMock.mockReset()
     usePreferenceStoreMock.mockReset()
     useTabsStoreMock.mockReset()
@@ -337,9 +330,6 @@ describe('EditorPanel', () => {
     }))
     usePreferenceStoreMock.mockReturnValue(reactive({
       showSidebar: true,
-    }))
-    useEditSettingsStoreMock.mockReturnValue(reactive({
-      effectEditorSide: 'right',
     }))
     useStatementAnimationDialogMock.mockReturnValue(statementAnimationDialogMock)
     useTabsStoreMock.mockReturnValue(reactive({

--- a/src/components/editor/EditorPanel.vue
+++ b/src/components/editor/EditorPanel.vue
@@ -3,11 +3,9 @@ import { ResizablePanel } from '~/components/ui/resizable'
 import { useEditorPanelShell } from '~/features/editor/shell/useEditorPanelShell'
 import { useShortcut } from '~/features/editor/shortcut/useShortcut'
 import { useShortcutContext } from '~/features/editor/shortcut/useShortcutContext'
-import { useEditSettingsStore } from '~/stores/edit-settings'
 
 const commandPanelRef = useTemplateRef<InstanceType<typeof ResizablePanel>>('commandPanel')
 const editorPanelRef = $(useTemplateRef('editorPanel'))
-const editSettingsStore = useEditSettingsStore()
 const { t } = useI18n()
 
 const {
@@ -144,7 +142,7 @@ defineExpose({ toggleCommandPanel })
         <SheetContent
           :to="editorPanelRef ?? undefined"
           :overlay="false"
-          :side="editSettingsStore.effectEditorSide"
+          side="right"
           class="p-4 max-w-none w-108 absolute sm:max-w-none"
           @open-auto-focus.prevent
           @close-auto-focus.prevent

--- a/src/features/editor/text-editor/__tests__/useTextEditorBindings.test.ts
+++ b/src/features/editor/text-editor/__tests__/useTextEditorBindings.test.ts
@@ -5,11 +5,9 @@ import { commandType } from 'webgal-parser/src/interface/sceneInterface'
 
 const {
   getSceneSelectionMock,
-  useEditSettingsStoreMock,
   useCommandPanelStoreMock,
 } = vi.hoisted(() => ({
   getSceneSelectionMock: vi.fn(),
-  useEditSettingsStoreMock: vi.fn(),
   useCommandPanelStoreMock: vi.fn(),
 }))
 
@@ -17,10 +15,6 @@ vi.mock('~/stores/editor', () => ({
   useEditorStore: () => ({
     getSceneSelection: getSceneSelectionMock,
   }),
-}))
-
-vi.mock('~/stores/edit-settings', () => ({
-  useEditSettingsStore: useEditSettingsStoreMock,
 }))
 
 vi.mock('~/stores/command-panel', () => ({
@@ -140,7 +134,6 @@ async function flushBindingUpdates() {
 describe('useTextEditorBindings', () => {
   afterEach(() => {
     getSceneSelectionMock.mockReset()
-    useEditSettingsStoreMock.mockReset()
     useCommandPanelStoreMock.mockReset()
   })
 
@@ -148,9 +141,6 @@ describe('useTextEditorBindings', () => {
     getSceneSelectionMock.mockReturnValue({
       lastLineNumber: 2,
       selectedStatementId: 2,
-    })
-    useEditSettingsStoreMock.mockReturnValue({
-      commandInsertPosition: 'cursor',
     })
     useCommandPanelStoreMock.mockReturnValue({
       getInsertText: vi.fn(),
@@ -175,9 +165,6 @@ describe('useTextEditorBindings', () => {
     getSceneSelectionMock.mockReturnValue({
       lastLineNumber: 2,
       selectedStatementId: 2,
-    })
-    useEditSettingsStoreMock.mockReturnValue({
-      commandInsertPosition: 'cursor',
     })
     useCommandPanelStoreMock.mockReturnValue({
       getInsertText: vi.fn(),
@@ -204,9 +191,6 @@ describe('useTextEditorBindings', () => {
     getSceneSelectionMock.mockReturnValue({
       lastLineNumber: 2,
       selectedStatementId: 2,
-    })
-    useEditSettingsStoreMock.mockReturnValue({
-      commandInsertPosition: 'cursor',
     })
     useCommandPanelStoreMock.mockReturnValue({
       getInsertText: vi.fn(),
@@ -238,9 +222,6 @@ describe('useTextEditorBindings', () => {
       lastLineNumber: 2,
       selectedStatementId: 2,
     })
-    useEditSettingsStoreMock.mockReturnValue({
-      commandInsertPosition: 'cursor',
-    })
     useCommandPanelStoreMock.mockReturnValue({
       getInsertText: vi.fn(),
     })
@@ -271,16 +252,13 @@ describe('useTextEditorBindings', () => {
     expect(binding?.getEmptyState?.()).not.toBe('multiple-edit-targets')
   })
 
-  it('命令面板插入单条命令后会把光标移动到插入文本末尾', async () => {
+  it('命令面板点击插入单条命令会跟随光标所在行并把光标移动到插入文本末尾', async () => {
     getSceneSelectionMock.mockReturnValue(undefined)
-    useEditSettingsStoreMock.mockReturnValue({
-      commandInsertPosition: 'cursor',
-    })
     useCommandPanelStoreMock.mockReturnValue({
       getInsertText: vi.fn(() => 'changeBg:room.png;'),
     })
 
-    const harness = await mountHarness('say:hello;\nold line')
+    const harness = await mountHarness('say:hello;\nold line\nfinal line')
     await flushBindingUpdates()
 
     harness.readCommandPanelHandler()?.insertCommand(commandType.say)
@@ -299,16 +277,13 @@ describe('useTextEditorBindings', () => {
     expect(harness.editor.revealPositionInCenterIfOutsideViewport).toHaveBeenCalledWith({ lineNumber: 3, column: 19 })
   })
 
-  it('插入命令组后会把光标移动到最后一行末尾', async () => {
+  it('命令面板点击插入命令组会跟随光标所在行并把光标移动到最后一行末尾', async () => {
     getSceneSelectionMock.mockReturnValue(undefined)
-    useEditSettingsStoreMock.mockReturnValue({
-      commandInsertPosition: 'cursor',
-    })
     useCommandPanelStoreMock.mockReturnValue({
       getInsertText: vi.fn(),
     })
 
-    const harness = await mountHarness('say:hello;\nold line')
+    const harness = await mountHarness('say:hello;\nold line\nfinal line')
     await flushBindingUpdates()
 
     harness.readCommandPanelHandler()?.insertGroup({
@@ -334,9 +309,6 @@ describe('useTextEditorBindings', () => {
 
   it('程序化语句更新会保留指定事务来源', async () => {
     getSceneSelectionMock.mockReturnValue(undefined)
-    useEditSettingsStoreMock.mockReturnValue({
-      commandInsertPosition: 'cursor',
-    })
     useCommandPanelStoreMock.mockReturnValue({
       getInsertText: vi.fn(),
     })

--- a/src/features/editor/text-editor/useTextEditorBindings.ts
+++ b/src/features/editor/text-editor/useTextEditorBindings.ts
@@ -3,7 +3,6 @@ import { createEmptySceneTextPanelSnapshot, resolveSceneTextPanelSnapshotFromCon
 import { hasMultipleEditTargets } from '~/features/editor/text-editor/text-editor-selection'
 import { useTextEditorHistory } from '~/features/editor/text-editor/useTextEditorHistory'
 import { useCommandPanelStore } from '~/stores/command-panel'
-import { useEditSettingsStore } from '~/stores/edit-settings'
 import { useEditorStore } from '~/stores/editor'
 
 import { createTextLineTarget } from '../statement-editor/useStatementEditor'
@@ -52,7 +51,6 @@ function resolveInsertedTextEndPosition(range: monaco.IRange, text: string): mon
 
 export function useTextEditorBindings(options: UseTextEditorBindingsOptions) {
   const editorStore = useEditorStore()
-  const editSettings = useEditSettingsStore()
   const commandPanelStore = useCommandPanelStore()
   const state = computed(() => options.getState())
 
@@ -134,9 +132,7 @@ export function useTextEditorBindings(options: UseTextEditorBindingsOptions) {
 
     const position = editor.getPosition() ?? { lineNumber: model.getLineCount(), column: 1 }
     const lineCount = model.getLineCount()
-    const targetLine = editSettings.commandInsertPosition === 'end'
-      ? lineCount
-      : Math.min(position.lineNumber, lineCount)
+    const targetLine = Math.min(position.lineNumber, lineCount)
     const lineLength = model.getLineMaxColumn(targetLine)
 
     const currentLineContent = model.getLineContent(targetLine)

--- a/src/features/editor/visual-editor/__tests__/useVisualEditorSceneRuntime.test.ts
+++ b/src/features/editor/visual-editor/__tests__/useVisualEditorSceneRuntime.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { computed, effectScope, nextTick, reactive } from 'vue'
+import { commandType } from 'webgal-parser/src/interface/sceneInterface'
 
 import { computeLineNumberFromStatementId } from '~/domain/document/scene-selection'
 import { buildStatements } from '~/domain/script/sentence'
@@ -13,7 +14,6 @@ const {
   scrollToSelectedStatementMock,
   useCommandPanelBridgeBindingMock,
   useCommandPanelStoreMock,
-  useEditSettingsStoreMock,
   useEditorStoreMock,
   useEditorViewStateStoreMock,
   usePreferenceStoreMock,
@@ -27,7 +27,6 @@ const {
   scrollToSelectedStatementMock: vi.fn(async () => undefined),
   useCommandPanelBridgeBindingMock: vi.fn(),
   useCommandPanelStoreMock: vi.fn(),
-  useEditSettingsStoreMock: vi.fn(),
   useEditorStoreMock: vi.fn(),
   useEditorViewStateStoreMock: vi.fn(),
   usePreferenceStoreMock: vi.fn(),
@@ -74,10 +73,6 @@ vi.mock('~/features/editor/visual-editor/visual-editor-focus', () => ({
 
 vi.mock('~/stores/command-panel', () => ({
   useCommandPanelStore: useCommandPanelStoreMock,
-}))
-
-vi.mock('~/stores/edit-settings', () => ({
-  useEditSettingsStore: useEditSettingsStoreMock,
 }))
 
 vi.mock('~/stores/editor', () => ({
@@ -133,7 +128,6 @@ describe('useVisualEditorSceneRuntime', () => {
     scrollToSelectedStatementMock.mockReset()
     useCommandPanelBridgeBindingMock.mockReset()
     useCommandPanelStoreMock.mockReset()
-    useEditSettingsStoreMock.mockReset()
     useEditorStoreMock.mockReset()
     useEditorViewStateStoreMock.mockReset()
     usePreferenceStoreMock.mockReset()
@@ -152,9 +146,6 @@ describe('useVisualEditorSceneRuntime', () => {
     useCommandPanelStoreMock.mockReturnValue({
       getInsertText: vi.fn(() => 'say:test'),
     })
-    useEditSettingsStoreMock.mockReturnValue(reactive({
-      commandInsertPosition: 'after',
-    }))
     useEditorStoreMock.mockReturnValue(reactive({
       applySceneStatementDelete: vi.fn(),
       applySceneStatementInsert: vi.fn(),
@@ -245,6 +236,70 @@ describe('useVisualEditorSceneRuntime', () => {
         visualType: 'scene',
       },
     }))
+
+    scope.stop()
+  })
+
+  it('命令面板点击插入会跟随当前选中语句', () => {
+    const scope = effectScope()
+    const state = createState([
+      {
+        id: 1,
+        parseError: false,
+        parsed: undefined,
+        rawText: 'say:first',
+      },
+      {
+        id: 2,
+        parseError: false,
+        parsed: undefined,
+        rawText: 'say:second',
+      },
+      {
+        id: 3,
+        parseError: false,
+        parsed: undefined,
+        rawText: 'say:third',
+      },
+    ])
+    const applySceneStatementInsert = vi.fn()
+    const scheduleAutoSaveIfEnabled = vi.fn()
+
+    useEditorStoreMock.mockReturnValue(reactive({
+      applySceneStatementDelete: vi.fn(),
+      applySceneStatementInsert,
+      applySceneStatementReorder: vi.fn(),
+      applySceneStatementUpdate: vi.fn(),
+      consumePendingSceneProjectionActivation: vi.fn(() => false),
+      currentState: {
+        kind: 'scene',
+        path: '/project/scene.txt',
+        projection: 'visual',
+      },
+      getSceneSelection: vi.fn(() => ({
+        lastEditedStatementId: 2,
+        lastLineNumber: 2,
+        selectedStatementId: 2,
+      })),
+      isSceneStatementCollapsed: vi.fn(() => false),
+      scheduleAutoSaveIfEnabled,
+      setSceneStatementCollapsed: vi.fn(),
+      syncScenePreview: vi.fn(),
+      syncSceneSelectionFromStatement: vi.fn(),
+    }))
+
+    scope.run(() => useVisualEditorSceneRuntime({
+      getScrollArea: () => undefined,
+      getState: () => state,
+    }))
+
+    const commandBinding = useCommandPanelBridgeBindingMock.mock.calls.at(-1)?.[0]
+    commandBinding?.insertCommand(commandType.say)
+
+    expect(applySceneStatementInsert).toHaveBeenCalledWith('/project/scene.txt', [
+      expect.objectContaining({ rawText: 'say:test' }),
+    ], 2)
+    expect(scheduleAutoSaveIfEnabled).toHaveBeenCalledWith('/project/scene.txt')
 
     scope.stop()
   })

--- a/src/features/editor/visual-editor/useVisualEditorSceneRuntime.ts
+++ b/src/features/editor/visual-editor/useVisualEditorSceneRuntime.ts
@@ -8,7 +8,6 @@ import { resolveVisualEditorCommandDropAction } from '~/features/editor/visual-e
 import { resolveVisualEditorDropAction } from '~/features/editor/visual-editor/visual-editor-file-drop'
 import { canRestoreVisualEditorCardFocus, findSelectedVisualEditorStatementCard } from '~/features/editor/visual-editor/visual-editor-focus'
 import { useCommandPanelStore } from '~/stores/command-panel'
-import { useEditSettingsStore } from '~/stores/edit-settings'
 import { isEditableEditor, SceneVisualProjectionState, useEditorStore } from '~/stores/editor'
 import { useEditorViewStateStore } from '~/stores/editor-view-state'
 import { usePreferenceStore } from '~/stores/preference'
@@ -38,7 +37,6 @@ export function useVisualEditorSceneRuntime(options: UseVisualEditorSceneRuntime
   const editorStore = useEditorStore()
   const editorViewStateStore = useEditorViewStateStore()
   const tabsStore = useTabsStore()
-  const editSettings = useEditSettingsStore()
   const preferenceStore = usePreferenceStore()
   const commandPanelStore = useCommandPanelStore()
   const workspaceStore = useWorkspaceStore()
@@ -452,9 +450,7 @@ export function useVisualEditorSceneRuntime(options: UseVisualEditorSceneRuntime
     }
 
     const newEntries = rawTexts.flatMap(text => buildStatements(text))
-    const insertAt = editSettings.commandInsertPosition === 'end'
-      ? state.value.statements.length
-      : resolveInsertIndexAfterSelection()
+    const insertAt = resolveInsertIndexAfterSelection()
     editorStore.applySceneStatementInsert(state.value.path, newEntries, insertAt)
 
     const lastInserted = newEntries.at(-1)

--- a/src/features/settings/__tests__/schema.test.ts
+++ b/src/features/settings/__tests__/schema.test.ts
@@ -14,13 +14,13 @@ describe('defineSettingsSchema', () => {
             immediate: true,
             label: '自动保存',
           },
-          effectEditorSide: {
+          selectField: {
             type: 'select',
-            default: 'right',
-            label: '效果编辑器方向',
+            default: 'primary',
+            label: '选择字段',
             options: [
-              { value: 'left', label: '左侧' },
-              { value: 'right', label: '右侧' },
+              { value: 'primary', label: '选项 A' },
+              { value: 'secondary', label: '选项 B' },
             ],
           },
           fontSize: {
@@ -41,13 +41,13 @@ describe('defineSettingsSchema', () => {
 
     expect(result.defaults).toEqual({
       autoSave: true,
-      effectEditorSide: 'right',
+      selectField: 'primary',
       fontSize: 14,
       projectPath: '',
     })
     expect(result.fieldNames).toEqual([
       'autoSave',
-      'effectEditorSide',
+      'selectField',
       'fontSize',
       'projectPath',
     ])
@@ -55,26 +55,26 @@ describe('defineSettingsSchema', () => {
 
     expect(result.validationSchema.parse({
       autoSave: false,
-      effectEditorSide: 'left',
+      selectField: 'secondary',
       fontSize: 24,
       projectPath: '/demo',
     })).toEqual({
       autoSave: false,
-      effectEditorSide: 'left',
+      selectField: 'secondary',
       fontSize: 24,
       projectPath: '/demo',
     })
 
     expect(() => result.validationSchema.parse({
       autoSave: true,
-      effectEditorSide: 'center',
+      selectField: 'unknown',
       fontSize: 14,
       projectPath: '',
     })).toThrow()
 
     expect(() => result.validationSchema.parse({
       autoSave: true,
-      effectEditorSide: 'right',
+      selectField: 'primary',
       fontSize: 4,
       projectPath: '',
     })).toThrow()

--- a/src/features/settings/edit-settings.ts
+++ b/src/features/settings/edit-settings.ts
@@ -22,26 +22,6 @@ export const editSettingsDefinition = defineSettingsSchema({
         label: t => t('settings.edit.autoApplyEffectEditorChanges.label'),
         description: t => t('settings.edit.autoApplyEffectEditorChanges.description'),
       },
-      commandInsertPosition: {
-        type: 'select',
-        default: 'afterCursor',
-        label: t => t('settings.edit.commandInsertPosition.label'),
-        description: t => t('settings.edit.commandInsertPosition.description'),
-        options: [
-          { value: 'afterCursor', label: t => t('settings.edit.commandInsertPosition.afterCursor') },
-          { value: 'end', label: t => t('settings.edit.commandInsertPosition.end') },
-        ],
-      },
-      effectEditorSide: {
-        type: 'select',
-        default: 'right',
-        label: t => t('settings.edit.effectEditorSide.label'),
-        description: t => t('settings.edit.effectEditorSide.description'),
-        options: [
-          { value: 'left', label: t => t('settings.edit.effectEditorSide.left') },
-          { value: 'right', label: t => t('settings.edit.effectEditorSide.right') },
-        ],
-      },
     },
   },
   preview: {

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -1097,11 +1097,6 @@ settings:
     collapseStatementsOnSidebarOpen:
       label: Collapse All Statements When Auxiliary Panel Opens
       description: Lock all statement cards in collapsed state when the auxiliary panel is opened
-    effectEditorSide:
-      description: Choose which side the effect editor drawer slides in from
-      label: Effect Editor Slide Direction
-      left: Left
-      right: Right
     showSidebarAssetPreview:
       label: Auxiliary Panel Statement Asset Preview
       description: Preview images and other assets referenced by statements in the editor auxiliary panel
@@ -1111,11 +1106,6 @@ settings:
     comboboxPathDelimiter:
       label: Cascading Selection Delimiter
       description: Specify the delimiter used to separate option hierarchy levels, for example /
-    commandInsertPosition:
-      label: Command Insert Position
-      description: Where to insert statements from the command panel
-      afterCursor: After Cursor
-      end: End
   storage:
     gamePath:
       label: Game Save Location

--- a/src/locales/ja.yml
+++ b/src/locales/ja.yml
@@ -1097,11 +1097,6 @@ settings:
     collapseStatementsOnSidebarOpen:
       label: 補助パネル展開時にすべてのステートメントを折りたたむ
       description: 補助パネルを開いた際、すべてのステートメントカードを折りたたみ状態にロックします
-    effectEditorSide:
-      description: エフェクトエディターのドロワーがスライドする方向を選択します
-      label: エフェクトエディターのスライド方向
-      left: 左
-      right: 右
     showSidebarAssetPreview:
       label: 補助パネルのステートメント資源プレビュー
       description: エディターの補助パネルでステートメントが参照する画像などのアセットをプレビュー
@@ -1111,11 +1106,6 @@ settings:
     comboboxPathDelimiter:
       label: カスケード選択の区切り文字
       description: 候補の階層を区切るための区切り文字を指定します。例：/
-    commandInsertPosition:
-      label: コマンド挿入位置
-      description: コマンドパネルからステートメントを挿入する位置
-      afterCursor: カーソルの後
-      end: 末尾
   storage:
     gamePath:
       label: ゲーム保存場所

--- a/src/locales/zh-Hans.yml
+++ b/src/locales/zh-Hans.yml
@@ -1097,11 +1097,6 @@ settings:
     collapseStatementsOnSidebarOpen:
       label: 展开辅助面板时强制折叠全部语句
       description: 打开辅助面板时，锁定所有语句卡片为折叠状态
-    effectEditorSide:
-      description: 选择效果编辑器抽屉从哪一侧滑出
-      label: 效果编辑器滑出方向
-      left: 左侧
-      right: 右侧
     showSidebarAssetPreview:
       label: 辅助面板语句资源预览
       description: 在编辑器辅助面板中预览语句引用的图片等资源
@@ -1111,11 +1106,6 @@ settings:
     comboboxPathDelimiter:
       label: 级联选择分隔符
       description: 指定用于划分选项层级的分隔符，例如 /
-    commandInsertPosition:
-      label: 命令插入位置
-      description: 从命令面板插入语句时的插入位置
-      afterCursor: 光标之后
-      end: 末尾
   storage:
     gamePath:
       label: 游戏保存位置

--- a/src/locales/zh-Hant.yml
+++ b/src/locales/zh-Hant.yml
@@ -1097,11 +1097,6 @@ settings:
     collapseStatementsOnSidebarOpen:
       label: 展開輔助面板時強制摺疊全部語句
       description: 開啟輔助面板時，鎖定所有語句卡片為摺疊狀態
-    effectEditorSide:
-      description: 選擇效果編輯器抽屜從哪一側滑出
-      label: 效果編輯器滑出方向
-      left: 左側
-      right: 右側
     showSidebarAssetPreview:
       label: 輔助面板語句資源預覽
       description: 在編輯器輔助面板中預覽語句引用的圖片等資源
@@ -1111,11 +1106,6 @@ settings:
     comboboxPathDelimiter:
       label: 級聯選擇分隔符
       description: 指定用於劃分選項層級的分隔符，例如 /
-    commandInsertPosition:
-      label: 命令插入位置
-      description: 從命令面板插入語句時的插入位置
-      afterCursor: 游標之後
-      end: 末尾
   storage:
     gamePath:
       label: 遊戲儲存位置

--- a/src/stores/__tests__/edit-settings.test.ts
+++ b/src/stores/__tests__/edit-settings.test.ts
@@ -12,8 +12,6 @@ describe('useEditSettingsStore', () => {
     expect(store.fontSize).toBe(14)
     expect(store.wordWrap).toBe(true)
     expect(store.minimap).toBe(false)
-    expect(store.effectEditorSide).toBe('right')
-    expect(store.commandInsertPosition).toBe('afterCursor')
     expect(store.enableComboboxPathDelimiter).toBe(true)
     expect(store.comboboxPathDelimiter).toBe('/')
     expect(store.enableLivePreview).toBe(true)
@@ -27,8 +25,6 @@ describe('useEditSettingsStore', () => {
     store.enableLivePreview = false
     store.enableRealtimeEffectPreview = false
     store.autoApplyEffectEditorChanges = true
-    store.effectEditorSide = 'left'
-    store.commandInsertPosition = 'end'
     store.enableComboboxPathDelimiter = false
     store.comboboxPathDelimiter = '>'
 
@@ -36,8 +32,6 @@ describe('useEditSettingsStore', () => {
     expect(store.enableLivePreview).toBe(false)
     expect(store.enableRealtimeEffectPreview).toBe(false)
     expect(store.autoApplyEffectEditorChanges).toBe(true)
-    expect(store.effectEditorSide).toBe('left')
-    expect(store.commandInsertPosition).toBe('end')
     expect(store.enableComboboxPathDelimiter).toBe(false)
     expect(store.comboboxPathDelimiter).toBe('>')
   })


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [ ] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [x] 代码重构
- [x] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

移除编辑设置中低价值的全局配置项：

- 移除“命令插入位置”设置。
- 移除“效果编辑器滑出方向”设置。
- 效果编辑器抽屉固定从右侧滑出。
- 命令面板点击插入固定跟随当前编辑上下文：
  - 文本模式：插入到当前光标所在行之后。
  - 可视模式：插入到当前选中语句之后。
  - 需要开头、末尾或中间任意精确位置时，继续使用已有拖拽系统。

同时清理了相关 i18n 文案、store 测试、旧设置 mock，以及过渡性的测试断言。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

这两个设置项带来的配置负担大于实际价值：

- “效果编辑器滑出方向”只是展示偏好，不应占用全局编辑设置。
- “命令插入位置”更像一次操作意图，不适合做成长期全局偏好。
- 当前已经有拖拽系统负责精确插入位置，因此点击行为应保持简单、稳定并跟随当前上下文。

该调整让编辑设置更聚焦，也降低了命令面板点击插入的隐式状态成本。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
