### PR TITLE
👷 固定 GitHub Actions 版本并加固 CI 工作流

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,8 +11,8 @@ on:
       - "src-tauri/**"
       - "package.json"
       - "bun.lock"
-      - "vite.config.ts"
-      - "unocss.config.ts"
+      - "*.config.js"
+      - "*.config.ts"
       - "tsconfig*.json"
       - ".github/workflows/build.yml"
   pull_request:
@@ -24,8 +24,8 @@ on:
       - "src-tauri/**"
       - "package.json"
       - "bun.lock"
-      - "vite.config.ts"
-      - "unocss.config.ts"
+      - "*.config.js"
+      - "*.config.ts"
       - "tsconfig*.json"
       - ".github/workflows/build.yml"
   workflow_dispatch:
@@ -67,7 +67,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.3
 
       - name: Install system dependencies (Ubuntu)
         if: matrix.os == 'ubuntu-latest'
@@ -81,17 +81,17 @@ jobs:
           targets: ${{ matrix.os == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
 
       - name: Rust cache
-        uses: swatinem/rust-cache@v2
+        uses: swatinem/rust-cache@v2.9.1
         with:
           workspaces: ./src-tauri -> target
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@v2.2.0
         with:
           bun-version-file: package.json
 
       - name: Install dependencies
-        run: bun install
+        run: bun ci
 
       - name: Build app
         id: tauri-build
@@ -120,7 +120,7 @@ jobs:
 
       - name: Upload build artifacts
         continue-on-error: true
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: ${{ steps.artifact-name.outputs.name }}
           path: "${{ join(fromJSON(steps.tauri-build.outputs.artifactPaths), '\n') }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Install system dependencies (Ubuntu)
         if: matrix.os == 'ubuntu-latest'
@@ -76,17 +76,18 @@ jobs:
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
 
       - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
+          toolchain: stable
           targets: ${{ matrix.os == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
 
       - name: Rust cache
-        uses: swatinem/rust-cache@v2.9.1
+        uses: swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: ./src-tauri -> target
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2.2.0
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version-file: package.json
 
@@ -95,7 +96,7 @@ jobs:
 
       - name: Build app
         id: tauri-build
-        uses: tauri-apps/tauri-action@v0.6.2
+        uses: tauri-apps/tauri-action@84b9d35b5fc46c1e45415bdb6144030364f7ebc5 # v0.6.2
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
@@ -120,7 +121,7 @@ jobs:
 
       - name: Upload build artifacts
         continue-on-error: true
-        uses: actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ steps.artifact-name.outputs.name }}
           path: "${{ join(fromJSON(steps.tauri-build.outputs.artifactPaths), '\n') }}"

--- a/.github/workflows/code-suggestions.yml
+++ b/.github/workflows/code-suggestions.yml
@@ -4,10 +4,11 @@ on:
   pull_request:
     paths:
       - "src/**"
+      - "scripts/**"
       - "package.json"
       - "bun.lock"
-      - "eslint.config.js"
-      - "stylelint.config.js"
+      - "*.config.js"
+      - "*.config.ts"
       - ".github/workflows/code-suggestions.yml"
       - ".github/workflows/lint.yml"
 
@@ -26,20 +27,20 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.3
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@v2.2.0
         with:
           bun-version-file: package.json
 
       - name: Install dependencies
-        run: bun install
+        run: bun ci
 
       - name: Run ESLint with reviewdog
         id: eslint
         continue-on-error: true
-        uses: reviewdog/action-eslint@v1
+        uses: reviewdog/action-eslint@v1.34.0
         with:
           reporter: github-pr-review
           tool_name: eslint
@@ -48,7 +49,7 @@ jobs:
       - name: Run ESLint i18n with reviewdog
         id: i18n
         continue-on-error: true
-        uses: reviewdog/action-eslint@v1
+        uses: reviewdog/action-eslint@v1.34.0
         with:
           reporter: github-pr-review
           tool_name: i18n
@@ -57,7 +58,7 @@ jobs:
       - name: Run Stylelint with reviewdog
         id: stylelint
         continue-on-error: true
-        uses: reviewdog/action-stylelint@v1
+        uses: reviewdog/action-stylelint@v1.30.2
         with:
           reporter: github-pr-review
           stylelint_input: "src/**/*.{css,vue}"

--- a/.github/workflows/code-suggestions.yml
+++ b/.github/workflows/code-suggestions.yml
@@ -27,10 +27,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2.2.0
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version-file: package.json
 
@@ -40,7 +40,7 @@ jobs:
       - name: Run ESLint with reviewdog
         id: eslint
         continue-on-error: true
-        uses: reviewdog/action-eslint@v1.34.0
+        uses: reviewdog/action-eslint@556a3fdaf8b4201d4d74d406013386aa4f7dab96 # v1.34.0
         with:
           reporter: github-pr-review
           tool_name: eslint
@@ -49,7 +49,7 @@ jobs:
       - name: Run ESLint i18n with reviewdog
         id: i18n
         continue-on-error: true
-        uses: reviewdog/action-eslint@v1.34.0
+        uses: reviewdog/action-eslint@556a3fdaf8b4201d4d74d406013386aa4f7dab96 # v1.34.0
         with:
           reporter: github-pr-review
           tool_name: i18n
@@ -58,7 +58,7 @@ jobs:
       - name: Run Stylelint with reviewdog
         id: stylelint
         continue-on-error: true
-        uses: reviewdog/action-stylelint@v1.30.2
+        uses: reviewdog/action-stylelint@dd2b435cc6a7c82705307a9dee740c9bbaa10411 # v1.30.2
         with:
           reporter: github-pr-review
           stylelint_input: "src/**/*.{css,vue}"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -16,10 +16,10 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.3
 
       - name: Dependency Review
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@v5.0.0
         with:
           comment-summary-in-pr: on-failure
           show-openssf-scorecard: false

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -16,10 +16,10 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Dependency Review
-        uses: actions/dependency-review-action@v5.0.0
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           comment-summary-in-pr: on-failure
           show-openssf-scorecard: false

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -44,10 +44,10 @@ jobs:
             command: bun lint:i18n
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2.2.0
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version-file: package.json
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,19 +5,22 @@ on:
     branches: [main]
     paths:
       - "src/**"
+      - "scripts/**"
       - "package.json"
       - "bun.lock"
-      - "eslint.config.js"
-      - "stylelint.config.js"
+      - "*.config.js"
+      - "*.config.ts"
       - ".github/workflows/lint.yml"
   pull_request:
     paths:
       - "src/**"
+      - "scripts/**"
       - "package.json"
       - "bun.lock"
-      - "eslint.config.js"
-      - "stylelint.config.js"
+      - "*.config.js"
+      - "*.config.ts"
       - ".github/workflows/lint.yml"
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
@@ -41,15 +44,15 @@ jobs:
             command: bun lint:i18n
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.3
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@v2.2.0
         with:
           bun-version-file: package.json
 
       - name: Install dependencies
-        run: bun install
+        run: bun ci
 
       - name: Run lint checks
         run: ${{ matrix.command }}

--- a/.github/workflows/pr-artifact-comment.yml
+++ b/.github/workflows/pr-artifact-comment.yml
@@ -11,11 +11,12 @@ jobs:
     if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion != 'cancelled' }}
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: read
       pull-requests: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.3
 
       - name: Fetch PR context
         id: pr-context
