### PR TITLE
👷 调整 CI 默认安装包策略并稳定 Release 资产命名

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,15 +47,19 @@ jobs:
           - os: ubuntu-latest
             platform: linux-x64
             target: x86_64-unknown-linux-gnu
+            bundle: appimage
           - os: macos-latest
             platform: macos-x64
             target: x86_64-apple-darwin
+            bundle: dmg
           - os: macos-latest
             platform: macos-arm64
             target: aarch64-apple-darwin
+            bundle: dmg
           - os: windows-latest
             platform: windows-x64
             target: x86_64-pc-windows-msvc
+            bundle: nsis
 
     env:
       GITHUB_PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -97,7 +101,7 @@ jobs:
         with:
           includeDebug: ${{ github.event_name == 'pull_request' }}
           includeRelease: ${{ github.event_name != 'pull_request' }}
-          args: -t ${{ matrix.target }} -c '{"bundle":{"createUpdaterArtifacts":false}}'
+          args: -t ${{ matrix.target }} -b ${{ matrix.bundle }} -c '{"bundle":{"createUpdaterArtifacts":false}}'
 
       - name: Compute artifact name
         id: artifact-name

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,5 +94,5 @@ jobs:
           releaseName: WebGAL Craft v__VERSION__
           releaseBody: ${{ needs.changelog.outputs.changelog }}
           releaseDraft: true
-          assetNamePattern: "[name]-v[version]-${{ matrix.releaseLabel }}[setup][ext]"
+          assetNamePattern: "webgal-craft-v[version]-${{ matrix.releaseLabel }}[setup][ext]"
           args: -t ${{ matrix.target }}


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [ ] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [ ] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [x] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

- 调整 `build.yml` 的构建矩阵，为各平台显式指定一个默认可安装格式：
  - Linux: `appimage`
  - macOS: `dmg`
  - Windows: `nsis`
- 调整 `tauri-action` 参数，在 CI build 中显式传入 `-b ${{ matrix.bundle }}`
- 调整 `release.yml` 的 `assetNamePattern`，将发布资产文件名前缀固定为 `webgal-craft`

这样可以让日常 `push` / `pull_request` 触发的 CI build 只承担“开发验证和临时试用”场景，而正式分发所需的完整格式仍由 release workflow 负责。

同时，release 资产命名不再依赖产品名称字段，避免产品名称调整后安装包文件名发生非预期变化。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

`build.yml` 的触发频率高，主要服务于开发验证和临时试用，不值得在每次运行时上传全部 bundle 产物。

当前如果在 CI build 中保留所有格式，会带来这些问题：

- 放大构建时间和上传时间
- 增加 artifact 存储占用
- 增加下载时的选择噪音
- 对日常验证收益有限

更合理的职责划分是：

- `build.yml` 只上传每个平台一个默认可安装格式
- `release.yml` 负责正式分发所需的完整格式集合

另外 #234 修改产品名称后，安装包名称也会随之变化。  
这次通过固定 release 资产文件名前缀，消除了这种由展示名称变更带来的发布文件名漂移。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [ ] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
