### PR TITLE
🐛 修复文本编辑器拖拽插入后辅助面板语句未更新

### DIFF
--- a/src/features/editor/text-editor/__tests__/text-editor-command-drop.test.ts
+++ b/src/features/editor/text-editor/__tests__/text-editor-command-drop.test.ts
@@ -66,6 +66,7 @@ describe('resolveTextEditorCommandDropAction', () => {
       kind: 'insert-statement-line',
       text: 'changeBg:room.png;',
       range: { startLineNumber: 2, startColumn: 1, endLineNumber: 2, endColumn: 1 },
+      selectionLineNumber: 2,
     })
   })
 
@@ -83,6 +84,7 @@ describe('resolveTextEditorCommandDropAction', () => {
       kind: 'insert-statement-line',
       text: 'changeBg:room.png;\n',
       range: { startLineNumber: 2, startColumn: 1, endLineNumber: 2, endColumn: 1 },
+      selectionLineNumber: 2,
     })
   })
 
@@ -100,6 +102,7 @@ describe('resolveTextEditorCommandDropAction', () => {
       kind: 'insert-statement-line',
       text: '\nchangeBg:room.png;',
       range: { startLineNumber: 2, startColumn: 24, endLineNumber: 2, endColumn: 24 },
+      selectionLineNumber: 3,
     })
   })
 
@@ -117,6 +120,7 @@ describe('resolveTextEditorCommandDropAction', () => {
       kind: 'insert-statement-line',
       text: '\nchangeBg:room.png;\nbgm:theme.ogg;',
       range: { startLineNumber: 2, startColumn: 11, endLineNumber: 2, endColumn: 11 },
+      selectionLineNumber: 4,
     })
   })
 })

--- a/src/features/editor/text-editor/__tests__/text-editor-file-drop.test.ts
+++ b/src/features/editor/text-editor/__tests__/text-editor-file-drop.test.ts
@@ -90,6 +90,7 @@ describe('text-editor-file-drop', () => {
       kind: 'insert-statement-line',
       text: 'changeBg:room.png;',
       range: { startLineNumber: 2, startColumn: 1, endLineNumber: 2, endColumn: 1 },
+      selectionLineNumber: 2,
     })
   })
 
@@ -108,6 +109,7 @@ describe('text-editor-file-drop', () => {
       kind: 'insert-statement-line',
       text: 'changeBg:room.png;\n',
       range: { startLineNumber: 2, startColumn: 1, endLineNumber: 2, endColumn: 1 },
+      selectionLineNumber: 2,
     })
   })
 