@@ -30,7 +31,7 @@ jobs:
 
       - name: Format artifact comment
         id: format-artifact-comment
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9.0.0
         with:
           result-encoding: string
           script: |
@@ -44,7 +45,7 @@ jobs:
             return createArtifactComment(artifactCommentData);
 
       - name: Post artifact comment to PR
-        uses: marocchino/sticky-pull-request-comment@v3
+        uses: marocchino/sticky-pull-request-comment@v3.0.4
         with:
           number: ${{ steps.pr-context.outputs.number }}
           header: artifacts

--- a/.github/workflows/pr-artifact-comment.yml
+++ b/.github/workflows/pr-artifact-comment.yml
@@ -16,7 +16,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Fetch PR context
         id: pr-context
@@ -31,7 +31,7 @@ jobs:
 
       - name: Format artifact comment
         id: format-artifact-comment
-        uses: actions/github-script@v9.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           result-encoding: string
           script: |
@@ -45,7 +45,7 @@ jobs:
             return createArtifactComment(artifactCommentData);
 
       - name: Post artifact comment to PR
-        uses: marocchino/sticky-pull-request-comment@v3.0.4
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
         with:
           number: ${{ steps.pr-context.outputs.number }}
           header: artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,10 +17,10 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2.2.0
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version-file: package.json
 
