### PR TITLE
🔧 显式限制 Tauri 打包产物格式

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -18,7 +18,7 @@
   },
   "bundle": {
     "active": true,
-    "targets": "all",
+    "targets": ["nsis", "dmg", "appimage", "deb"],
     "publisher": "Akirami",
     "category": "DeveloperTool",
     "shortDescription": "WebGAL visual novel studio.",
@@ -36,10 +36,6 @@
     ],
     "windows": {
       "allowDowngrades": false,
-      "wix": {
-        "language": ["en-US", "ja-JP", "zh-CN", "zh-TW"],
-        "upgradeCode": "bdba7c85-7131-5208-9076-cf4b42f755f3"
-      },
       "nsis": {
         "languages": ["English", "Japanese", "SimpChinese", "TradChinese"],
         "displayLanguageSelector": true,


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [ ] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [ ] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [x] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

- 将 `src-tauri/tauri.conf.json` 中的 `bundle.targets` 从 `"all"` 调整为显式的 `["nsis", "dmg", "appimage", "deb"]`
- 移除 Windows 下的 `wix` 配置，仅保留当前需要的 `nsis` 安装器配置
- 通过 Tauri 配置直接限制应用可生成的打包格式，避免继续产出不需要的安装包类型

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

前配置使用 `targets: "all"`，会让 Tauri 按默认能力尝试生成更多格式的安装包。

这次修改的目标很直接：把打包产物收敛到项目当前明确需要的格式集合，只保留 `nsis`、`dmg`、`appimage` 和 `deb`，同时移除不再需要的 `wix` 配置，降低后续维护和产物管理成本。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->

如果后续需要重新支持其他安装包格式，可以在 `tauri.conf.json` 中重新扩展 `bundle.targets`，并补回对应平台配置。

### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [ ] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
