### PR TITLE
🐛 修复效果编辑器还原按钮的预览回滚行为

### DIFF
--- a/src/features/editor/effect-editor/__tests__/useEffectEditorProvider-queue.test.ts
+++ b/src/features/editor/effect-editor/__tests__/useEffectEditorProvider-queue.test.ts
@@ -272,7 +272,7 @@ describe('useEffectEditorProvider', () => {
     })
   })
 
-  it('重置草稿时通过空 setEffect 回到效果预览基线', async () => {
+  it('重置草稿时通过打开表单时的 transform 回到效果预览基线', async () => {
     useEditSettingsStore().autoApplyEffectEditorChanges = false
 
     const provider = createEffectEditorProvider()
@@ -304,7 +304,9 @@ describe('useEffectEditorProvider', () => {
 
     expect(debugCommanderMock.syncScene).not.toHaveBeenCalled()
     expect(debugCommanderMock.executeCommand).not.toHaveBeenCalled()
-    expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', {})
+    expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', {
+      blur: 8,
+    })
     expect(provider.session?.draft).toEqual({
       duration: '',
       ease: '',
@@ -338,7 +340,7 @@ describe('useEffectEditorProvider', () => {
     })
   })
 
-  it('关闭并丢弃未应用变更时通过空 setEffect 重置预览', async () => {
+  it('关闭并丢弃未应用变更时通过打开表单时的 transform 重置预览', async () => {
     useEditSettingsStore().autoApplyEffectEditorChanges = false
 
     const provider = createEffectEditorProvider()
@@ -364,7 +366,9 @@ describe('useEffectEditorProvider', () => {
     expect(closed).toBe(true)
     expect(debugCommanderMock.syncScene).not.toHaveBeenCalled()
     expect(debugCommanderMock.executeCommand).not.toHaveBeenCalled()
-    expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', {})
+    expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', {
+      blur: 8,
+    })
   })
 
   it('关闭并丢弃仅修改时长的草稿不会发送效果预览重置', async () => {

--- a/src/features/editor/effect-editor/useEffectEditorProvider.ts
+++ b/src/features/editor/effect-editor/useEffectEditorProvider.ts
@@ -356,8 +356,9 @@ export function createEffectEditorProvider() {
     }
 
     try {
-      await debugCommander.setEffect(currentSession.effectTarget, {})
-      currentSession.previewedTransformFields = transformToFields(currentSession.initialDraft.transform)
+      const baselineTransform = cloneTransform(currentSession.initialDraft.transform)
+      await debugCommander.setEffect(currentSession.effectTarget, baselineTransform)
+      currentSession.previewedTransformFields = transformToFields(baselineTransform)
       currentSession.previewErrorWarned = false
     } catch (error) {
       logger.error(`重置效果预览失败: ${error}`)


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [x] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [x] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

修复效果编辑器还原按钮的预览回滚行为。

此前 `resetPreviewToBaseline()` 会向预览服务发送空 `transform`，导致点击还原或关闭并丢弃未应用改动时，预览效果被清空，而不是恢复到打开表单时的初始 `transform`。

现在回滚预览时会发送 `initialDraft.transform` 的克隆快照，并同步更新已预览字段缓存，保证还原按钮和关闭丢弃路径都回到同一个打开表单基线。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

效果编辑器的“还原”语义应该是恢复到打开表单时读取到的 transform，而不是重置为空效果。这个问题会导致用户在已有 transform 的语句上编辑后，点击还原时预览状态与表单草稿状态不一致。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
