### PR TITLE
🐛 修复文本编辑器行首拖拽插入后的光标位置

### DIFF
--- a/src/features/editor/text-editor/__tests__/useTextEditorBindings.test.ts
+++ b/src/features/editor/text-editor/__tests__/useTextEditorBindings.test.ts
@@ -307,6 +307,39 @@ describe('useTextEditorBindings', () => {
     expect(harness.editor.revealPositionInCenterIfOutsideViewport).toHaveBeenCalledWith({ lineNumber: 4, column: 17 })
   })
 
+  it('行首拖拽插入语句后会把光标停在插入语句行末', async () => {
+    getSceneSelectionMock.mockReturnValue(undefined)
+    useCommandPanelStoreMock.mockReturnValue({
+      getInsertText: vi.fn(),
+    })
+
+    const harness = await mountHarness('say:hello;\nchangeBg:old.png;')
+    await flushBindingUpdates()
+
+    expect(harness.bindings.applyProgrammaticInsert({
+      range: {
+        startLineNumber: 2,
+        startColumn: 1,
+        endLineNumber: 2,
+        endColumn: 1,
+      },
+      text: 'changeBg:room.png;\n',
+    }, 'external')).toBe(true)
+
+    expect(harness.editor.executeEdits).toHaveBeenCalledWith('file-drop', [{
+      range: {
+        startLineNumber: 2,
+        startColumn: 1,
+        endLineNumber: 2,
+        endColumn: 1,
+      },
+      text: 'changeBg:room.png;\n',
+      forceMoveMarkers: true,
+    }])
+    expect(harness.editor.setPosition).toHaveBeenCalledWith({ lineNumber: 2, column: 19 })
+    expect(harness.editor.revealPositionInCenterIfOutsideViewport).toHaveBeenCalledWith({ lineNumber: 2, column: 19 })
+  })
+
   it('程序化语句更新会保留指定事务来源', async () => {
     getSceneSelectionMock.mockReturnValue(undefined)
     useCommandPanelStoreMock.mockReturnValue({

--- a/src/features/editor/text-editor/useTextEditorBindings.ts
+++ b/src/features/editor/text-editor/useTextEditorBindings.ts
@@ -34,11 +34,12 @@ interface UseTextEditorBindingsOptions {
 }
 
 function resolveInsertedTextEndPosition(range: monaco.IRange, text: string): monaco.IPosition {
-  const segments = text.split('\n')
+  const cursorText = text.endsWith('\n') ? text.slice(0, -1) : text
+  const segments = cursorText.split('\n')
   if (segments.length === 1) {
     return {
       lineNumber: range.startLineNumber,
-      column: range.startColumn + text.length,
+      column: range.startColumn + cursorText.length,
     }
   }
 


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [x] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [x] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

修复文本编辑器中拖拽资源或命令到非空行行首后，光标错误落到下一行的问题。

行首插入动作会生成带尾随换行的插入文本，例如 `changeBg:room.png;\n`，用于把原有行内容后移。此前光标位置计算会把这个尾随换行也计入插入文本末尾，导致光标移动到下一行开头。现在光标定位会忽略用于结构调整的尾随换行，使光标停留在新插入语句的行末。

同时新增回归测试，覆盖行首拖拽插入后的光标位置。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

拖拽资源或命令到编辑器行首插入中间语句后，用户预期继续编辑刚插入的语句；光标落到下一行会打断后续编辑流程。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