@@ -125,6 +127,7 @@ describe('text-editor-file-drop', () => {
     expect(action).toMatchObject({
       kind: 'update-statement',
       caretRange: { startLineNumber: 2, startColumn: 10, endLineNumber: 2, endColumn: 10 },
+      selectionLineNumber: 2,
       payload: {
         rawText: 'say:world -speaker=Bob -line-2.ogg;',
       },
@@ -146,6 +149,7 @@ describe('text-editor-file-drop', () => {
       kind: 'insert-text',
       text: 'room.png',
       range: { startLineNumber: 2, startColumn: 5, endLineNumber: 2, endColumn: 5 },
+      selectionLineNumber: 2,
     })
   })
 
@@ -163,6 +167,7 @@ describe('text-editor-file-drop', () => {
     expect(action).toMatchObject({
       kind: 'insert-text',
       range: { startLineNumber: 2, startColumn: 11, endLineNumber: 2, endColumn: 11 },
+      selectionLineNumber: 2,
     })
   })
 

--- a/src/features/editor/text-editor/__tests__/useTextEditorRuntime-preview-sync.test.ts
+++ b/src/features/editor/text-editor/__tests__/useTextEditorRuntime-preview-sync.test.ts
@@ -464,6 +464,53 @@ describe('useTextEditorRuntime', () => {
     )
   })
 
+  it('命令面板语句投放插入新行后会选中新插入语句', () => {
+    const path = '/project/scene-command-drop-selection.txt'
+    const state = createState(path)
+    const editor = {
+      ...createEditor(),
+      getTargetAtClientPoint: vi.fn(() => ({
+        position: {
+          column: 5,
+          lineNumber: 1,
+        },
+      })),
+    }
+    editor.getModel.mockReturnValue({
+      getLineContent: vi.fn(() => 'say:old;'),
+      getLineCount: vi.fn(() => 1),
+      getLineMaxColumn: vi.fn(() => 9),
+    })
+    const applyProgrammaticInsert = vi.fn(() => true)
+    const editorStore = createEditableEditorStore(path)
+
+    useEditorStoreMock.mockReturnValue(editorStore)
+    useTabsStoreMock.mockReturnValue(createTabsStore(path))
+    useTextEditorBindingsMock.mockReturnValue({
+      applyProgrammaticInsert,
+      applyProgrammaticStatementUpdate: vi.fn(() => false),
+      consumePendingTextTransactionSource: vi.fn(),
+      handleCursorSelectionChange: vi.fn(),
+    })
+
+    const runtime = useTextEditorRuntime({
+      editorRef: shallowRef(editor) as never,
+      getState: () => state,
+    })
+
+    expect(runtime.handleCommandDrop({
+      label: 'Say',
+      rawTexts: ['say:new;'],
+      source: 'command-panel',
+      type: 'command-panel-statement',
+    }, {
+      x: 100,
+      y: 40,
+    })).toBe(true)
+
+    expect(editorStore.syncSceneSelectionFromTextLine).toHaveBeenCalledWith(path, 2)
+  })
+
   it('跨行移动光标时会同步预览到新的关注行', () => {
     const path = '/project/scene-cross-line.txt'
     const state = createState(path)

--- a/src/features/editor/text-editor/text-editor-drop-action.ts
+++ b/src/features/editor/text-editor/text-editor-drop-action.ts
@@ -6,12 +6,14 @@ import type { DragPosition } from '~/types/drag-drop'
 export interface TextEditorInsertTextDropAction {
   kind: 'insert-text'
   range: monaco.IRange
+  selectionLineNumber: number
   text: string
 }
 
 export interface TextEditorInsertStatementLineDropAction {
   kind: 'insert-statement-line'
   range: monaco.IRange
+  selectionLineNumber: number
   text: string
 }
 
@@ -19,6 +21,7 @@ export interface TextEditorUpdateStatementDropAction {
   caretRange: monaco.IRange
   kind: 'update-statement'
   payload: StatementUpdatePayload
+  selectionLineNumber: number
 }
 
 export type TextEditorDropAction =
@@ -58,6 +61,10 @@ function createLineEdgeRange(lineNumber: number, column: number): monaco.IRange 
   }
 }
 
+function countInsertedStatementLines(text: string): number {
+  return text.split('\n').length
+}
+
 export function createTextEditorStatementLineDropAction(options: {
   hit: monaco.IPosition
   inlinePlacement?: TextEditorInlineStatementPlacement
@@ -77,6 +84,7 @@ export function createTextEditorStatementLineDropAction(options: {
       kind: 'insert-statement-line',
       text: insertedStatementText,
       range: createLineEdgeRange(hit.lineNumber, 1),
+      selectionLineNumber: hit.lineNumber + countInsertedStatementLines(insertedStatementText) - 1,
     }
   }
 
@@ -85,6 +93,7 @@ export function createTextEditorStatementLineDropAction(options: {
       kind: 'insert-statement-line',
       text: `${insertedStatementText}\n`,
       range: createLineEdgeRange(hit.lineNumber, 1),
+      selectionLineNumber: hit.lineNumber + countInsertedStatementLines(insertedStatementText) - 1,
     }
   }
 
@@ -93,6 +102,7 @@ export function createTextEditorStatementLineDropAction(options: {
       kind: 'insert-statement-line',
       text: `\n${insertedStatementText}`,
       range: createLineEdgeRange(hit.lineNumber, lineMaxColumn),
+      selectionLineNumber: hit.lineNumber + countInsertedStatementLines(insertedStatementText),
     }
   }
 }

--- a/src/features/editor/text-editor/text-editor-file-drop.ts
+++ b/src/features/editor/text-editor/text-editor-file-drop.ts
@@ -73,6 +73,7 @@ export function resolveTextEditorFileDropAction(options: {
           rawText: nextRawText,
           parsed,
         },
+        selectionLineNumber: hit.lineNumber,
       }
     }
   }
@@ -81,5 +82,6 @@ export function resolveTextEditorFileDropAction(options: {
     kind: 'insert-text',
     text: asset.scriptPath,
     range: createTextEditorCollapsedRange(hit),
+    selectionLineNumber: hit.lineNumber,
   }
 }

--- a/src/features/editor/text-editor/useTextEditorRuntime.ts
+++ b/src/features/editor/text-editor/useTextEditorRuntime.ts
@@ -137,6 +137,9 @@ export function useTextEditorRuntime(options: UseTextEditorRuntimeOptions) {
       ? textEditorBindings.applyProgrammaticStatementUpdate(action.payload, 'external')
       : textEditorBindings.applyProgrammaticInsert(action, 'external')
 
+    if (applied) {
+      syncSceneSelection(action.selectionLineNumber)
+    }
     clearDropHover()
     return applied
   }
@@ -150,6 +153,9 @@ export function useTextEditorRuntime(options: UseTextEditorRuntimeOptions) {
 
     const applied = textEditorBindings.applyProgrammaticInsert(action, 'external')
 
+    if (applied) {
+      syncSceneSelection(action.selectionLineNumber)
+    }
     clearDropHover()
     return applied
   }


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [x] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [x] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

修复文本编辑器中拖拽资源或命令插入语句后，辅助面板仍显示旧语句的问题。

本次调整让文本编辑器 drop action 显式携带插入或更新后应选中的 `selectionLineNumber`，并在 drop 应用成功后立即同步 scene selection。这样辅助面板不再依赖 Monaco 后续光标事件来刷新目标语句，避免程序化 `setPosition()` 被 `CursorChangeReason.NotSet` 过滤后导致状态停留在旧行。

同时补充了命令拖拽、文件拖拽和 runtime 同步相关单元测试，覆盖空行插入、行首插入、行后插入、多行插入、语句更新和资源路径插入等场景。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

此前文本编辑器拖拽插入会先触发 Monaco 内容变更，再设置插入后的光标位置。内容同步阶段捕获到的仍可能是插入前光标行，而后续 `setPosition()` 产生的光标事件又可能被当前逻辑过滤，导致 `sceneSelection` 没有切换到新插入语句，辅助面板显示内容不自动更新。

此 PR 将 drop 后的选中行作为明确业务数据传递，修复该状态同步缺口。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
