### PR TITLE
♻️ 梳理系统日志并优化诊断信噪比

### DIFF
--- a/src-tauri/src/commands/engine.rs
+++ b/src-tauri/src/commands/engine.rs
@@ -95,7 +95,6 @@ pub async fn read_engine_manifest(engine_path: String) -> AppResult<EngineManife
     let manifest = match serde_json::from_str::<EngineManifest>(&content) {
         Ok(m) => m,
         Err(e) => {
-            log::error!("引擎清单解析失败 {}: {e}", manifest_path.display());
             return Ok(EngineManifestResult::Invalid {
                 reason: format!("解析失败: {e}"),
             });
@@ -103,7 +102,6 @@ pub async fn read_engine_manifest(engine_path: String) -> AppResult<EngineManife
     };
 
     if !manifest.has_required_fields() {
-        log::error!("引擎清单缺少必填字段: {}", manifest_path.display());
         return Ok(EngineManifestResult::Invalid {
             reason: "缺少必填字段".to_owned(),
         });
@@ -113,26 +111,13 @@ pub async fn read_engine_manifest(engine_path: String) -> AppResult<EngineManife
         Some(major) if major == SUPPORTED_SCHEMA_MAJOR => Ok(EngineManifestResult::Ok {
             manifest: Box::new(manifest),
         }),
-        Some(major) => {
-            log::error!(
-                "引擎清单 schemaVersion 不受支持 {}: 发现主版本 {major}，最高支持 {SUPPORTED_SCHEMA_MAJOR}",
-                manifest_path.display()
-            );
-            Ok(EngineManifestResult::UnsupportedSchema {
-                schema_version: manifest.schema_version,
-                supported_major: SUPPORTED_SCHEMA_MAJOR,
-            })
-        }
-        None => {
-            log::error!(
-                "引擎清单 schemaVersion 格式无效 {}: {}",
-                manifest_path.display(),
-                manifest.schema_version
-            );
-            Ok(EngineManifestResult::Invalid {
-                reason: format!("schemaVersion 格式无效: {}", manifest.schema_version),
-            })
-        }
+        Some(_) => Ok(EngineManifestResult::UnsupportedSchema {
+            schema_version: manifest.schema_version,
+            supported_major: SUPPORTED_SCHEMA_MAJOR,
+        }),
+        None => Ok(EngineManifestResult::Invalid {
+            reason: format!("schemaVersion 格式无效: {}", manifest.schema_version),
+        }),
     }
 }
 

--- a/src-tauri/src/commands/server.rs
+++ b/src-tauri/src/commands/server.rs
@@ -801,18 +801,6 @@ fn map_vfs_error(error: &VfsError) -> StatusCode {
     }
 }
 
-#[cfg(debug_assertions)]
-async fn timing_middleware(request: Request<Body>, next: axum::middleware::Next) -> Response {
-    let path = request.uri().path().to_owned();
-    let start = std::time::Instant::now();
-    let response = next.run(request).await;
-    let elapsed = start.elapsed();
-    if elapsed > std::time::Duration::from_millis(10) {
-        log::debug!("慢请求: {} - {:?}", path, elapsed);
-    }
-    response
-}
-
 #[tauri::command]
 pub async fn start_server(
     state: TauriState<'_, Mutex<ServerState>>,
@@ -833,6 +821,7 @@ pub async fn start_server(
         Err(_) => {
             let new_port =
                 pick_unused_port().ok_or_else(|| AppError::Server("无法找到可用端口".into()))?;
+            log::warn!("HTTP 服务器端口不可用，回退端口: {address} -> {host}:{new_port}");
             TcpListener::bind(format!("{host}:{new_port}")).await?
         }
     };
@@ -868,9 +857,6 @@ pub async fn start_server(
             ),
         )
         .with_state(state_guard.app_state.clone());
-
-    #[cfg(debug_assertions)]
-    let app = app.layer(axum::middleware::from_fn(timing_middleware));
 
     let (shutdown_tx, shutdown_rx) = oneshot::channel();
     let join_handle = tokio::spawn(async move {
@@ -956,7 +942,6 @@ pub async fn add_static_site(
         .await
         .insert(hash.clone(), cached_canonicals);
 
-    log::debug!("注册站点: {hash} -> {}", project_path.display());
     Ok(hash)
 }
 

--- a/src-tauri/src/commands/vfs.rs
+++ b/src-tauri/src/commands/vfs.rs
@@ -164,7 +164,6 @@ pub fn delete_vfs_path(
     let logical_path = sanitize_logical_path(&rel_path)?;
     let overlay = build_overlay(&project_path, &engine_path, template_path, &factory_cache)?;
     overlay.remove_logical_path(&logical_path)?;
-    log::debug!("VFS 删除: {}", logical_path.display());
     Ok(())
 }
 
@@ -182,11 +181,6 @@ pub fn rename_vfs_path(
     let target_path = sanitize_rename_target(parent, &new_name)?;
     let overlay = build_overlay(&project_path, &engine_path, template_path, &factory_cache)?;
     overlay.rename_logical_path(&logical_path, &target_path)?;
-    log::debug!(
-        "VFS 重命名: {} -> {}",
-        logical_path.display(),
-        target_path.display()
-    );
     Ok(to_logical_path_string(&target_path))
 }
 
@@ -203,11 +197,6 @@ pub fn move_vfs_path(
     let target_path = sanitize_move_target(&target_rel_path)?;
     let overlay = build_overlay(&project_path, &engine_path, template_path, &factory_cache)?;
     overlay.rename_logical_path(&logical_path, &target_path)?;
-    log::debug!(
-        "VFS 移动: {} -> {}",
-        logical_path.display(),
-        target_path.display()
-    );
     Ok(to_logical_path_string(&target_path))
 }
 
@@ -224,11 +213,6 @@ pub fn copy_vfs_path(
     let target_path = sanitize_logical_path(&target_rel_path)?;
     let overlay = build_overlay(&project_path, &engine_path, template_path, &factory_cache)?;
     overlay.copy_logical_path(&logical_path, &target_path)?;
-    log::debug!(
-        "VFS 复制: {} -> {}",
-        logical_path.display(),
-        target_path.display()
-    );
     Ok(to_logical_path_string(&target_path))
 }
 
@@ -239,7 +223,6 @@ pub fn is_template_dirty(project_path: String) -> AppResult<bool> {
 
 #[tauri::command]
 pub fn clean_template_upper(project_path: String) -> AppResult<()> {
-    log::debug!("VFS 清理模板 upper: {project_path}");
     vfs::clean_template_upper(Path::new(&project_path)).map_err(Into::into)
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,6 +9,11 @@ use commands::vfs::OverlayFactoryCache;
 use tauri_plugin_prevent_default::PlatformOptions;
 use tokio::sync::Mutex;
 
+#[cfg(debug_assertions)]
+const LOG_LEVEL: log::LevelFilter = log::LevelFilter::Debug;
+#[cfg(not(debug_assertions))]
+const LOG_LEVEL: log::LevelFilter = log::LevelFilter::Info;
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     let mut builder = tauri::Builder::default().setup(|app| {
@@ -59,9 +64,9 @@ pub fn run() {
                 .target(tauri_plugin_log::Target::new(
                     tauri_plugin_log::TargetKind::Webview,
                 ))
-                .level(log::LevelFilter::Debug)
+                .level(LOG_LEVEL)
                 .timezone_strategy(tauri_plugin_log::TimezoneStrategy::UseLocal)
-                .rotation_strategy(tauri_plugin_log::RotationStrategy::KeepAll)
+                .rotation_strategy(tauri_plugin_log::RotationStrategy::KeepSome(10))
                 .filter(|metadata| {
                     metadata.target() != "tao::platform_impl::platform::event_loop::runner"
                 })

--- a/src-tauri/src/vfs.rs
+++ b/src-tauri/src/vfs.rs
@@ -770,7 +770,7 @@ pub fn sanitize_request_path(raw_path: &str) -> Result<PathBuf, VfsError> {
 
 pub fn sanitize_logical_path(raw_path: &str) -> Result<PathBuf, VfsError> {
     if raw_path.contains('\0') || raw_path.contains('\\') || raw_path.contains("//") {
-        log::warn!("路径被拒绝（非法字符）: {raw_path:?}");
+        log::debug!("路径被拒绝（非法字符）: {raw_path:?}");
         return Err(VfsError::PathDenied);
     }
 
@@ -974,7 +974,7 @@ fn validate_path_segment(segment: &str) -> Result<(), VfsError> {
         || segment.ends_with('.')
         || segment.ends_with(' ')
     {
-        log::warn!("路径段被拒绝（无效格式）: {segment:?}");
+        log::debug!("路径段被拒绝（无效格式）: {segment:?}");
         return Err(VfsError::PathDenied);
     }
 
@@ -985,7 +985,7 @@ fn validate_path_segment(segment: &str) -> Result<(), VfsError> {
     ];
 
     if RESERVED.contains(&upper.as_str()) {
-        log::warn!("路径段被拒绝（Windows 保留名称）: {segment:?}");
+        log::debug!("路径段被拒绝（Windows 保留名称）: {segment:?}");
         return Err(VfsError::PathDenied);
     }
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { useResourcePreviewPrimer } from '~/composables/useResourcePreviewPrimer'
-import { db } from '~/database/db'
+import { runAppStartup } from '~/features/app-startup/app-startup'
 import { useAppUpdateController } from '~/features/app-update/useAppUpdateController'
 import { engineManager } from '~/services/engine-manager'
 import { resolveMissingStorageSavePaths } from '~/services/platform/storage-defaults'
@@ -9,63 +9,31 @@ import { templateManager } from '~/services/template-manager'
 import { useGeneralSettingsStore } from '~/stores/general-settings'
 import { useStorageSettingsStore } from '~/stores/storage-settings'
 
-async function initializeApp() {
-  const storageSettingsStore = useStorageSettingsStore()
-  const missingStoragePaths = await resolveMissingStorageSavePaths(storageSettingsStore)
-
-  if (Object.keys(missingStoragePaths).length > 0) {
-    storageSettingsStore.$patch(missingStoragePaths)
-  }
-}
+import { isDebug } from '~build/meta'
 
 useResourcePreviewPrimer()
 const generalSettingsStore = useGeneralSettingsStore()
+const storageSettingsStore = useStorageSettingsStore()
 const appUpdateController = useAppUpdateController()
 const router = useRouter()
 const { t } = useI18n()
 
-async function openLastProjectIfNeeded() {
-  if (!generalSettingsStore.openLastProject || router.currentRoute.value.path !== '/') {
-    return
-  }
-
-  try {
-    const lastGame = await db.games.orderBy('lastModified').last()
-    if (!lastGame || lastGame.status !== 'created') {
-      return
-    }
-
-    if (lastGame.availability !== 'available') {
-      logger.warn(`最近项目当前不可用，跳过自动打开: ${lastGame.path}`)
-      notify.warning(t('home.games.openLastProjectUnavailable', { name: lastGame.metadata.name }))
-      return
-    }
-
-    await router.push(`/edit/${lastGame.id}`)
-    logger.info(`自动打开最近项目: ${lastGame.metadata.name}`)
-  } catch (error) {
-    logger.error(`自动打开最近项目失败: ${error}`)
-  }
-}
-
-async function runValidation(label: string, validate: () => Promise<unknown>) {
-  try {
-    await validate()
-  } catch (error) {
-    logger.error(`${label}失败: ${error}`)
-  }
-}
-
 onMounted(async () => {
-  await logger.attachConsole()
-  await initializeApp()
-  await Promise.all([
-    runValidation('引擎校验', () => engineManager.validateAllEngines()),
-    runValidation('游戏校验', () => resourceReconcile.reconcileAllGames()),
-    runValidation('模板校验', () => templateManager.validateAllTemplates()),
-  ])
-  await openLastProjectIfNeeded()
-  void appUpdateController.checkForUpdate('startup')
+  if (isDebug) {
+    await logger.attachConsole()
+  }
+
+  await runAppStartup({
+    appUpdateController,
+    engineManager,
+    generalSettingsStore,
+    resourceReconcile,
+    resolveMissingStorageSavePaths,
+    router,
+    storageSettingsStore,
+    templateManager,
+    t,
+  })
 })
 
 // 全局阻止鼠标中键点击的默认滚动行为

--- a/src/components/editor/AssetPreview.vue
+++ b/src/components/editor/AssetPreview.vue
@@ -53,7 +53,7 @@ function handleMediaLoadedMetadata() {
 
   if (shouldResumePlayback) {
     void element.play().catch((error) => {
-      logger.warn(`资源预览恢复播放失败 (${props.state.path}): ${error}`)
+      logger.debug(`资源预览恢复播放失败 (${props.state.path}): ${error}`)
     })
   }
 }

--- a/src/components/editor/PreviewPanel.vue
+++ b/src/components/editor/PreviewPanel.vue
@@ -64,7 +64,6 @@ async function updateAspectRatio(): Promise<void> {
     }
 
     aspectRatio = nextStageSize.aspectRatio
-    logger.debug(`预览面板分辨率: ${nextStageSize.stageWidth}x${nextStageSize.stageHeight}`)
   } catch (error) {
     const fallbackStageSize = resolvePreviewPanelStageSize({
       currentGamePath: workspaceStore.currentGame?.path,

--- a/src/components/editor/StatementAudioPreview.vue
+++ b/src/components/editor/StatementAudioPreview.vue
@@ -275,7 +275,7 @@ async function playCurrentSource() {
   try {
     await instance.play()
   } catch (error) {
-    logger.warn(`辅助面板音频预览播放失败 (${src}): ${String(error)}`)
+    logger.debug(`辅助面板音频预览播放失败 (${src}): ${String(error)}`)
   }
 }
 

--- a/src/components/editor/useAssetViewItemsLoader.ts
+++ b/src/components/editor/useAssetViewItemsLoader.ts
@@ -103,7 +103,6 @@ export function useAssetViewItemsLoader<TItem>(options: UseAssetViewItemsLoaderO
       }
 
       if (!relativePath && error instanceof AppError && error.code === 'DIR_NOT_FOUND') {
-        void logger.debug(`资源目录 ${toValue(options.assetBasePath)} 不存在，返回空列表`)
         items.value = []
         return
       }

--- a/src/components/file-viewer/FileViewer.vue
+++ b/src/components/file-viewer/FileViewer.vue
@@ -167,9 +167,7 @@ function resolveBuiltInPreviewUrl(item: FileViewerItem, previewSize: FileViewerP
         resizeMode: 'contain',
       },
     })
-  } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : String(error)
-    void logger.error(`[FileViewer] 资源地址生成失败: ${item.path} - ${errorMessage}`)
+  } catch {
     return undefined
   }
 }

--- a/src/components/file-viewer/FileViewerBody.vue
+++ b/src/components/file-viewer/FileViewerBody.vue
@@ -366,9 +366,7 @@ function resolveDisplayPreviewUrl(item: FileViewerItem, previewSize: FileViewerP
     }
 
     return previewUrl
-  } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : String(error)
-    void logger.error(`[FileViewer] 资源地址生成失败: ${item.path} - ${errorMessage}`)
+  } catch {
     return undefined
   }
 }

--- a/src/components/file-viewer/FileViewerImageHoverCard.vue
+++ b/src/components/file-viewer/FileViewerImageHoverCard.vue
@@ -106,9 +106,7 @@ function updateDisplayPreviewUrl(): void {
 
   try {
     displayPreviewUrl = props.resolvePreviewUrl?.(props.item, resolvedPreviewSize)
-  } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : String(error)
-    void logger.error(`[FileViewer] 资源地址生成失败: ${props.item.path} - ${errorMessage}`)
+  } catch {
     displayPreviewUrl = undefined
   }
 }
@@ -143,7 +141,6 @@ function handlePreviewLoad(): void {
 function handlePreviewError(): void {
   displayPreviewUrl = undefined
   isPreviewLoaded = false
-  void logger.error(`[FileViewer] 悬浮预览加载失败: ${props.item.path}`)
 }
 
 function getPreviewFrameSize(

--- a/src/components/file-viewer/fileViewerImageDimensions.ts
+++ b/src/components/file-viewer/fileViewerImageDimensions.ts
@@ -42,9 +42,8 @@ export async function loadFileViewerImageDimensions(
       }
       imageDimensionsCache.set(cacheKey, dimensions)
       return dimensions
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error)
-      void logger.error(`[FileViewer] 读取图片尺寸失败: ${item.path} - ${errorMessage}`)
+    } catch {
+      return
     } finally {
       pendingImageDimensionRequests.delete(cacheKey)
     }

--- a/src/components/shared/AssetImage.vue
+++ b/src/components/shared/AssetImage.vue
@@ -42,18 +42,14 @@ const primarySrc = $computed(() => {
         previewBaseUrl: props.serveUrl,
         thumbnail: props.thumbnail,
       })
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error)
-      void logger.error(`[AssetImage] 资源地址生成失败: ${props.path} - ${errorMessage}`)
+    } catch {
       return
     }
   }
 
   try {
     return getAssetUrl(props.path, props.cacheVersion, props.serveUrl, props.thumbnail)
-  } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : String(error)
-    void logger.error(`[AssetImage] 资源地址生成失败: ${props.path} - ${errorMessage}`)
+  } catch {
     return
   }
 })
