### PR TITLE
🐛 修复资源预览预热重复触发

### DIFF
--- a/src/composables/__tests__/useResourcePreviewPrimer.test.ts
+++ b/src/composables/__tests__/useResourcePreviewPrimer.test.ts
@@ -3,27 +3,53 @@ import '~/__tests__/setup'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { nextTick, reactive } from 'vue'
 
+interface TestGame {
+  engineId?: string
+  path: string
+}
+
+interface TestEngine {
+  availability: 'available' | 'broken' | 'missing'
+  metadata: {
+    webgalVersion?: string
+  }
+  path: string
+  status: 'created' | 'creating' | 'error'
+}
+
 const {
   ensureServeUrlsMock,
   loggerErrorMock,
+  loggerWarnMock,
   resolveStaticAssetSiteMock,
   usePreviewRuntimeStoreMock,
   useResourceStoreMock,
 } = vi.hoisted(() => ({
   ensureServeUrlsMock: vi.fn(),
   loggerErrorMock: vi.fn(),
+  loggerWarnMock: vi.fn(),
   resolveStaticAssetSiteMock: vi.fn(),
   usePreviewRuntimeStoreMock: vi.fn(),
   useResourceStoreMock: vi.fn(),
 }))
 
 const resourceStoreState = reactive({
-  games: [] as { path: string }[],
-  engines: [] as { path: string, status?: string }[],
+  games: undefined as TestGame[] | undefined,
+  engines: undefined as TestEngine[] | undefined,
 })
 
 const previewRuntimeStoreState = {
   ensureServeUrls: ensureServeUrlsMock,
+}
+
+function createTestEngine(path: string, overrides: Partial<Omit<TestEngine, 'path'>> = {}): TestEngine {
+  return {
+    availability: 'available',
+    metadata: { webgalVersion: '4.6.1' },
+    path,
+    status: 'created',
+    ...overrides,
+  }
 }
 
 vi.mock('~/stores/resource', () => ({
@@ -42,7 +68,7 @@ vi.mock('~/services/game-manager', () => ({
 
 vi.mock('@tauri-apps/plugin-log', () => ({
   error: loggerErrorMock,
-  warn: vi.fn(),
+  warn: loggerWarnMock,
 }))
 
 import { useResourcePreviewPrimer } from '~/composables/useResourcePreviewPrimer'
@@ -59,8 +85,8 @@ describe('useResourcePreviewPrimer', () => {
   beforeEach(() => {
     vi.resetAllMocks()
 
-    resourceStoreState.games = []
-    resourceStoreState.engines = []
+    resourceStoreState.games = undefined
+    resourceStoreState.engines = undefined
 
     useResourceStoreMock.mockReturnValue(resourceStoreState)
     usePreviewRuntimeStoreMock.mockReturnValue(previewRuntimeStoreState)
@@ -78,7 +104,7 @@ describe('useResourcePreviewPrimer', () => {
       { path: '/games/alpha' },
     ]
     resourceStoreState.engines = [
-      { path: '/engines/fresh', status: 'created' },
+      createTestEngine('/engines/fresh'),
     ]
 
     stopPrimer = useResourcePreviewPrimer()
@@ -91,6 +117,9 @@ describe('useResourcePreviewPrimer', () => {
   })
 
   it('没有资源时不会触发预热', async () => {
+    resourceStoreState.games = []
+    resourceStoreState.engines = []
+
     stopPrimer = useResourcePreviewPrimer()
     await flushPrimerWatchers()
 
@@ -98,6 +127,9 @@ describe('useResourcePreviewPrimer', () => {
   })
 
   it('会在资源列表变化后补做预热', async () => {
+    resourceStoreState.games = []
+    resourceStoreState.engines = []
+
     stopPrimer = useResourcePreviewPrimer()
     await flushPrimerWatchers()
 
@@ -111,10 +143,46 @@ describe('useResourcePreviewPrimer', () => {
     expect(ensureServeUrlsMock).toHaveBeenCalledWith([{ projectPath: '/games/alpha' }])
   })
 
+  it('资源查询未全部初始化时不会预热', async () => {
+    resourceStoreState.games = [
+      { path: '/games/broken' },
+    ]
+    resolveStaticAssetSiteMock.mockRejectedValue(new Error('引擎不可用'))
+
+    stopPrimer = useResourcePreviewPrimer()
+    await flushPrimerWatchers()
+
+    expect(resolveStaticAssetSiteMock).not.toHaveBeenCalled()
+    expect(loggerWarnMock).not.toHaveBeenCalled()
+  })
+
+  it('资源列表等价更新时不会重复预热', async () => {
+    resourceStoreState.games = [
+      { path: '/games/broken' },
+    ]
+    resourceStoreState.engines = []
+    resolveStaticAssetSiteMock.mockRejectedValue(new Error('引擎不可用'))
+
+    stopPrimer = useResourcePreviewPrimer()
+    await flushPrimerWatchers()
+
+    expect(resolveStaticAssetSiteMock).toHaveBeenCalledTimes(1)
+    expect(loggerWarnMock).toHaveBeenCalledTimes(1)
+
+    resourceStoreState.games = [
+      { path: '/games/broken' },
+    ]
+    await flushPrimerWatchers()
+
+    expect(resolveStaticAssetSiteMock).toHaveBeenCalledTimes(1)
+    expect(loggerWarnMock).toHaveBeenCalledTimes(1)
+  })
+
   it('预热失败时会记录错误而不是吞掉拒绝', async () => {
     resourceStoreState.games = [
       { path: '/games/alpha' },
     ]
+    resourceStoreState.engines = []
     ensureServeUrlsMock.mockRejectedValue(new Error('server unavailable'))
 
     stopPrimer = useResourcePreviewPrimer()
@@ -130,7 +198,7 @@ describe('useResourcePreviewPrimer', () => {
       { path: '/games/broken' },
     ]
     resourceStoreState.engines = [
-      { path: '/engines/fresh', status: 'created' },
+      createTestEngine('/engines/fresh'),
     ]
     resolveStaticAssetSiteMock.mockImplementation(async (game: { path: string }) => {
       if (game.path === '/games/broken') {
@@ -149,9 +217,14 @@ describe('useResourcePreviewPrimer', () => {
   })
 
   it('会跳过状态非 created 的引擎', async () => {
+    resourceStoreState.games = []
     resourceStoreState.engines = [
-      { path: '/engines/fresh', status: 'created' },
-      { path: '/engines/missing', status: 'error' },
+      createTestEngine('/engines/fresh'),
+      createTestEngine('/engines/missing', {
+        availability: 'missing',
+        metadata: {},
+        status: 'error',
+      }),
     ]
 
     stopPrimer = useResourcePreviewPrimer()

--- a/src/composables/__tests__/useResourcePreviewPrimer.test.ts
+++ b/src/composables/__tests__/useResourcePreviewPrimer.test.ts
@@ -147,7 +147,6 @@ describe('useResourcePreviewPrimer', () => {
     resourceStoreState.games = [
       { path: '/games/broken' },
     ]
-    resolveStaticAssetSiteMock.mockRejectedValue(new Error('引擎不可用'))
 
     stopPrimer = useResourcePreviewPrimer()
     await flushPrimerWatchers()

--- a/src/composables/useResourcePreviewPrimer.ts
+++ b/src/composables/useResourcePreviewPrimer.ts
@@ -2,16 +2,51 @@ import { gameManager } from '~/services/game-manager'
 import { usePreviewRuntimeStore } from '~/stores/preview-runtime'
 import { useResourceStore } from '~/stores/resource'
 
+import type { Engine, Game } from '~/database/model'
+
+type PreviewPrimerGameInput = Pick<Game, 'engineId' | 'path'>
+type PreviewPrimerEngineInput = Pick<Engine, 'availability' | 'metadata' | 'path' | 'status'>
+
+function buildResourcePreviewPrimerSignature(
+  games: readonly PreviewPrimerGameInput[] | undefined,
+  engines: readonly PreviewPrimerEngineInput[] | undefined,
+): string | undefined {
+  if (!games || !engines) {
+    return
+  }
+
+  return JSON.stringify({
+    engines: engines
+      .map(engine => ({
+        availability: engine.availability,
+        path: engine.path,
+        status: engine.status,
+        webgalVersion: engine.metadata.webgalVersion ?? '',
+      }))
+      .toSorted((left, right) => left.path.localeCompare(right.path)),
+    games: games
+      .map(game => ({
+        engineId: game.engineId ?? '',
+        path: game.path,
+      }))
+      .toSorted((left, right) => left.path.localeCompare(right.path)),
+  })
+}
+
 export function useResourcePreviewPrimer(): () => void {
   const previewRuntimeStore = usePreviewRuntimeStore()
   const resourceStore = useResourceStore()
 
   return watch(
-    () => ({
-      engines: resourceStore.engines ?? [],
-      games: resourceStore.games ?? [],
-    }),
-    async ({ engines, games }) => {
+    () => buildResourcePreviewPrimerSignature(resourceStore.games, resourceStore.engines),
+    async () => {
+      const engines = resourceStore.engines
+      const games = resourceStore.games
+
+      if (!games || !engines) {
+        return
+      }
+
       if (games.length === 0 && engines.length === 0) {
         return
       }


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [x] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [x] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

修复资源预览预热在应用启动阶段可能重复触发的问题。

此前 `useResourcePreviewPrimer` 直接监听由 `games` / `engines` 数组组成的新对象。启动阶段 Dexie liveQuery 可能先后 emit 半初始化或等价资源列表，导致预热逻辑重复执行，并重复记录同一条 warn。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

启动时资源列表可能经历多次 liveQuery emission。对于资源预热来说，数组引用变化不等于预热输入变化。该问题会造成重复解析资源路径，并在失败资源存在时重复输出相同 warn。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
