### PR TITLE
🐛 修复效果编辑器持续时间拖拽丢失问题

### DIFF
--- a/src/composables/__tests__/useImmediatePointerDrag.test.ts
+++ b/src/composables/__tests__/useImmediatePointerDrag.test.ts
@@ -7,7 +7,14 @@ type ListenerMap = Record<string, Set<EventListenerOrEventListenerObject>>
 interface PointerLikeEvent {
   buttons?: number
   clientX?: number
+  currentTarget?: PointerCaptureTarget | null
   pointerId: number
+}
+
+interface PointerCaptureTarget {
+  hasPointerCapture?: (pointerId: number) => boolean
+  releasePointerCapture?: (pointerId: number) => void
+  setPointerCapture?: (pointerId: number) => void
 }
 
 const originalAddEventListener = globalThis.addEventListener
@@ -75,6 +82,31 @@ afterEach(() => {
 })
 
 describe('useImmediatePointerDrag', () => {
+  it('开始拖拽时会捕获当前指针并在结束时释放', () => {
+    const capturedPointers = new Set<number>()
+    const target: PointerCaptureTarget = {
+      hasPointerCapture: vi.fn(pointerId => capturedPointers.has(pointerId)),
+      releasePointerCapture: vi.fn((pointerId) => {
+        capturedPointers.delete(pointerId)
+      }),
+      setPointerCapture: vi.fn((pointerId) => {
+        capturedPointers.add(pointerId)
+      }),
+    }
+    const drag = useImmediatePointerDrag({
+      onEnd: vi.fn(),
+      onMove: vi.fn(),
+      onStart: event => ({ startX: event.clientX }),
+    })
+
+    drag.start(createPointerEvent({ currentTarget: target, pointerId: 7 }))
+    dispatchPointerEvent('pointerup', { pointerId: 7 })
+
+    expect(target.setPointerCapture).toHaveBeenCalledWith(7)
+    expect(target.releasePointerCapture).toHaveBeenCalledWith(7)
+    expect(capturedPointers.has(7)).toBe(false)
+  })
+
   it('正常收到 pointerup 时会结束拖拽', () => {
     const onEnd = vi.fn()
     const onMove = vi.fn()

--- a/src/composables/useImmediatePointerDrag.ts
+++ b/src/composables/useImmediatePointerDrag.ts
@@ -11,16 +11,59 @@ export interface UseImmediatePointerDragResult<S> {
   stop: (event?: PointerEvent) => void
 }
 
+interface PointerCaptureTarget {
+  hasPointerCapture?: (pointerId: number) => boolean
+  releasePointerCapture?: (pointerId: number) => void
+  setPointerCapture?: (pointerId: number) => void
+}
+
 export function useImmediatePointerDrag<S>(
   callbacks: ImmediatePointerDragCallbacks<S>,
 ): UseImmediatePointerDragResult<S> {
   let state: S | undefined
   let pointerId: number | undefined
+  let captureTarget: PointerCaptureTarget | undefined
 
   function removeListeners() {
     globalThis.removeEventListener('pointermove', handlePointerMove)
     globalThis.removeEventListener('pointerup', handlePointerEnd)
     globalThis.removeEventListener('pointercancel', handlePointerEnd)
+  }
+
+  function capturePointer(event: PointerEvent) {
+    const target = event.currentTarget as PointerCaptureTarget | null
+    if (typeof target?.setPointerCapture !== 'function') {
+      return
+    }
+
+    try {
+      target.setPointerCapture(event.pointerId)
+      captureTarget = target
+    } catch {
+      // capture 是增强能力，失败时仍保留全局事件监听。
+    }
+  }
+
+  function releasePointerCapture() {
+    if (captureTarget === undefined || pointerId === undefined) {
+      return
+    }
+
+    const target = captureTarget
+    captureTarget = undefined
+
+    if (typeof target.hasPointerCapture === 'function' && !target.hasPointerCapture(pointerId)) {
+      return
+    }
+    if (typeof target.releasePointerCapture !== 'function') {
+      return
+    }
+
+    try {
+      target.releasePointerCapture(pointerId)
+    } catch {
+      // capture 在元素失活时可能已经被浏览器释放。
+    }
   }
 
   function handlePointerMove(event: PointerEvent) {
@@ -50,6 +93,7 @@ export function useImmediatePointerDrag<S>(
 
     const current = state
     state = undefined
+    releasePointerCapture()
     pointerId = undefined
     removeListeners()
     callbacks.onEnd(event, current)
@@ -64,6 +108,7 @@ export function useImmediatePointerDrag<S>(
     stop()
     state = nextState
     pointerId = event.pointerId
+    capturePointer(event)
 
     globalThis.addEventListener('pointermove', handlePointerMove)
     globalThis.addEventListener('pointerup', handlePointerEnd)


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [x] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [x] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

修复效果编辑器持续时间 label scrub 在拖出效果编辑器区域后可能丢失拖拽的问题。

具体更改：

- 在 `useImmediatePointerDrag` 中为成功开始的拖拽调用 `setPointerCapture`
- 在拖拽结束、取消或组件卸载时释放 pointer capture
- 保留原有全局 pointer 事件监听作为基础拖拽机制，pointer capture 失败时不会中断拖拽
- 新增 `useImmediatePointerDrag` 回归测试，覆盖开始拖拽时捕获 pointer、结束拖拽时释放 pointer

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

效果编辑器的持续时间 scrub 使用 `useImmediatePointerDrag`。此前该 composable 只依赖 `globalThis` 上的 pointer 事件监听，当指针拖出编辑器区域或跨过独立事件边界时，后续 pointer 事件可能丢失，导致 scrub 中断。

项目其他拖拽实现中已经使用 pointer capture 解决过同类问题。本次将该能力补到共享的 immediate drag 原语中，使 duration scrub 以及其他 immediate drag 调用方获得一致行为。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
