### PR TITLE
🐛 修复 PR 构建产物评论的任务同步误判

### DIFF
--- a/scripts/collectArtifactCommentData.js
+++ b/scripts/collectArtifactCommentData.js
@@ -87,7 +87,7 @@ function collectFailedJob(job, uploadedPlatforms) {
     }
   }
 
-  if (!uploadedPlatforms.has(job.name)) {
+  if (job.conclusion === 'success' && !uploadedPlatforms.has(job.name)) {
     return {
       platform: job.name,
       failedStep: 'Upload build artifacts',

--- a/scripts/collectArtifactCommentData.js
+++ b/scripts/collectArtifactCommentData.js
@@ -3,7 +3,26 @@
 
 const artifactPlatformPattern = /(?<platform>(?<os>windows|macos|linux)-(?<arch>[a-z0-9]+))(?:-|$)/
 const platformJobPattern = /^(windows|macos|linux)-[a-z0-9]+$/
-const failedStepConclusions = new Set(['failure', 'cancelled', 'timed_out', 'startup_failure'])
+const failedJobConclusions = new Set(['failure', 'cancelled', 'timed_out', 'startup_failure', 'action_required'])
+const defaultJobsApiSyncDelayMs = 5000
+const defaultJobsApiSyncMaxAttempts = 6
+
+/**
+ * @typedef {{id:number, name: string, size_in_bytes: number, workflow_run: {id:number}}} Artifact
+ * @typedef {{name: string, conclusion?: string | null}} JobStep
+ * @typedef {{name: string, conclusion?: string | null, html_url: string, steps?: JobStep[]}} WorkflowJob
+ * @typedef {{artifacts: Artifact[], platformJobs: WorkflowJob[]}} ArtifactCommentSnapshot
+ * @typedef {{
+ *   rest: {
+ *     actions: {
+ *       listWorkflowRunArtifacts: (input: {owner: string, repo: string, run_id: number}) => Promise<{data: {artifacts: Artifact[]}}>,
+ *       listJobsForWorkflowRun: unknown,
+ *     }
+ *   },
+ *   paginate: (route: unknown, input: {owner: string, repo: string, run_id: number, per_page: number}) => Promise<WorkflowJob[]>,
+ * }} GitHubActionsClient
+ * @typedef {{repo: {owner: string, repo: string}, payload: {workflow_run: {id: number}}}} GitHubWorkflowContext
+ */
 
 /**
  * @param {{name: string}[]} artifacts
@@ -27,7 +46,16 @@ function getUploadedPlatforms(artifacts) {
  * @param {{conclusion?: string | null, name: string}[]} [steps]
  */
 function getFailedStepName(steps) {
-  return steps?.find(step => step.conclusion && failedStepConclusions.has(step.conclusion))?.name ?? 'Unknown step'
+  return steps?.find(step => step.conclusion && failedJobConclusions.has(step.conclusion))?.name ?? 'Unknown step'
+}
+
+/**
+ * @param {number} milliseconds
+ */
+function waitForMilliseconds(milliseconds) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, milliseconds)
+  })
 }
 
 /**
@@ -41,7 +69,16 @@ function getFailedStepName(steps) {
  * @returns {{platform: string, failedStep: string, conclusion: string, jobUrl: string} | undefined}
  */
 function collectFailedJob(job, uploadedPlatforms) {
-  if (job.conclusion !== 'success') {
+  if (!job.conclusion) {
+    return {
+      platform: job.name,
+      failedStep: getFailedStepName(job.steps),
+      conclusion: 'unknown',
+      jobUrl: job.html_url,
+    }
+  }
+
+  if (failedJobConclusions.has(job.conclusion)) {
     return {
       platform: job.name,
       failedStep: getFailedStepName(job.steps),
@@ -61,24 +98,42 @@ function collectFailedJob(job, uploadedPlatforms) {
 }
 
 /**
- * @param {{
- *   github: {
- *     rest: {
- *       actions: {
- *         listWorkflowRunArtifacts: (input: {owner: string, repo: string, run_id: number}) => Promise<{data: {artifacts: {id:number, name: string, size_in_bytes: number, workflow_run: {id:number}}[]}}>,
- *         listJobsForWorkflowRun: unknown,
- *       }
- *     },
- *     paginate: (route: unknown, input: {owner: string, repo: string, run_id: number, per_page: number}) => Promise<{name: string, conclusion?: string | null, html_url: string, steps?: {name: string, conclusion?: string | null}[]}[]>,
- *   },
- *   context: {
- *     repo: {owner: string, repo: string},
- *     payload: {workflow_run: {id: number}},
- *   },
- *   sha: string,
- * }} options
+ * @param {{name: string, conclusion?: string | null}[]} platformJobs
  */
-async function collectArtifactCommentData({ github, context, sha }) {
+function hasPendingJobConclusion(platformJobs) {
+  return platformJobs.some(job => !job.conclusion)
+}
+
+/**
+ * @param {{name: string, conclusion?: string | null}[]} platformJobs
+ * @param {Set<string>} uploadedPlatforms
+ */
+function hasMissingSuccessfulPlatformArtifact(platformJobs, uploadedPlatforms) {
+  return platformJobs.some(job => job.conclusion === 'success' && !uploadedPlatforms.has(job.name))
+}
+
+/**
+ * @param {{name: string}[]} artifacts
+ * @param {{name: string, conclusion?: string | null}[]} platformJobs
+ */
+function isArtifactCommentSnapshotSynced(artifacts, platformJobs) {
+  const uploadedPlatforms = getUploadedPlatforms(artifacts)
+
+  return !hasPendingJobConclusion(platformJobs)
+    && !hasMissingSuccessfulPlatformArtifact(platformJobs, uploadedPlatforms)
+}
+
+/**
+ * @param {{
+ *   github: GitHubActionsClient,
+ *   context: GitHubWorkflowContext,
+ * }} options
+ * @returns {Promise<ArtifactCommentSnapshot>}
+ */
+async function fetchArtifactCommentSnapshot({
+  github,
+  context,
+}) {
   const artifactsResponse = await github.rest.actions.listWorkflowRunArtifacts({
     owner: context.repo.owner,
     repo: context.repo.repo,
@@ -90,9 +145,79 @@ async function collectArtifactCommentData({ github, context, sha }) {
     run_id: context.payload.workflow_run.id,
     per_page: 100,
   })
-  const artifacts = artifactsResponse.data.artifacts
+
+  return {
+    artifacts: artifactsResponse.data.artifacts,
+    platformJobs: jobs.filter(job => platformJobPattern.test(job.name)),
+  }
+}
+
+/**
+ * @param {{
+ *   github: GitHubActionsClient,
+ *   context: GitHubWorkflowContext,
+ *   wait: (milliseconds: number) => Promise<void>,
+ *   jobsApiSyncDelayMs: number,
+ *   jobsApiSyncMaxAttempts: number,
+ *   attempt?: number,
+ * }} options
+ * @returns {Promise<ArtifactCommentSnapshot>}
+ */
+async function fetchSyncedArtifactCommentSnapshot({
+  github,
+  context,
+  wait,
+  jobsApiSyncDelayMs,
+  jobsApiSyncMaxAttempts,
+  attempt = 1,
+}) {
+  const snapshot = await fetchArtifactCommentSnapshot({ github, context })
+
+  if (isArtifactCommentSnapshotSynced(snapshot.artifacts, snapshot.platformJobs) || attempt >= jobsApiSyncMaxAttempts) {
+    return snapshot
+  }
+
+  await wait(jobsApiSyncDelayMs)
+
+  return fetchSyncedArtifactCommentSnapshot({
+    github,
+    context,
+    wait,
+    jobsApiSyncDelayMs,
+    jobsApiSyncMaxAttempts,
+    attempt: attempt + 1,
+  })
+}
+
+/**
+ * @param {{
+ *   github: GitHubActionsClient,
+ *   context: GitHubWorkflowContext,
+ *   sha: string,
+ *   wait?: (milliseconds: number) => Promise<void>,
+ *   jobsApiSyncDelayMs?: number,
+ *   jobsApiSyncMaxAttempts?: number,
+ * }} options
+ */
+async function collectArtifactCommentData({
+  github,
+  context,
+  sha,
+  wait = waitForMilliseconds,
+  jobsApiSyncDelayMs = defaultJobsApiSyncDelayMs,
+  jobsApiSyncMaxAttempts = defaultJobsApiSyncMaxAttempts,
+}) {
+  const maxAttempts = Math.max(1, jobsApiSyncMaxAttempts)
+  const delayMs = Math.max(0, jobsApiSyncDelayMs)
+  const { artifacts, platformJobs } = await fetchSyncedArtifactCommentSnapshot({
+    github,
+    context,
+    wait,
+    jobsApiSyncDelayMs: delayMs,
+    jobsApiSyncMaxAttempts: maxAttempts,
+  })
+
   const uploadedPlatforms = getUploadedPlatforms(artifacts)
-  const platformJobs = jobs.filter(job => platformJobPattern.test(job.name))
   const failedJobs = platformJobs
     .flatMap((job) => {
       const failedJob = collectFailedJob(job, uploadedPlatforms)

--- a/src/utils/__tests__/collect-artifact-comment-data.test.ts
+++ b/src/utils/__tests__/collect-artifact-comment-data.test.ts
@@ -3,146 +3,184 @@ import { describe, expect, it, vi } from 'vitest'
 
 import collectArtifactCommentData from '../../../scripts/collectArtifactCommentData.js'
 
+interface ArtifactFixture {
+  id: number
+  name: string
+  size_in_bytes: number
+  workflow_run: {
+    id: number
+  }
+}
+
+interface JobStepFixture {
+  name: string
+  conclusion?: string | null
+}
+
+interface JobFixture {
+  name: string
+  status?: string
+  conclusion?: string | null
+  html_url: string
+  steps?: JobStepFixture[]
+}
+
+const workflowRunId = 42
+const sha = 'abcdef0123456789'
+const workflowContext = {
+  repo: {
+    owner: 'project',
+    repo: 'webgal-craft',
+  },
+  payload: {
+    workflow_run: {
+      id: workflowRunId,
+    },
+  },
+}
+const windowsArtifact: ArtifactFixture = {
+  id: 1,
+  name: 'webgal-craft-v1.2.3-windows-x64-pr-12-abcdef0',
+  size_in_bytes: 10 * 1024 ** 2,
+  workflow_run: { id: workflowRunId },
+}
+const successfulBuildSteps: JobStepFixture[] = [
+  { name: 'Build app', conclusion: 'success' },
+  { name: 'Upload build artifacts', conclusion: 'success' },
+]
+
+function jobUrl(jobId: number) {
+  return `https://github.com/project/webgal-craft/runs/${workflowRunId}/jobs/${jobId}`
+}
+
+function createGithubClient({
+  artifacts = [],
+  jobs = [],
+}: {
+  artifacts?: ArtifactFixture[]
+  jobs?: JobFixture[]
+} = {}) {
+  const listWorkflowRunArtifacts = vi.fn().mockResolvedValue({
+    data: {
+      artifacts,
+    },
+  })
+  const paginate = vi.fn().mockResolvedValue(jobs)
+
+  return {
+    github: {
+      rest: {
+        actions: {
+          listWorkflowRunArtifacts,
+          listJobsForWorkflowRun: Symbol('listJobsForWorkflowRun'),
+        },
+      },
+      paginate,
+    },
+    paginate,
+  }
+}
+
+interface CollectOptions {
+  github: ReturnType<typeof createGithubClient>['github']
+  wait?: (milliseconds: number) => Promise<void>
+  jobsApiSyncDelayMs?: number
+  jobsApiSyncMaxAttempts?: number
+}
+
+function collectForTest({
+  github,
+  wait,
+  jobsApiSyncDelayMs,
+  jobsApiSyncMaxAttempts,
+}: CollectOptions) {
+  return collectArtifactCommentData({
+    github,
+    context: workflowContext,
+    sha,
+    wait,
+    jobsApiSyncDelayMs,
+    jobsApiSyncMaxAttempts,
+  })
+}
+
 describe('collectArtifactCommentData', () => {
   it('汇总 artifact 并归一化构建失败与上传失败的 job', async () => {
-    const listWorkflowRunArtifacts = vi.fn().mockResolvedValue({
-      data: {
-        artifacts: [
-          {
-            id: 1,
-            name: 'webgal-craft-v1.2.3-windows-x64-pr-12-abcdef0',
-            size_in_bytes: 10 * 1024 ** 2,
-            workflow_run: { id: 42 },
-          },
-        ],
-      },
+    const { github } = createGithubClient({
+      artifacts: [windowsArtifact],
+      jobs: [
+        {
+          name: 'windows-x64',
+          conclusion: 'success',
+          html_url: jobUrl(100),
+          steps: successfulBuildSteps,
+        },
+        {
+          name: 'linux-x64',
+          conclusion: 'failure',
+          html_url: jobUrl(101),
+          steps: [
+            { name: 'Build app', conclusion: 'failure' },
+          ],
+        },
+        {
+          name: 'macos-x64',
+          conclusion: 'success',
+          html_url: jobUrl(102),
+          steps: successfulBuildSteps,
+        },
+      ],
     })
-    const paginate = vi.fn().mockResolvedValue([
-      {
-        name: 'windows-x64',
-        conclusion: 'success',
-        html_url: 'https://github.com/project/webgal-craft/runs/42/jobs/100',
-        steps: [
-          { name: 'Build app', conclusion: 'success' },
-          { name: 'Upload build artifacts', conclusion: 'success' },
-        ],
-      },
-      {
-        name: 'linux-x64',
-        conclusion: 'failure',
-        html_url: 'https://github.com/project/webgal-craft/runs/42/jobs/101',
-        steps: [
-          { name: 'Build app', conclusion: 'failure' },
-        ],
-      },
-      {
-        name: 'macos-x64',
-        conclusion: 'success',
-        html_url: 'https://github.com/project/webgal-craft/runs/42/jobs/102',
-        steps: [
-          { name: 'Build app', conclusion: 'success' },
-          { name: 'Upload build artifacts', conclusion: 'success' },
-        ],
-      },
-    ])
 
-    const result = await collectArtifactCommentData({
-      github: {
-        rest: {
-          actions: {
-            listWorkflowRunArtifacts,
-            listJobsForWorkflowRun: Symbol('listJobsForWorkflowRun'),
-          },
-        },
-        paginate,
-      },
-      context: {
-        repo: {
-          owner: 'project',
-          repo: 'webgal-craft',
-        },
-        payload: {
-          workflow_run: {
-            id: 42,
-          },
-        },
-      },
-      sha: 'abcdef0123456789',
+    const result = await collectForTest({
+      github,
+      jobsApiSyncMaxAttempts: 1,
     })
 
     expect(result).toEqual({
-      artifacts: [
-        {
-          id: 1,
-          name: 'webgal-craft-v1.2.3-windows-x64-pr-12-abcdef0',
-          size_in_bytes: 10 * 1024 ** 2,
-          workflow_run: { id: 42 },
-        },
-      ],
-      sha: 'abcdef0123456789',
+      artifacts: [windowsArtifact],
+      sha,
       totalPlatformJobCount: 3,
       failedJobs: [
         {
           platform: 'linux-x64',
           failedStep: 'Build app',
           conclusion: 'failure',
-          jobUrl: 'https://github.com/project/webgal-craft/runs/42/jobs/101',
+          jobUrl: jobUrl(101),
         },
         {
           platform: 'macos-x64',
           failedStep: 'Upload build artifacts',
           conclusion: 'failure',
-          jobUrl: 'https://github.com/project/webgal-craft/runs/42/jobs/102',
+          jobUrl: jobUrl(102),
         },
       ],
     })
   })
 
   it('忽略非平台 job，并保留未知失败步骤的兜底文案', async () => {
-    const listWorkflowRunArtifacts = vi.fn().mockResolvedValue({
-      data: {
-        artifacts: [],
-      },
+    const { github } = createGithubClient({
+      jobs: [
+        {
+          name: 'setup',
+          conclusion: 'failure',
+          html_url: jobUrl(99),
+          steps: [
+            { name: 'Checkout', conclusion: 'failure' },
+          ],
+        },
+        {
+          name: 'macos-arm64',
+          conclusion: 'failure',
+          html_url: jobUrl(103),
+          steps: [],
+        },
+      ],
     })
-    const paginate = vi.fn().mockResolvedValue([
-      {
-        name: 'setup',
-        conclusion: 'failure',
-        html_url: 'https://github.com/project/webgal-craft/runs/42/jobs/099',
-        steps: [
-          { name: 'Checkout', conclusion: 'failure' },
-        ],
-      },
-      {
-        name: 'macos-arm64',
-        conclusion: 'failure',
-        html_url: 'https://github.com/project/webgal-craft/runs/42/jobs/103',
-        steps: [],
-      },
-    ])
 
-    const result = await collectArtifactCommentData({
-      github: {
-        rest: {
-          actions: {
-            listWorkflowRunArtifacts,
-            listJobsForWorkflowRun: Symbol('listJobsForWorkflowRun'),
-          },
-        },
-        paginate,
-      },
-      context: {
-        repo: {
-          owner: 'project',
-          repo: 'webgal-craft',
-        },
-        payload: {
-          workflow_run: {
-            id: 42,
-          },
-        },
-      },
-      sha: 'abcdef0123456789',
+    const result = await collectForTest({
+      github,
+      jobsApiSyncMaxAttempts: 1,
     })
 
     expect(result.failedJobs).toEqual([
@@ -150,9 +188,79 @@ describe('collectArtifactCommentData', () => {
         platform: 'macos-arm64',
         failedStep: 'Unknown step',
         conclusion: 'failure',
-        jobUrl: 'https://github.com/project/webgal-craft/runs/42/jobs/103',
+        jobUrl: jobUrl(103),
       },
     ])
     expect(result.totalPlatformJobCount).toBe(1)
+  })
+
+  it('等待平台 job 结论同步后再判断构建异常', async () => {
+    const { github, paginate } = createGithubClient({
+      artifacts: [windowsArtifact],
+    })
+    paginate
+      .mockResolvedValueOnce([
+        {
+          name: 'windows-x64',
+          status: 'completed',
+          conclusion: undefined,
+          html_url: jobUrl(100),
+          steps: successfulBuildSteps,
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          name: 'windows-x64',
+          status: 'completed',
+          conclusion: 'success',
+          html_url: jobUrl(100),
+          steps: successfulBuildSteps,
+        },
+      ])
+    const wait = vi.fn().mockResolvedValue(undefined)
+
+    const result = await collectForTest({
+      github,
+      wait,
+      jobsApiSyncDelayMs: 1,
+      jobsApiSyncMaxAttempts: 2,
+    })
+
+    expect(paginate).toHaveBeenCalledTimes(2)
+    expect(wait).toHaveBeenCalledWith(1)
+    expect(result.failedJobs).toEqual([])
+  })
+
+  it('重试耗尽后仍保留未知平台 job 状态', async () => {
+    const { github, paginate } = createGithubClient({
+      artifacts: [windowsArtifact],
+      jobs: [
+        {
+          name: 'windows-x64',
+          status: 'completed',
+          conclusion: undefined,
+          html_url: jobUrl(100),
+          steps: successfulBuildSteps,
+        },
+      ],
+    })
+    const wait = vi.fn().mockResolvedValue(undefined)
+
+    const result = await collectForTest({
+      github,
+      wait,
+      jobsApiSyncDelayMs: 1,
+      jobsApiSyncMaxAttempts: 2,
+    })
+
+    expect(paginate).toHaveBeenCalledTimes(2)
+    expect(result.failedJobs).toEqual([
+      {
+        platform: 'windows-x64',
+        failedStep: 'Unknown step',
+        conclusion: 'unknown',
+        jobUrl: jobUrl(100),
+      },
+    ])
   })
 })

--- a/src/utils/__tests__/collect-artifact-comment-data.test.ts
+++ b/src/utils/__tests__/collect-artifact-comment-data.test.ts
@@ -194,6 +194,37 @@ describe('collectArtifactCommentData', () => {
     expect(result.totalPlatformJobCount).toBe(1)
   })
 
+  it('忽略未成功且非失败的平台 job 缺失 artifact', async () => {
+    const { github } = createGithubClient({
+      jobs: [
+        {
+          name: 'linux-x64',
+          conclusion: 'skipped',
+          html_url: jobUrl(104),
+          steps: [
+            { name: 'Build app', conclusion: 'skipped' },
+          ],
+        },
+        {
+          name: 'macos-x64',
+          conclusion: 'neutral',
+          html_url: jobUrl(105),
+          steps: [
+            { name: 'Build app', conclusion: 'neutral' },
+          ],
+        },
+      ],
+    })
+
+    const result = await collectForTest({
+      github,
+      jobsApiSyncMaxAttempts: 1,
+    })
+
+    expect(result.failedJobs).toEqual([])
+    expect(result.totalPlatformJobCount).toBe(2)
+  })
+
   it('等待平台 job 结论同步后再判断构建异常', async () => {
     const { github, paginate } = createGithubClient({
       artifacts: [windowsArtifact],


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [x] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [ ] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [x] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

修复 `scripts/collectArtifactCommentData.js` 在生成 PR 构建产物评论时，对 GitHub Actions Jobs API 同步延迟的误判问题。

此前脚本会立即读取 workflow jobs 与 artifacts 并直接判定失败状态；当 Jobs API 中的平台任务 `conclusion` 尚未同步完成，或者成功任务对应的 artifact 还未及时可见时，评论可能错误地把构建标记为失败。

本次修改：
- 为 artifact/job 快照增加同步检查逻辑
- 在存在未同步 job 结论或成功任务缺少 artifact 时，按配置进行有限次重试
- 在重试耗尽后，将缺失结论的平台任务标记为 `unknown`，避免误报为正常成功
- 补充内部类型注释并拆分快照获取逻辑，便于后续维护

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

PR artifact 评论用于向 PR 直接反馈各平台构建产物状态。该流程依赖 `workflow_run` 完成后的 GitHub Actions API 数据，但 jobs 与 artifacts 在工作流刚结束时可能存在短暂的可见性延迟。

如果不做同步等待，评论内容会出现假失败，影响对 CI 结果的判断，也会降低该评论机制的可信度。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
