### PR TITLE
🐛 修复效果编辑器连续控件拖拽卡顿

### DIFF
--- a/src/features/editor/effect-editor/__tests__/useEffectContinuousControls.test.ts
+++ b/src/features/editor/effect-editor/__tests__/useEffectContinuousControls.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { reactive } from 'vue'
 
 import { useEffectContinuousControls } from '~/features/editor/effect-editor/useEffectContinuousControls'
@@ -6,8 +6,17 @@ import { useEffectContinuousControls } from '~/features/editor/effect-editor/use
 import type { DialField, NumberField } from '~/features/editor/command-registry/schema'
 import type { EffectControlDeps } from '~/features/editor/effect-editor/types'
 
-const { setupPreferenceStoreMock, usePreferenceStoreMock } = vi.hoisted(() => {
+type ParamDragState = object & { param: unknown }
+
+interface ParamDragRuntime {
+  end: (event?: PointerEvent) => void
+  move: (event: PointerEvent) => void
+  state: ParamDragState | undefined
+}
+
+const { paramDragRuntimes, setupPreferenceStoreMock, usePreferenceStoreMock } = vi.hoisted(() => {
   const usePreferenceStoreMock = vi.fn()
+  const paramDragRuntimes: ParamDragRuntime[] = []
 
   function setupPreferenceStoreMock() {
     return {
@@ -16,6 +25,7 @@ const { setupPreferenceStoreMock, usePreferenceStoreMock } = vi.hoisted(() => {
   }
 
   return {
+    paramDragRuntimes,
     setupPreferenceStoreMock,
     usePreferenceStoreMock,
   }
@@ -24,8 +34,64 @@ const { setupPreferenceStoreMock, usePreferenceStoreMock } = vi.hoisted(() => {
 const preferenceStoreState = reactive({
   effectEditorLinkedSliderLocks: {} as Record<string, boolean>,
 })
+const animationFrameCallbacks = new Map<number, FrameRequestCallback>()
+let nextAnimationFrameId = 0
 
 vi.mock('~/stores/preference', setupPreferenceStoreMock)
+
+vi.mock('~/features/editor/effect-editor/createParamDrag', () => ({
+  createParamDrag<P, S extends object>(callbacks: {
+    onEnd: (event: PointerEvent | undefined, state: S & { param: P }) => void
+    onMove: (event: PointerEvent, state: S & { param: P }) => void
+    onStart: (event: PointerEvent, param: P) => S | undefined
+  }) {
+    const runtime: ParamDragRuntime = {
+      state: undefined,
+      move(event) {
+        if (!runtime.state) {
+          return
+        }
+        callbacks.onMove(event, runtime.state as S & { param: P })
+      },
+      end(event) {
+        if (!runtime.state) {
+          return
+        }
+        const currentState = runtime.state as S & { param: P }
+        runtime.state = undefined
+        callbacks.onEnd(event, currentState)
+      },
+    }
+
+    paramDragRuntimes.push(runtime)
+
+    return {
+      drag: {
+        get active() {
+          return runtime.state !== undefined
+        },
+        get state() {
+          return runtime.state as (S & { param: P }) | undefined
+        },
+        start() {
+          return false
+        },
+        stop(event?: PointerEvent) {
+          runtime.end(event)
+        },
+      },
+      start(event: PointerEvent, param: P) {
+        const state = callbacks.onStart(event, param)
+        if (!state) {
+          runtime.state = undefined
+          return false
+        }
+        runtime.state = { ...state, param } as S & { param: P }
+        return true
+      },
+    }
+  },
+}))
 
 function createDeps(initialFields: Record<string, string> = {}) {
   const fields = reactive({ ...initialFields }) as Record<string, string>
@@ -78,11 +144,53 @@ function createDialField(overrides: Partial<DialField> = {}): DialField {
   }
 }
 
+function createPointerEvent(overrides: Partial<PointerEvent> = {}): PointerEvent {
+  return {
+    button: 0,
+    buttons: 1,
+    clientX: 100,
+    pointerId: 1,
+    pointerType: 'mouse',
+    preventDefault: vi.fn(),
+    ...overrides,
+  } as PointerEvent
+}
+
+function getParamDragRuntime(index: number): ParamDragRuntime {
+  const runtime = paramDragRuntimes[index]
+  expect(runtime).toBeDefined()
+  return runtime!
+}
+
+function flushNextAnimationFrame() {
+  const nextFrame = animationFrameCallbacks.entries().next().value
+  expect(nextFrame).toBeDefined()
+  const [frameId, callback] = nextFrame!
+  animationFrameCallbacks.delete(frameId)
+  callback(performance.now())
+}
+
 describe('useEffectContinuousControls', () => {
   beforeEach(() => {
     usePreferenceStoreMock.mockReset()
     preferenceStoreState.effectEditorLinkedSliderLocks = {}
     usePreferenceStoreMock.mockReturnValue(preferenceStoreState)
+    paramDragRuntimes.length = 0
+    animationFrameCallbacks.clear()
+    nextAnimationFrameId = 0
+
+    vi.stubGlobal('cancelAnimationFrame', vi.fn((frameId: number) => {
+      animationFrameCallbacks.delete(frameId)
+    }))
+    vi.stubGlobal('requestAnimationFrame', vi.fn((callback: FrameRequestCallback) => {
+      nextAnimationFrameId += 1
+      animationFrameCallbacks.set(nextAnimationFrameId, callback)
+      return nextAnimationFrameId
+    }))
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
   })
 
   it('updateNumberField 支持裁剪并按 continuous 模式 flush', () => {
@@ -100,6 +208,97 @@ describe('useEffectContinuousControls', () => {
       flush: true,
       deferAutoApply: false,
     })
+  })
+
+  it('position scrub 在同一帧内合并连续 transform 发射', () => {
+    const { deps, emitTransform, fields } = createDeps()
+    const controls = useEffectContinuousControls(deps)
+    const field = createNumberField({
+      defaultValue: 0,
+      effectGroup: 'position',
+      key: 'position.x',
+      scrubStep: 1,
+    })
+
+    controls.handleNumberLabelPointerDown(createPointerEvent(), field)
+    const numberScrub = getParamDragRuntime(0)
+
+    numberScrub.move(createPointerEvent({ clientX: 101 }))
+    numberScrub.move(createPointerEvent({ clientX: 105 }))
+
+    expect(fields['position.x']).toBe('5')
+    expect(emitTransform).not.toHaveBeenCalled()
+
+    flushNextAnimationFrame()
+
+    expect(emitTransform).toHaveBeenCalledTimes(1)
+    expect(emitTransform).toHaveBeenLastCalledWith(fields, {
+      schedule: 'continuous',
+      flush: false,
+      deferAutoApply: true,
+    })
+
+    numberScrub.end(createPointerEvent({ clientX: 105 }))
+
+    expect(emitTransform).toHaveBeenCalledTimes(2)
+    expect(emitTransform).toHaveBeenLastCalledWith(fields, {
+      schedule: 'continuous',
+      flush: true,
+      deferAutoApply: false,
+    })
+  })
+
+  it('滑条拖拽在同一帧内只发射最后一次 transform', () => {
+    const { deps, emitTransform, fields } = createDeps()
+    const controls = useEffectContinuousControls(deps)
+    const field = createNumberField({
+      key: 'alpha',
+      defaultValue: 1,
+      min: 0,
+      max: 1,
+      step: 0.01,
+    })
+
+    controls.updateSliderField(field, 0.8, { fromSlider: true })
+    controls.updateSliderField(field, 0.6, { fromSlider: true })
+
+    expect(fields.alpha).toBe('0.6')
+    expect(emitTransform).not.toHaveBeenCalled()
+
+    flushNextAnimationFrame()
+
+    expect(emitTransform).toHaveBeenCalledTimes(1)
+    expect(emitTransform).toHaveBeenLastCalledWith(fields, {
+      schedule: 'continuous',
+      flush: undefined,
+      deferAutoApply: true,
+    })
+  })
+
+  it('滑条提交会取消尚未发射的拖拽 transform', () => {
+    const { deps, emitTransform, fields } = createDeps()
+    const controls = useEffectContinuousControls(deps)
+    const field = createNumberField({
+      key: 'alpha',
+      defaultValue: 1,
+      min: 0,
+      max: 1,
+      step: 0.01,
+    })
+
+    controls.updateSliderField(field, 0.8, { fromSlider: true })
+    controls.updateSliderField(field, 0.6, { fromSlider: true, flush: true })
+
+    expect(fields.alpha).toBe('0.6')
+    expect(emitTransform).toHaveBeenCalledTimes(1)
+    expect(emitTransform).toHaveBeenLastCalledWith(fields, {
+      schedule: 'continuous',
+      flush: true,
+      deferAutoApply: false,
+    })
+
+    expect(animationFrameCallbacks.size).toBe(0)
+    expect(emitTransform).toHaveBeenCalledTimes(1)
   })
 
   it('slider 与 linked-slider 会应用中心吸附与锁定比例', () => {
@@ -204,7 +403,7 @@ describe('useEffectContinuousControls', () => {
     const dialField = createDialField()
 
     expect(controls.getDialDegree(dialField)).toBeCloseTo(180)
-    controls.updateDialField(dialField, 90, { flush: true })
+    controls.updateDialField(dialField, 90)
     expect(Number(fields.rotate)).toBeCloseTo(1.5708)
     expect(controls.getDialInputValue(dialField)).toBe('90')
   })

--- a/src/features/editor/effect-editor/__tests__/useEffectContinuousControls.test.ts
+++ b/src/features/editor/effect-editor/__tests__/useEffectContinuousControls.test.ts
@@ -113,6 +113,26 @@ function createDeps(initialFields: Record<string, string> = {}) {
   return { deps, emitTransform, fields }
 }
 
+function createSnapshotDeps(initialFields: Record<string, string> = {}) {
+  const sourceFields = reactive({ ...initialFields }) as Record<string, string>
+  const emitTransform = vi.fn()
+
+  const deps: EffectControlDeps = {
+    getFields: () => ({ ...sourceFields }),
+    getFieldValue: path => sourceFields[path] ?? '',
+    getNumberValue: (path, fallback) => {
+      const value = Number(sourceFields[path])
+      return Number.isFinite(value) ? value : fallback
+    },
+    setNumericField: (targetFields, path, value) => {
+      targetFields[path] = String(value)
+    },
+    emitTransform,
+  }
+
+  return { deps, emitTransform, sourceFields }
+}
+
 function createNumberField(overrides: Partial<NumberField> = {}): NumberField {
   return {
     key: 'x',
@@ -168,6 +188,12 @@ function flushNextAnimationFrame() {
   const [frameId, callback] = nextFrame!
   animationFrameCallbacks.delete(frameId)
   callback(performance.now())
+}
+
+function flushAllAnimationFrames() {
+  while (animationFrameCallbacks.size > 0) {
+    flushNextAnimationFrame()
+  }
 }
 
 describe('useEffectContinuousControls', () => {
@@ -355,6 +381,24 @@ describe('useEffectContinuousControls', () => {
     }), 1, { fromSlider: true, flush: true })
 
     expect(fields.alpha).toBeUndefined()
+    expect(emitTransform).not.toHaveBeenCalled()
+  })
+
+  it('滑条回到缺失字段默认值时不会发射同帧内排队的旧值', () => {
+    const { deps, emitTransform, sourceFields } = createSnapshotDeps()
+    const controls = useEffectContinuousControls(deps)
+    const field = createNumberField({
+      key: 'alpha',
+      defaultValue: 1,
+      min: 0,
+      max: 1,
+    })
+
+    controls.updateSliderField(field, 0.8, { fromSlider: true })
+    controls.updateSliderField(field, 1, { fromSlider: true })
+    flushAllAnimationFrames()
+
+    expect(sourceFields.alpha).toBeUndefined()
     expect(emitTransform).not.toHaveBeenCalled()
   })
 

--- a/src/features/editor/effect-editor/__tests__/useEffectContinuousControls.test.ts
+++ b/src/features/editor/effect-editor/__tests__/useEffectContinuousControls.test.ts
@@ -419,6 +419,24 @@ describe('useEffectContinuousControls', () => {
     expect(emitTransform).not.toHaveBeenCalled()
   })
 
+  it('linked-slider 回到缺失字段默认值时不会发射同帧内排队的旧值', () => {
+    const { deps, emitTransform, sourceFields } = createSnapshotDeps()
+    const controls = useEffectContinuousControls(deps)
+    const linkedField = createLinkedNumberField({
+      defaultValue: 1,
+      min: 0,
+      max: 2,
+    })
+
+    controls.updateLinkedSliderField(linkedField, 0, 0.8, { fromSlider: true })
+    controls.updateLinkedSliderField(linkedField, 0, 1, { fromSlider: true })
+    flushAllAnimationFrames()
+
+    expect(sourceFields.scaleX).toBeUndefined()
+    expect(sourceFields.scaleY).toBeUndefined()
+    expect(emitTransform).not.toHaveBeenCalled()
+  })
+
   it('锁定快照主轴为 0 时，linked-slider 会回退为双轴同步', () => {
     const { deps, fields } = createDeps({
       scaleX: '0',

--- a/src/features/editor/effect-editor/__tests__/useEffectContinuousControls.test.ts
+++ b/src/features/editor/effect-editor/__tests__/useEffectContinuousControls.test.ts
@@ -402,6 +402,70 @@ describe('useEffectContinuousControls', () => {
     expect(emitTransform).not.toHaveBeenCalled()
   })
 
+  it('滑条回到默认值时不会取消只触碰其他字段的待发射变更', () => {
+    const { deps, emitTransform, sourceFields } = createSnapshotDeps({
+      alpha: '1',
+    })
+    const controls = useEffectContinuousControls(deps)
+    const alphaField = createNumberField({
+      key: 'alpha',
+      defaultValue: 1,
+      min: 0,
+      max: 1,
+    })
+    const blurField = createNumberField({
+      key: 'blur',
+      defaultValue: 0,
+      min: 0,
+      max: 50,
+    })
+
+    controls.updateSliderField(blurField, 8, { fromSlider: true })
+    delete sourceFields.alpha
+    controls.updateSliderField(alphaField, 1, { fromSlider: true })
+    flushAllAnimationFrames()
+
+    expect(emitTransform).toHaveBeenCalledTimes(1)
+    expect(emitTransform).toHaveBeenLastCalledWith(expect.objectContaining({
+      blur: '8',
+    }), {
+      schedule: 'continuous',
+      flush: undefined,
+      deferAutoApply: true,
+    })
+  })
+
+  it('滑条清理后一帧内部分待发射字段时会保留其他已触碰字段', () => {
+    const { deps, emitTransform } = createSnapshotDeps()
+    const controls = useEffectContinuousControls(deps)
+    const alphaField = createNumberField({
+      key: 'alpha',
+      defaultValue: 1,
+      min: 0,
+      max: 1,
+    })
+    const blurField = createNumberField({
+      key: 'blur',
+      defaultValue: 0,
+      min: 0,
+      max: 50,
+    })
+
+    controls.updateSliderField(alphaField, 0.8, { fromSlider: true })
+    controls.updateSliderField(blurField, 8, { fromSlider: true })
+    controls.updateSliderField(blurField, 0, { fromSlider: true })
+    flushAllAnimationFrames()
+
+    expect(emitTransform).toHaveBeenCalledTimes(1)
+    expect(emitTransform).toHaveBeenLastCalledWith(expect.objectContaining({
+      alpha: '0.8',
+    }), {
+      schedule: 'continuous',
+      flush: undefined,
+      deferAutoApply: true,
+    })
+  })
+
   it('linked-slider 仅提交默认展示值时不会写入缺失字段', () => {
     const { deps, emitTransform, fields } = createDeps()
     const controls = useEffectContinuousControls(deps)
@@ -435,6 +499,40 @@ describe('useEffectContinuousControls', () => {
     expect(sourceFields.scaleX).toBeUndefined()
     expect(sourceFields.scaleY).toBeUndefined()
     expect(emitTransform).not.toHaveBeenCalled()
+  })
+
+  it('linked-slider 回到默认值时不会取消只触碰其他字段的待发射变更', () => {
+    const { deps, emitTransform, sourceFields } = createSnapshotDeps({
+      scaleX: '1',
+      scaleY: '1',
+    })
+    const controls = useEffectContinuousControls(deps)
+    const linkedField = createLinkedNumberField({
+      defaultValue: 1,
+      min: 0,
+      max: 2,
+    })
+    const blurField = createNumberField({
+      key: 'blur',
+      defaultValue: 0,
+      min: 0,
+      max: 50,
+    })
+
+    controls.updateSliderField(blurField, 8, { fromSlider: true })
+    delete sourceFields.scaleX
+    delete sourceFields.scaleY
+    controls.updateLinkedSliderField(linkedField, 0, 1, { fromSlider: true })
+    flushAllAnimationFrames()
+
+    expect(emitTransform).toHaveBeenCalledTimes(1)
+    expect(emitTransform).toHaveBeenLastCalledWith(expect.objectContaining({
+      blur: '8',
+    }), {
+      schedule: 'continuous',
+      flush: undefined,
+      deferAutoApply: true,
+    })
   })
 
   it('锁定快照主轴为 0 时，linked-slider 会回退为双轴同步', () => {

--- a/src/features/editor/effect-editor/useEffectContinuousControls.ts
+++ b/src/features/editor/effect-editor/useEffectContinuousControls.ts
@@ -53,9 +53,15 @@ export function useEffectContinuousControls(deps: EffectControlDeps) {
   interface PendingContinuousTransformEmit {
     fields: Record<string, string>
     options: EmitTransformOptions
+    touchedPaths: Set<string>
   }
 
   type ContinuousTransformEmitTiming = 'immediate' | 'nextFrame'
+
+  interface ContinuousTransformEmitConfig {
+    timing?: ContinuousTransformEmitTiming
+    touchedPaths?: readonly string[]
+  }
 
   let pendingContinuousTransformEmit: PendingContinuousTransformEmit | undefined
   let pendingContinuousTransformFrameId: number | undefined
@@ -71,8 +77,10 @@ export function useEffectContinuousControls(deps: EffectControlDeps) {
   function emitContinuousTransform(
     fields: Record<string, string>,
     options: EmitTransformOptions,
-    timing: ContinuousTransformEmitTiming = 'immediate',
+    config: ContinuousTransformEmitConfig = {},
   ) {
+    const { timing = 'immediate', touchedPaths = [] } = config
+
     if (options.flush) {
       cancelScheduledContinuousTransformEmit()
       deps.emitTransform(fields, options)
@@ -84,7 +92,25 @@ export function useEffectContinuousControls(deps: EffectControlDeps) {
       return
     }
 
-    pendingContinuousTransformEmit = { fields, options }
+    const nextTouchedPaths = new Set(touchedPaths)
+    if (pendingContinuousTransformEmit) {
+      for (const path of pendingContinuousTransformEmit.touchedPaths) {
+        if (!nextTouchedPaths.has(path)) {
+          if (path in pendingContinuousTransformEmit.fields) {
+            fields[path] = pendingContinuousTransformEmit.fields[path]
+          } else {
+            delete fields[path]
+          }
+        }
+        nextTouchedPaths.add(path)
+      }
+    }
+
+    pendingContinuousTransformEmit = {
+      fields,
+      options,
+      touchedPaths: nextTouchedPaths,
+    }
     if (pendingContinuousTransformFrameId !== undefined) {
       return
     }
@@ -101,21 +127,29 @@ export function useEffectContinuousControls(deps: EffectControlDeps) {
   }
 
   function clearPendingContinuousTransformField(path: string): boolean {
-    if (!pendingContinuousTransformEmit || !(path in pendingContinuousTransformEmit.fields)) {
-      return false
-    }
-    cancelScheduledContinuousTransformEmit()
-    return true
+    return clearPendingContinuousTransformFields([path])
   }
 
   function clearPendingContinuousTransformFields(paths: readonly string[]): boolean {
-    if (!pendingContinuousTransformEmit) {
+    const pending = pendingContinuousTransformEmit
+    if (!pending) {
       return false
     }
-    if (!paths.some(path => path in pendingContinuousTransformEmit!.fields)) {
+
+    let hasTouchedPath = false
+    for (const path of paths) {
+      delete pending.fields[path]
+      if (pending.touchedPaths.delete(path)) {
+        hasTouchedPath = true
+      }
+    }
+
+    if (!hasTouchedPath) {
       return false
     }
-    cancelScheduledContinuousTransformEmit()
+    if (pending.touchedPaths.size === 0) {
+      cancelScheduledContinuousTransformEmit()
+    }
     return true
   }
 
@@ -127,7 +161,9 @@ export function useEffectContinuousControls(deps: EffectControlDeps) {
     const fields = deps.getFields()
     if (!rawValue && rawValue !== 0) {
       delete fields[path]
-      emitContinuousTransform(fields, createContinuousTransformOptions(options?.flush))
+      emitContinuousTransform(fields, createContinuousTransformOptions(options?.flush), {
+        touchedPaths: [path],
+      })
       return undefined
     }
     const num = Number(rawValue)
@@ -156,7 +192,7 @@ export function useEffectContinuousControls(deps: EffectControlDeps) {
     emitContinuousTransform(
       result.fields,
       createContinuousTransformOptions(options.flush),
-      emitTiming,
+      { timing: emitTiming, touchedPaths: [param.key] },
     )
   }
 
@@ -259,7 +295,10 @@ export function useEffectContinuousControls(deps: EffectControlDeps) {
     emitContinuousTransform(
       result.fields,
       createContinuousTransformOptions(options.flush),
-      options.fromSlider ? 'nextFrame' : 'immediate',
+      {
+        timing: options.fromSlider ? 'nextFrame' : 'immediate',
+        touchedPaths: [param.key],
+      },
     )
   }
 
@@ -350,7 +389,10 @@ export function useEffectContinuousControls(deps: EffectControlDeps) {
         emitContinuousTransform(
           fields,
           createContinuousTransformOptions(options.flush),
-          options.fromSlider ? 'nextFrame' : 'immediate',
+          {
+            timing: options.fromSlider ? 'nextFrame' : 'immediate',
+            touchedPaths: [activePath, passivePath],
+          },
         )
       }
       return
@@ -370,6 +412,7 @@ export function useEffectContinuousControls(deps: EffectControlDeps) {
     }
 
     deps.setNumericField(result.fields, activePath, normalizedActive)
+    const touchedPaths = [activePath]
 
     if (isLinkedSliderLocked(param)) {
       const snapshot = getLinkedSliderLockSnapshot(param)
@@ -382,12 +425,16 @@ export function useEffectContinuousControls(deps: EffectControlDeps) {
         nextPassive = applySliderCenterSnap(clamp(nextPassive, param.min ?? 0, param.max ?? 0), param.center ?? 0, param.min ?? 0, param.max ?? 0)
       }
       deps.setNumericField(result.fields, passivePath, nextPassive)
+      touchedPaths.push(passivePath)
     }
 
     emitContinuousTransform(
       result.fields,
       createContinuousTransformOptions(options.flush),
-      options.fromSlider ? 'nextFrame' : 'immediate',
+      {
+        timing: options.fromSlider ? 'nextFrame' : 'immediate',
+        touchedPaths,
+      },
     )
   }
 
@@ -453,7 +500,7 @@ export function useEffectContinuousControls(deps: EffectControlDeps) {
     emitContinuousTransform(
       result.fields,
       createContinuousTransformOptions(options.flush),
-      emitTiming,
+      { timing: emitTiming, touchedPaths: [param.key] },
     )
   }
 

--- a/src/features/editor/effect-editor/useEffectContinuousControls.ts
+++ b/src/features/editor/effect-editor/useEffectContinuousControls.ts
@@ -100,6 +100,14 @@ export function useEffectContinuousControls(deps: EffectControlDeps) {
     })
   }
 
+  function clearPendingContinuousTransformField(path: string): boolean {
+    if (!pendingContinuousTransformEmit || !(path in pendingContinuousTransformEmit.fields)) {
+      return false
+    }
+    cancelScheduledContinuousTransformEmit()
+    return true
+  }
+
   function applyFieldUpdate(
     path: string,
     rawValue: string | number,
@@ -233,6 +241,7 @@ export function useEffectContinuousControls(deps: EffectControlDeps) {
       ? applySliderCenterSnap(clamp(result.value, param.min ?? 0, param.max ?? 0), param.center ?? 0, param.min ?? 0, param.max ?? 0)
       : result.value
     if (options.fromSlider && isImplicitDefaultWrite(param.key, normalized, param.defaultValue)) {
+      clearPendingContinuousTransformField(param.key)
       return
     }
     deps.setNumericField(result.fields, param.key, normalized)
@@ -246,6 +255,7 @@ export function useEffectContinuousControls(deps: EffectControlDeps) {
   function flushSliderField(param: NumberField) {
     const storedValue = getStoredFieldValue(param.key)
     if (storedValue === undefined) {
+      clearPendingContinuousTransformField(param.key)
       return
     }
     updateSliderField(param, storedValue, { flush: true })

--- a/src/features/editor/effect-editor/useEffectContinuousControls.ts
+++ b/src/features/editor/effect-editor/useEffectContinuousControls.ts
@@ -1,10 +1,9 @@
-import { DialField } from '~/features/editor/command-registry/schema'
 import { createParamDrag } from '~/features/editor/effect-editor/createParamDrag'
-import { EffectControlDeps } from '~/features/editor/effect-editor/types'
 import { usePreferenceStore } from '~/stores/preference'
 import { applyScrubStepModifier, clamp, degreeToRadian, getPointerAngleDegrees, normalizeAngleDelta, normalizeDegree, radianToDegree, roundByStep, roundToPrecision } from '~/utils/math'
 
-import type { NumberField } from '~/features/editor/command-registry/schema'
+import type { DialField, NumberField } from '~/features/editor/command-registry/schema'
+import type { EffectControlDeps, EmitTransformOptions } from '~/features/editor/effect-editor/types'
 
 /** NumberField 且必定有 linkedPairKey 的子类型（用于 linked-slider 控件） */
 type LinkedNumberField = NumberField & { linkedPairKey: string }
@@ -17,6 +16,10 @@ const SLIDER_CENTER_SNAP_TOLERANCE = 0.02
 const DIAL_DEGREE_SNAP = 15
 // 弧度值存储精度（4 位小数，约 0.006 度误差）
 const RADIAN_STORAGE_PRECISION = 4
+
+function createContinuousTransformOptions(flush?: boolean): EmitTransformOptions {
+  return { schedule: 'continuous', flush, deferAutoApply: !flush }
+}
 
 function getFieldValueWithDefault(
   getFieldValue: (path: string) => string,
@@ -47,6 +50,56 @@ export function useEffectContinuousControls(deps: EffectControlDeps) {
     value: number
   }
 
+  interface PendingContinuousTransformEmit {
+    fields: Record<string, string>
+    options: EmitTransformOptions
+  }
+
+  type ContinuousTransformEmitTiming = 'immediate' | 'nextFrame'
+
+  let pendingContinuousTransformEmit: PendingContinuousTransformEmit | undefined
+  let pendingContinuousTransformFrameId: number | undefined
+
+  function cancelScheduledContinuousTransformEmit() {
+    if (pendingContinuousTransformFrameId !== undefined) {
+      cancelAnimationFrame(pendingContinuousTransformFrameId)
+      pendingContinuousTransformFrameId = undefined
+    }
+    pendingContinuousTransformEmit = undefined
+  }
+
+  function emitContinuousTransform(
+    fields: Record<string, string>,
+    options: EmitTransformOptions,
+    timing: ContinuousTransformEmitTiming = 'immediate',
+  ) {
+    if (options.flush) {
+      cancelScheduledContinuousTransformEmit()
+      deps.emitTransform(fields, options)
+      return
+    }
+
+    if (timing === 'immediate') {
+      deps.emitTransform(fields, options)
+      return
+    }
+
+    pendingContinuousTransformEmit = { fields, options }
+    if (pendingContinuousTransformFrameId !== undefined) {
+      return
+    }
+
+    pendingContinuousTransformFrameId = requestAnimationFrame(() => {
+      pendingContinuousTransformFrameId = undefined
+      const pending = pendingContinuousTransformEmit
+      pendingContinuousTransformEmit = undefined
+      if (!pending) {
+        return
+      }
+      deps.emitTransform(pending.fields, pending.options)
+    })
+  }
+
   function applyFieldUpdate(
     path: string,
     rawValue: string | number,
@@ -55,7 +108,7 @@ export function useEffectContinuousControls(deps: EffectControlDeps) {
     const fields = deps.getFields()
     if (!rawValue && rawValue !== 0) {
       delete fields[path]
-      deps.emitTransform(fields, { schedule: 'continuous', flush: options?.flush, deferAutoApply: !options?.flush })
+      emitContinuousTransform(fields, createContinuousTransformOptions(options?.flush))
       return undefined
     }
     const num = Number(rawValue)
@@ -69,10 +122,11 @@ export function useEffectContinuousControls(deps: EffectControlDeps) {
   // Number 控件
   // ═══════════════════════════════════════
 
-  function updateNumberField(
+  function updateNumberFieldValue(
     param: NumberField,
     rawValue: string,
     options: { flush?: boolean, clampValue?: boolean } = {},
+    emitTiming: ContinuousTransformEmitTiming = 'immediate',
   ) {
     const result = applyFieldUpdate(param.key, rawValue, options)
     if (!result) {
@@ -80,7 +134,19 @@ export function useEffectContinuousControls(deps: EffectControlDeps) {
     }
     const finalValue = options.clampValue ? clamp(result.value, param.min, param.max) : result.value
     deps.setNumericField(result.fields, param.key, finalValue)
-    deps.emitTransform(result.fields, { schedule: 'continuous', flush: options.flush, deferAutoApply: !options.flush })
+    emitContinuousTransform(
+      result.fields,
+      createContinuousTransformOptions(options.flush),
+      emitTiming,
+    )
+  }
+
+  function updateNumberField(
+    param: NumberField,
+    rawValue: string,
+    options: { flush?: boolean, clampValue?: boolean } = {},
+  ) {
+    updateNumberFieldValue(param, rawValue, options)
   }
 
   function canScrubNumber(param: NumberField): boolean {
@@ -120,10 +186,10 @@ export function useEffectContinuousControls(deps: EffectControlDeps) {
       }
 
       state.lastValue = normalized
-      updateNumberField(state.param, String(normalized), { flush: false, clampValue: true })
+      updateNumberFieldValue(state.param, String(normalized), { flush: false, clampValue: true }, 'nextFrame')
     },
     onEnd(_event, state) {
-      updateNumberField(state.param, String(state.lastValue), { flush: true, clampValue: true })
+      updateNumberFieldValue(state.param, String(state.lastValue), { flush: true, clampValue: true })
     },
   })
 
@@ -170,7 +236,11 @@ export function useEffectContinuousControls(deps: EffectControlDeps) {
       return
     }
     deps.setNumericField(result.fields, param.key, normalized)
-    deps.emitTransform(result.fields, { schedule: 'continuous', flush: options.flush, deferAutoApply: !options.flush })
+    emitContinuousTransform(
+      result.fields,
+      createContinuousTransformOptions(options.flush),
+      options.fromSlider ? 'nextFrame' : 'immediate',
+    )
   }
 
   function flushSliderField(param: NumberField) {
@@ -256,7 +326,11 @@ export function useEffectContinuousControls(deps: EffectControlDeps) {
         const fields = deps.getFields()
         delete fields[activePath]
         delete fields[passivePath]
-        deps.emitTransform(fields, { schedule: 'continuous', flush: options.flush, deferAutoApply: !options.flush })
+        emitContinuousTransform(
+          fields,
+          createContinuousTransformOptions(options.flush),
+          options.fromSlider ? 'nextFrame' : 'immediate',
+        )
       }
       return
     }
@@ -288,7 +362,11 @@ export function useEffectContinuousControls(deps: EffectControlDeps) {
       deps.setNumericField(result.fields, passivePath, nextPassive)
     }
 
-    deps.emitTransform(result.fields, { schedule: 'continuous', flush: options.flush, deferAutoApply: !options.flush })
+    emitContinuousTransform(
+      result.fields,
+      createContinuousTransformOptions(options.flush),
+      options.fromSlider ? 'nextFrame' : 'immediate',
+    )
   }
 
   function flushLinkedSliderField(param: LinkedNumberField, index: 0 | 1) {
@@ -338,14 +416,23 @@ export function useEffectContinuousControls(deps: EffectControlDeps) {
     return value
   }
 
-  function updateDialField(param: DialField, rawDegree: string | number, options: { flush?: boolean } = {}) {
+  function updateDialField(
+    param: DialField,
+    rawDegree: string | number,
+    options: { flush?: boolean } = {},
+    emitTiming: ContinuousTransformEmitTiming = 'immediate',
+  ) {
     const result = applyFieldUpdate(param.key, rawDegree, options)
     if (!result) {
       return
     }
     const storeValue = dialDegreeToStoreValue(param, result.value)
     deps.setNumericField(result.fields, param.key, storeValue)
-    deps.emitTransform(result.fields, { schedule: 'continuous', flush: options.flush, deferAutoApply: !options.flush })
+    emitContinuousTransform(
+      result.fields,
+      createContinuousTransformOptions(options.flush),
+      emitTiming,
+    )
   }
 
   function flushDialField(param: DialField) {
@@ -395,7 +482,7 @@ export function useEffectContinuousControls(deps: EffectControlDeps) {
       }
 
       state.lastDegree = snappedDegree
-      updateDialField(state.param, snappedDegree, { flush: false })
+      updateDialField(state.param, snappedDegree, { flush: false }, 'nextFrame')
     },
     onEnd(_event, state) {
       updateDialField(state.param, String(state.lastDegree), { flush: true })
@@ -414,6 +501,8 @@ export function useEffectContinuousControls(deps: EffectControlDeps) {
   function resetLinkedSliderState() {
     linkedSliderLockSnapshots = {}
   }
+
+  tryOnUnmounted(cancelScheduledContinuousTransformEmit)
 
   return {
     // number

--- a/src/features/editor/effect-editor/useEffectContinuousControls.ts
+++ b/src/features/editor/effect-editor/useEffectContinuousControls.ts
@@ -108,6 +108,17 @@ export function useEffectContinuousControls(deps: EffectControlDeps) {
     return true
   }
 
+  function clearPendingContinuousTransformFields(paths: readonly string[]): boolean {
+    if (!pendingContinuousTransformEmit) {
+      return false
+    }
+    if (!paths.some(path => path in pendingContinuousTransformEmit!.fields)) {
+      return false
+    }
+    cancelScheduledContinuousTransformEmit()
+    return true
+  }
+
   function applyFieldUpdate(
     path: string,
     rawValue: string | number,
@@ -354,6 +365,7 @@ export function useEffectContinuousControls(deps: EffectControlDeps) {
       && isImplicitDefaultWrite(activePath, normalizedActive, param.defaultValue)
       && (!isLinkedSliderLocked(param) || getStoredFieldValue(passivePath) === undefined)
     ) {
+      clearPendingContinuousTransformFields([activePath, passivePath])
       return
     }
 


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [x] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [x] 测试用例
- [x] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

修复效果编辑器中变换参数的连续拖拽卡顿问题。

本次改动将 number scrub、slider、linked-slider、dial 等连续型控件在拖拽过程中的 transform 发射合并到下一帧，只发送同一帧内最后一次更新，避免在 pointermove 高频触发时同步推送完整 transform 更新导致编辑器侧输入卡顿。

最终提交或 flush 仍保持立即发射，确保拖拽结束时状态能及时落盘和触发最终预览。

同时新增回归测试覆盖：

- position.x / position.y scrub 同帧合并 transform 发射
- slider 拖拽同帧只发射最后一次 transform
- slider commit 会取消尚未发射的拖拽 transform

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

效果编辑器中拖拽变换参数，尤其是 XY 位移 scrub 和滑条时，滑条与数值显示会出现不跟手甚至短暂卡住的问题。控制台观察到实时预览命令中间帧缺失，根因是编辑器拖拽路径本身在 pointermove 频率下同步发射 transform，导致主线程更新压力过高，输入事件被合并或丢失。

通过按 animation frame 合并连续拖拽更新，可以降低编辑器侧同步更新频率，同时保留最终 flush 的立即性。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
