### PR TITLE
🐛 避免窗口状态恢复时闪烁

### DIFF
--- a/src-tauri/src/window.rs
+++ b/src-tauri/src/window.rs
@@ -26,7 +26,7 @@ impl WindowConfig {
             height: None,
             resizable: true,
             center: false,
-            visible: true,
+            visible: false,
             use_custom_title_bar: false,
         }
     }
@@ -69,13 +69,7 @@ impl WindowConfig {
             .min_size(620.0, 540.0)
             .size(1280.0, 800.0)
             .center(true)
-            .visible(false)
             .use_custom_title_bar(true)
-    }
-
-    pub fn visible(mut self, visible: bool) -> Self {
-        self.visible = visible;
-        self
     }
 
     fn apply_platform_tweaks<'a, R: Runtime, M: tauri::Manager<R>>(
@@ -179,7 +173,7 @@ mod tests {
         assert!(config.height.is_none());
         assert!(config.resizable);
         assert!(!config.center);
-        assert!(config.visible);
+        assert!(!config.visible);
         assert!(!config.use_custom_title_bar);
     }
 


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [x] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [ ] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

将 `WindowConfig::new` 的默认可见性改为隐藏创建，使通过该配置创建的 Tauri 窗口在 `tauri-plugin-window-state` 恢复位置和尺寸后再显示，避免窗口恢复状态时出现闪烁。

同时移除了 `WindowConfig::main` 中重复的 `.visible(false)` 调用，以及不再使用的 `visible` setter，保持窗口配置入口更简洁。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

测试游戏窗口在恢复上次位置和尺寸时会先显示再移动和改变大小，造成可见闪烁。主窗口此前已经通过隐藏创建规避该问题；现在将该策略下沉为 `WindowConfig` 的默认行为，使额外窗口也复用同一窗口生命周期策略，而不需要前端或调用方感知平台细节。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
