### PR TITLE
✨ 为效果编辑器补齐历史记录与快捷键

### DIFF
--- a/src/components/editor/EffectEditorPanel.vue
+++ b/src/components/editor/EffectEditorPanel.vue
@@ -16,6 +16,7 @@ interface EffectEditorPanelProps {
 const props = withDefaults(defineProps<EffectEditorPanelProps>(), {
   showFooter: true,
 })
+const panelRef = useTemplateRef<HTMLElement>('panelRef')
 
 const emit = defineEmits<{
   'update:transform': [payload: EffectEditorTransformUpdatePayload]
@@ -43,12 +44,17 @@ function tryEmitReset() {
 useShortcutContext({
   panelFocus: 'effectEditor',
 }, {
+  target: panelRef,
   trackFocus: true,
+})
+
+onMounted(() => {
+  panelRef.value?.focus({ preventScroll: true })
 })
 </script>
 
 <template>
-  <div class="flex flex-col h-full min-h-0">
+  <div ref="panelRef" tabindex="-1" class="outline-none flex flex-col h-full min-h-0">
     <EffectDraftForm
       class="flex-1 min-h-0"
       :transform="props.transform"

--- a/src/features/editor/effect-editor/__tests__/useEffectEditorProvider-queue.test.ts
+++ b/src/features/editor/effect-editor/__tests__/useEffectEditorProvider-queue.test.ts
@@ -485,4 +485,75 @@ describe('useEffectEditorProvider', () => {
       expect(provider.canApply).toBe(false)
     })
   })
+
+  it('自动应用关闭时会把一次拖拽变换记录为单个本地撤销条目', async () => {
+    useEditSettingsStore().autoApplyEffectEditorChanges = false
+
+    const provider = createEffectEditorProvider()
+
+    await provider.open({
+      baseSentence: createBaseSentence('{"blur":8}'),
+      effectTarget: 'fig-center',
+      onApply: vi.fn(),
+    })
+
+    provider.updateDraft({ transform: { blur: 12 } }, { deferAutoApply: true })
+    provider.updateDraft({ transform: { blur: 16 } })
+    provider.requestPreview({ schedule: 'immediate', flush: true })
+
+    await vi.waitFor(() => {
+      expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', { blur: 16 })
+    })
+
+    debugCommanderMock.setEffect.mockClear()
+
+    expect(provider.undoDraft()).toBe(true)
+    expect(provider.session?.draft.transform).toEqual({ blur: 8 })
+
+    await vi.waitFor(() => {
+      expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', { blur: 8 })
+    })
+
+    debugCommanderMock.setEffect.mockClear()
+
+    expect(provider.redoDraft()).toBe(true)
+    expect(provider.session?.draft.transform).toEqual({ blur: 16 })
+
+    await vi.waitFor(() => {
+      expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', { blur: 16 })
+    })
+  })
+
+  it('复制和粘贴当前效果时会克隆完整草稿并记录本地历史', async () => {
+    useEditSettingsStore().autoApplyEffectEditorChanges = false
+
+    const provider = createEffectEditorProvider()
+
+    await provider.open({
+      baseSentence: createBaseSentence('{"blur":8}'),
+      effectTarget: 'fig-center',
+      onApply: vi.fn(),
+    })
+
+    provider.updateDraft({
+      duration: '300',
+      ease: 'easeInOut',
+      transform: { alpha: 0.5, blur: 12 },
+    })
+
+    expect(provider.copyCurrentEffect()).toBe(true)
+
+    provider.updateDraft({
+      duration: '100',
+      ease: '',
+      transform: { blur: 2 },
+    })
+
+    expect(provider.pasteCurrentEffect()).toBe(true)
+    expect(provider.session?.draft).toEqual({
+      duration: '300',
+      ease: 'easeInOut',
+      transform: { alpha: 0.5, blur: 12 },
+    })
+  })
 })

