### PR TITLE
🔧 完善 Tauri 打包元数据并配置多语言安装器

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
-  "productName": "webgal-craft",
+  "productName": "WebGAL Craft",
   "version": "../package.json",
-  "identifier": "com.akirami.webgal-craft",
+  "identifier": "com.akirami.webgalcraft",
   "build": {
     "beforeDevCommand": "bun dev:web",
     "devUrl": "http://localhost:1420",
@@ -19,6 +19,14 @@
   "bundle": {
     "active": true,
     "targets": "all",
+    "publisher": "Akirami",
+    "category": "DeveloperTool",
+    "shortDescription": "WebGAL visual novel studio.",
+    "longDescription": "WebGAL Craft is a desktop visual novel creation tool for WebGAL, with visual editing, script editing, and real-time preview workflows.",
+    "homepage": "https://webgalcraft.com",
+    "license": "MPL-2.0",
+    "licenseFile": "../LICENSE",
+    "copyright": "Copyright (c) 2025 Akirami",
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",
@@ -26,6 +34,18 @@
       "icons/icon.icns",
       "icons/icon.ico"
     ],
+    "windows": {
+      "allowDowngrades": false,
+      "wix": {
+        "language": ["en-US", "ja-JP", "zh-CN", "zh-TW"],
+        "upgradeCode": "bdba7c85-7131-5208-9076-cf4b42f755f3"
+      },
+      "nsis": {
+        "languages": ["English", "Japanese", "SimpChinese", "TradChinese"],
+        "displayLanguageSelector": true,
+        "installerIcon": "icons/icon.ico"
+      }
+    },
     "createUpdaterArtifacts": true
   },
   "plugins": {


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [ ] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [ ] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [x] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

本次调整补全了 Tauri 桌面打包所需的应用元数据，并显式配置了 Windows 安装器相关选项。

具体包括：

- 将 `productName` 从 `webgal-craft` 统一为 `WebGAL Craft`
- 将桌面应用 `identifier` 从 `com.akirami.webgal-craft` 调整为 `com.akirami.webgalcraft`
- 为 `bundle` 补充 `publisher`、`category`、`shortDescription`、`longDescription`、`homepage`、`license`、`licenseFile`、`copyright`
- 为 WiX 配置多语言安装器和稳定的 `upgradeCode`
- 为 NSIS 配置多语言安装器、语言选择器和安装器图标

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

当前桌面端的 Tauri 配置已经满足开发运行需求，但发布配置仍缺少完整的应用元数据与安装器细节。

这次调整的目标是：

- 让安装包显示名称与品牌命名保持一致
- 明确声明发布所需的元数据，减少默认值和隐式行为
- 为 Windows 安装器补齐语言和升级相关配置
- 为后续正式发布提供更稳定的打包基础

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [ ] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
