### PR TITLE
🐛 修复可视化编辑器卡片点击区域被投放区覆盖

### DIFF
--- a/src/components/editor/VisualEditorScene.spec.ts
+++ b/src/components/editor/VisualEditorScene.spec.ts
@@ -468,6 +468,29 @@ describe('VisualEditorScene', () => {
     expect(firstItem!.querySelector('[data-statement-drag-handle]')).not.toBeNull()
   })
 
+  it('普通状态下插入投放区会放行指针事件', async () => {
+    const state = createSceneState()
+    renderInBrowser(VisualEditorScene, {
+      props: {
+        state,
+      },
+      global: {
+        plugins: [createPinia()],
+        stubs: globalStubs,
+      },
+    })
+
+    await nextTick()
+
+    const headDropSlot = document.querySelector<HTMLElement>('[data-visual-drop-slot="head"]')
+    const gapDropSlot = document.querySelector<HTMLElement>('[data-visual-drop-slot="gap-1-2"]')
+
+    expect(headDropSlot).not.toBeNull()
+    expect(gapDropSlot).not.toBeNull()
+    expect(headDropSlot!.classList.contains('pointer-events-none')).toBe(true)
+    expect(gapDropSlot!.classList.contains('pointer-events-none')).toBe(true)
+  })
+
   it('为 head / gap / update / tail 注册 drop target，并把 drop 目标传给 runtime', async () => {
     const registerDroppable = vi.fn()
     useDroppableRegistryMock.mockReturnValue({

--- a/src/components/editor/VisualEditorScene.vue
+++ b/src/components/editor/VisualEditorScene.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { FileText } from '@lucide/vue'
 
+import { useDragSession } from '~/composables/useDragSession'
 import { useDragSort } from '~/composables/useDragSort'
 import { useDroppableRegistry } from '~/composables/useDroppableRegistry'
 import { useShortcutContext } from '~/features/editor/shortcut/useShortcutContext'
@@ -35,6 +36,7 @@ interface RenderedVisualStatementRow {
 
 const props = defineProps<Props>()
 
+const dragSession = useDragSession()
 const editSettings = useEditSettingsStore()
 const dropRegistry = useDroppableRegistry()
 const editorSurfaceRef = useTemplateRef<HTMLDivElement>('editorSurfaceRef')
@@ -67,6 +69,12 @@ const statements = computed(() => props.state.statements)
 const isSceneEmpty = computed(() => props.state.statements.length === 0)
 const scrollViewportRef = shallowRef<HTMLElement>()
 const statementReadonly = $computed(() => preferenceStore.showSidebar && editSettings.collapseStatementsOnSidebarOpen)
+const isDropHitTestingEnabled = computed(() => {
+  const { isActive, mode, payload } = dragSession.state.value
+  return isActive
+    && mode === 'transfer'
+    && (payload?.type === 'file-system-item' || payload?.type === 'command-panel-statement')
+})
 const renderedStatementRows = computed<RenderedVisualStatementRow[]>(() => {
   const rows: RenderedVisualStatementRow[] = []
 
@@ -364,6 +372,7 @@ tryOnUnmounted(() => {
               <div
                 :ref="value => registerDropTarget(row.insertDropKey, resolveHTMLElement(value), row.insertDropTarget)"
                 :data-visual-drop-slot="row.insertDropSlot"
+                :class="{'pointer-events-none': !isDropHitTestingEnabled}"
                 class="inset-x-0 absolute z-10"
                 :style="buildInsertDropStyle(row)"
               />
@@ -409,6 +418,7 @@ tryOnUnmounted(() => {
           v-if="!isSceneEmpty"
           :ref="value => registerDropTarget('tail', resolveHTMLElement(value), tailDropTarget)"
           data-visual-drop-slot="tail"
+          :class="{'pointer-events-none': !isDropHitTestingEnabled}"
           class="mx-2 flex-1 relative"
           :style="{
             flexBasis: tailDropAreaSize,


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [x] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [x] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

修复可视化编辑器语句卡片列表中，插入投放区覆盖卡片上下边缘后导致卡片可点击范围变小的问题。

具体更改：

- 在 `VisualEditorScene` 中接入当前拖拽会话状态。
- 仅当处于 `transfer` 拖拽会话，且 payload 是文件或命令面板语句时，让插入/尾部投放区参与指针命中。
- 普通状态下为插入/尾部投放区添加 `pointer-events-none`，让卡片边缘点击可以穿透到卡片本体。
- 添加 browser 回归测试，覆盖普通状态下插入投放区放行指针事件的契约。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

卡片之间的投放区域需要向上下卡片延伸，以提升拖拽插入体验。但这些扩大的投放区域在普通状态下也参与了 pointer hit testing，导致点击卡片上下边缘时事件被投放区截获，表现为卡片可点击范围变小。

这个 PR 将“拖拽投放命中”和“普通点击命中”按拖拽会话状态区分，保留拖拽体验，同时恢复卡片正常点击范围。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->

本次修改只影响可视化编辑器语句列表的插入/尾部投放区命中行为，不改变语句重排、文件投放、命令投放的处理逻辑。

### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