@@ -84,7 +80,6 @@ watch(
 
 function handleError() {
   hasLoadError = true
-  void logger.error(`[AssetImage] 图片加载失败: ${props.path}`)
 }
 </script>
 

--- a/src/composables/useResourcePreviewPrimer.ts
+++ b/src/composables/useResourcePreviewPrimer.ts
@@ -20,13 +20,20 @@ export function useResourcePreviewPrimer(): () => void {
         const gameResults = await Promise.allSettled(
           games.map(game => gameManager.resolvePreviewSite(game)),
         )
+        const failedGameResults: string[] = []
         const gameSites = gameResults.flatMap((result, index) => {
           if (result.status === 'fulfilled') {
             return [result.value]
           }
-          void logger.warn(`跳过游戏预览预热 ${games[index]?.path}: ${result.reason}`)
+          failedGameResults.push(`${games[index]?.path ?? 'unknown'}: ${String(result.reason)}`)
           return []
         })
+        if (failedGameResults.length > 0) {
+          const sample = failedGameResults.slice(0, 3).join('; ')
+          const suffix = failedGameResults.length > 3 ? `; 另有 ${failedGameResults.length - 3} 个失败` : ''
+          void logger.warn(`资源预览预热跳过 ${failedGameResults.length} 个游戏: ${sample}${suffix}`)
+        }
+
         const engineSites = engines
           .filter(engine => engine.status === 'created')
           .map(engine => ({ projectPath: engine.path }))

--- a/src/features/app-startup/__tests__/app-startup.test.ts
+++ b/src/features/app-startup/__tests__/app-startup.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { AbsPath } from '~/domain/path'
+
+import { runAppStartup } from '../app-startup'
+
+import type { RunAppStartupOptions } from '../app-startup'
+
+vi.mock('@tauri-apps/plugin-log', () => ({
+  error: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+}))
+
+function createStartupOptions(overrides: Partial<RunAppStartupOptions> = {}): RunAppStartupOptions {
+  return {
+    appUpdateController: {
+      checkForUpdate: vi.fn(),
+    },
+    engineManager: {
+      validateAllEngines: vi.fn(async () => ({
+        failed: 0,
+        failures: [],
+        total: 0,
+      })),
+    },
+    generalSettingsStore: {
+      openLastProject: false,
+    },
+    resourceReconcile: {
+      reconcileAllGames: vi.fn(async () => ({
+        failed: 0,
+        failures: [],
+        total: 0,
+      })),
+    },
+    resolveMissingStorageSavePaths: vi.fn(async () => ({})),
+    router: {
+      currentRoute: {
+        value: {
+          path: '/',
+        },
+      },
+      push: vi.fn(),
+    },
+    storageSettingsStore: {
+      $patch: vi.fn(),
+      engineSavePath: '',
+      gameSavePath: '',
+      templateSavePath: '',
+    },
+    templateManager: {
+      validateAllTemplates: vi.fn(async () => ({
+        failed: 0,
+        failures: [],
+        total: 0,
+      })),
+    },
+    t: vi.fn((key: string) => key),
+    ...overrides,
+  }
+}
+
+describe('runAppStartup', () => {
+  it('初始化默认存储路径失败时会中止启动并抛出原始错误', async () => {
+    const error = new Error('document dir unavailable')
+    const checkForUpdate = vi.fn()
+    const validateAllEngines = vi.fn()
+
+    await expect(runAppStartup(createStartupOptions({
+      appUpdateController: {
+        checkForUpdate,
+      },
+      engineManager: {
+        validateAllEngines,
+      },
+      resolveMissingStorageSavePaths: vi.fn(async () => {
+        throw error
+      }),
+    }))).rejects.toThrow(error)
+
+    expect(validateAllEngines).not.toHaveBeenCalled()
+    expect(checkForUpdate).not.toHaveBeenCalled()
+  })
+
+  it('存在缺失存储路径时会写回默认值', async () => {
+    const patch = vi.fn()
+
+    await runAppStartup(createStartupOptions({
+      resolveMissingStorageSavePaths: vi.fn(async () => ({
+        gameSavePath: '/games',
+        templateSavePath: '/templates',
+      })),
+      storageSettingsStore: {
+        $patch: patch,
+        engineSavePath: '',
+        gameSavePath: '',
+        templateSavePath: '',
+      },
+    }))
+
+    expect(patch).toHaveBeenCalledWith({
+      gameSavePath: '/games',
+      templateSavePath: '/templates',
+    })
+  })
+
+  it('启动校验失败或返回异常摘要时仍会完成后续启动流程', async () => {
+    const checkForUpdate = vi.fn()
+    const validateAllEngines = vi.fn(async () => {
+      throw new Error('engine manifest missing')
+    })
+    const reconcileAllGames = vi.fn(async () => ({
+      failed: 2,
+      failures: [
+        { error: 'Error: manifest missing', path: AbsPath.from('/games/first') },
+        { error: 'Error: permission denied', path: AbsPath.from('/games/second') },
+      ],
+      total: 3,
+    }))
+    const validateAllTemplates = vi.fn(async () => ({
+      failed: 0,
+      failures: [],
+      total: 1,
+    }))
+
+    await runAppStartup(createStartupOptions({
+      appUpdateController: {
+        checkForUpdate,
+      },
+      engineManager: {
+        validateAllEngines,
+      },
+      resourceReconcile: {
+        reconcileAllGames,
+      },
+      templateManager: {
+        validateAllTemplates,
+      },
+    }))
+
+    expect(validateAllEngines).toHaveBeenCalledTimes(1)
+    expect(reconcileAllGames).toHaveBeenCalledTimes(1)
+    expect(validateAllTemplates).toHaveBeenCalledTimes(1)
+    expect(checkForUpdate).toHaveBeenCalledWith('startup')
+  })
+})

--- a/src/features/app-startup/app-startup.ts
+++ b/src/features/app-startup/app-startup.ts
@@ -1,0 +1,136 @@
+import { db } from '~/database/db'
+
+import type { Game } from '~/database/model'
+import type { StorageSavePathState } from '~/services/platform/storage-defaults'
+import type { ResourceValidationSummary } from '~/services/resource-validation-summary'
+
+interface AppStartupUpdateController {
+  checkForUpdate(reason: 'startup'): unknown
+}
+
+interface AppStartupEngineManager {
+  validateAllEngines(): Promise<ResourceValidationSummary>
+}
+
+interface AppStartupResourceReconcile {
+  reconcileAllGames(): Promise<ResourceValidationSummary>
+}
+
+interface AppStartupTemplateManager {
+  validateAllTemplates(): Promise<ResourceValidationSummary>
+}
+
+interface AppStartupRoute {
+  path: string
+}
+
+interface AppStartupRouter {
+  currentRoute: {
+    value: AppStartupRoute
+  }
+  push(path: string): Promise<unknown>
+}
+
+interface AppStartupGeneralSettingsStore {
+  openLastProject: boolean
+}
+
+interface AppStartupStorageSettingsStore extends StorageSavePathState {
+  $patch(patch: Partial<StorageSavePathState>): void
+}
+
+export interface RunAppStartupOptions {
+  appUpdateController: AppStartupUpdateController
+  engineManager: AppStartupEngineManager
+  generalSettingsStore: AppStartupGeneralSettingsStore
+  resourceReconcile: AppStartupResourceReconcile
+  resolveMissingStorageSavePaths(storageSettings: StorageSavePathState): Promise<Partial<StorageSavePathState>>
+  router: AppStartupRouter
+  storageSettingsStore: AppStartupStorageSettingsStore
+  templateManager: AppStartupTemplateManager
+  t(key: string, values?: Record<string, unknown>): string
+}
+
+async function initializeStoragePaths(options: RunAppStartupOptions): Promise<void> {
+  const missingStoragePaths = await options.resolveMissingStorageSavePaths(options.storageSettingsStore)
+
+  if (Object.keys(missingStoragePaths).length > 0) {
+    options.storageSettingsStore.$patch(missingStoragePaths)
+    logger.info(`初始化默认存储路径: ${Object.keys(missingStoragePaths).join(', ')}`)
+  }
+}
+
+async function openLastProjectIfNeeded(options: RunAppStartupOptions): Promise<void> {
+  if (!options.generalSettingsStore.openLastProject || options.router.currentRoute.value.path !== '/') {
+    return
+  }
+
+  try {
+    const lastGame = await db.games.orderBy('lastModified').last() as Game | undefined
+    if (!lastGame || lastGame.status !== 'created') {
+      return
+    }
+
+    if (lastGame.availability !== 'available') {
+      logger.warn(`最近项目当前不可用，跳过自动打开: ${lastGame.path}`)
+      notify.warning(options.t('home.games.openLastProjectUnavailable', { name: lastGame.metadata.name }))
+      return
+    }
+
+    await options.router.push(`/edit/${lastGame.id}`)
+    logger.info(`自动打开最近项目: ${lastGame.metadata.name} (${lastGame.path})`)
+  } catch (error) {
+    logger.error(`自动打开最近项目失败: ${error}`)
+  }
+}
+
+interface StartupValidationIssue {
+  count: number
+  label: string
+}
+
+async function runValidation(label: string, validate: () => Promise<ResourceValidationSummary>): Promise<StartupValidationIssue | undefined> {
+  try {
+    const summary = await validate()
+    if (summary.failed > 0) {
+      return {
+        count: summary.failed,
+        label,
+      }
+    }
+    return
+  } catch (error) {
+    logger.error(`${label}失败: ${error}`)
+    return {
+      count: 1,
+      label,
+    }
+  }
+}
+
+export async function runAppStartup(options: RunAppStartupOptions): Promise<void> {
+  logger.info('应用启动初始化开始')
+
+  try {
+    await initializeStoragePaths(options)
+    const validationResults = await Promise.all([
+      runValidation('引擎校验', () => options.engineManager.validateAllEngines()),
+      runValidation('游戏校验', () => options.resourceReconcile.reconcileAllGames()),
+      runValidation('模板校验', () => options.templateManager.validateAllTemplates()),
+    ])
+    const failedValidations = validationResults.filter((issue): issue is StartupValidationIssue => issue !== undefined)
+    await openLastProjectIfNeeded(options)
+    void options.appUpdateController.checkForUpdate('startup')
+    if (failedValidations.length > 0) {
+      const validationIssueSummary = failedValidations
+        .map(({ count, label }) => `${label} ${count} 个`)
+        .join('、')
+      logger.info(`应用启动初始化完成，校验异常 ${failedValidations.length} 类: ${validationIssueSummary}`)
+    } else {
+      logger.info('应用启动初始化完成')
+    }
+  } catch (error) {
+    logger.error(`应用启动初始化失败: ${error}`)
+    throw error
+  }
+}

--- a/src/features/editor/text-editor/useTextEditorWorkspace.ts
+++ b/src/features/editor/text-editor/useTextEditorWorkspace.ts
@@ -63,7 +63,6 @@ export function useTextEditorWorkspace(options: UseTextEditorWorkspaceOptions) {
       const model = monaco.editor.getModel(uri)
       if (model) {
         model.dispose()
-        logger.debug(`[TextEditor] LRU 淘汰模型: ${path}`)
       }
     },
   })

