### PR TITLE
💄 调整设置主题预览缩略图以更准确反映当前编辑页布局

### DIFF
--- a/src/components/app/ThemeStyleMap.vue
+++ b/src/components/app/ThemeStyleMap.vue
@@ -7,12 +7,12 @@ const AppMiniMap = (
   <div class="p-1 rounded-sm bg-[--color-background] flex flex-col gap-0.75 h-full">
     <div class="rounded-xs bg-[--color-contrast] h-1.5" />
     <div class="flex flex-1 gap-0.75">
-      <div class="rounded-xs bg-[--color-contrast] w-4" />
-      <div class="flex flex-col gap-0.75 w-10">
+      <div class="rounded-xs bg-[--color-contrast] w-7" />
+      <div class="flex flex-col gap-0.75 w-12">
         <div class="rounded-xs bg-[--color-contrast] h-full" />
         <div class="rounded-xs bg-[--color-contrast] h-5" />
       </div>
-      <div class="rounded-xs bg-[--color-contrast] w-9" />
+      <div class="rounded-xs bg-[--color-contrast] w-5" />
     </div>
   </div>
 )


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [ ] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [ ] 测试用例
- [ ] 性能优化
- [x] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

调整 `ThemeStyleMap.vue` 中主题预览缩略图的三栏宽度比例，使其更接近当前编辑页的实际布局结构。

具体来说，这次修改重新分配了左侧边栏、中间主内容区和右侧区域的视觉占比，减少了缩略图与真实编辑页之间的偏差，让主题选择时的预览信息更直观、更准确。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

当前主题预览缩略图表达的页面结构与编辑页现状存在一定偏差，容易让预览结果和实际使用感受脱节。

这次调整的目标不是引入新能力，而是提高主题预览的表达准确性，让缩略图能够更真实地反映当前编辑页布局。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [ ] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