--- a/src/features/editor/effect-editor/useEffectEditorProvider.ts
+++ b/src/features/editor/effect-editor/useEffectEditorProvider.ts
@@ -153,6 +153,10 @@ export function createEffectEditorProvider() {
   let session = $ref<EffectEditorSession>()
   let colorPreviewFrameId = $ref<number>()
   let nextSessionId = $ref(0)
+  let draftUndoStack: EffectEditorDraft[] = []
+  let draftRedoStack: EffectEditorDraft[] = []
+  let pendingDraftHistoryBefore: EffectEditorDraft | undefined
+  let effectClipboard: EffectEditorDraft | undefined
 
   // 40ms 节流（约 25fps）：平衡实时预览流畅度与 IPC 通信开销。
   // trailing=true 确保拖拽结束时的最终值一定会触发预览
@@ -180,6 +184,45 @@ export function createEffectEditorProvider() {
     if (colorPreviewFrameId !== undefined) {
       cancelAnimationFrame(colorPreviewFrameId)
       colorPreviewFrameId = undefined
+    }
+  }
+
+  function clearDraftHistory(): void {
+    draftUndoStack = []
+    draftRedoStack = []
+    pendingDraftHistoryBefore = undefined
+  }
+
+  function pushDraftUndoSnapshot(previousDraft: EffectEditorDraft, nextDraft: EffectEditorDraft): void {
+    if (isDraftEqual(previousDraft, nextDraft)) {
+      return
+    }
+
+    const snapshot = cloneDraft(previousDraft)
+    const lastSnapshot = draftUndoStack.at(-1)
+    if (!lastSnapshot || !isDraftEqual(lastSnapshot, snapshot)) {
+      draftUndoStack.push(snapshot)
+    }
+    draftRedoStack = []
+  }
+
+  function applyDraftSnapshot(
+    draftSnapshot: EffectEditorDraft,
+    options: { autoApply?: boolean, preview?: boolean } = {},
+  ): void {
+    if (!session) {
+      return
+    }
+
+    const nextDraft = cloneDraft(draftSnapshot)
+    session.draft = nextDraft
+    session.dirty = !isDraftEqual(nextDraft, session.baseDraft)
+
+    if (options.preview) {
+      requestPreview({ schedule: 'immediate', flush: true })
+    }
+    if (options.autoApply) {
+      autoApplyQueue.enqueue()
     }
   }
 
@@ -306,14 +349,35 @@ export function createEffectEditorProvider() {
       return
     }
 
+    const nextTransform = patch.transform === undefined
+      ? cloneTransform(session.draft.transform)
+      : cloneTransform(patch.transform)
+
     const nextDraft: EffectEditorDraft = {
-      transform: patch.transform ? cloneTransform(patch.transform) : cloneTransform(session.draft.transform),
+      transform: nextTransform,
       duration: patch.duration ?? session.draft.duration,
       ease: patch.ease ?? session.draft.ease,
     }
+    const previousDraft = cloneDraft(session.draft)
+    const changed = !isDraftEqual(previousDraft, nextDraft)
+    const shouldFinalizePendingHistory = !options.deferAutoApply && pendingDraftHistoryBefore !== undefined
 
-    session.draft = nextDraft
-    session.dirty = !isDraftEqual(nextDraft, session.baseDraft)
+    if (!changed && !shouldFinalizePendingHistory) {
+      return
+    }
+
+    if (options.deferAutoApply) {
+      if (!pendingDraftHistoryBefore) {
+        pendingDraftHistoryBefore = previousDraft
+      }
+    } else {
+      pushDraftUndoSnapshot(pendingDraftHistoryBefore ?? previousDraft, nextDraft)
+      pendingDraftHistoryBefore = undefined
+    }
+
+    if (changed) {
+      applyDraftSnapshot(nextDraft)
+    }
 
     if (!options.deferAutoApply) {
       autoApplyQueue.enqueue()
@@ -327,14 +391,12 @@ export function createEffectEditorProvider() {
 
     const currentSession = session
     const shouldResetPreview = needsPreviewBaselineReset(currentSession)
+    const previousDraft = cloneDraft(currentSession.draft)
+    const nextDraft = cloneDraft(currentSession.initialDraft)
 
-    updateDraft({
-      transform: cloneTransform(currentSession.initialDraft.transform),
-      duration: currentSession.initialDraft.duration,
-      ease: currentSession.initialDraft.ease,
-    }, {
-      deferAutoApply: true,
-    })
+    pushDraftUndoSnapshot(previousDraft, nextDraft)
+    pendingDraftHistoryBefore = undefined
+    applyDraftSnapshot(nextDraft)
 
     autoApplyQueue.cancel()
     previewQueue.cancel()
@@ -365,6 +427,64 @@ export function createEffectEditorProvider() {
     }
   }
 
+  function undoDraft(): boolean {
+    if (!session) {
+      return false
+    }
+
+    const targetDraft = draftUndoStack.pop()
+    if (!targetDraft) {
+      return false
+    }
+
+    pendingDraftHistoryBefore = undefined
+    draftRedoStack.push(cloneDraft(session.draft))
+    applyDraftSnapshot(targetDraft, { autoApply: true, preview: true })
+    return true
+  }
+
+  function redoDraft(): boolean {
+    if (!session) {
+      return false
+    }
+
+    const targetDraft = draftRedoStack.pop()
+    if (!targetDraft) {
+      return false
+    }
+
+    pendingDraftHistoryBefore = undefined
+    draftUndoStack.push(cloneDraft(session.draft))
+    applyDraftSnapshot(targetDraft, { autoApply: true, preview: true })
+    return true
+  }
+
+  function copyCurrentEffect(): boolean {
+    if (!session) {
+      return false
+    }
+
+    effectClipboard = cloneDraft(session.draft)
+    return true
+  }
+
+  function pasteCurrentEffect(): boolean {
+    if (!session || !effectClipboard) {
+      return false
+    }
+
+    const previousDraft = cloneDraft(session.draft)
+    const nextDraft = cloneDraft(effectClipboard)
+    if (isDraftEqual(previousDraft, nextDraft)) {
+      return false
+    }
+
+    pushDraftUndoSnapshot(previousDraft, nextDraft)
+    pendingDraftHistoryBefore = undefined
+    applyDraftSnapshot(nextDraft, { autoApply: true, preview: true })
+    return true
+  }
+
   async function confirmDiscardChanges(): Promise<EffectEditorCloseAction> {
     const modalStore = useModalStore()
 
@@ -380,6 +500,7 @@ export function createEffectEditorProvider() {
   async function close(options: { forceDiscard?: boolean, skipPreviewReset?: boolean } = {}): Promise<boolean> {
     if (!session) {
       isOpen = false
+      clearDraftHistory()
       return true
     }
 
@@ -389,6 +510,7 @@ export function createEffectEditorProvider() {
       // 需要二次检查 session 是否仍然存在
       if (!session) {
         isOpen = false
+        clearDraftHistory()
         return true
       }
     }
@@ -419,6 +541,7 @@ export function createEffectEditorProvider() {
 
     session = undefined
     isOpen = false
+    clearDraftHistory()
     return true
   }
 
@@ -484,6 +607,7 @@ export function createEffectEditorProvider() {
 
     autoApplyQueue.cancel()
     previewQueue.cancel()
+    clearDraftHistory()
     isOpen = true
     return true
   }
@@ -507,6 +631,10 @@ export function createEffectEditorProvider() {
     updateDraft,
     resetToInitialDraft,
     requestPreview,
+    undoDraft,
+    redoDraft,
+    copyCurrentEffect,
+    pasteCurrentEffect,
   }
 }
 

--- a/src/features/editor/shell/__tests__/useEditorPanelShell.test.ts
+++ b/src/features/editor/shell/__tests__/useEditorPanelShell.test.ts
@@ -46,10 +46,14 @@ const {
     canApply: false,
     canReset: false,
     close: vi.fn(async () => true),
+    copyCurrentEffect: vi.fn(() => true),
     isOpen: false,
+    pasteCurrentEffect: vi.fn(() => true),
     requestPreview: vi.fn(),
+    redoDraft: vi.fn(() => false),
     resetToInitialDraft: vi.fn(),
     session: undefined,
+    undoDraft: vi.fn(() => false),
     updateDraft: vi.fn(),
   },
   sidebarPanelMock: {
@@ -153,6 +157,12 @@ function createFixture(options: {
   }
 }
 
+function collectEffectShortcutBindings() {
+  return useShortcutMock.mock.calls
+    .map(call => call[0])
+    .filter(binding => String(binding.id).startsWith('effect.'))
+}
+
 describe('useEditorPanelShell', () => {
   beforeEach(() => {
     commandPanelBridgeMock.activeBinding.value = undefined
@@ -162,6 +172,12 @@ describe('useEditorPanelShell', () => {
     effectEditorProviderMock.canReset = false
     effectEditorProviderMock.close.mockClear()
     effectEditorProviderMock.close.mockResolvedValue(true)
+    effectEditorProviderMock.copyCurrentEffect.mockClear()
+    effectEditorProviderMock.pasteCurrentEffect.mockClear()
+    effectEditorProviderMock.redoDraft.mockClear()
+    effectEditorProviderMock.redoDraft.mockReturnValue(false)
+    effectEditorProviderMock.undoDraft.mockClear()
+    effectEditorProviderMock.undoDraft.mockReturnValue(false)
     effectEditorProviderMock.updateDraft.mockClear()
     effectEditorProviderMock.resetToInitialDraft.mockClear()
     useShortcutMock.mockReset()
@@ -214,6 +230,55 @@ describe('useEditorPanelShell', () => {
       keys: ['Mod+Shift+Z', 'Mod+Y'],
       when: { panelFocus: 'statementEditor' },
     }))
+
+    scope.stop()
+  })
+
+  it('只会注册 effect editor 焦点下的效果历史和剪贴板快捷键', () => {
+    const { scope } = createFixture()
+
+    expect(useShortcutMock).toHaveBeenCalledWith(expect.objectContaining({
+      id: 'effect.undo',
+      keys: 'Mod+Z',
+      when: {
+        panelFocus: 'effectEditor',
+      },
+    }))
+    expect(useShortcutMock).toHaveBeenCalledWith(expect.objectContaining({
+      id: 'effect.copy',
+      keys: 'Mod+C',
+      when: {
+        panelFocus: 'effectEditor',
+      },
+    }))
+    const effectBindings = collectEffectShortcutBindings()
+
+    expect(effectBindings.map(binding => [binding.id, binding.keys])).toEqual([
+      ['effect.undo', 'Mod+Z'],
+      ['effect.redo', ['Mod+Shift+Z', 'Mod+Y']],
+      ['effect.copy', 'Mod+C'],
+      ['effect.paste', 'Mod+V'],
+    ])
+    expect(effectBindings.every(binding => binding.allowInInput !== true)).toBe(true)
+    expect(effectBindings.every(binding => binding.when.panelFocus === 'effectEditor')).toBe(true)
+
+    scope.stop()
+  })
+
+  it('effect 历史和剪贴板快捷键会委托给 effect editor provider', async () => {
+    const { scope } = createFixture()
+    const effectBindings = new Map(collectEffectShortcutBindings()
+      .map(binding => [binding.id, binding]))
+
+    await effectBindings.get('effect.undo')?.execute()
+    await effectBindings.get('effect.redo')?.execute()
+    await effectBindings.get('effect.copy')?.execute()
+    await effectBindings.get('effect.paste')?.execute()
+
+    expect(effectEditorProviderMock.undoDraft).toHaveBeenCalledOnce()
+    expect(effectEditorProviderMock.redoDraft).toHaveBeenCalledOnce()
+    expect(effectEditorProviderMock.copyCurrentEffect).toHaveBeenCalledOnce()
+    expect(effectEditorProviderMock.pasteCurrentEffect).toHaveBeenCalledOnce()
 
     scope.stop()
   })

--- a/src/features/editor/shell/useEditorPanelShell.ts
+++ b/src/features/editor/shell/useEditorPanelShell.ts
@@ -10,6 +10,7 @@ import { useTabsStore } from '~/stores/tabs'
 
 import type { commandType } from 'webgal-parser/src/interface/sceneInterface'
 import type { Transform } from '~/domain/stage/types'
+import type { ShortcutDefinition } from '~/features/editor/shortcut/types'
 
 interface ResizablePanelLike {
   collapse: () => void
@@ -23,6 +24,13 @@ interface ReadonlyRefLike<T = unknown> {
 
 interface UseEditorPanelShellOptions {
   commandPanelRef: ReadonlyRefLike<ResizablePanelLike | null | undefined>
+}
+
+interface EffectEditorShortcutDefinition {
+  action: () => void
+  i18nKey: string
+  id: string
+  keys: ShortcutDefinition['keys']
 }
 
 export function useEditorPanelShell(options: UseEditorPanelShellOptions) {
@@ -95,6 +103,43 @@ export function useEditorPanelShell(options: UseEditorPanelShellOptions) {
     keys: ['Mod+Shift+Z', 'Mod+Y'],
     when: { panelFocus: 'statementEditor' },
   })
+
+  const effectEditorShortcutDefinitions: EffectEditorShortcutDefinition[] = [
+    {
+      action: effectEditorProvider.undoDraft,
+      i18nKey: 'shortcut.effect.undo',
+      id: 'effect.undo',
+      keys: 'Mod+Z',
+    },
+    {
+      action: effectEditorProvider.redoDraft,
+      i18nKey: 'shortcut.effect.redo',
+      id: 'effect.redo',
+      keys: ['Mod+Shift+Z', 'Mod+Y'],
+    },
+    {
+      action: effectEditorProvider.copyCurrentEffect,
+      i18nKey: 'shortcut.effect.copy',
+      id: 'effect.copy',
+      keys: 'Mod+C',
+    },
+    {
+      action: effectEditorProvider.pasteCurrentEffect,
+      i18nKey: 'shortcut.effect.paste',
+      id: 'effect.paste',
+      keys: 'Mod+V',
+    },
+  ]
+
+  for (const shortcut of effectEditorShortcutDefinitions) {
+    useShortcut({
+      execute: shortcut.action,
+      i18nKey: shortcut.i18nKey,
+      id: shortcut.id,
+      keys: shortcut.keys,
+      when: { panelFocus: 'effectEditor' },
+    })
+  }
 
   function focusTextEditorAfterEffectEditorClose(): void {
     if (currentProjection.value === 'text') {

--- a/src/features/editor/shortcut/__tests__/useShortcutDispatcher.browser.test.ts
+++ b/src/features/editor/shortcut/__tests__/useShortcutDispatcher.browser.test.ts
@@ -5,6 +5,7 @@ import { defineComponent, h, ref } from 'vue'
 
 import { renderInBrowser } from '~/__tests__/browser-render'
 import CommandPanelCard from '~/components/editor/CommandPanelCard.vue'
+import EffectEditorPanel from '~/components/editor/EffectEditorPanel.vue'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '~/components/ui/select'
 import { Tabs, TabsList, TabsTrigger } from '~/components/ui/tabs'
 import { TooltipProvider } from '~/components/ui/tooltip'
@@ -21,6 +22,7 @@ const shortcutActions = vi.hoisted(() => ({
   rename: vi.fn(),
   save: vi.fn(),
   setLeftPanelView: vi.fn(),
+  undoEffect: vi.fn(),
   toggleCommandPanel: vi.fn(),
   togglePreviewPanel: vi.fn(),
   toggleSidebar: vi.fn(),
@@ -282,6 +284,97 @@ function createStatementEditorSelectHarnessComponent() {
   })
 }
 
+function createEffectEditorFocusHarness() {
+  const EditorShortcutTarget = defineComponent({
+    name: 'EffectEditorFocusEditorTarget',
+    setup() {
+      const targetRef = ref<HTMLButtonElement>()
+
+      useShortcutContext({
+        panelFocus: 'editor',
+      }, {
+        target: targetRef,
+        trackFocus: true,
+      })
+
+      useShortcut({
+        execute: () => {
+          shortcutActions.undo()
+        },
+        i18nKey: 'shortcut.visual.undo',
+        id: 'visual.undo',
+        keys: 'Mod+Z',
+        when: {
+          panelFocus: 'editor',
+        },
+      })
+
+      return () => h('button', {
+        ref: targetRef,
+        type: 'button',
+      }, 'file-editor-surface')
+    },
+  })
+
+  const EffectEditorShortcutTarget = defineComponent({
+    name: 'EffectEditorFocusEffectTarget',
+    setup() {
+      useShortcut({
+        execute: () => {
+          shortcutActions.undoEffect()
+        },
+        i18nKey: 'shortcut.effect.undo',
+        id: 'effect.undo',
+        keys: 'Mod+Z',
+        when: {
+          panelFocus: 'effectEditor',
+        },
+      })
+
+      return () => h(EffectEditorPanel, {
+        canApply: false,
+        canReset: false,
+        duration: '',
+        ease: '',
+        transform: {},
+      })
+    },
+  })
+
+  const isEffectEditorOpen = ref(false)
+
+  function openEffectEditor() {
+    isEffectEditorOpen.value = true
+  }
+
+  const component = defineComponent({
+    name: 'EffectEditorFocusHarness',
+    setup() {
+      useShortcutDispatcher({
+        bindings: [],
+        executeContext: {},
+        platform: 'windows',
+      })
+
+      useShortcutContext({
+        panelFocus: 'none',
+      })
+
+      return () => h('div', [
+        h(EditorShortcutTarget),
+        isEffectEditorOpen.value
+          ? h(EffectEditorShortcutTarget)
+          : undefined,
+      ])
+    },
+  })
+
+  return {
+    component,
+    openEffectEditor,
+  }
+}
+
 function createComponentTargetHarnessComponent() {
   const ValueExposedButton = defineComponent({
     name: 'ValueExposedButton',
@@ -489,5 +582,53 @@ describe('useShortcutDispatcher', () => {
     }))
 
     expect(shortcutActions.undo).toHaveBeenCalledOnce()
+  })
+
+  it('效果编辑器打开后会接管焦点上下文并响应自身快捷键', async () => {
+    const { component, openEffectEditor } = createEffectEditorFocusHarness()
+
+    renderInBrowser(component, {
+      global: {
+        plugins: [createPinia()],
+        stubs: {
+          Button: defineComponent({
+            name: 'TestButtonStub',
+            setup(_, { attrs, slots }) {
+              return () => h('button', {
+                ...attrs,
+                type: 'button',
+              }, slots.default?.())
+            },
+          }),
+          EffectDraftForm: defineComponent({
+            name: 'EffectDraftForm',
+            setup() {
+              return () => h('div', 'effect-draft-form')
+            },
+          }),
+        },
+      },
+    })
+
+    const editorButton = page.getByRole('button', { name: 'file-editor-surface' })
+    const editorElement = await editorButton.element()
+
+    editorElement.focus()
+    expect(document.activeElement).toBe(editorElement)
+
+    openEffectEditor()
+
+    await expect.element(page.getByText('effect-draft-form')).toBeVisible()
+    await vi.waitFor(() => {
+      expect(useShortcutContextRegistry().resolveContext().panelFocus).toBe('effectEditor')
+    })
+
+    globalThis.dispatchEvent(new KeyboardEvent('keydown', {
+      ctrlKey: true,
+      key: 'z',
+    }))
+
+    expect(shortcutActions.undoEffect).toHaveBeenCalledOnce()
+    expect(shortcutActions.undo).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [ ] 错误修复
- [x] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [x] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

- 为效果编辑器补齐本地撤销、重做能力，支持在即时调参过程中回退和重试。
- 为当前效果补齐 `Mod+C` / `Mod+V` 复制粘贴能力，粘贴时会克隆完整草稿并写入本地历史，保持操作可撤销。
- 为效果编辑器面板补齐焦点管理与快捷键上下文，仅在 `effectEditor` 焦点下注册 `Mod+Z`、`Mod+Shift+Z` / `Mod+Y`、`Mod+C`、`Mod+V`。
- 补充 effect editor provider 与 shell 层测试，覆盖拖拽变换的历史合并、复制粘贴、快捷键注册与委托。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

效果编辑器原本缺少本地历史与快捷键支持，即时编辑链路只能前进不能回退，重复调参和复用参数的成本都偏高。这次改动的目标是把效果编辑器补齐到更符合桌面编辑器预期的交互基线：可撤销、可重做、可复制、可粘贴。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->

- 拖拽过程中延迟自动应用的多次更新会合并为单个撤销条目，避免历史栈被高频滑动噪声淹没。
- 快捷键只在效果编辑器获得焦点时生效，避免影响文本编辑器和其他输入场景。

### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