--- a/src/features/home/__tests__/useDiscoverResources.test.ts
+++ b/src/features/home/__tests__/useDiscoverResources.test.ts
@@ -10,6 +10,7 @@ const {
   existsMock,
   getEnginePreviewAssetsMock,
   getTemplateMetadataMock,
+  loggerErrorMock,
   modalOpenMock,
   notifyErrorMock,
   notifyInfoMock,
@@ -35,6 +36,7 @@ const {
   existsMock: vi.fn(),
   getEnginePreviewAssetsMock: vi.fn(),
   getTemplateMetadataMock: vi.fn(),
+  loggerErrorMock: vi.fn(),
   modalOpenMock: vi.fn(),
   notifyErrorMock: vi.fn(),
   notifyInfoMock: vi.fn(),
@@ -57,7 +59,7 @@ vi.mock('@tauri-apps/plugin-fs', () => ({
 }))
 
 vi.mock('@tauri-apps/plugin-log', () => ({
-  error: vi.fn(),
+  error: loggerErrorMock,
   info: vi.fn(),
   warn: vi.fn(),
   debug: vi.fn(),
@@ -140,6 +142,7 @@ describe('useDiscoverResources', () => {
     existsMock.mockReset()
     getEnginePreviewAssetsMock.mockReset()
     getTemplateMetadataMock.mockReset()
+    loggerErrorMock.mockReset()
     modalOpenMock.mockReset()
     notifyErrorMock.mockReset()
     notifyInfoMock.mockReset()
@@ -622,5 +625,50 @@ describe('useDiscoverResources', () => {
 
     expect(notifyErrorMock).not.toHaveBeenCalled()
     expect(notifyInfoMock).toHaveBeenCalledWith('home.games.importCancelled (1/1)')
+  })
+
+  it('批量导入失败日志只统计样例之外的剩余失败数', async () => {
+    resolveHomeTabDefinitionMock.mockReturnValue({ discoveryType: 'templates' })
+    useWorkspaceStoreMock.mockReturnValue({ activeTab: 'templates' })
+    readDirMock.mockImplementation(async (path: string) => {
+      switch (path) {
+        case '/templates': {
+          return [
+            { isDirectory: true, name: 'first' },
+            { isDirectory: true, name: 'second' },
+            { isDirectory: true, name: 'third' },
+            { isDirectory: true, name: 'fourth' },
+          ]
+        }
+        default: {
+          return []
+        }
+      }
+    })
+    validateTemplateMock.mockResolvedValue(true)
+    getTemplateMetadataMock.mockImplementation(async (path: AbsPath) => ({
+      name: AbsPath.basename(path),
+    }))
+    templateImportMock.mockImplementation(async (path: AbsPath) => {
+      throw new Error(`failed ${AbsPath.basename(path)}`)
+    })
+
+    const { useDiscoverResources } = await import('../useDiscoverResources')
+    const discoverResources = useDiscoverResources()
+
+    await discoverResources.checkResourcesForActiveTab()
+
+    const modalProps = modalOpenMock.mock.calls[0]?.[1] as { onImport?: (paths: AbsPath[]) => Promise<void> } | undefined
+    await modalProps?.onImport?.([
+      AbsPath.from('/templates/first'),
+      AbsPath.from('/templates/second'),
+      AbsPath.from('/templates/third'),
+      AbsPath.from('/templates/fourth'),
+    ])
+
+    expect(loggerErrorMock).toHaveBeenCalledWith(
+      expect.stringContaining('样例 /templates/first -> Error: failed first; /templates/second -> Error: failed second; /templates/third -> Error: failed third 等 1 个'),
+    )
+    expect(loggerErrorMock).not.toHaveBeenCalledWith(expect.stringContaining(' 等 4 个'))
   })
 })

--- a/src/features/home/useDiscoverResources.ts
+++ b/src/features/home/useDiscoverResources.ts
@@ -381,7 +381,8 @@ export function useDiscoverResources() {
         .slice(0, 3)
         .map(({ error, path }) => `${path} -> ${error}`)
         .join('; ')
-      const suffix = failedImports.length > 3 ? ` 等 ${failedImports.length} 个` : ''
+      const remaining = Math.max(0, failedImports.length - 3)
+      const suffix = failedImports.length > 3 ? ` 等 ${remaining} 个` : ''
       logger.error(
         `[资源发现] 批量导入失败: 失败 ${failedImports.length}/${paths.length}, `
         + `样例 ${samplePaths}${suffix}`,

--- a/src/features/home/useDiscoverResources.ts
+++ b/src/features/home/useDiscoverResources.ts
@@ -352,21 +352,41 @@ export function useDiscoverResources() {
         try {
           const result = await importFn(path)
           const outcome = isHomeResourceImportOutcome(result) ? result : undefined
-          return resolveHomeResourceImportNotification(undefined, outcome)
+          return {
+            notification: resolveHomeResourceImportNotification(undefined, outcome),
+          }
         } catch (error) {
           const notification = resolveHomeResourceImportNotification(error)
-          if (notification.kind !== 'import-cancelled') {
-            logger.error(`[资源发现] 导入失败: ${path} - ${error}`)
+          return {
+            notification,
+            failure: notification.kind === 'import-cancelled'
+              ? undefined
+              : { path, error },
           }
-          return notification
         }
       }),
     )
+    const notifications = results.map(result => result.notification)
+    const failedImports = results
+      .map(result => result.failure)
+      .filter((failure): failure is { path: AbsPath, error: unknown } => failure !== undefined)
 
-    const successCount = results.filter(result => result.level === 'success').length
-    const alreadyRegisteredCount = results.filter(result => result.kind === 'already-registered').length
-    const cancelCount = results.filter(result => result.kind === 'import-cancelled').length
-    const failCount = results.filter(result => result.level === 'error').length
+    const successCount = notifications.filter(result => result.level === 'success').length
+    const alreadyRegisteredCount = notifications.filter(result => result.kind === 'already-registered').length
+    const cancelCount = notifications.filter(result => result.kind === 'import-cancelled').length
+    const failCount = notifications.filter(result => result.level === 'error').length
+
+    if (failedImports.length > 0) {
+      const samplePaths = failedImports
+        .slice(0, 3)
+        .map(({ error, path }) => `${path} -> ${error}`)
+        .join('; ')
+      const suffix = failedImports.length > 3 ? ` 等 ${failedImports.length} 个` : ''
+      logger.error(
+        `[资源发现] 批量导入失败: 失败 ${failedImports.length}/${paths.length}, `
+        + `样例 ${samplePaths}${suffix}`,
+      )
+    }
 
     if (successCount > 0) {
       notify.success(`${messages.success} (${successCount}/${paths.length})`)

--- a/src/plugins/editor/index.ts
+++ b/src/plugins/editor/index.ts
@@ -593,7 +593,6 @@ async function getContentSuggestion(model: monaco.editor.ITextModel, position: m
       // 使用映射表获取文件类型
       const fileType = COMMAND_TO_FILE_TYPE_MAP[command]
       if (!fileType) {
-        logger.debug(`[editor][completion] 未实现的文件补全命令类型: "${String(command)}"`)
         return []
       }
       return await getFileSuggestion(model, position, fileType, content)

--- a/src/services/__tests__/engine-manager.test.ts
+++ b/src/services/__tests__/engine-manager.test.ts
@@ -23,6 +23,7 @@ const {
   gameWhereEqualsMock,
   gameWhereMock,
   iconPathMock,
+  loggerWarnMock,
   readEngineManifestMock,
   resourceStoreMock,
   useResourceStoreMock,
@@ -46,6 +47,7 @@ const {
   gameWhereEqualsMock: vi.fn(),
   gameWhereMock: vi.fn(),
   iconPathMock: vi.fn(),
+  loggerWarnMock: vi.fn(),
   readEngineManifestMock: vi.fn(),
   resourceStoreMock: {
     finishProgress: vi.fn(),
@@ -64,7 +66,7 @@ vi.mock('@tauri-apps/plugin-log', () => ({
   debug: vi.fn(),
   error: vi.fn(),
   info: vi.fn(),
-  warn: vi.fn(),
+  warn: loggerWarnMock,
   attachConsole: vi.fn(),
 }))
 
@@ -128,6 +130,7 @@ describe('engineManager', () => {
     gameWhereEqualsMock.mockReset()
     gameWhereMock.mockReset()
     iconPathMock.mockReset()
+    loggerWarnMock.mockReset()
     readEngineManifestMock.mockReset()
     resourceStoreMock.finishProgress.mockReset()
     resourceStoreMock.updateProgress.mockReset()
@@ -336,7 +339,7 @@ describe('engineManager', () => {
     readEngineManifestMock.mockResolvedValue({ status: 'missing' })
     validateDirectoryStructureMock.mockResolvedValue(true)
 
-    await expect(engineManager.importEngine(AbsPath.from('/downloads/LegacyEngine'))).rejects.toEqual(
+    await expect(engineManager.importEngine(AbsPath.from('/downloads/unsupportedEngine'))).rejects.toEqual(
       new AppError('INVALID_MANIFEST', '不支持导入旧版引擎，请导入包含该引擎的项目或使用受支持的引擎版本', {
         details: { reason: 'LEGACY_ENGINE' },
       }),
@@ -344,6 +347,7 @@ describe('engineManager', () => {
 
     expect(addMock).not.toHaveBeenCalled()
     expect(copyDirectoryWithProgressMock).not.toHaveBeenCalled()
+    expect(loggerWarnMock).toHaveBeenCalledWith('[引擎导入] 引擎清单无效: 路径=/downloads/unsupportedEngine, 原因=缺少 webgal-engine.json')
   })
 
   it('importEngine 会拒绝 schemaVersion 不受支持的引擎', async () => {
@@ -365,6 +369,9 @@ describe('engineManager', () => {
 
     expect(addMock).not.toHaveBeenCalled()
     expect(copyDirectoryWithProgressMock).not.toHaveBeenCalled()
+    expect(loggerWarnMock).toHaveBeenCalledWith(
+      '[引擎导入] 引擎清单无效: 路径=/downloads/futureEngine, 原因=schemaVersion 2.0.0 不受支持，最高支持主版本 1',
+    )
   })
 
   it('importEngine 会拒绝 manifest 解析失败的引擎', async () => {
@@ -382,6 +389,8 @@ describe('engineManager', () => {
         },
       }),
     )
+
+    expect(loggerWarnMock).toHaveBeenCalledWith('[引擎导入] 引擎清单无效: 路径=/downloads/brokenEngine, 原因=缺少必填字段')
   })
 
   it('importEngine 在同 engineId+version 已注册时幂等返回既有 ID', async () => {
@@ -582,6 +591,75 @@ describe('engineManager', () => {
     await engineManager.validateAllEngines()
 
     expect(enginesUpdateMock).toHaveBeenCalledWith('engine-1', { availability: 'broken' })
+  })
+
+  it('validateAllEngines 遇到多个 manifest 结构性问题时会返回失败摘要', async () => {
+    enginesToArrayMock.mockResolvedValue([
+      createTestEngine({
+        id: 'engine-1',
+        path: AbsPath.from('/engines/first'),
+        status: 'created',
+      }),
+      createTestEngine({
+        id: 'engine-2',
+        path: AbsPath.from('/engines/second'),
+        status: 'created',
+      }),
+    ])
+    existsMock.mockResolvedValue(true)
+    validateDirectoryStructureMock.mockResolvedValue(true)
+    readEngineManifestMock.mockImplementation(async (path: AbsPath) => {
+      if (path === '/engines/first') {
+        return { reason: '缺少必填字段', status: 'invalid' }
+      }
+      return {
+        schemaVersion: '2.0.0',
+        status: 'unsupportedSchema',
+        supportedMajor: 1,
+      }
+    })
+
+    await expect(engineManager.validateAllEngines()).resolves.toEqual({
+      failed: 2,
+      failures: [
+        { error: '缺少必填字段', path: '/engines/first' },
+        { error: 'schemaVersion 2.0.0 不受支持，最高支持主版本 1', path: '/engines/second' },
+      ],
+      total: 2,
+    })
+
+    expect(enginesUpdateMock).toHaveBeenCalledWith('engine-1', { availability: 'broken' })
+    expect(enginesUpdateMock).toHaveBeenCalledWith('engine-2', { availability: 'broken' })
+  })
+
+  it('validateAllEngines 遇到多个校验异常时会返回失败摘要', async () => {
+    enginesToArrayMock.mockResolvedValue([
+      createTestEngine({
+        id: 'engine-1',
+        path: AbsPath.from('/engines/first'),
+        status: 'created',
+      }),
+      createTestEngine({
+        id: 'engine-2',
+        path: AbsPath.from('/engines/second'),
+        status: 'created',
+      }),
+    ])
+    existsMock.mockImplementation(async (path: string) => {
+      if (path === '/engines/first') {
+        throw new Error('disk unavailable')
+      }
+      throw new Error('permission denied')
+    })
+
+    await expect(engineManager.validateAllEngines()).resolves.toEqual({
+      failed: 2,
+      failures: [
+        { error: 'Error: disk unavailable', path: '/engines/first' },
+        { error: 'Error: permission denied', path: '/engines/second' },
+      ],
+      total: 2,
+    })
   })
 
   it('uninstallEngine 会阻止删除仍有关联游戏的引擎', async () => {

--- a/src/services/__tests__/game-manager.test.ts
+++ b/src/services/__tests__/game-manager.test.ts
@@ -1334,6 +1334,8 @@ describe('gameManager', () => {
     await expect(gameManager.importGame(AbsPath.from('/games/missing'))).rejects.toEqual(
       new AppError('DIR_NOT_FOUND', '游戏目录不存在'),
     )
+
+    expect(warnMock).toHaveBeenCalledWith('[游戏导入] 游戏目录不存在: /games/missing')
   })
 
   it('importGame 遇到缺失 game/config.txt 的目录时抛出 INVALID_STRUCTURE', async () => {
@@ -1342,6 +1344,8 @@ describe('gameManager', () => {
     await expect(gameManager.importGame(AbsPath.from('/games/invalid'))).rejects.toEqual(
       new AppError('INVALID_STRUCTURE', '无效的游戏文件夹'),
     )
+
+    expect(warnMock).toHaveBeenCalledWith('[游戏导入] 无效的游戏文件夹: /games/invalid')
   })
 
   it('importGame 在 config.txt 解析失败时抛出 INVALID_CONFIG', async () => {
@@ -1351,6 +1355,8 @@ describe('gameManager', () => {
     await expect(gameManager.importGame(AbsPath.from('/games/bad-config'))).rejects.toMatchObject({
       code: 'INVALID_CONFIG',
     })
+
+    expect(warnMock).toHaveBeenCalledWith(expect.stringContaining('[游戏导入] 游戏配置解析失败: /games/bad-config'))
   })
 
   it('inspectGame 在路径不存在时返回 missing + DIR_NOT_FOUND', async () => {

--- a/src/services/__tests__/path-operation.test.ts
+++ b/src/services/__tests__/path-operation.test.ts
@@ -36,6 +36,13 @@ vi.mock('@tauri-apps/plugin-fs', () => ({
   exists: existsMock,
 }))
 
+vi.mock('@tauri-apps/plugin-log', () => ({
+  debug: vi.fn(),
+  error: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+}))
+
 vi.mock('~/services/backup-manager', () => ({
   backupManager: backupManagerMock,
 }))

--- a/src/services/__tests__/resource-reconcile.test.ts
+++ b/src/services/__tests__/resource-reconcile.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { createTestGame } from '~/__tests__/factories'
+import { AbsPath } from '~/domain/path'
+import { resourceReconcile } from '~/services/resource-reconcile'
+
+const {
+  dbGamesToArrayMock,
+  dbGamesUpdateMock,
+  gameInspectMock,
+} = vi.hoisted(() => ({
+  dbGamesToArrayMock: vi.fn(),
+  dbGamesUpdateMock: vi.fn(),
+  gameInspectMock: vi.fn(),
+}))
+
+vi.mock('@tauri-apps/plugin-log', () => ({
+  warn: vi.fn(),
+}))
+
+vi.mock('~/database/db', () => ({
+  db: {
+    games: {
+      toArray: dbGamesToArrayMock,
+      update: dbGamesUpdateMock,
+    },
+  },
+}))
+
+vi.mock('~/services/game-manager', () => ({
+  gameManager: {
+    inspectGame: gameInspectMock,
+  },
+}))
+
+vi.mock('~/services/engine-manager', () => ({
+  engineManager: {
+    inspectEngine: vi.fn(),
+  },
+}))
+
+vi.mock('~/services/template-manager', () => ({
+  templateManager: {
+    inspectTemplateAvailability: vi.fn(),
+  },
+}))
+
+describe('resourceReconcile', () => {
+  beforeEach(() => {
+    dbGamesToArrayMock.mockReset()
+    dbGamesUpdateMock.mockReset()
+    gameInspectMock.mockReset()
+  })
+
+  it('reconcileAllGames 遇到多个游戏校验异常时会返回失败摘要', async () => {
+    dbGamesToArrayMock.mockResolvedValue([
+      createTestGame({
+        id: 'game-1',
+        path: AbsPath.from('/games/first'),
+      }),
+      createTestGame({
+        id: 'game-2',
+        path: AbsPath.from('/games/second'),
+      }),
+    ])
+    gameInspectMock.mockImplementation(async (path: AbsPath) => {
+      if (path === '/games/first') {
+        throw new Error('disk unavailable')
+      }
+      throw new Error('permission denied')
+    })
+
+    await expect(resourceReconcile.reconcileAllGames()).resolves.toEqual({
+      failed: 2,
+      failures: [
+        { error: 'Error: disk unavailable', path: '/games/first' },
+        { error: 'Error: permission denied', path: '/games/second' },
+      ],
+      total: 2,
+    })
+  })
+})

--- a/src/services/__tests__/resource-reconcile.test.ts
+++ b/src/services/__tests__/resource-reconcile.test.ts
@@ -78,5 +78,7 @@ describe('resourceReconcile', () => {
       ],
       total: 2,
     })
+    expect(dbGamesUpdateMock).toHaveBeenCalledWith('game-1', { availability: 'broken' })
+    expect(dbGamesUpdateMock).toHaveBeenCalledWith('game-2', { availability: 'broken' })
   })
 })

--- a/src/services/__tests__/resource-validation-summary.test.ts
+++ b/src/services/__tests__/resource-validation-summary.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { AbsPath } from '~/domain/path'
+import {
+  createResourceValidationFailure,
+  createResourceValidationSummary,
+  logResourceValidationSummary,
+} from '~/services/resource-validation-summary'
+
+const { loggerWarnMock } = vi.hoisted(() => ({
+  loggerWarnMock: vi.fn(),
+}))
+
+vi.mock('@tauri-apps/plugin-log', () => ({
+  warn: loggerWarnMock,
+}))
+
+describe('createResourceValidationFailure', () => {
+  it('会把未知错误稳定转换成字符串', () => {
+    expect(createResourceValidationFailure(AbsPath.from('/games/demo'), new Error('disk unavailable')))
+      .toEqual({
+        error: 'Error: disk unavailable',
+        path: '/games/demo',
+      })
+  })
+})
+
+describe('createResourceValidationSummary', () => {
+  it('会根据失败列表生成数量摘要', () => {
+    const failures = [
+      { error: 'missing config', path: AbsPath.from('/games/first') },
+      { error: 'permission denied', path: AbsPath.from('/games/second') },
+    ]
+
+    expect(createResourceValidationSummary(3, failures)).toEqual({
+      failed: 2,
+      failures,
+      total: 3,
+    })
+  })
+})
+
+describe('logResourceValidationSummary', () => {
+  beforeEach(() => {
+    loggerWarnMock.mockReset()
+  })
+
+  it('没有失败时不会写入日志', () => {
+    logResourceValidationSummary('游戏校验', {
+      failed: 0,
+      failures: [],
+      total: 2,
+    })
+
+    expect(loggerWarnMock).not.toHaveBeenCalled()
+  })
+
+  it('会截断样例并写入剩余异常数量', () => {
+    logResourceValidationSummary('模板校验', {
+      failed: 4,
+      failures: [
+        { error: 'missing config', path: AbsPath.from('/templates/first') },
+        { error: 'invalid json', path: AbsPath.from('/templates/second') },
+        { error: 'unsupported version', path: AbsPath.from('/templates/third') },
+        { error: 'permission denied', path: AbsPath.from('/templates/fourth') },
+      ],
+      total: 5,
+    })
+
+    expect(loggerWarnMock).toHaveBeenCalledWith(
+      '模板校验异常 4/5: /templates/first -> missing config; /templates/second -> invalid json; /templates/third -> unsupported version; 另有 1 个异常',
+    )
+  })
+})

--- a/src/services/__tests__/template-manager.test.ts
+++ b/src/services/__tests__/template-manager.test.ts
@@ -17,6 +17,7 @@ const {
   dbTemplatesWhereMock,
   deleteFileMock,
   existsMock,
+  loggerWarnMock,
   readTextFileMock,
   readProjectConfigMock,
   resourceStoreMock,
@@ -35,6 +36,7 @@ const {
   dbTemplatesWhereMock: vi.fn(),
   deleteFileMock: vi.fn(),
   existsMock: vi.fn(),
+  loggerWarnMock: vi.fn(),
   readTextFileMock: vi.fn(),
   readProjectConfigMock: vi.fn(),
   resourceStoreMock: {
@@ -51,7 +53,7 @@ vi.mock('@tauri-apps/plugin-log', () => ({
   debug: vi.fn(),
   error: vi.fn(),
   info: vi.fn(),
-  warn: vi.fn(),
+  warn: loggerWarnMock,
 }))
 
 vi.mock('@tauri-apps/plugin-fs', () => ({
@@ -154,6 +156,7 @@ describe('templateManager', () => {
       ['template.json'],
     )
     expect(readTextFileMock).not.toHaveBeenCalled()
+    expect(loggerWarnMock).toHaveBeenCalledWith('[模板导入] 无效的模板文件夹: /source/template')
   })
 
   it('importTemplate 会复制到模板托管目录并写入数据库', async () => {
@@ -268,6 +271,33 @@ describe('templateManager', () => {
     expect(dbTemplatesDeleteMock).toHaveBeenCalledWith('template-creating')
   })
 
+  it('validateAllTemplates 清理 creating 残留失败时会返回失败摘要', async () => {
+    dbTemplatesToArrayMock.mockResolvedValue([
+      {
+        id: 'template-creating',
+        path: '/templates/Creating Template',
+        pathLookupKey: '/templates/creating template',
+        createdAt: 0,
+        status: 'creating',
+        metadata: {
+          name: 'Creating Template',
+        },
+      },
+    ])
+    existsMock.mockImplementation(async (path: string) => path === '/templates/Creating Template')
+    deleteFileMock.mockRejectedValue(new Error('trash unavailable'))
+
+    await expect(templateManager.validateAllTemplates()).resolves.toEqual({
+      failed: 1,
+      failures: [
+        { error: 'Error: trash unavailable', path: '/templates/Creating Template' },
+      ],
+      total: 1,
+    })
+
+    expect(dbTemplatesDeleteMock).toHaveBeenCalledWith('template-creating')
+  })
+
   it('validateAllTemplates 会把结构无效的已创建模板标记为 broken', async () => {
     dbTemplatesToArrayMock.mockResolvedValue([
       {
@@ -368,6 +398,104 @@ describe('templateManager', () => {
     expect(dbTemplatesUpdateMock).toHaveBeenCalledWith('template-created', { availability: 'broken' })
     expect(dbTemplatesDeleteMock).not.toHaveBeenCalled()
     expect(deleteFileMock).not.toHaveBeenCalled()
+  })
+
+  it('validateAllTemplates 遇到多个元数据读取失败时会返回失败摘要', async () => {
+    dbTemplatesToArrayMock.mockResolvedValue([
+      {
+        id: 'template-first',
+        path: '/templates/first',
+        pathLookupKey: '/templates/first',
+        createdAt: 0,
+        status: 'created',
+        availability: 'available',
+        metadata: {
+          name: 'First',
+        },
+      },
+      {
+        id: 'template-second',
+        path: '/templates/second',
+        pathLookupKey: '/templates/second',
+        createdAt: 0,
+        status: 'created',
+        availability: 'available',
+        metadata: {
+          name: 'Second',
+        },
+      },
+    ])
+    existsMock.mockResolvedValue(true)
+    validateDirectoryStructureMock.mockResolvedValue(true)
+    readTextFileMock.mockImplementation(async (path: string | URL) => {
+      if (String(path).includes('/templates/first')) {
+        throw new Error('invalid template.json')
+      }
+      throw new Error('permission denied')
+    })
+
+    await expect(templateManager.validateAllTemplates()).resolves.toEqual({
+      failed: 2,
+      failures: [
+        { error: 'Error: invalid template.json', path: '/templates/first' },
+        { error: 'Error: permission denied', path: '/templates/second' },
+      ],
+      total: 2,
+    })
+
+    expect(dbTemplatesUpdateMock).toHaveBeenCalledWith('template-first', { availability: 'broken' })
+    expect(dbTemplatesUpdateMock).toHaveBeenCalledWith('template-second', { availability: 'broken' })
+  })
+
+  it('validateAllTemplates 遇到多个校验异常时会返回失败摘要', async () => {
+    dbTemplatesToArrayMock.mockResolvedValue([
+      {
+        id: 'template-first',
+        path: '/templates/first',
+        pathLookupKey: '/templates/first',
+        createdAt: 0,
+        status: 'created',
+        availability: 'available',
+        metadata: {
+          name: 'First',
+        },
+      },
+      {
+        id: 'template-second',
+        path: '/templates/second',
+        pathLookupKey: '/templates/second',
+        createdAt: 0,
+        status: 'created',
+        availability: 'available',
+        metadata: {
+          name: 'Second',
+        },
+      },
+    ])
+    existsMock.mockImplementation(async (path: string) => {
+      if (path === '/templates/first' || path === '/templates/second') {
+        return true
+      }
+      return false
+    })
+    validateDirectoryStructureMock.mockImplementation(async (path: string) => {
+      if (path === '/templates/first') {
+        throw new Error('disk unavailable')
+      }
+      throw new Error('permission denied')
+    })
+
+    await expect(templateManager.validateAllTemplates()).resolves.toEqual({
+      failed: 2,
+      failures: [
+        { error: 'Error: disk unavailable', path: '/templates/first' },
+        { error: 'Error: permission denied', path: '/templates/second' },
+      ],
+      total: 2,
+    })
+
+    expect(dbTemplatesUpdateMock).toHaveBeenCalledWith('template-first', { availability: 'broken' })
+    expect(dbTemplatesUpdateMock).toHaveBeenCalledWith('template-second', { availability: 'broken' })
   })
 
   it('deleteTemplate 会递归删除模板目录并清理数据库记录', async () => {

--- a/src/services/__tests__/template-manager.test.ts
+++ b/src/services/__tests__/template-manager.test.ts
@@ -498,6 +498,38 @@ describe('templateManager', () => {
     expect(dbTemplatesUpdateMock).toHaveBeenCalledWith('template-second', { availability: 'broken' })
   })
 
+  it('validateAllTemplates 标记 broken 失败时仍返回校验失败摘要', async () => {
+    dbTemplatesToArrayMock.mockResolvedValue([
+      {
+        id: 'template-created',
+        path: '/templates/broken',
+        pathLookupKey: '/templates/broken',
+        createdAt: 0,
+        status: 'created',
+        availability: 'available',
+        metadata: {
+          name: 'Broken',
+        },
+      },
+    ])
+    existsMock.mockResolvedValue(true)
+    validateDirectoryStructureMock.mockRejectedValue(new Error('disk unavailable'))
+    dbTemplatesUpdateMock.mockRejectedValue(new Error('indexeddb unavailable'))
+
+    await expect(templateManager.validateAllTemplates()).resolves.toEqual({
+      failed: 1,
+      failures: [
+        { error: 'Error: disk unavailable', path: '/templates/broken' },
+      ],
+      total: 1,
+    })
+
+    expect(dbTemplatesUpdateMock).toHaveBeenCalledWith('template-created', { availability: 'broken' })
+    expect(loggerWarnMock).toHaveBeenCalledWith(
+      '[模板校验] 标记模板为 broken 失败 (/templates/broken): Error: indexeddb unavailable',
+    )
+  })
+
   it('deleteTemplate 会递归删除模板目录并清理数据库记录', async () => {
     await templateManager.deleteTemplate({
       id: 'template-created',

--- a/src/services/directory-cache.ts
+++ b/src/services/directory-cache.ts
@@ -145,7 +145,7 @@ async function loadDirectoryItems(absolutePath: AbsPath, includeStats: boolean):
   }
 
   if (failed.length > 0) {
-    void logger.warn(`[DirectoryCache] 目录 ${absolutePath} 有 ${failed.length} 个项目读取失败，已跳过`)
+    void logger.debug(`[DirectoryCache] 目录 ${absolutePath} 有 ${failed.length} 个项目读取失败，已跳过`)
   }
 
   return items

--- a/src/services/engine-manager.ts
+++ b/src/services/engine-manager.ts
@@ -16,6 +16,11 @@ import {
   ResourceWarning,
 } from '~/services/resource-health'
 import { toLookupPathKey } from '~/services/resource-path/lookup'
+import {
+  createResourceValidationFailure,
+  createResourceValidationSummary,
+  logResourceValidationSummary,
+} from '~/services/resource-validation-summary'
 import { EngineMetadata, EnginePreviewAssets } from '~/services/types'
 import { useResourceStore } from '~/stores/resource'
 import { useRuntimeTaskStore } from '~/stores/runtime-task'
@@ -23,6 +28,8 @@ import { useStorageSettingsStore } from '~/stores/storage-settings'
 import { EngineManifest, EngineManifestResult } from '~/types/engine'
 import { AppError } from '~/types/errors'
 import { EngineRef } from '~/types/project-config'
+
+import type { ResourceValidationFailure, ResourceValidationSummary } from '~/services/resource-validation-summary'
 
 interface EngineSnapshot {
   engineId: string
@@ -216,36 +223,67 @@ function buildDeleteCheckResult(associatedGames: Game[]): DeleteEngineCheckResul
   return { canDelete: true }
 }
 
-async function validateAllEngines(): Promise<void> {
+async function validateEngineRecordForBatch(engine: Engine): Promise<ResourceValidationFailure | undefined> {
+  try {
+    const pathExists = await exists(engine.path)
+    const structureValid = pathExists ? await validateEngine(engine.path) : false
+    const classification = structureValid ? await classifyEngine(engine.path) : undefined
+    const nextAvailability: ResourceAvailability = classifyAvailability({
+      pathExists,
+      structureValid,
+      semanticsValid: classification?.status === 'ok',
+    })
+    if (engine.availability !== nextAvailability) {
+      await db.engines.update(engine.id, { availability: nextAvailability })
+    }
+    const manifestIssue = describeEngineManifestValidationIssue(classification)
+    return manifestIssue
+      ? createResourceValidationFailure(engine.path, manifestIssue)
+      : undefined
+  } catch (error) {
+    return createResourceValidationFailure(engine.path, error)
+  }
+}
+
+function describeEngineManifestValidationIssue(classification: EngineManifestResult | undefined): string | undefined {
+  if (!classification || classification.status === 'ok') {
+    return
+  }
+
+  if (classification.status === 'missing') {
+    return '缺少 webgal-engine.json'
+  }
+
+  if (classification.status === 'invalid') {
+    return classification.reason
+  }
+
+  return `schemaVersion ${classification.schemaVersion} 不受支持，最高支持主版本 ${classification.supportedMajor}`
+}
+
+async function validateAllEngines(): Promise<ResourceValidationSummary> {
   const engines = await db.engines.toArray()
-  await Promise.all(engines
+  const targets = engines
     .filter(engine => engine.status !== 'creating' && engine.status !== 'error')
-    .map(async (engine) => {
-      try {
-        const pathExists = await exists(engine.path)
-        const structureValid = pathExists ? await validateEngine(engine.path) : false
-        const classification = structureValid ? await classifyEngine(engine.path) : undefined
-        const nextAvailability: ResourceAvailability = classifyAvailability({
-          pathExists,
-          structureValid,
-          semanticsValid: classification?.status === 'ok',
-        })
-        if (engine.availability !== nextAvailability) {
-          await db.engines.update(engine.id, { availability: nextAvailability })
-        }
-      } catch (error) {
-        logger.warn(`引擎校验异常: ${error}`)
-      }
-    }))
+  const validationResults = await Promise.all(targets.map(engine => validateEngineRecordForBatch(engine)))
+  const failures = validationResults
+    .filter((failure): failure is ResourceValidationFailure => failure !== undefined)
+  const summary = createResourceValidationSummary(targets.length, failures)
+  logResourceValidationSummary('引擎校验', summary)
+  return summary
 }
 
 async function assertEngineImportable(enginePath: AbsPath): Promise<EngineSnapshot> {
   if (!(await validateEngine(enginePath))) {
-    logger.error(`[引擎导入] 无效的引擎文件夹: ${enginePath}`)
+    logger.warn(`[引擎导入] 无效的引擎文件夹: ${enginePath}`)
     throw new AppError('INVALID_STRUCTURE', '无效的引擎文件夹')
   }
 
   const classification = await classifyEngine(enginePath)
+  const manifestIssue = describeEngineManifestValidationIssue(classification)
+  if (manifestIssue) {
+    logger.warn(`[引擎导入] 引擎清单无效: 路径=${enginePath}, 原因=${manifestIssue}`)
+  }
   if (classification.status === 'unsupportedSchema') {
     throw new AppError(
       'INVALID_MANIFEST',
@@ -427,7 +465,10 @@ async function importEngine(enginePath: AbsPath): Promise<ImportEngineResult> {
   )
 
   if (sourceLookupKey === targetLookupKey) {
-    logger.info(`[引擎导入] 引擎已在托管目录，直接注册: ${normalizedPath}`)
+    logger.info(
+      `[引擎导入] 直接注册托管目录: 名称=${snapshot.name}, 引擎ID=${snapshot.engineId}, `
+      + `版本=${snapshot.version ?? '未知'}, 路径=${normalizedPath}`,
+    )
     return { id: await registerEngine(targetPath, snapshot), alreadyRegistered: false }
   }
 
@@ -436,7 +477,10 @@ async function importEngine(enginePath: AbsPath): Promise<ImportEngineResult> {
     throw new AppError('TARGET_CONFLICT', '目标引擎目录已存在，请先清理后重试')
   }
 
-  logger.info(`[引擎 ${snapshot.name}] 开始导入`)
+  logger.info(
+    `[引擎导入] 开始: 名称=${snapshot.name}, 引擎ID=${snapshot.engineId}, `
+    + `版本=${snapshot.version ?? '未知'}, 源=${normalizedPath}, 目标=${targetPath}`,
+  )
   const engineId = await registerEngine(targetPath, {
     ...snapshot,
     status: 'creating',
@@ -447,17 +491,23 @@ async function importEngine(enginePath: AbsPath): Promise<ImportEngineResult> {
 
   try {
     await copyAndFinalizeEngine(engineId, normalizedPath, targetPath)
-    logger.info(`[引擎 ${snapshot.name}] 导入完成`)
+    logger.info(
+      `[引擎导入] 完成: ID=${engineId}, 名称=${snapshot.name}, 引擎ID=${snapshot.engineId}, `
+      + `版本=${snapshot.version ?? '未知'}, 源=${normalizedPath}, 目标=${targetPath}`,
+    )
     return { id: engineId, alreadyRegistered: false }
   } catch (error) {
-    logger.error(`[引擎导入] 导入失败: ${error}`)
+    logger.error(
+      `[引擎导入] 失败: ID=${engineId}, 名称=${snapshot.name}, 引擎ID=${snapshot.engineId}, `
+      + `版本=${snapshot.version ?? '未知'}, 源=${normalizedPath}, 目标=${targetPath} - ${error}`,
+    )
     useResourceStore().finishProgress(engineId)
     await db.engines.update(engineId, { status: 'error' }).catch((error_) => {
-      logger.warn(`[引擎导入] 清理异常 - 更新状态失败: ${error_}`)
+      logger.warn(`[引擎导入] 清理异常 - 更新状态失败: ID=${engineId}, 目标=${targetPath} - ${error_}`)
     })
     if (await exists(targetPath)) {
       await fsCmds.deleteFile(targetPath, true).catch((error_) => {
-        logger.warn(`[引擎导入] 清理异常 - 删除目录失败: ${error_}`)
+        logger.warn(`[引擎导入] 清理异常 - 删除目录失败: ID=${engineId}, 目标=${targetPath} - ${error_}`)
       })
     }
     throw error
@@ -475,7 +525,7 @@ function assertDeletable(deleteCheck: DeleteEngineCheckResult): void {
 
 async function uninstallEngine(engine: Engine): Promise<void> {
   assertDeletable(await canDeleteEngine(engine.id))
-  logger.info(`[引擎卸载] ${engine.name}@${engine.version ?? 'unknown'}: ${engine.path}`)
+  logger.info(`[引擎卸载] ${engine.name}@${engine.version ?? '未知'}: ${engine.path}`)
   if (engine.availability === 'available') {
     try {
       await fsCmds.deleteFile(engine.path, true)

--- a/src/services/game-manager.ts
+++ b/src/services/game-manager.ts
@@ -750,6 +750,11 @@ async function createGame(gameName: string, gamePath: AbsPath, engineId: string,
   const { templateBinding } = options
 
   const targetExisted = await exists(gamePath)
+  const templateLabel = templateBinding ? formatTemplateBindingName(templateBinding) : '无'
+  logger.info(
+    `[游戏创建] 开始: 名称=${gameName}, 路径=${gamePath}, 引擎ID=${engineId}, `
+    + `模板=${templateLabel}, 目标已存在=${targetExisted ? '是' : '否'}`,
+  )
   let gameId: string | undefined
   const finishUpdateBlocker = useRuntimeTaskStore()
     .beginBlockingTask(`create-game:${crypto.randomUUID()}`)
@@ -820,19 +825,32 @@ async function createGame(gameName: string, gamePath: AbsPath, engineId: string,
       ...snapshot,
     })
     resourceStore.finishProgress(gameId)
+    logger.info(
+      `[游戏创建] 完成: ID=${gameId}, 名称=${gameName}, 路径=${gamePath}, `
+      + `引擎ID=${engineId}, 模板=${templateLabel}`,
+    )
 
     return gameId
   } catch (error) {
-    logger.error(`创建游戏失败: ${error}`)
+    logger.error(
+      `[游戏创建] 失败: 记录ID=${gameId ?? '无'}, 名称=${gameName}, 路径=${gamePath}, `
+      + `引擎ID=${engineId}, 模板=${templateLabel} - ${error}`,
+    )
     if (gameId) {
       resourceStore.finishProgress(gameId)
       await db.games.delete(gameId).catch((error_) => {
-        logger.warn(`[游戏创建] 清理异常 - 删除记录失败: ${error_}`)
+        logger.warn(
+          `[游戏创建] 清理异常 - 删除记录失败: ID=${gameId}, 名称=${gameName}, 路径=${gamePath}, `
+          + `引擎ID=${engineId}, 模板=${templateLabel} - ${error_}`,
+        )
       })
     }
     if (!targetExisted && await exists(gamePath)) {
       await fsCmds.deleteFile(gamePath, true).catch((error_) => {
-        logger.warn(`[游戏创建] 清理异常 - 删除目录失败: ${error_}`)
+        logger.warn(
+          `[游戏创建] 清理异常 - 删除目录失败: 记录ID=${gameId ?? '无'}, 名称=${gameName}, 路径=${gamePath}, `
+          + `引擎ID=${engineId}, 模板=${templateLabel} - ${error_}`,
+        )
       })
     }
     throw error
@@ -1065,7 +1083,7 @@ async function importGame(gamePath: AbsPath, options: ImportGameOptions = {}): P
   const inspection = await inspectGame(normalizedPath)
   if (inspection.availability !== 'available') {
     const { code, message, details } = inspection.blockingIssue!
-    logger.error(`[游戏导入] ${message}: ${normalizedPath}`)
+    logger.warn(`[游戏导入] ${message}: ${normalizedPath}`)
     throw new AppError(code, message, { details })
   }
 

--- a/src/services/path-operation.ts
+++ b/src/services/path-operation.ts
@@ -1190,6 +1190,13 @@ export function createPathOperationService(deps: PathOperationDeps) {
     let pathMutationFailed = false
     const gamePath = deps.getGamePath()
     const warnings: PathOperationWarning[] = []
+    const startedAt = Date.now()
+    const rewriteCount = plan.rewrites.length
+    const referenceCount = plan.rewrites.reduce((total, rewrite) => total + rewrite.referenceCount, 0)
+    logger.debug(
+      `[PathOperation] 开始执行: ${plan.kind} ${plan.sourcePath} -> ${plan.targetPath}, `
+      + `重写文件 ${rewriteCount} 个, 引用 ${referenceCount} 处`,
+    )
 
     try {
       await validatePlanBaseline(deps, plan)
@@ -1297,6 +1304,10 @@ export function createPathOperationService(deps: PathOperationDeps) {
       if (fsResult.echoMode === 'synthetic') {
         deps.pathOperationRegistry.release(pendingId)
       }
+      logger.info(
+        `[PathOperation] 执行完成: ${plan.kind} ${plan.sourcePath} -> ${fsResult.newPath}, `
+        + `重写文件 ${rewriteCount} 个, 警告 ${warnings.length} 个, 耗时 ${Date.now() - startedAt}ms`,
+      )
 
       return {
         plan,
@@ -1321,6 +1332,10 @@ export function createPathOperationService(deps: PathOperationDeps) {
       } finally {
         deps.pathOperationRegistry.release(pendingId)
       }
+      logger.warn(
+        `[PathOperation] 执行失败: ${plan.kind} ${plan.sourcePath} -> ${plan.targetPath}, `
+        + `已应用文件变更 ${appliedFsResult ? '是' : '否'}, 耗时 ${Date.now() - startedAt}ms - ${toErrorMessage(error)}`,
+      )
       throw error
     }
   }
@@ -1351,6 +1366,7 @@ export function createPathOperationService(deps: PathOperationDeps) {
       return await apply(confirmedPlan)
     } catch (error) {
       if (error instanceof PathOperationError && error.code === 'stale-plan') {
+        logger.debug(`[PathOperation] 计划过期，重新规划: ${input.kind} ${input.sourcePath}`)
         const nextPlan = await plan(input)
         if (nextPlan.blockedReasons.length > 0) {
           throw createBlockedPlanError(nextPlan)

--- a/src/services/resource-index/__tests__/service.test.ts
+++ b/src/services/resource-index/__tests__/service.test.ts
@@ -9,10 +9,12 @@ import { createAssetKey } from '~/services/resource-index/keys'
 
 const {
   getConfigMock,
+  loggerWarnMock,
   onMock,
   useWorkspaceStoreMock,
 } = vi.hoisted(() => ({
   getConfigMock: vi.fn(),
+  loggerWarnMock: vi.fn(),
   onMock: vi.fn(),
   useWorkspaceStoreMock: vi.fn(),
 }))
@@ -28,7 +30,9 @@ vi.mock('~/composables/useFileSystemEvents', () => ({
 }))
 
 vi.mock('@tauri-apps/plugin-log', () => ({
-  warn: vi.fn(),
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: loggerWarnMock,
 }))
 
 vi.mock('~/services/config-manager', () => ({
@@ -122,6 +126,7 @@ describe('useResourceIndex', () => {
       entries: [],
       unmanagedLineCount: 0,
     })
+    loggerWarnMock.mockReset()
   })
 
   it('启动后会建立资源清单，并支持按 assetType 和相对路径查询', async () => {
@@ -355,6 +360,192 @@ describe('useResourceIndex', () => {
           ],
         },
       ])
+    } finally {
+      scope.stop()
+    }
+  })
+
+  it('全量构建遇到多个解析失败的 scene 文件时只写入一条聚合诊断日志', async () => {
+    readDirMock.mockImplementation(async (path: string | URL) => {
+      switch (String(path)) {
+        case '/project/game': {
+          return [
+            createDirEntry('scene', true),
+          ]
+        }
+        case '/project/game/scene': {
+          return [
+            createDirEntry('bad-a.txt', false),
+            createDirEntry('bad-b.txt', false),
+          ]
+        }
+        default: {
+          throw new TypeError(`unexpected readDir path: ${String(path)}`)
+        }
+      }
+    })
+    readTextFileMock.mockImplementation(async (path: string | URL) => {
+      if (String(path).endsWith('bad-a.txt')) {
+        throw new Error('missing semicolon')
+      }
+      throw new Error('invalid command')
+    })
+
+    const { useResourceIndex, useResourceIndexBootstrap } = await import('../service')
+
+    const scope = effectScope()
+    let resourceIndex!: ReturnType<typeof useResourceIndex>
+    scope.run(() => {
+      useResourceIndexBootstrap()
+      resourceIndex = useResourceIndex()
+    })
+
+    try {
+      await waitFor(() => resourceIndex.status.value === 'ready')
+
+      const parseFailureLogCalls = loggerWarnMock.mock.calls.filter(([message]) =>
+        String(message).startsWith('资源索引跳过'),
+      )
+      expect(parseFailureLogCalls).toHaveLength(1)
+      expect(parseFailureLogCalls[0]).toEqual([
+        '资源索引跳过 2 个解析失败的引用来源: /project/game/scene/bad-a.txt -> Error: missing semicolon; /project/game/scene/bad-b.txt -> Error: invalid command',
+      ])
+    } finally {
+      scope.stop()
+    }
+  })
+
+  it('增量重建遇到相同解析失败时会按冷却窗口写入诊断日志', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'))
+    readDirMock.mockImplementation(async (path: string | URL) => {
+      switch (String(path)) {
+        case '/project/game': {
+          return [
+            createDirEntry('background', true),
+            createDirEntry('scene', true),
+          ]
+        }
+        case '/project/game/background': {
+          return [
+            createDirEntry('old-bg.jpg', false),
+          ]
+        }
+        case '/project/game/scene': {
+          return [
+            createDirEntry('intro.txt', false),
+          ]
+        }
+        default: {
+          throw new TypeError(`unexpected readDir path: ${String(path)}`)
+        }
+      }
+    })
+    readTextFileMock.mockResolvedValue('changeBg:old-bg.jpg;')
+
+    const { useResourceIndex, useResourceIndexBootstrap } = await import('../service')
+
+    const scope = effectScope()
+    let resourceIndex!: ReturnType<typeof useResourceIndex>
+    scope.run(() => {
+      useResourceIndexBootstrap()
+      resourceIndex = useResourceIndex()
+    })
+
+    try {
+      await waitFor(() => resourceIndex.status.value === 'ready')
+      loggerWarnMock.mockClear()
+
+      readTextFileMock.mockRejectedValue(new Error('invalid command'))
+      emitFileSystemEvent('file:modified', {
+        type: 'file:modified',
+        path: '/project/game/scene/intro.txt',
+      })
+      await waitFor(() => loggerWarnMock.mock.calls.length === 1)
+
+      emitFileSystemEvent('file:modified', {
+        type: 'file:modified',
+        path: '/project/game/scene/intro.txt',
+      })
+      await flushMicrotasks()
+
+      expect(loggerWarnMock).toHaveBeenCalledTimes(1)
+
+      vi.setSystemTime(new Date(Date.now() + 10 * 60 * 1000))
+      emitFileSystemEvent('file:modified', {
+        type: 'file:modified',
+        path: '/project/game/scene/intro.txt',
+      })
+      await waitFor(() => loggerWarnMock.mock.calls.length === 2)
+
+      emitFileSystemEvent('file:removed', {
+        type: 'file:removed',
+        path: '/project/game/scene/intro.txt',
+      })
+      await flushMicrotasks()
+      emitFileSystemEvent('file:created', {
+        type: 'file:created',
+        path: '/project/game/scene/intro.txt',
+      })
+      await waitFor(() => loggerWarnMock.mock.calls.length === 3)
+
+      readTextFileMock.mockRejectedValue(new Error('missing semicolon'))
+      emitFileSystemEvent('file:modified', {
+        type: 'file:modified',
+        path: '/project/game/scene/intro.txt',
+      })
+      await waitFor(() => loggerWarnMock.mock.calls.length === 4)
+    } finally {
+      vi.useRealTimers()
+      scope.stop()
+    }
+  })
+
+  it('清空工作目录后重新打开同一路径时会重新记录解析失败', async () => {
+    readDirMock.mockImplementation(async (path: string | URL) => {
+      switch (String(path)) {
+        case '/project/game': {
+          return [
+            createDirEntry('scene', true),
+          ]
+        }
+        case '/project/game/scene': {
+          return [
+            createDirEntry('intro.txt', false),
+          ]
+        }
+        default: {
+          throw new TypeError(`unexpected readDir path: ${String(path)}`)
+        }
+      }
+    })
+    readTextFileMock.mockRejectedValue(new Error('invalid command'))
+
+    const { useResourceIndex, useResourceIndexBootstrap } = await import('../service')
+
+    const scope = effectScope()
+    let resourceIndex!: ReturnType<typeof useResourceIndex>
+    scope.run(() => {
+      useResourceIndexBootstrap()
+      resourceIndex = useResourceIndex()
+    })
+
+    try {
+      await waitFor(() => resourceIndex.status.value === 'ready')
+      expect(loggerWarnMock.mock.calls.filter(([message]) =>
+        String(message).startsWith('资源索引跳过'),
+      )).toHaveLength(1)
+
+      loggerWarnMock.mockClear()
+      workspaceStoreState.CWD = undefined
+      await waitFor(() => resourceIndex.status.value === 'idle')
+
+      workspaceStoreState.CWD = '/project'
+      await waitFor(() => resourceIndex.status.value === 'ready')
+
+      expect(loggerWarnMock.mock.calls.filter(([message]) =>
+        String(message).startsWith('资源索引跳过'),
+      )).toHaveLength(1)
     } finally {
       scope.stop()
     }

--- a/src/services/resource-index/__tests__/service.test.ts
+++ b/src/services/resource-index/__tests__/service.test.ts
@@ -809,7 +809,7 @@ describe('useResourceIndex', () => {
     }
   })
 
-  it('同一 scene 连续修改时会忽略较早完成的旧切片', async () => {
+  it('同一 scene 连续修改时会忽略较早完成的旧切片及其解析失败日志', async () => {
     readDirMock.mockImplementation(async (path: string | URL) => {
       switch (String(path)) {
         case '/project/game': {
@@ -858,10 +858,10 @@ describe('useResourceIndex', () => {
       await waitFor(() => resourceIndex.status.value === 'ready')
 
       const oldKey = createAssetKey('asset', 'background', RelPath.from('old.jpg'))
-      const staleKey = createAssetKey('asset', 'background', RelPath.from('stale.jpg'))
       const freshKey = createAssetKey('asset', 'background', RelPath.from('fresh.jpg'))
 
       expect(resourceIndex.getReferencesTo(oldKey)).toHaveLength(1)
+      loggerWarnMock.mockClear()
 
       const staleRead = createDeferred<string>()
       const freshRead = createDeferred<string>()
@@ -880,12 +880,12 @@ describe('useResourceIndex', () => {
       freshRead.resolve('changeBg:fresh.jpg;')
       await waitFor(() => resourceIndex.getReferencesTo(freshKey).length === 1)
 
-      staleRead.resolve('changeBg:stale.jpg;')
+      staleRead.reject(new Error('stale read failed'))
       await flushMicrotasks()
 
       expect(resourceIndex.getReferencesTo(oldKey)).toHaveLength(0)
-      expect(resourceIndex.getReferencesTo(staleKey)).toHaveLength(0)
       expect(resourceIndex.getReferencesTo(freshKey)).toHaveLength(1)
+      expect(loggerWarnMock).not.toHaveBeenCalled()
     } finally {
       scope.stop()
     }

--- a/src/services/resource-index/__tests__/service.test.ts
+++ b/src/services/resource-index/__tests__/service.test.ts
@@ -377,6 +377,8 @@ describe('useResourceIndex', () => {
           return [
             createDirEntry('bad-a.txt', false),
             createDirEntry('bad-b.txt', false),
+            createDirEntry('bad-c.txt', false),
+            createDirEntry('bad-d.txt', false),
           ]
         }
         default: {
@@ -388,7 +390,13 @@ describe('useResourceIndex', () => {
       if (String(path).endsWith('bad-a.txt')) {
         throw new Error('missing semicolon')
       }
-      throw new Error('invalid command')
+      if (String(path).endsWith('bad-b.txt')) {
+        throw new Error('invalid command')
+      }
+      if (String(path).endsWith('bad-c.txt')) {
+        throw new Error('unknown asset')
+      }
+      throw new Error('unclosed quote')
     })
 
     const { useResourceIndex, useResourceIndexBootstrap } = await import('../service')
@@ -408,7 +416,7 @@ describe('useResourceIndex', () => {
       )
       expect(parseFailureLogCalls).toHaveLength(1)
       expect(parseFailureLogCalls[0]).toEqual([
-        '资源索引跳过 2 个解析失败的引用来源: /project/game/scene/bad-a.txt -> Error: missing semicolon; /project/game/scene/bad-b.txt -> Error: invalid command',
+        '资源索引跳过 4 个解析失败的引用来源: /project/game/scene/bad-a.txt -> Error: missing semicolon; /project/game/scene/bad-b.txt -> Error: invalid command; /project/game/scene/bad-c.txt -> Error: unknown asset 等 1 个',
       ])
     } finally {
       scope.stop()

--- a/src/services/resource-index/references.ts
+++ b/src/services/resource-index/references.ts
@@ -233,7 +233,7 @@ export function logReferenceSourceFailures(failures: AssetReferenceSourceFailure
     .slice(0, 3)
     .map(({ error, sourcePath }) => `${sourcePath} -> ${String(error)}`)
     .join('; ')
-  const suffix = nextFailures.length > 3 ? ` 等 ${nextFailures.length} 个` : ''
+  const suffix = nextFailures.length > 3 ? ` 等 ${nextFailures.length - 3} 个` : ''
   logger.warn(
     `资源索引跳过 ${nextFailures.length} 个解析失败的引用来源: `
     + `${sampleFailures}${suffix}`,

--- a/src/services/resource-index/references.ts
+++ b/src/services/resource-index/references.ts
@@ -45,10 +45,32 @@ export interface AssetReferenceIndexSnapshot {
   records: AssetReferenceRecord[]
 }
 
+interface AssetReferenceSourceFailure {
+  sourcePath: AbsPath
+  error: unknown
+}
+
+interface AssetReferenceSlice extends AssetReferenceIndexSnapshot {
+  failures: AssetReferenceSourceFailure[]
+}
+
+interface LoggedReferenceSourceFailure {
+  signature: string
+  loggedAt: number
+}
+
+const REFERENCE_SOURCE_FAILURE_RELOG_INTERVAL_MS = 5 * 60 * 1000
+
+const loggedReferenceSourceFailures = new Map<AbsPath, LoggedReferenceSourceFailure>()
+
 export function createEmptyAssetReferenceIndexSnapshot(): AssetReferenceIndexSnapshot {
   return {
     records: [],
   }
+}
+
+export function clearReferenceSourceFailureLogCache(): void {
+  loggedReferenceSourceFailures.clear()
 }
 
 export async function buildAssetReferenceIndex(
@@ -59,6 +81,7 @@ export async function buildAssetReferenceIndex(
     ...listAssetsByAssetType(catalog, 'scene').map(entry => buildSceneReferenceSlice(entry.absolutePath)),
     buildGameConfigReferenceSlice(gamePath),
   ])
+  logReferenceSourceFailures(sourceSlices.flatMap(slice => slice.failures))
 
   return {
     records: sourceSlices.flatMap(slice => slice.records),
@@ -71,11 +94,15 @@ export async function rebuildReferenceSource(
   sourcePath: AbsPath,
 ): Promise<AssetReferenceIndexSnapshot> {
   if (isGameConfigPath(gamePath, sourcePath)) {
-    return replaceReferenceSource(snapshot, sourcePath, await buildGameConfigReferenceSlice(gamePath))
+    const slice = await buildGameConfigReferenceSlice(gamePath)
+    logReferenceSourceFailures(slice.failures)
+    return replaceReferenceSource(snapshot, sourcePath, slice)
   }
 
   if (isScenePath(gamePath, sourcePath)) {
-    return replaceReferenceSource(snapshot, sourcePath, await buildSceneReferenceSlice(sourcePath))
+    const slice = await buildSceneReferenceSlice(sourcePath)
+    logReferenceSourceFailures(slice.failures)
+    return replaceReferenceSource(snapshot, sourcePath, slice)
   }
 
   return snapshot
@@ -85,6 +112,7 @@ export function removeReferenceSource(
   snapshot: AssetReferenceIndexSnapshot,
   sourcePath: AbsPath,
 ): AssetReferenceIndexSnapshot {
+  clearReferenceSourceFailure(sourcePath)
   return {
     records: snapshot.records.filter(record => record.sourcePath !== sourcePath),
   }
@@ -155,23 +183,66 @@ function replaceReferenceSource(
   }
 }
 
-async function buildSceneReferenceSlice(sourcePath: AbsPath): Promise<AssetReferenceIndexSnapshot> {
+function createEmptyAssetReferenceSlice(failures: AssetReferenceSourceFailure[] = []): AssetReferenceSlice {
+  return {
+    records: [],
+    failures,
+  }
+}
+
+function clearReferenceSourceFailure(sourcePath: AbsPath): void {
+  loggedReferenceSourceFailures.delete(sourcePath)
+}
+
+function logReferenceSourceFailures(failures: AssetReferenceSourceFailure[]): void {
+  const now = Date.now()
+  const nextFailures = failures.filter(({ error, sourcePath }) => {
+    const signature = String(error)
+    const loggedFailure = loggedReferenceSourceFailures.get(sourcePath)
+    if (
+      loggedFailure?.signature === signature
+      && now - loggedFailure.loggedAt < REFERENCE_SOURCE_FAILURE_RELOG_INTERVAL_MS
+    ) {
+      return false
+    }
+
+    loggedReferenceSourceFailures.set(sourcePath, { signature, loggedAt: now })
+    return true
+  })
+
+  if (nextFailures.length === 0) {
+    return
+  }
+
+  const sampleFailures = nextFailures
+    .slice(0, 3)
+    .map(({ error, sourcePath }) => `${sourcePath} -> ${String(error)}`)
+    .join('; ')
+  const suffix = nextFailures.length > 3 ? ` 等 ${nextFailures.length} 个` : ''
+  logger.warn(
+    `资源索引跳过 ${nextFailures.length} 个解析失败的引用来源: `
+    + `${sampleFailures}${suffix}`,
+  )
+}
+
+async function buildSceneReferenceSlice(sourcePath: AbsPath): Promise<AssetReferenceSlice> {
   try {
     const text = await readTextFile(sourcePath)
     const scene = parseScene(text, AbsPath.basename(sourcePath), sourcePath)
     const sentences = scene?.sentenceList ?? []
+    clearReferenceSourceFailure(sourcePath)
     return {
       records: sentences.flatMap((sentence, index) =>
         extractSentenceReferences(sourcePath, sentence, index + 1),
       ),
+      failures: [],
     }
   } catch (error) {
-    logger.warn(`资源索引跳过解析失败的场景文件 (${sourcePath}): ${error}`)
-    return createEmptyAssetReferenceIndexSnapshot()
+    return createEmptyAssetReferenceSlice([{ sourcePath, error }])
   }
 }
 
-async function buildGameConfigReferenceSlice(gamePath: AbsPath): Promise<AssetReferenceIndexSnapshot> {
+async function buildGameConfigReferenceSlice(gamePath: AbsPath): Promise<AssetReferenceSlice> {
   const sourcePath = gameConfigPath(gamePath)
 
   try {
@@ -180,16 +251,17 @@ async function buildGameConfigReferenceSlice(gamePath: AbsPath): Promise<AssetRe
     const titleBgm = findGameConfigEntryValue(config.entries, 'Title_bgm')
     const gameLogo = findGameConfigEntryValue(config.entries, 'Game_Logo')
 
+    clearReferenceSourceFailure(sourcePath)
     return {
       records: [
         ...createGameConfigReferenceRecords(sourcePath, 'Title_img', 'background', titleImage),
         ...createGameConfigReferenceRecords(sourcePath, 'Title_bgm', 'bgm', titleBgm),
         ...createGameConfigReferenceRecords(sourcePath, 'Game_Logo', 'background', gameLogo, { splitValues: true }),
       ],
+      failures: [],
     }
   } catch (error) {
-    logger.warn(`资源索引跳过解析失败的游戏配置 (${sourcePath}): ${error}`)
-    return createEmptyAssetReferenceIndexSnapshot()
+    return createEmptyAssetReferenceSlice([{ sourcePath, error }])
   }
 }
 

--- a/src/services/resource-index/references.ts
+++ b/src/services/resource-index/references.ts
@@ -45,12 +45,17 @@ export interface AssetReferenceIndexSnapshot {
   records: AssetReferenceRecord[]
 }
 
-interface AssetReferenceSourceFailure {
+export interface AssetReferenceSourceFailure {
   sourcePath: AbsPath
   error: unknown
 }
 
 interface AssetReferenceSlice extends AssetReferenceIndexSnapshot {
+  failures: AssetReferenceSourceFailure[]
+}
+
+export interface AssetReferenceSourceUpdate {
+  snapshot: AssetReferenceIndexSnapshot
   failures: AssetReferenceSourceFailure[]
 }
 
@@ -92,20 +97,27 @@ export async function rebuildReferenceSource(
   snapshot: AssetReferenceIndexSnapshot,
   gamePath: AbsPath,
   sourcePath: AbsPath,
-): Promise<AssetReferenceIndexSnapshot> {
+): Promise<AssetReferenceSourceUpdate> {
   if (isGameConfigPath(gamePath, sourcePath)) {
     const slice = await buildGameConfigReferenceSlice(gamePath)
-    logReferenceSourceFailures(slice.failures)
-    return replaceReferenceSource(snapshot, sourcePath, slice)
+    return {
+      snapshot: replaceReferenceSource(snapshot, sourcePath, slice),
+      failures: slice.failures,
+    }
   }
 
   if (isScenePath(gamePath, sourcePath)) {
     const slice = await buildSceneReferenceSlice(sourcePath)
-    logReferenceSourceFailures(slice.failures)
-    return replaceReferenceSource(snapshot, sourcePath, slice)
+    return {
+      snapshot: replaceReferenceSource(snapshot, sourcePath, slice),
+      failures: slice.failures,
+    }
   }
 
-  return snapshot
+  return {
+    snapshot,
+    failures: [],
+  }
 }
 
 export function removeReferenceSource(
@@ -123,9 +135,12 @@ export async function renameReferenceSource(
   gamePath: AbsPath,
   oldPath: AbsPath,
   newPath: AbsPath,
-): Promise<AssetReferenceIndexSnapshot> {
+): Promise<AssetReferenceSourceUpdate> {
   if (!isGameConfigPath(gamePath, newPath) && !isScenePath(gamePath, newPath)) {
-    return removeReferenceSource(snapshot, oldPath)
+    return {
+      snapshot: removeReferenceSource(snapshot, oldPath),
+      failures: [],
+    }
   }
 
   return rebuildReferenceSource(removeReferenceSource(snapshot, oldPath), gamePath, newPath)
@@ -194,7 +209,7 @@ function clearReferenceSourceFailure(sourcePath: AbsPath): void {
   loggedReferenceSourceFailures.delete(sourcePath)
 }
 
-function logReferenceSourceFailures(failures: AssetReferenceSourceFailure[]): void {
+export function logReferenceSourceFailures(failures: AssetReferenceSourceFailure[]): void {
   const now = Date.now()
   const nextFailures = failures.filter(({ error, sourcePath }) => {
     const signature = String(error)

--- a/src/services/resource-index/service.ts
+++ b/src/services/resource-index/service.ts
@@ -21,6 +21,7 @@ import {
   findMissingAssetReferences,
   getReferencesFromSource,
   getReferencesToAsset,
+  logReferenceSourceFailures,
   rebuildReferenceSource,
   removeReferenceSource,
   renameReferenceSource,
@@ -28,7 +29,7 @@ import {
 
 import type { AssetCatalogSnapshot } from './catalog'
 import type { AssetKey } from './keys'
-import type { AssetReferenceIndexSnapshot, AssetReferenceRecord } from './references'
+import type { AssetReferenceIndexSnapshot, AssetReferenceRecord, AssetReferenceSourceFailure } from './references'
 
 type ResourceIndexStatus = 'idle' | 'building' | 'ready' | 'degraded'
 
@@ -216,8 +217,8 @@ async function rebuildReferenceForPath(gamePath: AbsPath, path: AbsPath): Promis
   }
 
   const updateVersion = beginReferenceSourceUpdate([path])
-  const references = await rebuildReferenceSource(currentState.references, gamePath, path)
-  applyReferenceSourceUpdate(gamePath, [path], path, getReferencesFromSource(references, path), updateVersion)
+  const { failures, snapshot } = await rebuildReferenceSource(currentState.references, gamePath, path)
+  applyReferenceSourceUpdate(gamePath, [path], path, getReferencesFromSource(snapshot, path), failures, updateVersion)
 }
 
 function beginReferenceSourceUpdate(sourcePaths: AbsPath[]): number {
@@ -268,6 +269,7 @@ function applyReferenceSourceUpdate(
   removedSourcePaths: AbsPath[],
   sourcePath: AbsPath,
   records: AssetReferenceRecord[],
+  failures: AssetReferenceSourceFailure[],
   updateVersion: number,
 ): void {
   const currentState = resourceIndexState.value
@@ -287,6 +289,7 @@ function applyReferenceSourceUpdate(
       records,
     ),
   })
+  logReferenceSourceFailures(failures)
   clearReferenceSourceUpdate(removedSourcePaths, updateVersion)
 }
 
@@ -298,12 +301,13 @@ async function renameReferenceForPath(gamePath: AbsPath, oldPath: AbsPath, newPa
 
   const affectedSourcePaths = [oldPath, newPath]
   const updateVersion = beginReferenceSourceUpdate(affectedSourcePaths)
-  const references = await renameReferenceSource(currentState.references, gamePath, oldPath, newPath)
+  const { failures, snapshot } = await renameReferenceSource(currentState.references, gamePath, oldPath, newPath)
   applyReferenceSourceUpdate(
     gamePath,
     affectedSourcePaths,
     newPath,
-    getReferencesFromSource(references, newPath),
+    getReferencesFromSource(snapshot, newPath),
+    failures,
     updateVersion,
   )
 }

--- a/src/services/resource-index/service.ts
+++ b/src/services/resource-index/service.ts
@@ -16,6 +16,7 @@ import {
 } from './catalog'
 import {
   buildAssetReferenceIndex,
+  clearReferenceSourceFailureLogCache,
   createEmptyAssetReferenceIndexSnapshot,
   findMissingAssetReferences,
   getReferencesFromSource,
@@ -56,6 +57,10 @@ let pendingDirectoryRebuildTimer: ReturnType<typeof setTimeout> | undefined
 let referenceSourceUpdateVersion = 0
 const referenceSourceUpdateVersions = new Map<AbsPath, number>()
 
+interface RebuildResourceIndexOptions {
+  completionLogLevel?: 'debug' | 'info'
+}
+
 function setResourceIndexState(nextState: ResourceIndexState): void {
   resourceIndexState.value = nextState
 }
@@ -74,13 +79,14 @@ function scheduleDirectoryRebuild(gamePath: AbsPath): void {
     if (resourceIndexState.value.gamePath !== gamePath) {
       return
     }
-    void rebuildResourceIndex(gamePath)
+    void rebuildResourceIndex(gamePath, { completionLogLevel: 'debug' })
   }, DIRECTORY_REBUILD_DEBOUNCE_MS)
 }
 
 function clearResourceIndexState(): void {
   buildVersion += 1
   referenceSourceUpdateVersions.clear()
+  clearReferenceSourceFailureLogCache()
   clearPendingDirectoryRebuild()
   setResourceIndexState({
     status: 'idle',
@@ -91,10 +97,20 @@ function clearResourceIndexState(): void {
   })
 }
 
-async function rebuildResourceIndex(gamePath: AbsPath): Promise<void> {
+async function rebuildResourceIndex(
+  gamePath: AbsPath,
+  options: RebuildResourceIndexOptions = {},
+): Promise<void> {
   const currentBuildVersion = ++buildVersion
+  const startedAt = Date.now()
+  const previousGamePath = resourceIndexState.value.gamePath
+  const completionLogLevel = options.completionLogLevel ?? 'info'
   referenceSourceUpdateVersions.clear()
+  if (previousGamePath !== gamePath) {
+    clearReferenceSourceFailureLogCache()
+  }
 
+  logger.debug(`资源索引开始构建: ${gamePath}`)
   setResourceIndexState({
     status: 'building',
     gamePath,
@@ -119,12 +135,17 @@ async function rebuildResourceIndex(gamePath: AbsPath): Promise<void> {
       references,
       dirty: false,
     })
+    const completionMessage = `资源索引构建完成: ${gamePath}, `
+      + `资源 ${catalog.entries.size} 个, 引用 ${references.records.length} 条, `
+      + `耗时 ${Date.now() - startedAt}ms`
+    logger[completionLogLevel](completionMessage)
 
     if (needsFollowUpRebuild) {
-      void rebuildResourceIndex(gamePath)
+      logger.debug(`资源索引构建期间收到变更，安排跟进重建: ${gamePath}`)
+      void rebuildResourceIndex(gamePath, { completionLogLevel })
     }
   } catch (error) {
-    logger.warn(`资源索引构建失败: ${error}`)
+    logger.warn(`资源索引构建失败: ${gamePath}, 耗时 ${Date.now() - startedAt}ms - ${error}`)
     if (currentBuildVersion !== buildVersion) {
       return
     }

--- a/src/services/resource-reconcile.ts
+++ b/src/services/resource-reconcile.ts
@@ -1,25 +1,37 @@
 import { db } from '~/database/db'
 import { engineManager } from '~/services/engine-manager'
 import { gameManager } from '~/services/game-manager'
+import {
+  createResourceValidationFailure,
+  createResourceValidationSummary,
+  logResourceValidationSummary,
+} from '~/services/resource-validation-summary'
 import { templateManager } from '~/services/template-manager'
 
 import type { Engine, Game, Template } from '~/database/model'
 import type { ResourceAvailability } from '~/services/resource-health'
+import type { ResourceValidationFailure, ResourceValidationSummary } from '~/services/resource-validation-summary'
 
 // 三个 reconcile 函数结构一致：跑 inspect、若 availability 变化则落库、把最新结果回给调用方。
 // 这里有意保持三份独立实现，避免为差异极小的资源类型引入泛型抽象。
 
 async function reconcileGameRecord(game: Pick<Game, 'id' | 'path' | 'availability'>): Promise<ResourceAvailability> {
   try {
-    const { availability } = await gameManager.inspectGame(game.path)
-    if (game.availability !== availability) {
-      await db.games.update(game.id, { availability })
-    }
-    return availability
+    return await inspectAndPatchGameAvailability(game)
   } catch (error) {
     logger.warn(`游戏校验异常: ${error}`)
     return game.availability
   }
+}
+
+async function inspectAndPatchGameAvailability(
+  game: Pick<Game, 'id' | 'path' | 'availability'>,
+): Promise<ResourceAvailability> {
+  const { availability } = await gameManager.inspectGame(game.path)
+  if (game.availability !== availability) {
+    await db.games.update(game.id, { availability })
+  }
+  return availability
 }
 
 async function reconcileEngineRecord(engine: Pick<Engine, 'id' | 'path' | 'availability'>): Promise<ResourceAvailability> {
@@ -57,11 +69,27 @@ async function reconcileTemplateRecord(template: Pick<Template, 'id' | 'path' | 
   }
 }
 
-async function reconcileAllGames(): Promise<void> {
+async function reconcileGameRecordForBatch(
+  game: Pick<Game, 'id' | 'path' | 'availability'>,
+): Promise<ResourceValidationFailure | undefined> {
+  try {
+    await inspectAndPatchGameAvailability(game)
+    return
+  } catch (error) {
+    return createResourceValidationFailure(game.path, error)
+  }
+}
+
+async function reconcileAllGames(): Promise<ResourceValidationSummary> {
   const games = await db.games.toArray()
-  await Promise.all(games
+  const targets = games
     .filter(game => game.status === 'created')
-    .map(game => reconcileGameRecord(game)))
+  const validationResults = await Promise.all(targets.map(game => reconcileGameRecordForBatch(game)))
+  const failures = validationResults
+    .filter((failure): failure is ResourceValidationFailure => failure !== undefined)
+  const summary = createResourceValidationSummary(targets.length, failures)
+  logResourceValidationSummary('游戏校验', summary)
+  return summary
 }
 
 export const resourceReconcile = {

--- a/src/services/resource-reconcile.ts
+++ b/src/services/resource-reconcile.ts
@@ -76,6 +76,9 @@ async function reconcileGameRecordForBatch(
     await inspectAndPatchGameAvailability(game)
     return
   } catch (error) {
+    if (game.availability !== 'broken') {
+      await db.games.update(game.id, { availability: 'broken' })
+    }
     return createResourceValidationFailure(game.path, error)
   }
 }

--- a/src/services/resource-validation-summary.ts
+++ b/src/services/resource-validation-summary.ts
@@ -1,0 +1,46 @@
+import type { AbsPath } from '~/domain/path'
+
+export interface ResourceValidationFailure {
+  error: string
+  path: AbsPath
+}
+
+export interface ResourceValidationSummary {
+  failed: number
+  failures: ResourceValidationFailure[]
+  total: number
+}
+
+export function createResourceValidationFailure(path: AbsPath, error: unknown): ResourceValidationFailure {
+  return {
+    error: String(error),
+    path,
+  }
+}
+
+export function createResourceValidationSummary(
+  total: number,
+  failures: ResourceValidationFailure[],
+): ResourceValidationSummary {
+  return {
+    failed: failures.length,
+    failures,
+    total,
+  }
+}
+
+export function logResourceValidationSummary(label: string, summary: ResourceValidationSummary): void {
+  if (summary.failed === 0) {
+    return
+  }
+
+  const sample = summary.failures
+    .slice(0, 3)
+    .map(({ error, path }) => `${path} -> ${error}`)
+    .join('; ')
+  const suffix = summary.failures.length > 3
+    ? `; 另有 ${summary.failures.length - 3} 个异常`
+    : ''
+
+  logger.warn(`${label}异常 ${summary.failed}/${summary.total}: ${sample}${suffix}`)
+}

--- a/src/services/template-manager.ts
+++ b/src/services/template-manager.ts
@@ -8,12 +8,18 @@ import { AbsPath } from '~/domain/path'
 import { templateManifestPath } from '~/services/platform/app-paths'
 import { ResourceAvailability } from '~/services/resource-health'
 import { caseFoldedEquals, toLookupPathKey } from '~/services/resource-path/lookup'
+import {
+  createResourceValidationFailure,
+  createResourceValidationSummary,
+  logResourceValidationSummary,
+} from '~/services/resource-validation-summary'
 import { TemplateMetadata } from '~/services/types'
 import { useResourceStore } from '~/stores/resource'
 import { useStorageSettingsStore } from '~/stores/storage-settings'
 import { AppError } from '~/types/errors'
 
 import type { Game, Template } from '~/database/model'
+import type { ResourceValidationFailure, ResourceValidationSummary } from '~/services/resource-validation-summary'
 
 interface RegisterTemplateOptions {
   metadata?: TemplateMetadata
@@ -35,6 +41,12 @@ interface TemplateDeleteBlockers {
 interface TemplateAssociationInspection {
   associatedGame?: Game
   uncheckedGame?: Game
+}
+
+interface TemplateAvailabilityInspection {
+  availability: ResourceAvailability
+  failure?: unknown
+  metadata?: TemplateMetadata
 }
 
 async function validateTemplate(templatePath: AbsPath): Promise<boolean> {
@@ -179,19 +191,19 @@ async function canDeleteTemplate(templateName: string): Promise<DeleteTemplateCh
   return { canDelete: true }
 }
 
-async function deleteTemplateDirectoryIfExists(path: AbsPath): Promise<void> {
+async function deleteTemplateDirectoryIfExists(path: AbsPath): Promise<unknown | undefined> {
   try {
     if (await exists(path)) {
       await fsCmds.deleteFile(path, true)
     }
   } catch (error) {
-    logger.warn(`[模板清理] 删除目录失败 (${path}): ${error}`)
+    return error
   }
 }
 
 async function assertTemplateImportable(templatePath: AbsPath): Promise<TemplateMetadata> {
   if (!(await validateTemplate(templatePath))) {
-    logger.error(`[模板导入] 无效的模板文件夹: ${templatePath}`)
+    logger.warn(`[模板导入] 无效的模板文件夹: ${templatePath}`)
     throw new AppError('INVALID_STRUCTURE', '无效的模板文件夹')
   }
 
@@ -217,7 +229,7 @@ async function installTemplate(templatePath: AbsPath, metadata: TemplateMetadata
     throw new AppError('IO_ERROR', '目标模板目录已存在，请先清理后重试')
   }
 
-  logger.info(`[模板 ${metadata.name}] 开始安装`)
+  logger.info(`[模板安装] 开始: 名称=${metadata.name}, 源=${templatePath}, 目标=${targetPath}`)
   const id = await registerTemplate(targetPath, {
     metadata,
     status: 'creating',
@@ -230,13 +242,17 @@ async function installTemplate(templatePath: AbsPath, metadata: TemplateMetadata
 
     await db.templates.update(id, { status: 'created' })
     resourceStore.finishProgress(id)
-    logger.info(`[模板 ${metadata.name}] 安装完成`)
+    logger.info(`[模板安装] 完成: ID=${id}, 名称=${metadata.name}, 源=${templatePath}, 目标=${targetPath}`)
   } catch (error) {
+    logger.error(`[模板安装] 失败: ID=${id}, 名称=${metadata.name}, 源=${templatePath}, 目标=${targetPath} - ${error}`)
     resourceStore.finishProgress(id)
     await db.templates.delete(id).catch((error_) => {
-      logger.warn(`[模板清理] 删除记录失败 (${id}): ${error_}`)
+      logger.warn(`[模板清理] 删除记录失败: ID=${id}, 目标=${targetPath} - ${error_}`)
     })
-    await deleteTemplateDirectoryIfExists(targetPath)
+    const directoryCleanupError = await deleteTemplateDirectoryIfExists(targetPath)
+    if (directoryCleanupError) {
+      logger.warn(`[模板清理] 删除目录失败 (${targetPath}): ${directoryCleanupError}`)
+    }
     throw error
   }
 }
@@ -285,10 +301,7 @@ async function deleteTemplate(template: Template): Promise<void> {
   await db.templates.delete(template.id)
 }
 
-async function inspectTemplateAvailability(templatePath: AbsPath): Promise<{
-  availability: ResourceAvailability
-  metadata?: TemplateMetadata
-}> {
+async function inspectTemplateAvailabilityInternal(templatePath: AbsPath): Promise<TemplateAvailabilityInspection> {
   if (!(await exists(templatePath))) {
     return { availability: 'missing' }
   }
@@ -299,31 +312,41 @@ async function inspectTemplateAvailability(templatePath: AbsPath): Promise<{
     const metadata = await getTemplateMetadata(templatePath)
     return { availability: 'available', metadata }
   } catch (error) {
-    logger.warn(`[模板校验] 读取元数据失败 (${templatePath}): ${error}`)
-    return { availability: 'broken' }
+    return { availability: 'broken', failure: error }
   }
 }
 
-async function validateAllTemplates(): Promise<void> {
-  const templates = await db.templates.toArray()
+async function inspectTemplateAvailability(templatePath: AbsPath): Promise<{
+  availability: ResourceAvailability
+  metadata?: TemplateMetadata
+}> {
+  const { availability, failure, metadata } = await inspectTemplateAvailabilityInternal(templatePath)
+  if (failure) {
+    logger.warn(`[模板校验] 读取元数据失败 (${templatePath}): ${failure}`)
+  }
+  return { availability, metadata }
+}
 
-  await Promise.allSettled(templates.map(async (template) => {
-    if (template.status === 'creating') {
-      // creating 是上次未完成的导入残留，仍按既有逻辑清理
-      await deleteTemplateDirectoryIfExists(template.path)
+async function validateTemplateRecordForBatch(template: Template): Promise<ResourceValidationFailure | undefined> {
+  if (template.status === 'creating') {
+    // creating 是上次未完成的导入残留，仍按既有逻辑清理
+    const directoryCleanupError = await deleteTemplateDirectoryIfExists(template.path)
+    try {
       await db.templates.delete(template.id)
-      return
+    } catch (error) {
+      return createResourceValidationFailure(template.path, error)
     }
+    return directoryCleanupError
+      ? createResourceValidationFailure(template.path, directoryCleanupError)
+      : undefined
+  }
 
-    if (template.status !== 'created') {
-      return
-    }
+  if (template.status !== 'created') {
+    return
+  }
 
-    const inspection = await inspectTemplateAvailability(template.path).catch((error) => {
-      logger.warn(`[模板校验] 校验异常 (${template.path}): ${error}`)
-      return { availability: 'broken' as ResourceAvailability, metadata: undefined }
-    })
-
+  try {
+    const inspection = await inspectTemplateAvailabilityInternal(template.path)
     const patch: Partial<Template> = {}
     if (template.availability !== inspection.availability) {
       patch.availability = inspection.availability
@@ -336,7 +359,27 @@ async function validateAllTemplates(): Promise<void> {
     if (Object.keys(patch).length > 0) {
       await db.templates.update(template.id, patch)
     }
-  }))
+    return inspection.failure
+      ? createResourceValidationFailure(template.path, inspection.failure)
+      : undefined
+  } catch (error) {
+    if (template.availability !== 'broken') {
+      await db.templates.update(template.id, { availability: 'broken' })
+    }
+    return createResourceValidationFailure(template.path, error)
+  }
+}
+
+async function validateAllTemplates(): Promise<ResourceValidationSummary> {
+  const templates = await db.templates.toArray()
+
+  const targets = templates.filter(template => template.status === 'created' || template.status === 'creating')
+  const validationResults = await Promise.all(targets.map(template => validateTemplateRecordForBatch(template)))
+  const failures = validationResults
+    .filter((failure): failure is ResourceValidationFailure => failure !== undefined)
+  const summary = createResourceValidationSummary(targets.length, failures)
+  logResourceValidationSummary('模板校验', summary)
+  return summary
 }
 
 export const templateManager = {

--- a/src/services/template-manager.ts
+++ b/src/services/template-manager.ts
@@ -364,7 +364,11 @@ async function validateTemplateRecordForBatch(template: Template): Promise<Resou
       : undefined
   } catch (error) {
     if (template.availability !== 'broken') {
-      await db.templates.update(template.id, { availability: 'broken' })
+      try {
+        await db.templates.update(template.id, { availability: 'broken' })
+      } catch (updateError) {
+        logger.warn(`[模板校验] 标记模板为 broken 失败 (${template.path}): ${updateError}`)
+      }
     }
     return createResourceValidationFailure(template.path, error)
   }

--- a/src/stores/__tests__/preview-runtime.test.ts
+++ b/src/stores/__tests__/preview-runtime.test.ts
@@ -31,6 +31,7 @@ vi.mock('~/commands/server', () => ({
 
 vi.mock('@tauri-apps/plugin-log', () => ({
   error: loggerErrorMock,
+  info: vi.fn(),
 }))
 
 describe('usePreviewRuntimeStore', () => {

--- a/src/stores/__tests__/preview-sync.test.ts
+++ b/src/stores/__tests__/preview-sync.test.ts
@@ -17,6 +17,7 @@ vi.mock('~/commands/server', () => ({
 }))
 
 vi.mock('@tauri-apps/plugin-log', () => ({
+  debug: vi.fn(),
   warn: vi.fn(),
 }))
 

--- a/src/stores/file.ts
+++ b/src/stores/file.ts
@@ -20,8 +20,6 @@ import { handleError } from '~/utils/error-handler'
 import type { WatchEvent } from '@tauri-apps/plugin-fs'
 import type { VfsDirEntry, VfsSource } from '~/types/project-config'
 
-import { isDebug } from '~build/meta'
-
 /**
  * 最大缓存项数
  */
@@ -578,13 +576,6 @@ export const useFileStore = defineStore('file', () => {
       | { eventType: 'modified', path: AbsPath },
   ): void {
     const prefix = item.isDir ? 'directory' : 'file'
-
-    if (isDebug) {
-      const detail = options.eventType === 'renamed'
-        ? `${options.oldPath} -> ${options.newPath}`
-        : options.path
-      logger.debug(`[FileSystemEvent] ${prefix}:${options.eventType} - ${detail}`)
-    }
 
     if (options.eventType === 'created') {
       fileSystemEvents.emit({ type: `${prefix}:created`, path: options.path, parentId: options.parentId })

--- a/src/stores/preview-runtime.ts
+++ b/src/stores/preview-runtime.ts
@@ -43,9 +43,11 @@ export const usePreviewRuntimeStore = defineStore('previewRuntime', () => {
     const startTask = (async () => {
       try {
         const previewSyncStore = usePreviewSyncStore()
+        logger.info('预览服务器开始启动: 127.0.0.1:8899')
         serverUrl = await serverCmds.startServer('127.0.0.1', 8899, (message) => {
           previewSyncStore.consumeHostEvent(message)
         })
+        logger.info(`预览服务器启动完成: ${serverUrl}`)
         return serverUrl
       } catch (error) {
         logger.error(`服务器启动失败: ${error}`)

--- a/src/stores/preview-session.ts
+++ b/src/stores/preview-session.ts
@@ -17,7 +17,7 @@ async function resolvePreviewGameId(gamePath: AbsPath): Promise<string | undefin
     const gameKey = findGameConfigEntryValue(gameConfig.entries, PREVIEW_GAME_KEY_RAW_KEY)?.trim()
     return gameKey || undefined
   } catch (error) {
-    logger.warn(`读取预览会话 Game_key 失败: ${error}`)
+    logger.warn(`读取预览会话 Game_key 失败: ${gamePath} - ${error}`)
     return
   }
 }

--- a/src/stores/preview-sync.ts
+++ b/src/stores/preview-sync.ts
@@ -25,7 +25,7 @@ function parseHostEvent(rawEvent: string): EventEnvelopeByType | undefined {
 
     return parsed
   } catch (error) {
-    logger.warn(`解析预览同步 host event 失败: ${error}`)
+    logger.debug(`解析预览同步 host event 失败: ${error}`)
     return undefined
   }
 }
@@ -52,7 +52,7 @@ export const usePreviewSyncStore = defineStore('previewSync', () => {
       }
       case 'preview.event.fast-preview-timeout': {
         fastPreviewTimeout = event.payload
-        logger.warn(
+        logger.debug(
           `实时预览快进超时: scene=${event.payload.sceneName}, target=${event.payload.targetSentenceId}, stopped=${event.payload.sentenceId}, forwarded=${event.payload.forwardedLineCount}, elapsed=${event.payload.elapsedMs}/${event.payload.maxDurationMs}ms`,
         )
         return


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [ ] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [x] 代码重构
- [x] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

- 提取 `runAppStartup` 和 `resource-validation-summary`，统一应用启动、资源校验和异常摘要日志，确保启动链路与批量校验具备稳定的诊断信息。
- 为引擎/模板/游戏导入、游戏创建、路径操作、资源索引构建、预览服务器启动、端口回退等关键链路补充上下文化日志，记录路径、ID、版本、耗时和执行状态。
- 将资源索引解析失败、资源预热跳过、批量导入失败等场景改为聚合日志，并为重复失败增加冷却窗口，减少重复告警。
- 移除或降级高频低价值日志，包括文件系统事件、VFS 路径拒绝、慢请求、资源地址生成失败、图片/音频预览失败、编辑器补全未实现分支等，降低日志噪音。
- 补充启动流程、资源校验摘要、资源索引失败聚合/重试窗口，以及日志语义调整相关测试。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

当前日志主要有两个问题：

1. 关键业务链路缺少统一、可追踪的诊断上下文，批量校验或导入失败时难以快速定位问题资源和失败样例。
2. 预览、文件监听、VFS 和调试路径存在较多高频低价值日志，容易刷屏并污染日志流，掩盖真正需要关注的异常。

这个 PR 的目标是提升生产问题排查时的信息密度，同时降低预期失败和调试日志对日志系统与排查效率的干扰。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