@@ -45,11 +45,11 @@ jobs:
       changelog: ${{ steps.release-drafter.outputs.body }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Generate release changelog
         id: release-drafter
-        uses: release-drafter/release-drafter@v7.3.1
+        uses: release-drafter/release-drafter@693d20e7c1ce1a81d3a41962f85914253b518449 # v7.3.1
         env:
           GITHUB_TOKEN: ${{ github.token }}
 
@@ -83,7 +83,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Install system dependencies (Ubuntu)
         if: matrix.os == 'ubuntu-latest'
@@ -92,17 +92,18 @@ jobs:
           sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
 
       - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
+          toolchain: stable
           targets: ${{ matrix.os == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
 
       - name: Rust cache
-        uses: swatinem/rust-cache@v2.9.1
+        uses: swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: ./src-tauri -> target
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2.2.0
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version-file: package.json
 
@@ -110,7 +111,7 @@ jobs:
         run: bun ci
 
       - name: Build and create release
-        uses: tauri-apps/tauri-action@v0.6.2
+        uses: tauri-apps/tauri-action@84b9d35b5fc46c1e45415bdb6144030364f7ebc5 # v0.6.2
         env:
           GITHUB_TOKEN: ${{ github.token }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,32 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  validate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6.0.3
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2.2.0
+        with:
+          bun-version-file: package.json
+
+      - name: Validate release version
+        shell: bash
+        run: |
+          package_version="$(bun -p "require('./package.json').version")"
+          expected_tag="v${package_version}"
+
+          if [[ "${GITHUB_REF_TYPE}" == "tag" && "${GITHUB_REF_NAME}" != "${expected_tag}" ]]; then
+            echo "Release tag ${GITHUB_REF_NAME} does not match package version ${package_version}. Expected ${expected_tag}."
+            exit 1
+          fi
+
   changelog:
+    needs: validate
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -20,11 +45,11 @@ jobs:
       changelog: ${{ steps.release-drafter.outputs.body }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.3
 
       - name: Generate release changelog
         id: release-drafter
-        uses: release-drafter/release-drafter@v6
+        uses: release-drafter/release-drafter@v7.3.1
         env:
           GITHUB_TOKEN: ${{ github.token }}
 
@@ -58,7 +83,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.3
 
       - name: Install system dependencies (Ubuntu)
         if: matrix.os == 'ubuntu-latest'
@@ -72,17 +97,17 @@ jobs:
           targets: ${{ matrix.os == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
 
       - name: Rust cache
-        uses: swatinem/rust-cache@v2
+        uses: swatinem/rust-cache@v2.9.1
         with:
           workspaces: ./src-tauri -> target
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@v2.2.0
         with:
           bun-version-file: package.json
 
       - name: Install dependencies
-        run: bun install
+        run: bun ci
 
       - name: Build and create release
         uses: tauri-apps/tauri-action@v0.6.2

--- a/.github/workflows/rust-lint.yml
+++ b/.github/workflows/rust-lint.yml
@@ -4,12 +4,19 @@ on:
   push:
     branches: [main]
     paths:
-      - "src-tauri/**"
+      - "src-tauri/**/*.rs"
+      - "src-tauri/Cargo.toml"
+      - "src-tauri/Cargo.lock"
+      - "src-tauri/.rustfmt.toml"
       - ".github/workflows/rust-lint.yml"
   pull_request:
     paths:
-      - "src-tauri/**"
+      - "src-tauri/**/*.rs"
+      - "src-tauri/Cargo.toml"
+      - "src-tauri/Cargo.lock"
+      - "src-tauri/.rustfmt.toml"
       - ".github/workflows/rust-lint.yml"
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
@@ -33,7 +40,7 @@ jobs:
             needs-deps: false
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.3
 
       - name: Install system dependencies
         if: ${{ matrix.needs-deps }}
@@ -47,7 +54,7 @@ jobs:
           components: clippy, rustfmt
 
       - name: Rust cache
-        uses: swatinem/rust-cache@v2
+        uses: swatinem/rust-cache@v2.9.1
         with:
           workspaces: ./src-tauri -> target
 

--- a/.github/workflows/rust-lint.yml
+++ b/.github/workflows/rust-lint.yml
@@ -40,7 +40,7 @@ jobs:
             needs-deps: false
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Install system dependencies
         if: ${{ matrix.needs-deps }}
@@ -49,12 +49,13 @@ jobs:
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
 
       - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
+          toolchain: stable
           components: clippy, rustfmt
 
       - name: Rust cache
-        uses: swatinem/rust-cache@v2.9.1
+        uses: swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: ./src-tauri -> target
 

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -4,11 +4,15 @@ on:
   push:
     branches: [main]
     paths:
-      - "src-tauri/**"
+      - "src-tauri/**/*.rs"
+      - "src-tauri/Cargo.toml"
+      - "src-tauri/Cargo.lock"
       - ".github/workflows/rust-test.yml"
   pull_request:
     paths:
-      - "src-tauri/**"
+      - "src-tauri/**/*.rs"
+      - "src-tauri/Cargo.toml"
+      - "src-tauri/Cargo.lock"
       - ".github/workflows/rust-test.yml"
   workflow_dispatch:
 
@@ -24,7 +28,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.3
 
       - name: Install system dependencies
         run: |
@@ -35,7 +39,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Rust cache
-        uses: swatinem/rust-cache@v2
+        uses: swatinem/rust-cache@v2.9.1
         with:
           workspaces: ./src-tauri -> target
 

--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -28,7 +28,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Install system dependencies
         run: |
@@ -36,10 +36,12 @@ jobs:
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
 
       - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: stable
 
       - name: Rust cache
-        uses: swatinem/rust-cache@v2.9.1
+        uses: swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: ./src-tauri -> target
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,8 @@ on:
       - "integration/**"
       - "package.json"
       - "bun.lock"
-      - "vite.config.ts"
+      - "*.config.js"
+      - "*.config.ts"
       - "tsconfig*.json"
       - ".github/workflows/test.yml"
   pull_request:
@@ -17,7 +18,8 @@ on:
       - "integration/**"
       - "package.json"
       - "bun.lock"
-      - "vite.config.ts"
+      - "*.config.js"
+      - "*.config.ts"
       - "tsconfig*.json"
       - ".github/workflows/test.yml"
   workflow_dispatch:
@@ -49,15 +51,15 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.3
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@v2.2.0
         with:
           bun-version-file: package.json
 
       - name: Install dependencies
-        run: bun install
+        run: bun ci
 
       - name: Install Playwright Chromium
         if: ${{ matrix.needs-playwright }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,10 +51,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2.2.0
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version-file: package.json
 

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -5,25 +5,24 @@ on:
     branches: [main]
     paths:
       - "src/**"
+      - "scripts/**"
       - "package.json"
       - "bun.lock"
-      - "vite.config.ts"
-      - "unocss.config.ts"
-      - "eslint.config.js"
-      - "stylelint.config.js"
+      - "*.config.js"
+      - "*.config.ts"
       - "tsconfig*.json"
       - ".github/workflows/typecheck.yml"
   pull_request:
     paths:
       - "src/**"
+      - "scripts/**"
       - "package.json"
       - "bun.lock"
-      - "vite.config.ts"
-      - "unocss.config.ts"
-      - "eslint.config.js"
-      - "stylelint.config.js"
+      - "*.config.js"
+      - "*.config.ts"
       - "tsconfig*.json"
       - ".github/workflows/typecheck.yml"
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
@@ -36,15 +35,15 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v6.0.3
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@v2.2.0
         with:
           bun-version-file: package.json
 
       - name: Install dependencies
-        run: bun install
+        run: bun ci
 
       - name: Run frontend typecheck
         run: bun typecheck

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -35,10 +35,10 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6.0.3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2.2.0
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version-file: package.json
 


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [ ] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [ ] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [x] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

- 统一多个前端工作流的 `paths` 过滤规则，改为覆盖 `*.config.*` 并纳入 `scripts/**`
- 将多个 GitHub Actions 固定到明确版本，减少上游漂移带来的不确定性
- 将 `bun install` 替换为 `bun ci`，让 CI 依赖安装与锁文件保持严格一致
- 为 `lint`、`typecheck`、`rust-lint` 等工作流补充 `workflow_dispatch`
- 收紧 Rust 相关工作流的触发范围，只在 Rust 相关文件变化时运行
- 为 `release` 工作流新增版本校验，要求 tag 与 `package.json` 中的版本一致
- 为 PR 构建产物评论工作流补充 `actions: read` 权限，并同步升级相关 Action 版本

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

- 现有工作流对配置文件和脚本变更的覆盖不一致，容易出现该跑的不跑或无关改动触发 CI
- 未固定的 Action 版本和宽松的依赖安装方式会降低 CI 的可复现性
- `release` 缺少 tag/version 一致性保护，存在误发版风险

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [ ] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
