### PR TITLE
🚸 调整首页头部品牌入口跳转地址

### DIFF
--- a/src/components/home/AppHeader.vue
+++ b/src/components/home/AppHeader.vue
@@ -4,7 +4,6 @@ import { openUrl } from '@tauri-apps/plugin-opener'
 
 import { useModalStore } from '~/stores/modal'
 
-import { github } from '~build/git'
 import webgalCraftTextSvg from '/webgal-craft-text.svg?raw'
 
 const modalStore = useModalStore()
@@ -14,8 +13,8 @@ const modalStore = useModalStore()
   <header class="border-b bg-white dark:bg-gray-950">
     <div class="mx-auto px-4 container flex h-16 items-center lg:px-8 sm:px-6">
       <div
-        class="mr-4 flex gap-2 items-center" :class="{ 'cursor-pointer': github }"
-        @click="github && openUrl(github)"
+        class="mr-4 flex gap-2 cursor-pointer items-center"
+        @click="openUrl('https://webgalcraft.com')"
       >
         <img src="/webgal-craft-logo.svg" class="size-10" alt="WebGAL Craft logo">
         <!-- eslint-disable-next-line vue/no-v-html -->


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [ ] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [ ] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [x] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

- 将首页头部品牌区域的点击目标统一调整为 `https://webgalcraft.com`
- 移除该入口对构建时 `github` 变量的依赖
- 让品牌区域的可点击反馈与实际行为保持一致

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

首页头部的品牌区域属于明确的官方入口，更适合始终提供稳定一致的跳转目标。

这次修改将入口统一到官网，同时去掉对构建元信息的耦合，避免不同构建环境下出现不同的跳转行为。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [ ] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
