### PR TITLE
🐛 修复发现游戏时显示目录名的问题

### DIFF
--- a/src/features/home/__tests__/useDiscoverResources.test.ts
+++ b/src/features/home/__tests__/useDiscoverResources.test.ts
@@ -9,6 +9,7 @@ const {
   engineIdentityKeyOfMock,
   existsMock,
   getEnginePreviewAssetsMock,
+  getGameSnapshotMock,
   getTemplateMetadataMock,
   loggerErrorMock,
   modalOpenMock,
@@ -35,6 +36,7 @@ const {
   ),
   existsMock: vi.fn(),
   getEnginePreviewAssetsMock: vi.fn(),
+  getGameSnapshotMock: vi.fn(),
   getTemplateMetadataMock: vi.fn(),
   loggerErrorMock: vi.fn(),
   modalOpenMock: vi.fn(),
@@ -100,7 +102,7 @@ vi.mock('~/services/engine-manager', () => ({
 
 vi.mock('~/services/game-manager', () => ({
   gameManager: {
-    getGamePreviewAssets: vi.fn(),
+    getGameSnapshot: getGameSnapshotMock,
     identityKeyOf: gameIdentityKeyOfMock,
     importGame: vi.fn(),
     resolvePreviewSite: vi.fn(),
@@ -141,6 +143,7 @@ describe('useDiscoverResources', () => {
     engineIdentityKeyOfMock.mockClear()
     existsMock.mockReset()
     getEnginePreviewAssetsMock.mockReset()
+    getGameSnapshotMock.mockReset()
     getTemplateMetadataMock.mockReset()
     loggerErrorMock.mockReset()
     modalOpenMock.mockReset()
@@ -174,6 +177,16 @@ describe('useDiscoverResources', () => {
     getEnginePreviewAssetsMock.mockResolvedValue({
       icon: {
         path: '/engines/WebGAL/4.5.0/icons/favicon.ico',
+      },
+    })
+    getGameSnapshotMock.mockResolvedValue({
+      metadata: {
+        name: 'Demo Game',
+        titleImg: 'cover.png',
+      },
+      previewAssets: {
+        icon: { path: 'icons/favicon.ico' },
+        cover: { path: 'game/background/cover.png' },
       },
     })
   })
@@ -437,13 +450,63 @@ describe('useDiscoverResources', () => {
     expect(engineIdentityKeyOfMock).toHaveBeenCalled()
   })
 
+  it('发现有效游戏目录时会使用游戏配置名称展示', async () => {
+    const { gameManager } = await import('~/services/game-manager')
+    vi.mocked(gameManager.validateGame).mockResolvedValue(true)
+    vi.mocked(gameManager.getGameSnapshot).mockResolvedValue({
+      metadata: {
+        name: 'Config Game',
+        titleImg: 'cover.png',
+      },
+      previewAssets: {
+        icon: { path: 'icons/favicon.ico' },
+        cover: { path: 'game/background/cover.png' },
+      },
+    })
+    vi.mocked(gameManager.resolvePreviewSite).mockResolvedValue({
+      projectPath: AbsPath.from('/games/demo-folder'),
+    })
+    resolveHomeTabDefinitionMock.mockReturnValue({ discoveryType: 'games' })
+    useWorkspaceStoreMock.mockReturnValue({ activeTab: 'games' })
+    useStorageSettingsStoreMock.mockReturnValue({
+      engineSavePath: '/engines',
+      gameSavePath: '/games',
+      templateSavePath: '/templates',
+    })
+    readDirMock.mockImplementation(async (path: string) => {
+      switch (path) {
+        case '/games': {
+          return [{ isDirectory: true, name: 'demo-folder' }]
+        }
+        default: {
+          return []
+        }
+      }
+    })
+
+    const { useDiscoverResources } = await import('../useDiscoverResources')
+    const discoverResources = useDiscoverResources()
+
+    await discoverResources.checkResourcesForActiveTab()
+
+    expect(modalOpenMock).toHaveBeenCalledWith('DiscoveredResourcesModal', expect.objectContaining({
+      type: 'games',
+      resources: [
+        {
+          icon: 'icons/favicon.ico',
+          name: 'Config Game',
+          path: '/games/demo-folder',
+          previewSite: {
+            projectPath: '/games/demo-folder',
+          },
+        },
+      ],
+    }))
+  })
+
   it('已导入同路径游戏时通过 gameManager.identityKeyOf 去重', async () => {
     const { gameManager } = await import('~/services/game-manager')
     vi.mocked(gameManager.validateGame).mockResolvedValue(true)
-    vi.mocked(gameManager.getGamePreviewAssets).mockResolvedValue({
-      icon: { path: 'icons/favicon.ico' },
-      cover: { path: 'game/background/cover.png' },
-    })
     vi.mocked(gameManager.resolvePreviewSite).mockResolvedValue({
       projectPath: AbsPath.from('/games/demo'),
     })
@@ -497,10 +560,6 @@ describe('useDiscoverResources', () => {
   it('批量导入发现的游戏时会提供组合依赖解析回调', async () => {
     const { gameManager } = await import('~/services/game-manager')
     vi.mocked(gameManager.validateGame).mockResolvedValue(true)
-    vi.mocked(gameManager.getGamePreviewAssets).mockResolvedValue({
-      icon: { path: 'icons/favicon.ico' },
-      cover: { path: 'game/background/cover.png' },
-    })
     vi.mocked(gameManager.resolvePreviewSite).mockResolvedValue({
       projectPath: AbsPath.from('/games/demo'),
     })
@@ -542,10 +601,6 @@ describe('useDiscoverResources', () => {
   it('批量导入发现的游戏命中已注册资源时提示已导入', async () => {
     const { gameManager } = await import('~/services/game-manager')
     vi.mocked(gameManager.validateGame).mockResolvedValue(true)
-    vi.mocked(gameManager.getGamePreviewAssets).mockResolvedValue({
-      icon: { path: 'icons/favicon.ico' },
-      cover: { path: 'game/background/cover.png' },
-    })
     vi.mocked(gameManager.resolvePreviewSite).mockResolvedValue({
       projectPath: AbsPath.from('/games/demo'),
     })
@@ -587,10 +642,6 @@ describe('useDiscoverResources', () => {
     const { gameManager } = await import('~/services/game-manager')
     const { AppError } = await import('~/types/errors')
     vi.mocked(gameManager.validateGame).mockResolvedValue(true)
-    vi.mocked(gameManager.getGamePreviewAssets).mockResolvedValue({
-      icon: { path: 'icons/favicon.ico' },
-      cover: { path: 'game/background/cover.png' },
-    })
     vi.mocked(gameManager.resolvePreviewSite).mockResolvedValue({
       projectPath: AbsPath.from('/games/demo'),
     })

--- a/src/features/home/useDiscoverResources.ts
+++ b/src/features/home/useDiscoverResources.ts
@@ -76,7 +76,7 @@ async function discoverGames(): Promise<DiscoveredResource[]> {
   const games = await discoverResourcesInDirectory(gameSavePath, gameManager.validateGame)
   return Promise.all(
     games.map(async (resource) => {
-      const previewAssets = await gameManager.getGamePreviewAssets(resource.path)
+      const snapshot = await gameManager.getGameSnapshot(resource.path)
       let previewSite: StaticSiteConfig | undefined
 
       try {
@@ -87,7 +87,8 @@ async function discoverGames(): Promise<DiscoveredResource[]> {
 
       return {
         ...resource,
-        icon: previewAssets.icon.path,
+        name: snapshot.metadata.name,
+        icon: snapshot.previewAssets.icon.path,
         previewSite,
       }
     }),


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [x] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [x] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

修复首页发现游戏资源时显示文件夹名的问题。

发现游戏目录后，现在复用 `gameManager.getGameSnapshot()` 获取游戏快照，并使用其中的 `metadata.name` 作为发现资源弹窗中的展示名称。同时复用同一个快照中的 `previewAssets`，避免在发现逻辑中重复读取或解析游戏配置。

补充了回归测试，覆盖目录名与 `game/config.txt` 中 `Game_name` 不一致时，弹窗应展示配置中的游戏名。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

此前发现游戏资源时，`DiscoveredResource.name` 直接来自扫描到的目录名。对于目录名和游戏配置名不一致的项目，用户在导入确认弹窗中看到的是文件夹名，而不是实际游戏名。

项目中已有 `gameManager.getGameSnapshot()` 作为读取游戏元数据和预览资源的统一入口，因此本次修复复用现有能力，没有新增配置解析逻辑或兼容层。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
