### PR TITLE
✨ 支持资源浏览器中键打开普通标签

### DIFF
--- a/src/components/editor/AssetView.spec.ts
+++ b/src/components/editor/AssetView.spec.ts
@@ -362,6 +362,35 @@ function createLoadingStateFileViewerStub() {
   })
 }
 
+function createAuxClickFileViewerStub() {
+  return defineComponent({
+    name: 'StubAuxClickFileViewer',
+    props: {
+      items: {
+        type: Array as PropType<FileViewerItem[]>,
+        required: true,
+      },
+    },
+    emits: ['auxclick'],
+    setup(props, { emit }) {
+      return () => {
+        const fileItem = props.items.find(item => !item.isDir)
+
+        return h('button', {
+          'type': 'button',
+          'data-testid': 'auxclick-file',
+          'disabled': !fileItem,
+          'onClick': () => {
+            if (fileItem) {
+              emit('auxclick', fileItem)
+            }
+          },
+        }, 'auxclick')
+      }
+    },
+  })
+}
+
 function createFileViewerDragPayload(item: FileViewerItem): FileSystemDragPayload {
   return {
     isDir: item.isDir,
@@ -626,6 +655,47 @@ describe('AssetView', () => {
 
     await expect.element(page.getByTestId('preview-context')).toHaveAttribute('data-preview-cwd', '/games/demo')
     await expect.element(page.getByTestId('preview-context')).toHaveAttribute('data-preview-base-url', 'http://127.0.0.1:8899/game/demo/')
+  })
+
+  it('FileViewer 上抛中键点击时会以普通标签打开资源', async () => {
+    const openTab = vi.fn()
+    useTabsStoreMock.mockReturnValue({
+      findTabIndex: vi.fn(() => -1),
+      fixPreviewTab: vi.fn(),
+      openTab,
+      tabs: [],
+    })
+    getFolderContentsMock.mockResolvedValue([
+      createAssetFileSystemItem({
+        isDir: false,
+        mimeType: 'image/png',
+        modifiedAt: 2,
+        name: 'hero.png',
+        path: '/project/game/background/hero.png',
+        size: 1024,
+      }),
+    ])
+    setPreviewUnavailable()
+
+    renderInBrowser(createHarness('background'), {
+      global: {
+        stubs: {
+          ...commonGlobalStubs,
+          FileViewer: createAuxClickFileViewerStub(),
+        },
+      },
+    })
+
+    await vi.waitFor(() => {
+      expect(getFolderContentsMock).toHaveBeenCalledTimes(1)
+    })
+    await page.getByTestId('auxclick-file').click()
+
+    expect(openTab).toHaveBeenCalledWith(
+      'hero.png',
+      '/project/game/background/hero.png',
+      { forceNormal: true },
+    )
   })
 
   it('右键重命名会以 Popover 形式打开并调用 pathOperation.perform', async () => {

--- a/src/components/editor/AssetView.vue
+++ b/src/components/editor/AssetView.vue
@@ -413,6 +413,13 @@ function handleSelect(item: FileViewerItem): void {
   lastSelectedAt = now
 }
 
+function handleAuxClick(item: FileViewerItem): void {
+  if (item.isDir) {
+    return
+  }
+  tabsStore.openTab(item.name, AbsPath.from(item.path), { forceNormal: true })
+}
+
 function closeRenamePopover(): void {
   isRenamePopoverOpen = false
   isRenameSubmitting = false
@@ -761,6 +768,7 @@ for (const eventType of FILE_SYSTEM_REFRESH_EVENT_TYPES) {
       :zoom="preferenceStore.assetZoom[0]"
       @navigate="handleNavigate"
       @select="handleSelect"
+      @auxclick="handleAuxClick"
       @file-transfer-drop="handleFileTransferDrop"
       @update:sort-by="(value) => emit('update:sortBy', value)"
       @update:sort-order="(value) => emit('update:sortOrder', value)"

--- a/src/components/file-viewer/FileViewer.spec.ts
+++ b/src/components/file-viewer/FileViewer.spec.ts
@@ -1373,6 +1373,32 @@ describe('FileViewer', () => {
     expect(document.querySelector('[data-file-viewer-background-surface="true"]')).toBeNull()
   })
 
+  it('中键点击文件项会上抛 auxclick，且不会触发左键选择', async () => {
+    viewportWidthMock.value = 780
+    const item = createItem(1)
+    const onSelect = vi.fn()
+    const onAuxclick = vi.fn()
+
+    renderInBrowser(FileViewer, {
+      props: {
+        items: [item],
+        onAuxclick,
+        onSelect,
+        viewMode: 'grid',
+      },
+      global: {
+        stubs: globalStubs,
+      },
+    })
+
+    getFileViewerItemElement(item)
+      .dispatchEvent(new MouseEvent('auxclick', { bubbles: true, button: 1 }))
+    await nextTick()
+
+    expect(onAuxclick).toHaveBeenCalledWith(item)
+    expect(onSelect).not.toHaveBeenCalled()
+  })
+
   it('提供 #context-menu slot 时会向每个条目透传当前 item', async () => {
     viewportWidthMock.value = 780
 

--- a/src/components/file-viewer/FileViewer.vue
+++ b/src/components/file-viewer/FileViewer.vue
@@ -54,6 +54,8 @@ interface FileViewerProps {
 interface FileViewerEmits {
   /** 文件被单击选中 */
   'select': [item: FileViewerItem]
+  /** 资源项被鼠标中键点击 */
+  'auxclick': [item: FileViewerItem]
   /** 文件夹被单击，请求导航进入 */
   'navigate': [item: FileViewerItem]
   /** 更新排序字段 */
@@ -297,6 +299,13 @@ function handleItemClick(item: FileViewerItem) {
   emit('select', item)
 }
 
+function handleItemAuxClick(item: FileViewerItem) {
+  if (!item.path) {
+    return
+  }
+  emit('auxclick', item)
+}
+
 function getFileViewerDragPayload(element: HTMLElement): FileSystemDragPayload {
   const { dataset } = element
   const path = dataset.fileViewerPath ?? ''
@@ -521,6 +530,7 @@ defineExpose(fileViewerExpose)
           :get-drag-source-props="getDragSourceProps"
           :resolve-preview-url="previewUrlResolver"
           @file-transfer-drop="handleBodyFileTransferDrop"
+          @item-aux-click="handleItemAuxClick"
           @item-click="handleItemClick"
         >
           <template v-if="$slots.icon" #icon="{ item, iconSize }">

--- a/src/components/file-viewer/FileViewerBody.vue
+++ b/src/components/file-viewer/FileViewerBody.vue
@@ -85,6 +85,7 @@ const emit = defineEmits<{
     operation: DragTransferOperation,
   ]
   itemClick: [item: FileViewerItem]
+  itemAuxClick: [item: FileViewerItem]
 }>()
 
 const slots = useSlots()
@@ -149,6 +150,13 @@ function formatDateTime(timestamp: number): string {
 
 function handleItemClick(item: FileViewerItem): void {
   emit('itemClick', item)
+}
+
+function handleItemAuxClick(event: MouseEvent, item: FileViewerItem): void {
+  if (event.button !== 1) {
+    return
+  }
+  emit('itemAuxClick', item)
 }
 
 function resolveHTMLElement(value: unknown): HTMLElement | undefined {
@@ -543,6 +551,7 @@ onUnmounted(() => {
               getFileViewerDropTargetClass(displayItem.item),
             ]"
             @click="handleItemClick(displayItem.item)"
+            @auxclick="(event: MouseEvent) => handleItemAuxClick(event, displayItem.item)"
           >
             <FileViewerImageHoverCard
               :close-delay="resolveHoverCardCloseDelay(displayItem.item.path)"
@@ -618,6 +627,7 @@ onUnmounted(() => {
             ]"
             :style="{ height: `${listItemHeight}px` }"
             @click="handleItemClick(displayItem.item)"
+            @auxclick="(event: MouseEvent) => handleItemAuxClick(event, displayItem.item)"
           >
             <div class="flex flex-1 gap-2 min-w-0 items-center">
               <FileViewerImageHoverCard


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [ ] 错误修复
- [x] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [x] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

为资源浏览器补充鼠标中键点击资源项的交互支持。

具体更改：
- `FileViewerBody` 监听资源项 `auxclick`，仅在鼠标中键点击时上抛事件。
- `FileViewer` 对外暴露 `auxclick` 事件，保持组件只表达交互，不耦合标签打开策略。
- `AssetView` 接收资源项中键事件后，使用 `tabsStore.openTab(..., { forceNormal: true })` 以普通标签打开文件资源。
- 补充 `FileViewer` 和 `AssetView` 测试，覆盖中键事件上抛、普通标签打开，以及不触发左键选择。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

资源浏览器此前缺少中键打开资源的能力，用户体验与场景浏览器不一致。

本次更改对齐场景浏览器行为：中键点击文件资源时强制打开普通标签页，而不是走预览标签逻辑；同时不影响已有左键选择、目录导航、右键菜单和拖拽行为。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
