### PR TITLE
✨ 为效果编辑器补齐变换基线预览语义

### DIFF
--- a/src/components/editor/EffectEditorPanel.vue
+++ b/src/components/editor/EffectEditorPanel.vue
@@ -1,10 +1,18 @@
 <script setup lang="ts">
-import { Transform } from '~/domain/stage/types'
-import { EffectEditorPreviewPayload, EffectEditorTransformUpdatePayload } from '~/features/editor/effect-editor/useEffectEditorProvider'
 import { useShortcutContext } from '~/features/editor/shortcut/useShortcutContext'
+
+import type { Transform } from '~/domain/stage/types'
+import type {
+  EffectEditorPreviewPayload,
+  EffectEditorTransformUpdatePayload,
+} from '~/features/editor/effect-editor/useEffectEditorProvider'
+import type { TransformBaselineSource } from '~/features/editor/transform-resolution/model'
 
 interface EffectEditorPanelProps {
   transform: Transform
+  baselineSource?: TransformBaselineSource
+  baselineTransform?: Transform
+  previewFieldValue?: (path: string) => string | undefined
   duration: string
   ease: string
   canApply: boolean
@@ -23,6 +31,7 @@ const emit = defineEmits<{
   'update:duration': [value: string]
   'update:ease': [value: string]
   'preview': [payload: EffectEditorPreviewPayload]
+  'cancel-preview': []
   'apply': []
   'reset': []
 }>()
@@ -58,6 +67,9 @@ onMounted(() => {
     <EffectDraftForm
       class="flex-1 min-h-0"
       :transform="props.transform"
+      :baseline-source="props.baselineSource"
+      :baseline-transform="props.baselineTransform"
+      :preview-field-value="props.previewFieldValue"
       :duration="props.duration"
       :ease="props.ease"
       :inline="props.inline"
@@ -66,6 +78,7 @@ onMounted(() => {
       @update:duration="emit('update:duration', $event)"
       @update:ease="emit('update:ease', $event)"
       @preview="emit('preview', $event)"
+      @cancel-preview="emit('cancel-preview')"
     />
 
     <div v-if="props.showFooter" class="mt-4 flex gap-2 justify-end">

--- a/src/components/editor/effect-editor/EffectDraftForm.spec.ts
+++ b/src/components/editor/effect-editor/EffectDraftForm.spec.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { page } from 'vitest/browser'
 
 import { createBrowserConsoleMonitor, createBrowserLocalizedI18n } from '~/__tests__/browser'
-import { createBrowserValueStub, renderInBrowser } from '~/__tests__/browser-render'
+import { createBrowserInputStub, createBrowserValueStub, renderInBrowser } from '~/__tests__/browser-render'
 import { EFFECT_CATEGORIES } from '~/features/editor/effect-editor/effect-editor-config'
 
 vi.mock('~/stores/workspace', () => ({
@@ -17,7 +17,7 @@ import EffectDraftForm from './EffectDraftForm.vue'
 const globalStubs = {
   Button: createBrowserValueStub('StubButton', 'button'),
   ColorPicker: createBrowserValueStub('StubColorPicker'),
-  Input: createBrowserValueStub('StubInput', 'input'),
+  Input: createBrowserInputStub('StubInput'),
   InputGroup: createBrowserValueStub('StubInputGroup'),
   InputGroupAddon: createBrowserValueStub('StubInputGroupAddon', 'span'),
   InputGroupInput: createBrowserValueStub('StubInputGroupInput', 'input'),
@@ -35,7 +35,7 @@ const globalStubs = {
 const { expectNoConsoleMessage } = createBrowserConsoleMonitor()
 
 describe('EffectDraftForm', () => {
-  it('为 linked-slider 的 X/Y 数字输入提供唯一的可访问名称', async () => {
+  it('为联动滑条的 X/Y 数字输入提供唯一的可访问名称', async () => {
     renderInBrowser(EffectDraftForm, {
       props: {
         duration: '200',
@@ -78,5 +78,95 @@ describe('EffectDraftForm', () => {
 
     await expect.element(page.getByText('过渡时间')).toBeInTheDocument()
     expect(page.getByRole('group').elements()).toHaveLength(EFFECT_CATEGORIES.length)
+  })
+
+  it('显示基线字段后修改其他字段不会把基线写入变换', async () => {
+    const transformUpdates = vi.fn()
+
+    renderInBrowser(EffectDraftForm, {
+      props: {
+        'baselineTransform': {
+          position: { x: 1000, y: 20 },
+        },
+        'duration': '300',
+        'ease': '',
+        'onUpdate:transform': transformUpdates,
+        'transform': {},
+      },
+      global: {
+        plugins: [createPinia(), createBrowserLocalizedI18n()],
+        stubs: globalStubs,
+      },
+    })
+
+    await expect.element(page.getByRole('spinbutton', { name: 'X 位移' })).toHaveValue(1000)
+
+    const alphaInput = page.getByRole('group', { name: '效果' }).getByRole('spinbutton', { name: '不透明度' })
+    await alphaInput.fill('0.8')
+
+    expect(transformUpdates).toHaveBeenCalledWith({
+      value: {
+        alpha: 0.8,
+      },
+      deferAutoApply: true,
+      flush: undefined,
+    })
+  })
+
+  it('基线或浮层预览展示值不会启用清除按钮', async () => {
+    renderInBrowser(EffectDraftForm, {
+      props: {
+        baselineTransform: {
+          position: { x: 1000 },
+        },
+        duration: '300',
+        ease: '',
+        previewFieldValue: (path: string) => path === 'position.y' ? '20' : undefined,
+        transform: {},
+      },
+      global: {
+        plugins: [createPinia(), createBrowserLocalizedI18n()],
+        stubs: globalStubs,
+      },
+    })
+
+    await expect.element(page.getByRole('spinbutton', { name: 'X 位移' })).toHaveValue(1000)
+    await expect.element(page.getByRole('spinbutton', { name: 'Y 位移' })).toHaveValue(20)
+    await expect.element(page.getByRole('button', { name: '清除X 位移' })).not.toBeInTheDocument()
+    await expect.element(page.getByRole('button', { name: '清除Y 位移' })).not.toBeInTheDocument()
+  })
+
+  it('显示浮层预览字段后修改其他字段不会把预览值写入变换', async () => {
+    const transformUpdates = vi.fn()
+
+    renderInBrowser(EffectDraftForm, {
+      props: {
+        'duration': '300',
+        'ease': '',
+        'onUpdate:transform': transformUpdates,
+        'previewFieldValue': (path: string) => path === 'position.x' ? '88' : undefined,
+        'transform': {
+          position: { x: 12 },
+        },
+      },
+      global: {
+        plugins: [createPinia(), createBrowserLocalizedI18n()],
+        stubs: globalStubs,
+      },
+    })
+
+    await expect.element(page.getByRole('spinbutton', { name: 'X 位移' })).toHaveValue(88)
+
+    const alphaInput = page.getByRole('group', { name: '效果' }).getByRole('spinbutton', { name: '不透明度' })
+    await alphaInput.fill('0.8')
+
+    expect(transformUpdates).toHaveBeenCalledWith({
+      value: {
+        alpha: 0.8,
+        position: { x: 12 },
+      },
+      deferAutoApply: true,
+      flush: undefined,
+    })
   })
 })

--- a/src/components/editor/effect-editor/EffectDraftForm.vue
+++ b/src/components/editor/effect-editor/EffectDraftForm.vue
@@ -13,7 +13,6 @@ import {
   DEFAULT_EASE_OPTION_VALUE,
   EFFECT_CATEGORIES,
   EFFECT_EASE_OPTIONS,
-  getValueByPath,
   transformToFields,
 } from '~/features/editor/effect-editor/effect-editor-config'
 import { useEffectClearControls } from '~/features/editor/effect-editor/useEffectClearControls'
@@ -24,6 +23,7 @@ import {
   createEffectPreviewEmitter,
 } from '~/features/editor/effect-editor/useEffectEditorProvider'
 import { useEffectSegmentedControl } from '~/features/editor/effect-editor/useEffectSegmentedControl'
+import { resolveTransformDraftDisplay } from '~/features/editor/transform-resolution/model'
 import { useWorkspaceStore } from '~/stores/workspace'
 
 import type {
@@ -38,9 +38,13 @@ import type {
   EffectEditorPreviewPayload,
   EffectEditorTransformUpdatePayload,
 } from '~/features/editor/effect-editor/useEffectEditorProvider'
+import type { TransformBaselineSource } from '~/features/editor/transform-resolution/model'
 
 interface EffectDraftFormProps {
   transform: Transform
+  baselineSource?: TransformBaselineSource
+  baselineTransform?: Transform
+  previewFieldValue?: (path: string) => string | undefined
   duration: string
   ease: string
   easeDisabled?: boolean
@@ -59,6 +63,7 @@ const emit = defineEmits<{
   'update:duration': [value: string]
   'update:ease': [value: string]
   'preview': [payload: EffectEditorPreviewPayload]
+  'cancel-preview': []
 }>()
 
 const EFFECT_DRAFT_CATEGORY_RENDER_MODELS: EffectDraftCategoryRenderModel[] = EFFECT_CATEGORIES.map((category, index) => ({
@@ -72,9 +77,15 @@ const workspaceStore = useWorkspaceStore()
 const resolveEffectDraftLabel = (value: I18nLike | undefined) => resolveI18n(value, t)
 const easeModelValue = $computed(() => props.ease || DEFAULT_EASE_OPTION_VALUE)
 const isPanelLayout = $computed(() => props.layout === 'panel')
+const storedFields = $computed(() => transformToFields(props.transform))
+const displayFields = $computed(() => transformToFields(resolveTransformDraftDisplay({
+  baselineSource: props.baselineSource,
+  baselineTransform: props.baselineTransform,
+  explicitDraftTransform: props.transform,
+}).displayTransform))
 
 function getFields(): Record<string, string> {
-  return transformToFields(props.transform)
+  return { ...storedFields }
 }
 
 const { emitTransform } = createEffectPreviewEmitter({
@@ -95,9 +106,11 @@ const {
 })
 
 function getFieldValue(path: string): string {
-  const source = props.transform as unknown as Record<string, unknown>
-  const value = getValueByPath(source, path)
-  return (value === undefined) ? '' : String(value)
+  return props.previewFieldValue?.(path) ?? displayFields[path] ?? ''
+}
+
+function getStoredFieldValue(path: string): string | undefined {
+  return storedFields[path]
 }
 
 function getNumberValue(path: string, fallback: number): number {
@@ -120,9 +133,11 @@ function setNumericField(fields: Record<string, string>, path: string, value: nu
 const controlDeps: EffectControlDeps = {
   getFields,
   getFieldValue,
+  getStoredFieldValue,
   getNumberValue,
   setNumericField,
   emitTransform,
+  cancelPreview: () => emit('cancel-preview'),
 }
 
 const {
@@ -251,9 +266,9 @@ const categoryControls: EffectDraftCategoryControls = {
 
 onUnmounted(() => {
   stopDurationScrub()
-  numberScrub.stop()
-  dialDrag.stop()
-  colorDrag.stop()
+  numberScrub.cancel()
+  dialDrag.cancel()
+  colorDrag.cancel()
   clearPendingColorFlush()
   resetLinkedSliderState()
 })

--- a/src/composables/__tests__/useImmediatePointerDrag.test.ts
+++ b/src/composables/__tests__/useImmediatePointerDrag.test.ts
@@ -53,6 +53,15 @@ function invokeListener(listener: EventListenerOrEventListenerObject, payload: P
   listener.handleEvent(createPointerEvent(payload) as unknown as Event)
 }
 
+function invokeGlobalListener(listener: EventListenerOrEventListenerObject, event: Event) {
+  if (typeof listener === 'function') {
+    listener(event)
+    return
+  }
+
+  listener.handleEvent(event)
+}
+
 function dispatchPointerEvent(eventName: string, payload: PointerLikeEvent) {
   const listeners = listenerMap[eventName]
   if (!listeners) {
@@ -61,6 +70,17 @@ function dispatchPointerEvent(eventName: string, payload: PointerLikeEvent) {
 
   for (const listener of listeners) {
     invokeListener(listener, payload)
+  }
+}
+
+function dispatchGlobalEvent(eventName: string, event: Event) {
+  const listeners = listenerMap[eventName]
+  if (!listeners) {
+    return
+  }
+
+  for (const listener of listeners) {
+    invokeGlobalListener(listener, event)
   }
 }
 
@@ -134,6 +154,101 @@ describe('useImmediatePointerDrag', () => {
 
     expect(onMove).toHaveBeenCalledTimes(1)
     expect(onEnd).toHaveBeenCalledTimes(1)
+    expect(drag.active).toBe(false)
+  })
+
+  it('取消拖拽时释放指针且不触发结束回调', () => {
+    const capturedPointers = new Set<number>()
+    const target: PointerCaptureTarget = Object.assign(new EventTarget(), {
+      hasPointerCapture: vi.fn(pointerId => capturedPointers.has(pointerId)),
+      releasePointerCapture: vi.fn((pointerId) => {
+        capturedPointers.delete(pointerId)
+      }),
+      setPointerCapture: vi.fn((pointerId) => {
+        capturedPointers.add(pointerId)
+      }),
+    })
+    const onEnd = vi.fn()
+    const onCancel = vi.fn()
+    const onMove = vi.fn()
+    const drag = useImmediatePointerDrag({
+      onCancel,
+      onEnd,
+      onMove,
+      onStart: event => ({ startX: event.clientX }),
+    })
+
+    drag.start(createPointerEvent({ currentTarget: target, pointerId: 7 }))
+    drag.cancel()
+    dispatchPointerEvent('pointermove', { clientX: 20, pointerId: 7 })
+
+    expect(target.releasePointerCapture).toHaveBeenCalledWith(7)
+    expect(capturedPointers.has(7)).toBe(false)
+    expect(onCancel).toHaveBeenCalledWith({ startX: 0 })
+    expect(onEnd).not.toHaveBeenCalled()
+    expect(onMove).not.toHaveBeenCalled()
+    expect(drag.active).toBe(false)
+  })
+
+  it('收到 pointercancel 时会取消拖拽而不是结束拖拽', () => {
+    const onCancel = vi.fn()
+    const onEnd = vi.fn()
+    const onMove = vi.fn()
+    const drag = useImmediatePointerDrag({
+      onCancel,
+      onEnd,
+      onMove,
+      onStart: event => ({ startX: event.clientX }),
+    })
+
+    drag.start(createPointerEvent({ clientX: 10, pointerId: 7 }))
+    dispatchPointerEvent('pointermove', { clientX: 20, pointerId: 7 })
+    dispatchPointerEvent('pointercancel', { clientX: 20, pointerId: 7 })
+    dispatchPointerEvent('pointermove', { clientX: 30, pointerId: 7 })
+
+    expect(onMove).toHaveBeenCalledTimes(1)
+    expect(onCancel).toHaveBeenCalledWith({ startX: 10 })
+    expect(onEnd).not.toHaveBeenCalled()
+    expect(drag.active).toBe(false)
+  })
+
+  it('按下 Escape 时会取消拖拽而不是结束拖拽', () => {
+    const onCancel = vi.fn()
+    const onEnd = vi.fn()
+    const drag = useImmediatePointerDrag({
+      onCancel,
+      onEnd,
+      onMove: vi.fn(),
+      onStart: event => ({ startX: event.clientX }),
+    })
+
+    drag.start(createPointerEvent({ clientX: 10, pointerId: 7 }))
+    const event = Object.assign(new Event('keydown', { cancelable: true }), {
+      key: 'Escape',
+    })
+    dispatchGlobalEvent('keydown', event)
+
+    expect(event.defaultPrevented).toBe(true)
+    expect(onCancel).toHaveBeenCalledWith({ startX: 10 })
+    expect(onEnd).not.toHaveBeenCalled()
+    expect(drag.active).toBe(false)
+  })
+
+  it('窗口失焦时会取消拖拽而不是结束拖拽', () => {
+    const onCancel = vi.fn()
+    const onEnd = vi.fn()
+    const drag = useImmediatePointerDrag({
+      onCancel,
+      onEnd,
+      onMove: vi.fn(),
+      onStart: event => ({ startX: event.clientX }),
+    })
+
+    drag.start(createPointerEvent({ clientX: 10, pointerId: 7 }))
+    dispatchGlobalEvent('blur', new Event('blur'))
+
+    expect(onCancel).toHaveBeenCalledWith({ startX: 10 })
+    expect(onEnd).not.toHaveBeenCalled()
     expect(drag.active).toBe(false)
   })
 

--- a/src/composables/useImmediatePointerDrag.ts
+++ b/src/composables/useImmediatePointerDrag.ts
@@ -14,10 +14,12 @@ export interface ImmediatePointerDragCallbacks<S> {
   onStart: (event: ImmediatePointerDragEvent) => S | undefined
   onMove: (event: ImmediatePointerDragEvent, state: S) => void
   onEnd: (event: ImmediatePointerDragEvent | undefined, state: S) => void
+  onCancel?: (state: S) => void
 }
 
 export interface UseImmediatePointerDragResult<S> {
   active: boolean
+  cancel: () => void
   end: (event: ImmediatePointerDragEvent) => void
   move: (event: ImmediatePointerDragEvent) => void
   state: S | undefined
@@ -41,7 +43,9 @@ export function useImmediatePointerDrag<S>(
   function removeListeners() {
     globalThis.removeEventListener('pointermove', handlePointerMove)
     globalThis.removeEventListener('pointerup', handlePointerEnd)
-    globalThis.removeEventListener('pointercancel', handlePointerEnd)
+    globalThis.removeEventListener('pointercancel', handlePointerCancel)
+    globalThis.removeEventListener('keydown', handleKeyDown)
+    globalThis.removeEventListener('blur', handleWindowBlur)
   }
 
   function capturePointer(event: ImmediatePointerDragEvent) {
@@ -100,6 +104,30 @@ export function useImmediatePointerDrag<S>(
     stop(event)
   }
 
+  function handlePointerCancel(event: ImmediatePointerDragEvent) {
+    if (event.pointerId !== pointerId) {
+      return
+    }
+    cancel()
+  }
+
+  function handleKeyDown(event: KeyboardEvent) {
+    if (event.key !== 'Escape' || state === undefined) {
+      return
+    }
+
+    event.preventDefault()
+    cancel()
+  }
+
+  function handleWindowBlur() {
+    if (state === undefined) {
+      return
+    }
+
+    cancel()
+  }
+
   function stop(event?: ImmediatePointerDragEvent) {
     if (state === undefined) {
       return
@@ -111,6 +139,19 @@ export function useImmediatePointerDrag<S>(
     pointerId = undefined
     removeListeners()
     callbacks.onEnd(event, current)
+  }
+
+  function cancel() {
+    if (state === undefined) {
+      return
+    }
+
+    const current = state
+    state = undefined
+    releasePointerCapture()
+    pointerId = undefined
+    removeListeners()
+    callbacks.onCancel?.(current)
   }
 
   function start(event: ImmediatePointerDragEvent): boolean {
@@ -126,16 +167,19 @@ export function useImmediatePointerDrag<S>(
 
     globalThis.addEventListener('pointermove', handlePointerMove)
     globalThis.addEventListener('pointerup', handlePointerEnd)
-    globalThis.addEventListener('pointercancel', handlePointerEnd)
+    globalThis.addEventListener('pointercancel', handlePointerCancel)
+    globalThis.addEventListener('keydown', handleKeyDown)
+    globalThis.addEventListener('blur', handleWindowBlur)
     return true
   }
 
-  tryOnUnmounted(stop)
+  tryOnUnmounted(cancel)
 
   return {
     get active() {
       return state !== undefined
     },
+    cancel,
     end: handlePointerEnd,
     move: handlePointerMove,
     get state() {

--- a/src/features/editor/effect-editor/__tests__/useEffectClearControls.test.ts
+++ b/src/features/editor/effect-editor/__tests__/useEffectClearControls.test.ts
@@ -12,6 +12,7 @@ function createDeps(initialFields: Record<string, string>) {
   const deps: EffectControlDeps = {
     getFields: () => fields,
     getFieldValue: path => fields[path] ?? '',
+    getStoredFieldValue: path => fields[path],
     getNumberValue: () => 0,
     setNumericField: vi.fn(),
     emitTransform,

--- a/src/features/editor/effect-editor/__tests__/useEffectColorControl.test.ts
+++ b/src/features/editor/effect-editor/__tests__/useEffectColorControl.test.ts
@@ -16,6 +16,7 @@ const { createParamDragModule, dragController } = vi.hoisted(() => {
   function createParamDragModule() {
     return {
       createParamDrag<P, S>(callbacks: {
+        onCancel?: (state: S & { param: P }) => void
         onStart: (event: ImmediatePointerDragEvent, param: P) => unknown
         // 这些测试只覆盖开始/结束语义；保留 onMove 是为了让 mock 签名贴近真实 API。
         onMove: (event: ImmediatePointerDragEvent, state: S & { param: P }) => unknown
@@ -34,6 +35,14 @@ const { createParamDragModule, dragController } = vi.hoisted(() => {
                 return
               }
               callbacks.onEnd(event, { param: dragController.param as P } as S & { param: P })
+              dragController.active = false
+              dragController.param = undefined
+            },
+            cancel() {
+              if (!dragController.active) {
+                return
+              }
+              callbacks.onCancel?.({ param: dragController.param as P } as S & { param: P })
               dragController.active = false
               dragController.param = undefined
             },
@@ -63,6 +72,7 @@ function createDeps(initialFields: Record<string, string> = {}) {
   const deps: EffectControlDeps = {
     getFields: () => fields,
     getFieldValue: path => fields[path] ?? '',
+    getStoredFieldValue: path => fields[path],
     getNumberValue: (path, fallback) => {
       const value = Number(fields[path])
       return Number.isFinite(value) ? value : fallback
@@ -209,6 +219,26 @@ describe('useEffectColorControl', () => {
       r: '10',
       g: '20',
       b: '30',
+    })
+  })
+
+  it('颜色拖拽取消时会取消当前预览交互并丢弃 pending flush', () => {
+    const { deps, emitTransform } = createDeps()
+    const cancelPreview = vi.fn()
+    const depsWithCancel = deps as EffectControlDeps & { cancelPreview: () => void }
+    depsWithCancel.cancelPreview = cancelPreview
+    const control = useEffectColorControl(depsWithCancel)
+    const field = createColorField()
+
+    control.handleColorPickerPointerDown(createPointerEvent(), field)
+    control.handleColorPickerChange(field, { rgba: { r: 10, g: 20, b: 30 } })
+    control.colorDrag.cancel?.()
+
+    expect(cancelPreview).toHaveBeenCalledOnce()
+    expect(emitTransform).toHaveBeenCalledTimes(1)
+    expect(emitTransform).toHaveBeenLastCalledWith(expect.any(Object), {
+      schedule: 'color',
+      deferAutoApply: true,
     })
   })
 })

--- a/src/features/editor/effect-editor/__tests__/useEffectContinuousControls.test.ts
+++ b/src/features/editor/effect-editor/__tests__/useEffectContinuousControls.test.ts
@@ -10,6 +10,7 @@ import type { EffectControlDeps } from '~/features/editor/effect-editor/types'
 type ParamDragState = object & { param: unknown }
 
 interface ParamDragRuntime {
+  cancel: () => void
   end: (event?: ImmediatePointerDragEvent) => void
   move: (event: ImmediatePointerDragEvent) => void
   state: ParamDragState | undefined
@@ -42,12 +43,21 @@ vi.mock('~/stores/preference', setupPreferenceStoreMock)
 
 vi.mock('~/features/editor/effect-editor/createParamDrag', () => ({
   createParamDrag<P, S extends object>(callbacks: {
+    onCancel?: (state: S & { param: P }) => void
     onEnd: (event: ImmediatePointerDragEvent | undefined, state: S & { param: P }) => void
     onMove: (event: ImmediatePointerDragEvent, state: S & { param: P }) => void
     onStart: (event: ImmediatePointerDragEvent, param: P) => S | undefined
   }) {
     const runtime: ParamDragRuntime = {
       state: undefined,
+      cancel() {
+        if (!runtime.state) {
+          return
+        }
+        const currentState = runtime.state as S & { param: P }
+        runtime.state = undefined
+        callbacks.onCancel?.(currentState)
+      },
       move(event) {
         if (!runtime.state) {
           return
@@ -80,6 +90,9 @@ vi.mock('~/features/editor/effect-editor/createParamDrag', () => ({
         stop(event?: ImmediatePointerDragEvent) {
           runtime.end(event)
         },
+        cancel() {
+          runtime.cancel()
+        },
       },
       start(event: ImmediatePointerDragEvent, param: P) {
         const state = callbacks.onStart(event, param)
@@ -101,6 +114,7 @@ function createDeps(initialFields: Record<string, string> = {}) {
   const deps: EffectControlDeps = {
     getFields: () => fields,
     getFieldValue: path => fields[path] ?? '',
+    getStoredFieldValue: path => fields[path],
     getNumberValue: (path, fallback) => {
       const value = Number(fields[path])
       return Number.isFinite(value) ? value : fallback
@@ -121,6 +135,7 @@ function createSnapshotDeps(initialFields: Record<string, string> = {}) {
   const deps: EffectControlDeps = {
     getFields: () => ({ ...sourceFields }),
     getFieldValue: path => sourceFields[path] ?? '',
+    getStoredFieldValue: path => sourceFields[path],
     getNumberValue: (path, fallback) => {
       const value = Number(sourceFields[path])
       return Number.isFinite(value) ? value : fallback
@@ -278,6 +293,34 @@ describe('useEffectContinuousControls', () => {
     })
   })
 
+  it('number scrub 取消时会取消当前预览交互而不是 flush 最终值', () => {
+    const { deps, emitTransform } = createDeps()
+    const cancelPreview = vi.fn()
+    const depsWithCancel = deps as EffectControlDeps & { cancelPreview: () => void }
+    depsWithCancel.cancelPreview = cancelPreview
+    const controls = useEffectContinuousControls(depsWithCancel)
+    const field = createNumberField({
+      defaultValue: 0,
+      key: 'position.x',
+      scrubStep: 1,
+    })
+
+    controls.handleNumberLabelPointerDown(createPointerEvent(), field)
+    const numberScrub = getParamDragRuntime(0)
+
+    numberScrub.move(createPointerEvent({ clientX: 104 }))
+    flushNextAnimationFrame()
+    numberScrub.cancel()
+
+    expect(cancelPreview).toHaveBeenCalledOnce()
+    expect(emitTransform).toHaveBeenCalledTimes(1)
+    expect(emitTransform).toHaveBeenLastCalledWith(expect.any(Object), {
+      schedule: 'continuous',
+      flush: false,
+      deferAutoApply: true,
+    })
+  })
+
   it('滑条拖拽在同一帧内只发射最后一次 transform', () => {
     const { deps, emitTransform, fields } = createDeps()
     const controls = useEffectContinuousControls(deps)
@@ -331,7 +374,7 @@ describe('useEffectContinuousControls', () => {
     expect(emitTransform).toHaveBeenCalledTimes(1)
   })
 
-  it('slider 与 linked-slider 会应用中心吸附与锁定比例', () => {
+  it('普通滑条与联动滑条会应用中心吸附与锁定比例', () => {
     const { deps, fields } = createDeps({
       scaleX: '2',
       scaleY: '4',
@@ -470,7 +513,7 @@ describe('useEffectContinuousControls', () => {
     })
   })
 
-  it('linked-slider 仅提交默认展示值时不会写入缺失字段', () => {
+  it('联动滑条仅提交默认展示值时不会写入缺失字段', () => {
     const { deps, emitTransform, fields } = createDeps()
     const controls = useEffectContinuousControls(deps)
     const linkedField = createLinkedNumberField({
@@ -487,7 +530,7 @@ describe('useEffectContinuousControls', () => {
     expect(emitTransform).not.toHaveBeenCalled()
   })
 
-  it('linked-slider 回到缺失字段默认值时不会发射同帧内排队的旧值', () => {
+  it('联动滑条回到缺失字段默认值时不会发射同帧内排队的旧值', () => {
     const { deps, emitTransform, sourceFields } = createSnapshotDeps()
     const controls = useEffectContinuousControls(deps)
     const linkedField = createLinkedNumberField({
@@ -505,7 +548,7 @@ describe('useEffectContinuousControls', () => {
     expect(emitTransform).not.toHaveBeenCalled()
   })
 
-  it('linked-slider 回到默认值时不会取消只触碰其他字段的待发射变更', () => {
+  it('联动滑条回到默认值时不会取消只触碰其他字段的待发射变更', () => {
     const { deps, emitTransform, sourceFields } = createSnapshotDeps({
       scaleX: '1',
       scaleY: '1',
@@ -539,7 +582,7 @@ describe('useEffectContinuousControls', () => {
     })
   })
 
-  it('锁定快照主轴为 0 时，linked-slider 会回退为双轴同步', () => {
+  it('锁定快照主轴为 0 时联动滑条会回退为双轴同步', () => {
     const { deps, fields } = createDeps({
       scaleX: '0',
       scaleY: '5',
@@ -556,6 +599,41 @@ describe('useEffectContinuousControls', () => {
 
     expect(fields.scaleX).toBe('3')
     expect(fields.scaleY).toBe('3')
+  })
+
+  it('dial 拖拽取消时会取消当前预览交互而不是 flush 最终值', () => {
+    const { deps, emitTransform } = createDeps()
+    const cancelPreview = vi.fn()
+    const depsWithCancel = deps as EffectControlDeps & { cancelPreview: () => void }
+    depsWithCancel.cancelPreview = cancelPreview
+    const controls = useEffectContinuousControls(depsWithCancel)
+    const field = createDialField({
+      dialUnit: 'deg',
+    })
+
+    controls.handleDialPointerDown(createPointerEvent({
+      currentTarget: {
+        getBoundingClientRect: () => ({
+          height: 20,
+          left: 90,
+          top: 90,
+          width: 20,
+        }),
+      } as unknown as EventTarget,
+    }), field)
+    const dialDrag = getParamDragRuntime(1)
+
+    dialDrag.move(createPointerEvent({ clientX: 100, clientY: 120 }))
+    flushNextAnimationFrame()
+    dialDrag.cancel()
+
+    expect(cancelPreview).toHaveBeenCalledOnce()
+    expect(emitTransform).toHaveBeenCalledTimes(1)
+    expect(emitTransform).toHaveBeenLastCalledWith(expect.any(Object), {
+      schedule: 'continuous',
+      flush: false,
+      deferAutoApply: true,
+    })
   })
 
   it('dial 会在 deg/rad 之间双向转换，并保留四位弧度精度', () => {
@@ -581,5 +659,19 @@ describe('useEffectContinuousControls', () => {
     controls.flushDialField(createDialField())
 
     expect(Number(fields.rotate)).toBeCloseTo(Math.PI / 2)
+  })
+
+  it('角度旋钮会按展示精度写入，避免显示值和生效值不一致', () => {
+    const { deps, fields } = createDeps()
+    const controls = useEffectContinuousControls(deps)
+
+    controls.updateDialField(createDialField({
+      dialUnit: 'deg',
+    }), 12.3456)
+
+    expect(fields.rotate).toBe('12.35')
+    expect(controls.getDialInputValue(createDialField({
+      dialUnit: 'deg',
+    }))).toBe('12.35')
   })
 })

--- a/src/features/editor/effect-editor/__tests__/useEffectEditorProvider-queue.test.ts
+++ b/src/features/editor/effect-editor/__tests__/useEffectEditorProvider-queue.test.ts
@@ -1,7 +1,7 @@
 import '~/__tests__/mocks/i18n'
-import '~/__tests__/mocks/modal-store'
 
-import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { effectScope } from 'vue'
 import { commandType } from 'webgal-parser/src/interface/sceneInterface'
 
 import {
@@ -10,21 +10,53 @@ import {
   serializeTransform,
   transformToFields,
 } from '~/features/editor/effect-editor/effect-editor-config'
-import { createEffectEditorProvider } from '~/features/editor/effect-editor/useEffectEditorProvider'
+import { createEffectEditorProvider, useEffectEditorProvider } from '~/features/editor/effect-editor/useEffectEditorProvider'
 import { useEditSettingsStore } from '~/stores/edit-settings'
 
 import type { ISentence } from 'webgal-parser/src/interface/sceneInterface'
 import type { Transform } from '~/domain/stage/types'
 import type { EffectEditorDraft } from '~/features/editor/effect-editor/useEffectEditorProvider'
+import type { TransformBaselineSessionClient } from '~/features/editor/transform-resolution/baseline-session'
+import type { SetEffectPhase } from '~/types/editorPreviewProtocol'
 
 const debugCommanderMock = vi.hoisted(() => ({
   executeCommand: vi.fn<(command: string) => Promise<void>>(async () => { /* no-op */ }),
-  setEffect: vi.fn<(target: string, transform: Transform) => Promise<void>>(async () => { /* no-op */ }),
-  syncScene: vi.fn<(scenePath: string, lineNumber: number, lineText: string, immediate?: boolean) => Promise<void>>(async () => { /* no-op */ }),
+  setEffect: vi.fn<(target: string, transform: Transform, options?: { phase?: SetEffectPhase }) => Promise<void>>(async () => { /* no-op */ }),
+  syncScene: vi.fn<(scenePath: string, lineNumber: number, lineText: string, options?: { transformBaselineRevision?: string, settleMode?: 'immediate' }) => Promise<void>>(async () => { /* no-op */ }),
+}))
+
+const previewSyncStoreMock = vi.hoisted(() => ({
+  isPreviewReady: true,
+  queryBaseTransform: vi.fn(async () => ({ status: 'unavailable' } as const)),
+  queryTransformBaseline: vi.fn(async () => ({ status: 'unavailable' } as const)),
+}))
+
+const loggerWarnMock = vi.hoisted(() => vi.fn())
+const loggerErrorMock = vi.hoisted(() => vi.fn())
+const modalOpenMock = vi.hoisted(() => vi.fn((
+  _name: string,
+  payload: { onApply?: () => void, onDiscard?: () => void, onCancel?: () => void },
+) => {
+  payload.onCancel?.()
 }))
 
 vi.mock('~/services/debug-commander', () => ({
   debugCommander: debugCommanderMock,
+}))
+
+vi.mock('~/stores/preview-sync', () => ({
+  usePreviewSyncStore: () => previewSyncStoreMock,
+}))
+
+vi.mock('~/stores/modal', () => ({
+  useModalStore: () => ({
+    open: modalOpenMock,
+  }),
+}))
+
+vi.mock('@tauri-apps/plugin-log', () => ({
+  error: loggerErrorMock,
+  warn: loggerWarnMock,
 }))
 
 function createBaseSentence(transformJson: string = ''): ISentence {
@@ -43,12 +75,91 @@ function createBaseSentence(transformJson: string = ''): ISentence {
   }
 }
 
+function createBaselineClient(): TransformBaselineSessionClient {
+  return {
+    queryBaseTransform: vi.fn(async () => ({
+      status: 'ready',
+      transform: {
+        position: { x: 0, y: 20 },
+      },
+    } as const)),
+    queryTransformBaseline: vi.fn(async () => ({
+      status: 'ready',
+      transform: {
+        position: { x: 1000 },
+      },
+    } as const)),
+    syncScene: vi.fn(async () => { /* no-op */ }),
+  }
+}
+
+function createUnavailableBaselineClient(): TransformBaselineSessionClient {
+  return {
+    queryBaseTransform: vi.fn(async () => ({
+      status: 'unavailable',
+    } as const)),
+    queryTransformBaseline: vi.fn(async () => ({
+      status: 'unavailable',
+    } as const)),
+    syncScene: vi.fn(async () => { /* no-op */ }),
+  }
+}
+
+function createProvider(options: {
+  baselineClient?: TransformBaselineSessionClient
+} = {}) {
+  return createEffectEditorProvider({
+    baselineClient: options.baselineClient ?? createUnavailableBaselineClient(),
+  })
+}
+
+function createOpenTarget(options: {
+  baseSentence?: ISentence
+  effectTarget?: string
+  scenePath?: string
+  sentenceId?: number
+  onApply?: (result: EffectEditorDraft) => void | Promise<void>
+} = {}) {
+  return {
+    baseSentence: options.baseSentence ?? createBaseSentence(),
+    effectTarget: options.effectTarget ?? 'fig-center',
+    scenePath: options.scenePath ?? 'scene/start.txt',
+    sentenceId: options.sentenceId ?? 3,
+    onApply: options.onApply ?? (() => { /* no-op */ }),
+  }
+}
+
 function cloneDraft(draft: EffectEditorDraft): EffectEditorDraft {
   return {
     transform: structuredClone(draft.transform),
     duration: draft.duration,
     ease: draft.ease,
   }
+}
+
+function setupImmediateAnimationFrame(): void {
+  let nextFrameId = 0
+  const frameTimers = new Map<number, ReturnType<typeof setTimeout>>()
+
+  vi.stubGlobal('requestAnimationFrame', vi.fn((callback: FrameRequestCallback) => {
+    nextFrameId += 1
+    const frameId = nextFrameId
+    const timerId = setTimeout(() => {
+      frameTimers.delete(frameId)
+      callback(Date.now())
+    }, 0)
+    frameTimers.set(frameId, timerId)
+    return frameId
+  }))
+  vi.stubGlobal('cancelAnimationFrame', vi.fn((frameId: number) => {
+    const timerId = frameTimers.get(frameId)
+    if (timerId === undefined) {
+      return
+    }
+
+    clearTimeout(timerId)
+    frameTimers.delete(frameId)
+  }))
 }
 
 type RuntimeGlobals = typeof globalThis & {
@@ -75,7 +186,6 @@ type RuntimeGlobals = typeof globalThis & {
       id?: string,
     ) => void
   }
-  useThrottleFn?: <T extends (...args: unknown[]) => unknown>(fn: T) => T
 }
 
 const runtimeGlobals = globalThis as RuntimeGlobals
@@ -83,7 +193,6 @@ const originalRuntimeGlobals = {
   $ref: runtimeGlobals.$ref,
   toRaw: runtimeGlobals.toRaw,
   useI18n: runtimeGlobals.useI18n,
-  useThrottleFn: runtimeGlobals.useThrottleFn,
   parseTransformJson: runtimeGlobals.parseTransformJson,
   serializeTransform: runtimeGlobals.serializeTransform,
   fieldsToTransform: runtimeGlobals.fieldsToTransform,
@@ -107,7 +216,6 @@ beforeAll(() => {
   runtimeGlobals.$ref = value => value
   runtimeGlobals.toRaw = value => value
   runtimeGlobals.useI18n = () => ({ t: key => key })
-  runtimeGlobals.useThrottleFn = fn => fn
   runtimeGlobals.parseTransformJson = parseTransformJson
   runtimeGlobals.serializeTransform = serializeTransform
   runtimeGlobals.fieldsToTransform = fieldsToTransform
@@ -128,7 +236,6 @@ afterAll(() => {
   restoreRuntimeGlobal('$ref', originalRuntimeGlobals.$ref)
   restoreRuntimeGlobal('toRaw', originalRuntimeGlobals.toRaw)
   restoreRuntimeGlobal('useI18n', originalRuntimeGlobals.useI18n)
-  restoreRuntimeGlobal('useThrottleFn', originalRuntimeGlobals.useThrottleFn)
   restoreRuntimeGlobal('parseTransformJson', originalRuntimeGlobals.parseTransformJson)
   restoreRuntimeGlobal('serializeTransform', originalRuntimeGlobals.serializeTransform)
   restoreRuntimeGlobal('fieldsToTransform', originalRuntimeGlobals.fieldsToTransform)
@@ -138,6 +245,8 @@ afterAll(() => {
 })
 
 beforeEach(() => {
+  setupImmediateAnimationFrame()
+
   const editSettingsStore = useEditSettingsStore()
   editSettingsStore.enableLivePreview = true
   editSettingsStore.enableRealtimeEffectPreview = true
@@ -149,22 +258,114 @@ beforeEach(() => {
   debugCommanderMock.executeCommand.mockImplementation(async () => { /* no-op */ })
   debugCommanderMock.setEffect.mockImplementation(async () => { /* no-op */ })
   debugCommanderMock.syncScene.mockImplementation(async () => { /* no-op */ })
+  modalOpenMock.mockReset()
+  modalOpenMock.mockImplementation((
+    _name: string,
+    payload: { onApply?: () => void, onDiscard?: () => void, onCancel?: () => void },
+  ) => {
+    payload.onCancel?.()
+  })
+  previewSyncStoreMock.queryBaseTransform.mockReset()
+  previewSyncStoreMock.queryTransformBaseline.mockReset()
+  previewSyncStoreMock.isPreviewReady = true
+  loggerWarnMock.mockReset()
+  loggerErrorMock.mockReset()
+  previewSyncStoreMock.queryBaseTransform.mockImplementation(async () => ({ status: 'unavailable' }))
+  previewSyncStoreMock.queryTransformBaseline.mockImplementation(async () => ({ status: 'unavailable' }))
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
 })
 
 describe('useEffectEditorProvider', () => {
-  it('将 transform 设置为默认值时仍应视为可应用改动', async () => {
+  it('未产生 visual preview 时关闭效果编辑器不会重复恢复场景预览', async () => {
+    useEditSettingsStore().autoApplyEffectEditorChanges = false
+    const provider = createEffectEditorProvider()
+
+    await provider.open(createOpenTarget({
+      scenePath: '/games/demo/game/scene/start.txt',
+    }))
+
+    await vi.waitFor(() => {
+      expect(debugCommanderMock.syncScene).toHaveBeenCalledWith(
+        '/games/demo/game/scene/start.txt',
+        3,
+        'changeFigure:figure.png;',
+        {
+          settleMode: 'immediate',
+        },
+      )
+    })
+
+    const closed = await provider.close()
+
+    expect(closed).toBe(true)
+    expect(debugCommanderMock.syncScene).toHaveBeenCalledTimes(1)
+    expect(debugCommanderMock.syncScene).toHaveBeenLastCalledWith(
+      '/games/demo/game/scene/start.txt',
+      3,
+      'changeFigure:figure.png;',
+      {
+        settleMode: 'immediate',
+      },
+    )
+  })
+
+  it('打开普通效果编辑器时会解析基础基线并立即同步场景', async () => {
+    const baselineClient = createBaselineClient()
+    const provider = createProvider({ baselineClient })
+
+    await provider.open(createOpenTarget())
+
+    await vi.waitFor(() => {
+      expect(provider.session?.baselineTransform).toEqual({
+        position: { x: 0, y: 20 },
+      })
+    })
+
+    expect(baselineClient.syncScene).toHaveBeenCalledWith(
+      'scene/start.txt',
+      3,
+      'changeFigure:figure.png;',
+      {
+        settleMode: 'immediate',
+      },
+    )
+    expect(baselineClient.queryBaseTransform).toHaveBeenCalledTimes(1)
+    expect(baselineClient.queryTransformBaseline).not.toHaveBeenCalled()
+    expect(provider.session?.baselineTransform).toEqual({
+      position: { x: 0, y: 20 },
+    })
+  })
+
+  it('基线查询失败后会结束等待状态', async () => {
+    const baselineClient = createUnavailableBaselineClient()
+    vi.mocked(baselineClient.queryBaseTransform).mockRejectedValueOnce(new Error('query failed'))
+    const provider = createProvider({ baselineClient })
+
+    await provider.open(createOpenTarget())
+
+    await vi.waitFor(() => {
+      expect(provider.session?.baselineResolved).toBe(true)
+    })
+
+    expect(provider.session?.baselineSource).toBe('unknown')
+    expect(provider.session?.baselineTransform).toBeUndefined()
+    expect(loggerWarnMock).toHaveBeenCalledWith(expect.stringContaining('解析效果编辑器 transform baseline 失败'))
+  })
+
+  it('将变换设置为默认值时仍应视为可应用改动', async () => {
     useEditSettingsStore().autoApplyEffectEditorChanges = false
 
     const applyCalls: EffectEditorDraft[] = []
-    const provider = createEffectEditorProvider()
+    const provider = createProvider()
 
-    await provider.open({
-      baseSentence: createBaseSentence(),
-      effectTarget: 'fig-center',
+    await provider.open(createOpenTarget({
       onApply(result) {
         applyCalls.push(cloneDraft(result))
       },
-    })
+    }))
 
     expect(provider.canApply).toBe(false)
 
@@ -177,16 +378,14 @@ describe('useEffectEditorProvider', () => {
     expect(applyCalls[0]?.transform.blur).toBe(0)
   })
 
-  it('实时预览在字段被清除后直接发送缺失该字段的 setEffect', async () => {
+  it('实时预览在字段被清除后会发送缺失该字段的效果', async () => {
     useEditSettingsStore().autoApplyEffectEditorChanges = false
 
-    const provider = createEffectEditorProvider()
+    const provider = createProvider()
 
-    await provider.open({
+    await provider.open(createOpenTarget({
       baseSentence: createBaseSentence('{"alpha":0.5,"blur":8}'),
-      effectTarget: 'fig-center',
-      onApply() { /* no-op */ },
-    })
+    }))
 
     provider.updateDraft({ transform: { alpha: 0.5 } })
     provider.requestPreview({ schedule: 'immediate' })
@@ -198,19 +397,19 @@ describe('useEffectEditorProvider', () => {
     expect(debugCommanderMock.executeCommand).not.toHaveBeenCalled()
     expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', {
       alpha: 0.5,
+    }, {
+      phase: 'preview',
     })
   })
 
-  it('实时预览在最后一个显式字段被清除后发送空 transform', async () => {
+  it('实时预览在最后一个显式字段被清除后发送空变换', async () => {
     useEditSettingsStore().autoApplyEffectEditorChanges = false
 
-    const provider = createEffectEditorProvider()
+    const provider = createProvider()
 
-    await provider.open({
+    await provider.open(createOpenTarget({
       baseSentence: createBaseSentence('{"blur":8}'),
-      effectTarget: 'fig-center',
-      onApply() { /* no-op */ },
-    })
+    }))
 
     provider.updateDraft({ transform: {} })
     provider.requestPreview({ schedule: 'immediate' })
@@ -220,21 +419,21 @@ describe('useEffectEditorProvider', () => {
 
     expect(debugCommanderMock.syncScene).not.toHaveBeenCalled()
     expect(debugCommanderMock.executeCommand).not.toHaveBeenCalled()
-    expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', {})
+    expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', {}, {
+      phase: 'preview',
+    })
   })
 
-  it('实时预览在字段更新时直接发送 setEffect', async () => {
+  it('实时预览在字段更新时会发送最新效果', async () => {
     useEditSettingsStore().autoApplyEffectEditorChanges = false
 
-    const provider = createEffectEditorProvider()
+    const provider = createProvider()
 
-    await provider.open({
+    await provider.open(createOpenTarget({
       baseSentence: createBaseSentence('{"blur":8}'),
-      effectTarget: 'fig-center',
-      onApply() { /* no-op */ },
-    })
+    }))
 
-    provider.updateDraft({ transform: { blur: 12 } })
+    provider.updateDraft({ transform: { blur: 12 } }, { deferAutoApply: true })
     provider.requestPreview({ schedule: 'immediate' })
     await vi.waitFor(() => {
       expect(debugCommanderMock.setEffect).toHaveBeenCalledTimes(1)
@@ -244,19 +443,500 @@ describe('useEffectEditorProvider', () => {
     expect(debugCommanderMock.executeCommand).not.toHaveBeenCalled()
     expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', {
       blur: 12,
+    }, {
+      phase: 'preview',
     })
   })
 
-  it('实时预览跳过已经发送过的相同 transform', async () => {
+  it('实时预览发送 preview phase 并在 flush 时提交 commit phase', async () => {
     useEditSettingsStore().autoApplyEffectEditorChanges = false
 
-    const provider = createEffectEditorProvider()
+    const provider = createProvider()
 
-    await provider.open({
+    await provider.open(createOpenTarget({
       baseSentence: createBaseSentence('{"blur":8}'),
-      effectTarget: 'fig-center',
-      onApply() { /* no-op */ },
+    }))
+
+    provider.updateDraft({ transform: { blur: 12 } }, { deferAutoApply: true })
+    provider.requestPreview({ schedule: 'immediate' })
+    await vi.waitFor(() => {
+      expect(debugCommanderMock.setEffect).toHaveBeenCalledTimes(1)
     })
+
+    provider.requestPreview({ schedule: 'immediate', flush: true })
+    await vi.waitFor(() => {
+      expect(debugCommanderMock.setEffect).toHaveBeenCalledTimes(2)
+    })
+
+    expect(debugCommanderMock.setEffect.mock.calls[0]).toEqual([
+      'fig-center',
+      { blur: 12 },
+      { phase: 'preview' },
+    ])
+    expect(debugCommanderMock.setEffect.mock.calls[1]).toEqual([
+      'fig-center',
+      { blur: 12 },
+      { phase: 'commit' },
+    ])
+  })
+
+  it('应用效果编辑器时会先发送最终 commit phase 再更新本地提交基线', async () => {
+    useEditSettingsStore().autoApplyEffectEditorChanges = false
+    const applyCalls: EffectEditorDraft[] = []
+    const provider = createProvider()
+
+    await provider.open(createOpenTarget({
+      baseSentence: createBaseSentence('{"blur":8}'),
+      onApply(result) {
+        applyCalls.push(cloneDraft(result))
+      },
+    }))
+
+    provider.updateDraft({ transform: { blur: 12 } })
+
+    const applied = await provider.apply()
+
+    expect(applied).toBe(true)
+    expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', { blur: 12 }, {
+      phase: 'commit',
+    })
+    expect(applyCalls).toEqual([
+      {
+        duration: '',
+        ease: '',
+        transform: { blur: 12 },
+      },
+    ])
+  })
+
+  it('应用仅修改时长和缓动的草稿不会发送 runtime commit 但会持久化编辑器草稿', async () => {
+    useEditSettingsStore().autoApplyEffectEditorChanges = false
+
+    const applyCalls: EffectEditorDraft[] = []
+    const provider = createProvider()
+
+    await provider.open(createOpenTarget({
+      baseSentence: {
+        ...createBaseSentence('{"blur":8}'),
+        args: [
+          { key: 'transform', value: '{"blur":8}' },
+          { key: 'duration', value: '100' },
+          { key: 'ease', value: 'easeIn' },
+        ],
+      },
+      onApply(result) {
+        applyCalls.push(cloneDraft(result))
+      },
+    }))
+
+    provider.updateDraft({ duration: '300', ease: 'easeOut' })
+
+    const applied = await provider.apply()
+
+    expect(applied).toBe(true)
+    expect(debugCommanderMock.setEffect).not.toHaveBeenCalled()
+    expect(applyCalls).toEqual([
+      {
+        duration: '300',
+        ease: 'easeOut',
+        transform: { blur: 8 },
+      },
+    ])
+  })
+
+  it('同一帧内多次 immediate preview 只发送最新草稿', async () => {
+    useEditSettingsStore().autoApplyEffectEditorChanges = false
+
+    const frameCallbacks: FrameRequestCallback[] = []
+    const provider = createProvider()
+
+    await provider.open(createOpenTarget({
+      baseSentence: createBaseSentence('{"blur":8}'),
+    }))
+
+    vi.stubGlobal('requestAnimationFrame', vi.fn((callback: FrameRequestCallback) => {
+      frameCallbacks.push(callback)
+      return frameCallbacks.length
+    }))
+    vi.stubGlobal('cancelAnimationFrame', vi.fn())
+
+    provider.updateDraft({ transform: { blur: 12 } }, { deferAutoApply: true })
+    provider.requestPreview({ schedule: 'immediate' })
+    provider.updateDraft({ transform: { blur: 16 } }, { deferAutoApply: true })
+    provider.requestPreview({ schedule: 'immediate' })
+    provider.updateDraft({ transform: { blur: 20 } }, { deferAutoApply: true })
+    provider.requestPreview({ schedule: 'immediate' })
+
+    expect(debugCommanderMock.setEffect).not.toHaveBeenCalled()
+    expect(frameCallbacks).toHaveLength(1)
+
+    frameCallbacks[0]?.(16)
+
+    await vi.waitFor(() => {
+      expect(debugCommanderMock.setEffect).toHaveBeenCalledTimes(1)
+    })
+    expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', { blur: 20 }, {
+      phase: 'preview',
+    })
+  })
+
+  it('预览覆盖态不会改写响应式 draft，且同一帧只发送最新覆盖值', async () => {
+    useEditSettingsStore().autoApplyEffectEditorChanges = false
+
+    const frameCallbacks: FrameRequestCallback[] = []
+    const provider = createProvider()
+
+    await provider.open(createOpenTarget({
+      baseSentence: createBaseSentence('{"blur":8}'),
+    }))
+
+    vi.stubGlobal('requestAnimationFrame', vi.fn((callback: FrameRequestCallback) => {
+      frameCallbacks.push(callback)
+      return frameCallbacks.length
+    }))
+    vi.stubGlobal('cancelAnimationFrame', vi.fn())
+
+    provider.updatePreviewTransform(() => ({ blur: 12 }))
+    provider.requestPreview({ schedule: 'immediate' })
+    provider.updatePreviewTransform(() => ({ blur: 20 }))
+    provider.requestPreview({ schedule: 'immediate' })
+
+    expect(provider.session?.draft.transform).toEqual({ blur: 8 })
+    expect(debugCommanderMock.setEffect).not.toHaveBeenCalled()
+    expect(frameCallbacks).toHaveLength(1)
+
+    frameCallbacks[0]?.(16)
+
+    await vi.waitFor(() => {
+      expect(debugCommanderMock.setEffect).toHaveBeenCalledTimes(1)
+    })
+    expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', { blur: 20 }, {
+      phase: 'preview',
+    })
+    expect(provider.session?.draft.transform).toEqual({ blur: 8 })
+  })
+
+  it('preview in-flight 时只保留最新 transform 并丢弃旧中间值', async () => {
+    useEditSettingsStore().autoApplyEffectEditorChanges = false
+
+    const previewCalls: Transform[] = []
+    const previewResolvers: (() => void)[] = []
+    const provider = createProvider()
+
+    debugCommanderMock.setEffect.mockImplementation(async (_target, transform) => {
+      previewCalls.push(structuredClone(transform))
+      await new Promise<void>((resolve) => {
+        previewResolvers.push(resolve)
+      })
+    })
+
+    await provider.open(createOpenTarget({
+      baseSentence: createBaseSentence('{"blur":8}'),
+    }))
+
+    provider.updateDraft({ transform: { blur: 12 } }, { deferAutoApply: true })
+    provider.requestPreview({ schedule: 'immediate' })
+    await vi.waitFor(() => {
+      expect(previewCalls).toEqual([{ blur: 12 }])
+    })
+
+    provider.updateDraft({ transform: { blur: 16 } })
+    provider.requestPreview({ schedule: 'immediate' })
+    provider.updateDraft({ transform: { blur: 20 } })
+    provider.requestPreview({ schedule: 'immediate' })
+
+    expect(previewCalls).toEqual([{ blur: 12 }])
+
+    previewResolvers[0]?.()
+    await vi.waitFor(() => {
+      expect(previewCalls).toEqual([
+        { blur: 12 },
+        { blur: 20 },
+      ])
+    })
+
+    expect(debugCommanderMock.setEffect.mock.calls.map(call => call[2])).toEqual([
+      { phase: 'preview' },
+      { phase: 'preview' },
+    ])
+  })
+
+  it('preview accepted 状态未知时关闭会尝试恢复 runtime 可见状态', async () => {
+    useEditSettingsStore().autoApplyEffectEditorChanges = false
+
+    const provider = createProvider()
+    let callCount = 0
+
+    debugCommanderMock.setEffect.mockImplementation(async () => {
+      callCount++
+      if (callCount === 1) {
+        throw new Error('preview command timeout')
+      }
+    })
+
+    await provider.open(createOpenTarget({
+      baseSentence: createBaseSentence('{"blur":8}'),
+    }))
+
+    provider.updateDraft({ transform: { blur: 12 } }, { deferAutoApply: true })
+    provider.requestPreview({ schedule: 'immediate' })
+
+    await vi.waitFor(() => {
+      expect(debugCommanderMock.setEffect).toHaveBeenCalledTimes(1)
+    })
+
+    const closed = await provider.close({ forceDiscard: true })
+
+    expect(closed).toBe(true)
+    expect(debugCommanderMock.setEffect.mock.calls).toEqual([
+      ['fig-center', { blur: 12 }, { phase: 'preview' }],
+      ['fig-center', { blur: 8 }, { phase: 'preview' }],
+    ])
+  })
+
+  it('scope dispose 会恢复 visual preview 并废弃当前 session', async () => {
+    useEditSettingsStore().autoApplyEffectEditorChanges = false
+
+    const scope = effectScope()
+    let provider: ReturnType<typeof createEffectEditorProvider> | undefined
+
+    scope.run(() => {
+      provider = createProvider()
+    })
+    if (!provider) {
+      throw new Error('effect editor provider was not created')
+    }
+
+    await provider.open(createOpenTarget({
+      baseSentence: createBaseSentence('{"blur":8}'),
+    }))
+
+    provider.updateDraft({ transform: { blur: 12 } }, { deferAutoApply: true })
+    provider.requestPreview({ schedule: 'immediate' })
+
+    await vi.waitFor(() => {
+      expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', { blur: 12 }, {
+        phase: 'preview',
+      })
+    })
+
+    debugCommanderMock.setEffect.mockClear()
+    scope.stop()
+
+    await vi.waitFor(() => {
+      expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', { blur: 8 }, {
+        phase: 'preview',
+      })
+    })
+    expect(provider.isOpen).toBe(false)
+    expect(provider.session).toBeUndefined()
+  })
+
+  it('useEffectEditorProvider 创建的 provider 会在 scope dispose 时恢复 preview', async () => {
+    useEditSettingsStore().autoApplyEffectEditorChanges = false
+
+    const scope = effectScope()
+    let provider: ReturnType<typeof useEffectEditorProvider> | undefined
+
+    scope.run(() => {
+      provider = useEffectEditorProvider()
+    })
+    if (!provider) {
+      throw new Error('effect editor provider was not created')
+    }
+
+    await provider.open(createOpenTarget({
+      baseSentence: createBaseSentence('{"blur":8}'),
+    }))
+
+    provider.updateDraft({ transform: { blur: 12 } }, { deferAutoApply: true })
+    provider.requestPreview({ schedule: 'immediate' })
+
+    await vi.waitFor(() => {
+      expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', { blur: 12 }, {
+        phase: 'preview',
+      })
+    })
+
+    debugCommanderMock.setEffect.mockClear()
+    scope.stop()
+
+    await vi.waitFor(() => {
+      expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', { blur: 8 }, {
+        phase: 'preview',
+      })
+    })
+  })
+
+  it('scope dispose 恢复失败时废弃当前 session', async () => {
+    useEditSettingsStore().autoApplyEffectEditorChanges = false
+
+    const scope = effectScope()
+    let provider: ReturnType<typeof createEffectEditorProvider> | undefined
+
+    scope.run(() => {
+      provider = createProvider()
+    })
+    if (!provider) {
+      throw new Error('effect editor provider was not created')
+    }
+
+    debugCommanderMock.setEffect.mockImplementation(async (_target, transform, options) => {
+      if (options?.phase === 'preview' && transform.blur === 8) {
+        throw new Error('restore failed')
+      }
+    })
+
+    await provider.open(createOpenTarget({
+      baseSentence: createBaseSentence('{"blur":8}'),
+    }))
+
+    provider.updateDraft({ transform: { blur: 12 } }, { deferAutoApply: true })
+    provider.requestPreview({ schedule: 'immediate' })
+
+    await vi.waitFor(() => {
+      expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', { blur: 12 }, {
+        phase: 'preview',
+      })
+    })
+
+    debugCommanderMock.setEffect.mockClear()
+    scope.stop()
+
+    await vi.waitFor(() => {
+      expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', { blur: 8 }, {
+        phase: 'preview',
+      })
+    })
+    await vi.waitFor(() => {
+      expect(provider?.isOpen).toBe(false)
+    })
+    expect(provider.session).toBeUndefined()
+  })
+
+  it('preview 明确失败后保留草稿并继续发送最新预览', async () => {
+    useEditSettingsStore().autoApplyEffectEditorChanges = false
+
+    const provider = createProvider()
+
+    debugCommanderMock.setEffect.mockRejectedValueOnce(new Error('preview failed'))
+
+    await provider.open(createOpenTarget({
+      baseSentence: createBaseSentence('{"blur":8}'),
+    }))
+
+    provider.updateDraft({ transform: { blur: 12 } }, { deferAutoApply: true })
+    provider.requestPreview({ schedule: 'immediate' })
+
+    await vi.waitFor(() => {
+      expect(debugCommanderMock.setEffect).toHaveBeenCalledTimes(1)
+    })
+
+    debugCommanderMock.setEffect.mockClear()
+    provider.updateDraft({ transform: { blur: 20 } }, { deferAutoApply: true })
+    provider.requestPreview({ schedule: 'immediate' })
+
+    await vi.waitFor(() => {
+      expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', { blur: 20 }, {
+        phase: 'preview',
+      })
+    })
+    expect(provider.session?.draft.transform).toEqual({ blur: 20 })
+  })
+
+  it('应用效果编辑器时 final commit 会排在已发送 preview 后', async () => {
+    useEditSettingsStore().autoApplyEffectEditorChanges = false
+
+    const order: string[] = []
+    const previewResolvers: (() => void)[] = []
+    const provider = createProvider()
+
+    debugCommanderMock.setEffect.mockImplementation(async (_target, transform, options) => {
+      if (options?.phase === 'preview' && transform.blur === 12) {
+        order.push('preview:start')
+        await new Promise<void>((resolve) => {
+          previewResolvers.push(resolve)
+        })
+        order.push('preview:end')
+        return
+      }
+
+      order.push(`${options?.phase}:${transform.blur}`)
+    })
+
+    await provider.open(createOpenTarget({
+      baseSentence: createBaseSentence('{"blur":8}'),
+    }))
+
+    provider.updateDraft({ transform: { blur: 12 } }, { deferAutoApply: true })
+    provider.requestPreview({ schedule: 'immediate' })
+
+    await vi.waitFor(() => {
+      expect(order).toEqual(['preview:start'])
+    })
+
+    provider.updateDraft({ transform: { blur: 20 } })
+    const applyPromise = provider.apply()
+
+    await Promise.resolve()
+    expect(order).toEqual(['preview:start'])
+
+    previewResolvers[0]?.()
+    await applyPromise
+
+    expect(order).toEqual(['preview:start', 'preview:end', 'commit:20'])
+  })
+
+  it('flush commit 会使用触发 flush 时的草稿快照', async () => {
+    useEditSettingsStore().autoApplyEffectEditorChanges = false
+
+    const order: string[] = []
+    const previewResolvers: (() => void)[] = []
+    const provider = createProvider()
+
+    debugCommanderMock.setEffect.mockImplementation(async (_target, transform, options) => {
+      if (options?.phase === 'preview' && transform.blur === 12) {
+        order.push('preview:start:12')
+        await new Promise<void>((resolve) => {
+          previewResolvers.push(resolve)
+        })
+        order.push('preview:end:12')
+        return
+      }
+
+      order.push(`${options?.phase}:${transform.blur}`)
+    })
+
+    await provider.open(createOpenTarget({
+      baseSentence: createBaseSentence('{"blur":8}'),
+    }))
+
+    provider.updateDraft({ transform: { blur: 12 } }, { deferAutoApply: true })
+    provider.requestPreview({ schedule: 'immediate' })
+
+    await vi.waitFor(() => {
+      expect(order).toEqual(['preview:start:12'])
+    })
+
+    provider.updateDraft({ transform: { blur: 16 } })
+    provider.requestPreview({ schedule: 'immediate', flush: true })
+    provider.updateDraft({ transform: { blur: 20 } }, { deferAutoApply: true })
+    provider.requestPreview({ schedule: 'immediate' })
+
+    previewResolvers[0]?.()
+    await vi.waitFor(() => {
+      expect(order).toEqual(['preview:start:12', 'preview:end:12', 'commit:16', 'preview:20'])
+    })
+  })
+
+  it('普通实时预览会跳过相同变换但 flush 会提交最终 commit', async () => {
+    useEditSettingsStore().autoApplyEffectEditorChanges = false
+
+    const provider = createProvider()
+
+    await provider.open(createOpenTarget({
+      baseSentence: createBaseSentence('{"blur":8}'),
+    }))
 
     provider.updateDraft({ transform: { blur: 12 } }, { deferAutoApply: true })
     provider.requestPreview({ schedule: 'immediate' })
@@ -268,20 +948,55 @@ describe('useEffectEditorProvider', () => {
     provider.requestPreview({ schedule: 'continuous', flush: true })
 
     await vi.waitFor(() => {
-      expect(debugCommanderMock.setEffect).toHaveBeenCalledTimes(1)
+      expect(debugCommanderMock.setEffect).toHaveBeenCalledTimes(2)
     })
+
+    expect(debugCommanderMock.setEffect.mock.calls.map(call => call[2])).toEqual([
+      { phase: 'preview' },
+      { phase: 'commit' },
+    ])
+  })
+
+  it('flush 时变换等于提交基线且没有可见预览污染时不会发送 runtime commit', async () => {
+    useEditSettingsStore().autoApplyEffectEditorChanges = false
+
+    const provider = createProvider()
+
+    await provider.open(createOpenTarget({
+      baseSentence: createBaseSentence('{"blur":8}'),
+    }))
+
+    provider.requestPreview({ schedule: 'immediate', flush: true })
+    await Promise.resolve()
+
+    expect(debugCommanderMock.setEffect).not.toHaveBeenCalled()
+  })
+
+  it('flush 是 no-op 时缺少 target 不会产生缺失 target 警告', async () => {
+    useEditSettingsStore().autoApplyEffectEditorChanges = false
+
+    const provider = createProvider()
+
+    await provider.open(createOpenTarget({
+      baseSentence: createBaseSentence('{"blur":8}'),
+      effectTarget: '',
+    }))
+
+    provider.requestPreview({ schedule: 'immediate', flush: true })
+    await Promise.resolve()
+
+    expect(loggerWarnMock).not.toHaveBeenCalled()
+    expect(debugCommanderMock.setEffect).not.toHaveBeenCalled()
   })
 
   it('重置草稿时通过打开表单时的 transform 回到效果预览基线', async () => {
     useEditSettingsStore().autoApplyEffectEditorChanges = false
 
-    const provider = createEffectEditorProvider()
+    const provider = createProvider()
 
-    await provider.open({
+    await provider.open(createOpenTarget({
       baseSentence: createBaseSentence('{"blur":8}'),
-      effectTarget: 'fig-center',
-      onApply() { /* no-op */ },
-    })
+    }))
 
     provider.updateDraft({
       duration: '300',
@@ -291,6 +1006,8 @@ describe('useEffectEditorProvider', () => {
     await vi.waitFor(() => {
       expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', {
         blur: 12,
+      }, {
+        phase: 'preview',
       })
     })
 
@@ -306,6 +1023,8 @@ describe('useEffectEditorProvider', () => {
     expect(debugCommanderMock.executeCommand).not.toHaveBeenCalled()
     expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', {
       blur: 8,
+    }, {
+      phase: 'preview',
     })
     expect(provider.session?.draft).toEqual({
       duration: '',
@@ -319,13 +1038,11 @@ describe('useEffectEditorProvider', () => {
   it('重置仅修改时长的草稿不会发送效果预览重置', async () => {
     useEditSettingsStore().autoApplyEffectEditorChanges = false
 
-    const provider = createEffectEditorProvider()
+    const provider = createProvider()
 
-    await provider.open({
+    await provider.open(createOpenTarget({
       baseSentence: createBaseSentence('{"blur":8}'),
-      effectTarget: 'fig-center',
-      onApply() { /* no-op */ },
-    })
+    }))
 
     provider.updateDraft({ duration: '300' })
     provider.resetToInitialDraft()
@@ -343,19 +1060,24 @@ describe('useEffectEditorProvider', () => {
   it('关闭并丢弃未应用变更时通过打开表单时的 transform 重置预览', async () => {
     useEditSettingsStore().autoApplyEffectEditorChanges = false
 
-    const provider = createEffectEditorProvider()
+    const baselineClient = createUnavailableBaselineClient()
+    const provider = createProvider({ baselineClient })
 
-    await provider.open({
+    await provider.open(createOpenTarget({
       baseSentence: createBaseSentence('{"blur":8}'),
-      effectTarget: 'fig-center',
-      onApply() { /* no-op */ },
+    }))
+    await vi.waitFor(() => {
+      expect(baselineClient.syncScene).toHaveBeenCalled()
     })
+    vi.mocked(baselineClient.syncScene).mockClear()
 
     provider.updateDraft({ transform: { blur: 12 } })
     provider.requestPreview({ schedule: 'immediate' })
     await vi.waitFor(() => {
       expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', {
         blur: 12,
+      }, {
+        phase: 'preview',
       })
     })
 
@@ -368,19 +1090,878 @@ describe('useEffectEditorProvider', () => {
     expect(debugCommanderMock.executeCommand).not.toHaveBeenCalled()
     expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', {
       blur: 8,
+    }, {
+      phase: 'preview',
     })
+    expect(baselineClient.syncScene).not.toHaveBeenCalled()
+  })
+
+  it('关闭时等待已发送 preview 完成后再发送 restore preview', async () => {
+    useEditSettingsStore().autoApplyEffectEditorChanges = false
+
+    const order: string[] = []
+    const previewResolvers: (() => void)[] = []
+    const baselineClient = createUnavailableBaselineClient()
+    const provider = createProvider({ baselineClient })
+
+    debugCommanderMock.setEffect.mockImplementation(async (_target, transform, options) => {
+      if (options?.phase === 'preview' && transform.blur === 12) {
+        order.push('preview:start')
+        await new Promise<void>((resolve) => {
+          previewResolvers.push(resolve)
+        })
+        order.push('preview:end')
+        return
+      }
+
+      order.push(`${options?.phase}:${transform.blur}`)
+    })
+    vi.mocked(baselineClient.syncScene).mockImplementation(async () => {
+      order.push('sync')
+    })
+
+    await provider.open(createOpenTarget({
+      baseSentence: createBaseSentence('{"blur":8}'),
+    }))
+    await vi.waitFor(() => {
+      expect(baselineClient.syncScene).toHaveBeenCalled()
+    })
+    order.length = 0
+    vi.mocked(baselineClient.syncScene).mockClear()
+
+    provider.updateDraft({ transform: { blur: 12 } })
+    provider.requestPreview({ schedule: 'immediate' })
+    await vi.waitFor(() => {
+      expect(order).toEqual(['preview:start'])
+    })
+
+    const closePromise = provider.close({ forceDiscard: true })
+    await Promise.resolve()
+
+    expect(order).toEqual(['preview:start'])
+
+    previewResolvers[0]?.()
+    await closePromise
+
+    expect(order).toEqual(['preview:start', 'preview:end', 'preview:8'])
+    expect(baselineClient.syncScene).not.toHaveBeenCalled()
+  })
+
+  it('关闭发生在 deferred 交互批处理中时会恢复到 committed base draft', async () => {
+    useEditSettingsStore().autoApplyEffectEditorChanges = false
+
+    const provider = createProvider()
+
+    await provider.open(createOpenTarget({
+      baseSentence: createBaseSentence('{"blur":8}'),
+    }))
+
+    provider.updateDraft({ transform: { blur: 16 } })
+    provider.requestPreview({ schedule: 'immediate' })
+
+    await vi.waitFor(() => {
+      expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', { blur: 16 }, {
+        phase: 'preview',
+      })
+    })
+
+    debugCommanderMock.setEffect.mockClear()
+
+    provider.updateDraft({ transform: { blur: 20 } }, { deferAutoApply: true })
+    provider.requestPreview({ schedule: 'immediate' })
+
+    await vi.waitFor(() => {
+      expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', { blur: 20 }, {
+        phase: 'preview',
+      })
+    })
+
+    debugCommanderMock.setEffect.mockClear()
+
+    const closed = await provider.close({ forceDiscard: true })
+
+    expect(closed).toBe(true)
+    expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', { blur: 8 }, {
+      phase: 'preview',
+    })
+  })
+
+  it('自动应用开启时关闭 deferred 交互不会把当前拖拽草稿提交为 commit', async () => {
+    const applyCalls: EffectEditorDraft[] = []
+    const provider = createProvider()
+
+    await provider.open(createOpenTarget({
+      baseSentence: createBaseSentence('{"blur":8}'),
+      onApply(result) {
+        applyCalls.push(cloneDraft(result))
+      },
+    }))
+
+    provider.updateDraft({ transform: { blur: 16 } })
+
+    await vi.waitFor(() => {
+      expect(applyCalls.map(call => call.transform)).toEqual([{ blur: 16 }])
+    })
+    expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', { blur: 16 }, {
+      phase: 'commit',
+    })
+    debugCommanderMock.setEffect.mockClear()
+
+    provider.updateDraft({ transform: { blur: 20 } }, { deferAutoApply: true })
+    provider.requestPreview({ schedule: 'immediate' })
+
+    await vi.waitFor(() => {
+      expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', { blur: 20 }, {
+        phase: 'preview',
+      })
+    })
+    debugCommanderMock.setEffect.mockClear()
+
+    const closed = await provider.close()
+
+    expect(closed).toBe(true)
+    expect(applyCalls.map(call => call.transform)).toEqual([{ blur: 16 }])
+    expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', { blur: 16 }, {
+      phase: 'preview',
+    })
+    expect(debugCommanderMock.setEffect).not.toHaveBeenCalledWith('fig-center', { blur: 20 }, {
+      phase: 'commit',
+    })
+  })
+
+  it('关闭弹窗取消时会恢复 deferred 交互的 rollback preview', async () => {
+    useEditSettingsStore().autoApplyEffectEditorChanges = false
+
+    const provider = createProvider()
+
+    await provider.open(createOpenTarget({
+      baseSentence: createBaseSentence('{"blur":8}'),
+    }))
+
+    provider.updateDraft({ transform: { blur: 16 } })
+    provider.requestPreview({ schedule: 'immediate' })
+
+    await vi.waitFor(() => {
+      expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', { blur: 16 }, {
+        phase: 'preview',
+      })
+    })
+    debugCommanderMock.setEffect.mockClear()
+
+    provider.updateDraft({ transform: { blur: 20 } }, { deferAutoApply: true })
+    provider.requestPreview({ schedule: 'immediate' })
+
+    await vi.waitFor(() => {
+      expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', { blur: 20 }, {
+        phase: 'preview',
+      })
+    })
+    debugCommanderMock.setEffect.mockClear()
+
+    const closed = await provider.close()
+
+    expect(closed).toBe(false)
+    expect(provider.isOpen).toBe(true)
+    expect(provider.session?.draft.transform).toEqual({ blur: 16 })
+    expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', { blur: 16 }, {
+      phase: 'preview',
+    })
+  })
+
+  it('关闭时 restore 明确失败会保留 session 并允许再次恢复', async () => {
+    useEditSettingsStore().autoApplyEffectEditorChanges = false
+
+    const provider = createProvider()
+    let failRestore = true
+
+    debugCommanderMock.setEffect.mockImplementation(async (_target, transform, options) => {
+      if (options?.phase === 'preview' && transform.blur === 8 && failRestore) {
+        throw new Error('restore failed')
+      }
+    })
+
+    await provider.open(createOpenTarget({
+      baseSentence: createBaseSentence('{"blur":8}'),
+    }))
+
+    provider.updateDraft({ transform: { blur: 12 } })
+    provider.requestPreview({ schedule: 'immediate' })
+    await vi.waitFor(() => {
+      expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', { blur: 12 }, {
+        phase: 'preview',
+      })
+    })
+
+    const closed = await provider.close({ forceDiscard: true })
+
+    expect(closed).toBe(false)
+    expect(provider.isOpen).toBe(true)
+
+    failRestore = false
+    debugCommanderMock.setEffect.mockClear()
+    const retriedClosed = await provider.close({ forceDiscard: true })
+
+    expect(retriedClosed).toBe(true)
+    expect(provider.isOpen).toBe(false)
+    expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', { blur: 8 }, {
+      phase: 'preview',
+    })
+  })
+
+  it('关闭时 restore 普通 timeout 会保留 session 并允许再次恢复', async () => {
+    useEditSettingsStore().autoApplyEffectEditorChanges = false
+
+    const provider = createProvider()
+    let failRestore = true
+
+    debugCommanderMock.setEffect.mockImplementation(async (_target, transform, options) => {
+      if (options?.phase === 'preview' && transform.blur === 8 && failRestore) {
+        failRestore = false
+        throw new Error('preview.command.set-effect command timeout')
+      }
+    })
+
+    await provider.open(createOpenTarget({
+      baseSentence: createBaseSentence('{"blur":8}'),
+    }))
+
+    provider.updateDraft({ transform: { blur: 12 } })
+    provider.requestPreview({ schedule: 'immediate' })
+    await vi.waitFor(() => {
+      expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', { blur: 12 }, {
+        phase: 'preview',
+      })
+    })
+
+    const closed = await provider.close({ forceDiscard: true })
+
+    expect(closed).toBe(false)
+    expect(provider.isOpen).toBe(true)
+
+    debugCommanderMock.setEffect.mockClear()
+    const retriedClosed = await provider.close({ forceDiscard: true })
+
+    expect(retriedClosed).toBe(true)
+    expect(provider.isOpen).toBe(false)
+    expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', { blur: 8 }, {
+      phase: 'preview',
+    })
+  })
+
+  it('commit 明确失败后会保留草稿并允许继续预览最新草稿', async () => {
+    useEditSettingsStore().autoApplyEffectEditorChanges = false
+
+    const provider = createProvider()
+    const failCommit = true
+
+    debugCommanderMock.setEffect.mockImplementation(async (_target, _transform, options) => {
+      if (options?.phase === 'commit' && failCommit) {
+        throw new Error('commit failed')
+      }
+    })
+
+    await provider.open(createOpenTarget({
+      baseSentence: createBaseSentence('{"blur":8}'),
+    }))
+
+    provider.updateDraft({ transform: { blur: 12 } })
+    expect(await provider.apply()).toBe(false)
+    expect(provider.session?.draft.transform).toEqual({ blur: 12 })
+
+    debugCommanderMock.setEffect.mockClear()
+    provider.updateDraft({ transform: { blur: 20 } }, { deferAutoApply: true })
+    provider.requestPreview({ schedule: 'immediate' })
+
+    await vi.waitFor(() => {
+      expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', { blur: 20 }, {
+        phase: 'preview',
+      })
+    })
+    expect(provider.session?.draft.transform).toEqual({ blur: 20 })
+  })
+
+  it('commit accepted 状态未知后会阻止新的交互预览', async () => {
+    useEditSettingsStore().autoApplyEffectEditorChanges = false
+
+    const provider = createProvider()
+
+    debugCommanderMock.setEffect.mockImplementation(async (_target, _transform, options) => {
+      if (options?.phase === 'commit') {
+        throw new Error('preview state reset')
+      }
+    })
+
+    await provider.open(createOpenTarget({
+      baseSentence: createBaseSentence('{"blur":8}'),
+    }))
+
+    provider.updateDraft({ transform: { blur: 12 } })
+    expect(await provider.apply()).toBe(false)
+
+    debugCommanderMock.setEffect.mockClear()
+    provider.updateDraft({ transform: { blur: 20 } }, { deferAutoApply: true })
+    provider.requestPreview({ schedule: 'immediate' })
+
+    expect(debugCommanderMock.setEffect).not.toHaveBeenCalled()
+    expect(provider.session?.draft.transform).toEqual({ blur: 12 })
+  })
+
+  it('commit 普通 timeout 后允许继续预览并基于最新草稿再次应用', async () => {
+    useEditSettingsStore().autoApplyEffectEditorChanges = false
+
+    const provider = createProvider()
+    const commitTransforms: Transform[] = []
+    let failFirstCommit = true
+
+    debugCommanderMock.setEffect.mockImplementation(async (_target, transform, options) => {
+      if (options?.phase !== 'commit') {
+        return
+      }
+
+      commitTransforms.push(structuredClone(transform))
+      if (failFirstCommit) {
+        failFirstCommit = false
+        throw new Error('preview.command.set-effect command timeout')
+      }
+    })
+
+    await provider.open(createOpenTarget({
+      baseSentence: createBaseSentence('{"blur":8}'),
+    }))
+
+    provider.updateDraft({ transform: { blur: 12 } })
+    expect(await provider.apply()).toBe(false)
+
+    debugCommanderMock.setEffect.mockClear()
+    provider.updateDraft({ transform: { blur: 20 } }, { deferAutoApply: true })
+    provider.requestPreview({ schedule: 'immediate' })
+
+    await vi.waitFor(() => {
+      expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', { blur: 20 }, {
+        phase: 'preview',
+      })
+    })
+
+    expect(await provider.apply()).toBe(true)
+    expect(commitTransforms).toEqual([{ blur: 12 }, { blur: 20 }])
+  })
+
+  it('commit 明确失败后 discard close 可以关闭 session', async () => {
+    useEditSettingsStore().autoApplyEffectEditorChanges = false
+
+    const provider = createProvider()
+    const failCommit = true
+
+    modalOpenMock.mockImplementation((
+      _name: string,
+      payload: { onApply?: () => void, onDiscard?: () => void, onCancel?: () => void },
+    ) => {
+      payload.onDiscard?.()
+    })
+    debugCommanderMock.setEffect.mockImplementation(async (_target, _transform, options) => {
+      if (options?.phase === 'commit' && failCommit) {
+        throw new Error('commit failed')
+      }
+    })
+
+    await provider.open(createOpenTarget({
+      baseSentence: createBaseSentence('{"blur":8}'),
+    }))
+
+    provider.updateDraft({ transform: { blur: 12 } })
+    expect(await provider.apply()).toBe(false)
+
+    const closed = await provider.close()
+
+    expect(closed).toBe(true)
+    expect(provider.isOpen).toBe(false)
+  })
+
+  it('runtime commit 成功但编辑器应用失败后丢弃关闭会恢复 runtime 可见状态', async () => {
+    useEditSettingsStore().autoApplyEffectEditorChanges = false
+
+    const provider = createProvider()
+
+    await provider.open(createOpenTarget({
+      baseSentence: createBaseSentence('{"blur":8}'),
+      onApply() {
+        throw new Error('apply failed')
+      },
+    }))
+
+    provider.updateDraft({ transform: { blur: 12 } })
+    expect(await provider.apply()).toBe(false)
+    expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', { blur: 12 }, {
+      phase: 'commit',
+    })
+
+    debugCommanderMock.setEffect.mockClear()
+
+    const closed = await provider.close({ forceDiscard: true })
+
+    expect(closed).toBe(true)
+    expect(provider.isOpen).toBe(false)
+    expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', { blur: 8 }, {
+      phase: 'preview',
+    })
+  })
+
+  it('commit accepted 状态未知后重新打开会废弃旧 preview session 并创建新 session', async () => {
+    useEditSettingsStore().autoApplyEffectEditorChanges = false
+
+    const provider = createProvider()
+    let failCommit = true
+
+    debugCommanderMock.setEffect.mockImplementation(async (_target, _transform, options) => {
+      if (options?.phase === 'commit' && failCommit) {
+        throw new Error('preview state reset')
+      }
+    })
+
+    await provider.open(createOpenTarget({
+      baseSentence: createBaseSentence('{"blur":8}'),
+    }))
+
+    provider.updateDraft({ transform: { blur: 12 } })
+    expect(await provider.apply()).toBe(false)
+
+    failCommit = false
+    debugCommanderMock.setEffect.mockClear()
+
+    const opened = await provider.open(createOpenTarget({
+      baseSentence: createBaseSentence('{"blur":4}'),
+      effectTarget: 'fig-right',
+    }))
+
+    expect(opened).toBe(true)
+    expect(provider.isOpen).toBe(true)
+    expect(provider.session?.effectTarget).toBe('fig-right')
+    expect(provider.session?.draft.transform).toEqual({ blur: 4 })
+
+    provider.updateDraft({ transform: { blur: 6 } }, { deferAutoApply: true })
+    provider.requestPreview({ schedule: 'immediate' })
+
+    await vi.waitFor(() => {
+      expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-right', { blur: 6 }, {
+        phase: 'preview',
+      })
+    })
+  })
+
+  it('scope dispose 在 commit 明确失败后会关闭当前 preview session', async () => {
+    useEditSettingsStore().autoApplyEffectEditorChanges = false
+
+    const scope = effectScope()
+    let provider: ReturnType<typeof createEffectEditorProvider> | undefined
+
+    scope.run(() => {
+      provider = createProvider()
+    })
+    if (!provider) {
+      throw new Error('effect editor provider was not created')
+    }
+
+    debugCommanderMock.setEffect.mockImplementation(async (_target, _transform, options) => {
+      if (options?.phase === 'commit') {
+        throw new Error('commit failed')
+      }
+    })
+
+    await provider.open(createOpenTarget({
+      baseSentence: createBaseSentence('{"blur":8}'),
+    }))
+
+    provider.updateDraft({ transform: { blur: 12 } })
+    expect(await provider.apply()).toBe(false)
+
+    scope.stop()
+
+    await vi.waitFor(() => {
+      expect(provider?.isOpen).toBe(false)
+    })
+    expect(provider.session).toBeUndefined()
+  })
+
+  it('commit in-flight 期间继续编辑时明确失败后不会重试旧快照并允许再次应用最新草稿', async () => {
+    useEditSettingsStore().autoApplyEffectEditorChanges = false
+
+    const commitResolvers: (() => void)[] = []
+    const commitTransforms: Transform[] = []
+    const provider = createProvider()
+
+    debugCommanderMock.setEffect.mockImplementation(async (_target, transform, options) => {
+      if (options?.phase !== 'commit') {
+        return
+      }
+
+      commitTransforms.push(structuredClone(transform))
+      if (commitTransforms.length === 1) {
+        await new Promise<void>((resolve) => {
+          commitResolvers.push(resolve)
+        })
+        throw new Error('commit failed')
+      }
+    })
+
+    await provider.open(createOpenTarget({
+      baseSentence: createBaseSentence('{"blur":8}'),
+    }))
+
+    provider.updateDraft({ transform: { blur: 12 } })
+    const firstApply = provider.apply()
+
+    await vi.waitFor(() => {
+      expect(commitTransforms).toEqual([{ blur: 12 }])
+    })
+
+    provider.updateDraft({ transform: { blur: 20 } }, { deferAutoApply: true })
+    commitResolvers[0]?.()
+
+    await expect(firstApply).resolves.toBe(false)
+    expect(provider.session?.draft.transform).toEqual({ blur: 20 })
+    expect(commitTransforms).toEqual([{ blur: 12 }])
+
+    await expect(provider.apply()).resolves.toBe(true)
+    expect(commitTransforms).toEqual([{ blur: 12 }, { blur: 20 }])
+  })
+
+  it('commit 明确失败后会继续发送已经排队的最新 preview', async () => {
+    useEditSettingsStore().autoApplyEffectEditorChanges = false
+
+    const order: string[] = []
+    const previewResolvers: (() => void)[] = []
+    const provider = createProvider()
+
+    debugCommanderMock.setEffect.mockImplementation(async (_target, transform, options) => {
+      if (options?.phase === 'preview' && transform.blur === 12) {
+        order.push('preview:start:12')
+        await new Promise<void>((resolve) => {
+          previewResolvers.push(resolve)
+        })
+        order.push('preview:end:12')
+        return
+      }
+
+      order.push(`${options?.phase}:${transform.blur}`)
+      if (options?.phase === 'commit' && transform.blur === 16) {
+        throw new Error('commit failed')
+      }
+    })
+
+    await provider.open(createOpenTarget({
+      baseSentence: createBaseSentence('{"blur":8}'),
+    }))
+
+    provider.updateDraft({ transform: { blur: 12 } }, { deferAutoApply: true })
+    provider.requestPreview({ schedule: 'immediate' })
+
+    await vi.waitFor(() => {
+      expect(order).toEqual(['preview:start:12'])
+    })
+
+    provider.updateDraft({ transform: { blur: 16 } })
+    provider.requestPreview({ schedule: 'immediate', flush: true })
+    provider.updateDraft({ transform: { blur: 20 } }, { deferAutoApply: true })
+    provider.requestPreview({ schedule: 'immediate' })
+
+    previewResolvers[0]?.()
+
+    await vi.waitFor(() => {
+      expect(order).toEqual(['preview:start:12', 'preview:end:12', 'commit:16', 'preview:20'])
+    })
+    expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', { blur: 20 }, {
+      phase: 'preview',
+    })
+  })
+
+  it('commit accepted 状态未知后不会继续发送已经排队的后续 preview', async () => {
+    useEditSettingsStore().autoApplyEffectEditorChanges = false
+
+    const order: string[] = []
+    const previewResolvers: (() => void)[] = []
+    const provider = createProvider()
+
+    debugCommanderMock.setEffect.mockImplementation(async (_target, transform, options) => {
+      if (options?.phase === 'preview' && transform.blur === 12) {
+        order.push('preview:start:12')
+        await new Promise<void>((resolve) => {
+          previewResolvers.push(resolve)
+        })
+        order.push('preview:end:12')
+        return
+      }
+
+      order.push(`${options?.phase}:${transform.blur}`)
+      if (options?.phase === 'commit' && transform.blur === 16) {
+        throw new Error('preview state reset')
+      }
+    })
+
+    await provider.open(createOpenTarget({
+      baseSentence: createBaseSentence('{"blur":8}'),
+    }))
+
+    provider.updateDraft({ transform: { blur: 12 } }, { deferAutoApply: true })
+    provider.requestPreview({ schedule: 'immediate' })
+
+    await vi.waitFor(() => {
+      expect(order).toEqual(['preview:start:12'])
+    })
+
+    provider.updateDraft({ transform: { blur: 16 } })
+    provider.requestPreview({ schedule: 'immediate', flush: true })
+    provider.updateDraft({ transform: { blur: 20 } }, { deferAutoApply: true })
+    provider.requestPreview({ schedule: 'immediate' })
+
+    previewResolvers[0]?.()
+
+    await vi.waitFor(() => {
+      expect(order).toEqual(['preview:start:12', 'preview:end:12', 'commit:16'])
+    })
+    expect(debugCommanderMock.setEffect).not.toHaveBeenCalledWith('fig-center', { blur: 20 }, {
+      phase: 'preview',
+    })
+  })
+
+  it('自动应用 reset 时会先发送 runtime commit 再持久化编辑器草稿', async () => {
+    useEditSettingsStore().autoApplyEffectEditorChanges = true
+
+    const applyCalls: EffectEditorDraft[] = []
+    const provider = createProvider()
+
+    await provider.open(createOpenTarget({
+      baseSentence: createBaseSentence('{"blur":8}'),
+      onApply(result) {
+        applyCalls.push(cloneDraft(result))
+      },
+    }))
+
+    provider.updateDraft({ transform: { blur: 12 } })
+    provider.requestPreview({ schedule: 'immediate', flush: true })
+
+    await vi.waitFor(() => {
+      expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', { blur: 12 }, {
+        phase: 'commit',
+      })
+    })
+    await vi.waitFor(() => {
+      expect(applyCalls).toEqual([
+        {
+          duration: '',
+          ease: '',
+          transform: { blur: 12 },
+        },
+      ])
+    })
+
+    debugCommanderMock.setEffect.mockClear()
+    applyCalls.length = 0
+
+    provider.resetToInitialDraft()
+
+    await vi.waitFor(() => {
+      expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', { blur: 8 }, {
+        phase: 'commit',
+      })
+    })
+    await vi.waitFor(() => {
+      expect(applyCalls).toEqual([
+        {
+          duration: '',
+          ease: '',
+          transform: { blur: 8 },
+        },
+      ])
+    })
+  })
+
+  it('取消未发送的 queued preview 不会同步场景', async () => {
+    useEditSettingsStore().autoApplyEffectEditorChanges = false
+
+    const baselineClient = createUnavailableBaselineClient()
+    const provider = createProvider({ baselineClient })
+    vi.stubGlobal('requestAnimationFrame', vi.fn(() => 1))
+    vi.stubGlobal('cancelAnimationFrame', vi.fn())
+
+    await provider.open(createOpenTarget({
+      baseSentence: createBaseSentence('{"blur":8}'),
+    }))
+
+    provider.updateDraft({ transform: { blur: 12 } })
+    provider.requestPreview({ schedule: 'frame' })
+    await provider.cancelPreview()
+
+    expect(debugCommanderMock.setEffect).not.toHaveBeenCalled()
+    expect(baselineClient.syncScene).not.toHaveBeenCalled()
+  })
+
+  it('取消交互会丢弃尚未触发的 continuous trailing preview', async () => {
+    useEditSettingsStore().autoApplyEffectEditorChanges = false
+    vi.useFakeTimers()
+    vi.setSystemTime(0)
+
+    try {
+      const provider = createProvider()
+
+      await provider.open(createOpenTarget({
+        baseSentence: createBaseSentence('{"blur":8}'),
+      }))
+
+      provider.updateDraft({ transform: { blur: 16 } })
+      provider.updateDraft({ transform: { blur: 20 } }, { deferAutoApply: true })
+      provider.requestPreview({ schedule: 'continuous' })
+
+      expect(debugCommanderMock.setEffect).not.toHaveBeenCalled()
+
+      await provider.cancelPreview()
+      await vi.advanceTimersByTimeAsync(40)
+
+      expect(debugCommanderMock.setEffect).not.toHaveBeenCalled()
+      expect(provider.session?.draft.transform).toEqual({ blur: 16 })
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('取消已发送 preview 时会等待 preview 后发送 rollback draft restore', async () => {
+    useEditSettingsStore().autoApplyEffectEditorChanges = false
+
+    const order: string[] = []
+    const previewResolvers: (() => void)[] = []
+    const baselineClient = createUnavailableBaselineClient()
+    const provider = createProvider({ baselineClient })
+
+    debugCommanderMock.setEffect.mockImplementation(async (_target, transform, options) => {
+      if (options?.phase === 'preview' && transform.blur === 12) {
+        order.push('preview:start')
+        await new Promise<void>((resolve) => {
+          previewResolvers.push(resolve)
+        })
+        order.push('preview:end')
+        return
+      }
+
+      order.push(`${options?.phase}:${transform.blur}`)
+    })
+    vi.mocked(baselineClient.syncScene).mockImplementation(async () => {
+      order.push('sync')
+    })
+
+    await provider.open(createOpenTarget({
+      baseSentence: createBaseSentence('{"blur":8}'),
+    }))
+    await vi.waitFor(() => {
+      expect(baselineClient.syncScene).toHaveBeenCalled()
+    })
+    order.length = 0
+    vi.mocked(baselineClient.syncScene).mockClear()
+
+    provider.updateDraft({ transform: { blur: 12 } }, { deferAutoApply: true })
+    provider.requestPreview({ schedule: 'immediate' })
+    await vi.waitFor(() => {
+      expect(order).toEqual(['preview:start'])
+    })
+
+    const cancelPromise = provider.cancelPreview()
+    await Promise.resolve()
+
+    expect(order).toEqual(['preview:start'])
+
+    previewResolvers[0]?.()
+    await cancelPromise
+
+    expect(order).toEqual(['preview:start', 'preview:end', 'preview:8'])
+    expect(provider.session?.draft.transform).toEqual({ blur: 8 })
+    expect(baselineClient.syncScene).not.toHaveBeenCalled()
+  })
+
+  it('取消回滚后显式预览 rollback transform 不依赖额外 runtime 字段去重', async () => {
+    useEditSettingsStore().autoApplyEffectEditorChanges = false
+
+    const baselineClient = createUnavailableBaselineClient()
+    const provider = createProvider({ baselineClient })
+
+    await provider.open(createOpenTarget({
+      baseSentence: createBaseSentence('{"blur":8}'),
+    }))
+    vi.mocked(baselineClient.syncScene).mockClear()
+
+    provider.updateDraft({ transform: { blur: 12 } })
+    provider.requestPreview({ schedule: 'immediate' })
+    await vi.waitFor(() => {
+      expect(debugCommanderMock.setEffect).toHaveBeenCalledTimes(1)
+    })
+
+    await provider.cancelPreview()
+    debugCommanderMock.setEffect.mockClear()
+
+    provider.requestPreview({ schedule: 'immediate' })
+
+    await vi.waitFor(() => {
+      expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', { blur: 12 }, {
+        phase: 'preview',
+      })
+    })
+  })
+
+  it('关闭已接管回滚时交互取消不会额外发送 restore preview', async () => {
+    useEditSettingsStore().autoApplyEffectEditorChanges = false
+
+    const order: string[] = []
+    const previewResolvers: (() => void)[] = []
+    const baselineClient = createUnavailableBaselineClient()
+    const provider = createProvider({ baselineClient })
+
+    debugCommanderMock.setEffect.mockImplementation(async (_target, transform, options) => {
+      if (options?.phase === 'preview' && transform.blur === 12) {
+        order.push('preview:start')
+        await new Promise<void>((resolve) => {
+          previewResolvers.push(resolve)
+        })
+        order.push('preview:end')
+        return
+      }
+
+      order.push(`${options?.phase}:${transform.blur}`)
+    })
+    vi.mocked(baselineClient.syncScene).mockImplementation(async () => {
+      order.push('sync')
+    })
+
+    await provider.open(createOpenTarget({
+      baseSentence: createBaseSentence('{"blur":8}'),
+    }))
+    await vi.waitFor(() => {
+      expect(baselineClient.syncScene).toHaveBeenCalled()
+    })
+    order.length = 0
+    vi.mocked(baselineClient.syncScene).mockClear()
+
+    provider.updateDraft({ transform: { blur: 12 } })
+    provider.requestPreview({ schedule: 'immediate' })
+    await vi.waitFor(() => {
+      expect(order).toEqual(['preview:start'])
+    })
+
+    const closePromise = provider.close({ forceDiscard: true })
+    const cancelPromise = provider.cancelPreview()
+    await Promise.resolve()
+
+    previewResolvers[0]?.()
+    await Promise.all([closePromise, cancelPromise])
+
+    expect(order).toEqual(['preview:start', 'preview:end', 'preview:8'])
+    expect(baselineClient.syncScene).not.toHaveBeenCalled()
   })
 
   it('关闭并丢弃仅修改时长的草稿不会发送效果预览重置', async () => {
     useEditSettingsStore().autoApplyEffectEditorChanges = false
 
-    const provider = createEffectEditorProvider()
+    const provider = createProvider()
 
-    await provider.open({
+    await provider.open(createOpenTarget({
       baseSentence: createBaseSentence('{"blur":8}'),
-      effectTarget: 'fig-center',
-      onApply() { /* no-op */ },
-    })
+    }))
 
     provider.updateDraft({ duration: '300' })
 
@@ -392,21 +1973,19 @@ describe('useEffectEditorProvider', () => {
     expect(debugCommanderMock.setEffect).not.toHaveBeenCalled()
   })
 
-  it('autoApplyQueued 在提交未完成时可串行消费后续草稿', async () => {
+  it('自动应用提交未完成时可串行消费后续草稿', async () => {
     const applyCalls: EffectEditorDraft[] = []
     const resolvers: (() => void)[] = []
-    const provider = createEffectEditorProvider()
+    const provider = createProvider()
 
-    await provider.open({
-      baseSentence: createBaseSentence(),
-      effectTarget: 'fig-center',
+    await provider.open(createOpenTarget({
       onApply(result) {
         applyCalls.push(cloneDraft(result))
         return new Promise<void>((resolve) => {
           resolvers.push(resolve)
         })
       },
-    })
+    }))
 
     provider.updateDraft({ duration: '100' })
     await vi.waitFor(() => {
@@ -427,30 +2006,31 @@ describe('useEffectEditorProvider', () => {
     })
   })
 
-  it('autoApplyQueued 与 previewQueued 交错时保持最终一致性', async () => {
+  it('自动应用与普通预览请求交错时只通过 commit 收敛运行时状态', async () => {
     const applyCalls: EffectEditorDraft[] = []
     const applyResolvers: (() => void)[] = []
-    const previewCalls: Transform[] = []
-    const previewResolvers: (() => void)[] = []
-    const provider = createEffectEditorProvider()
+    const runtimeCalls: { phase: SetEffectPhase | undefined, transform: Transform }[] = []
+    const runtimeResolvers: (() => void)[] = []
+    const provider = createProvider()
 
-    debugCommanderMock.setEffect.mockImplementation(async (_target, transform) => {
-      previewCalls.push(structuredClone(transform))
+    debugCommanderMock.setEffect.mockImplementation(async (_target, transform, options) => {
+      runtimeCalls.push({
+        phase: options?.phase,
+        transform: structuredClone(transform),
+      })
       await new Promise<void>((resolve) => {
-        previewResolvers.push(resolve)
+        runtimeResolvers.push(resolve)
       })
     })
 
-    await provider.open({
-      baseSentence: createBaseSentence(),
-      effectTarget: 'fig-center',
+    await provider.open(createOpenTarget({
       onApply(result) {
         applyCalls.push(cloneDraft(result))
         return new Promise<void>((resolve) => {
           applyResolvers.push(resolve)
         })
       },
-    })
+    }))
 
     provider.updateDraft({
       duration: '100',
@@ -458,29 +2038,45 @@ describe('useEffectEditorProvider', () => {
     })
     provider.requestPreview({ schedule: 'immediate' })
     await vi.waitFor(() => {
-      expect(applyCalls.length).toBe(1)
-      expect(previewCalls.length).toBe(1)
+      expect(runtimeCalls.length).toBe(1)
     })
+    expect(runtimeCalls[0]).toEqual({
+      phase: 'commit',
+      transform: { alpha: 0.2 },
+    })
+    expect(applyCalls).toHaveLength(0)
 
     provider.updateDraft({
       duration: '200',
       transform: { alpha: 0.8 },
     })
     provider.requestPreview({ schedule: 'immediate' })
-    expect(applyCalls.length).toBe(1)
-    expect(previewCalls.length).toBe(1)
+    expect(applyCalls).toHaveLength(0)
+    expect(runtimeCalls.length).toBe(1)
+
+    runtimeResolvers[0]?.()
+    await vi.waitFor(() => {
+      expect(applyCalls.length).toBe(1)
+      expect(applyCalls.at(-1)?.duration).toBe('100')
+    })
 
     applyResolvers[0]?.()
-    previewResolvers[0]?.()
+    await vi.waitFor(() => {
+      expect(runtimeCalls.length).toBe(2)
+    })
+    expect(runtimeCalls[1]).toEqual({
+      phase: 'commit',
+      transform: { alpha: 0.8 },
+    })
+
+    runtimeResolvers[1]?.()
     await vi.waitFor(() => {
       expect(applyCalls.length).toBe(2)
-      expect(previewCalls.length).toBe(2)
       expect(applyCalls.at(-1)?.duration).toBe('200')
-      expect(previewCalls.at(-1)?.alpha).toBe(0.8)
+      expect(runtimeCalls.at(-1)?.transform.alpha).toBe(0.8)
     })
 
     applyResolvers[1]?.()
-    previewResolvers[1]?.()
     await vi.waitFor(() => {
       expect(provider.canApply).toBe(false)
     })
@@ -491,18 +2087,20 @@ describe('useEffectEditorProvider', () => {
 
     const provider = createEffectEditorProvider()
 
-    await provider.open({
+    await provider.open(createOpenTarget({
       baseSentence: createBaseSentence('{"blur":8}'),
       effectTarget: 'fig-center',
       onApply: vi.fn(),
-    })
+    }))
 
     provider.updateDraft({ transform: { blur: 12 } }, { deferAutoApply: true })
     provider.updateDraft({ transform: { blur: 16 } })
     provider.requestPreview({ schedule: 'immediate', flush: true })
 
     await vi.waitFor(() => {
-      expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', { blur: 16 })
+      expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', { blur: 16 }, {
+        phase: 'commit',
+      })
     })
 
     debugCommanderMock.setEffect.mockClear()
@@ -511,7 +2109,9 @@ describe('useEffectEditorProvider', () => {
     expect(provider.session?.draft.transform).toEqual({ blur: 8 })
 
     await vi.waitFor(() => {
-      expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', { blur: 8 })
+      expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', { blur: 8 }, {
+        phase: 'preview',
+      })
     })
 
     debugCommanderMock.setEffect.mockClear()
@@ -520,8 +2120,115 @@ describe('useEffectEditorProvider', () => {
     expect(provider.session?.draft.transform).toEqual({ blur: 16 })
 
     await vi.waitFor(() => {
-      expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', { blur: 16 })
+      expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', { blur: 16 }, {
+        phase: 'preview',
+      })
     })
+  })
+
+  it('自动应用开启时 undo 和 redo 会先同步 preview 再自动提交', async () => {
+    const applyCalls: EffectEditorDraft[] = []
+    const provider = createEffectEditorProvider()
+
+    await provider.open(createOpenTarget({
+      baseSentence: createBaseSentence('{"blur":8}'),
+      effectTarget: 'fig-center',
+      onApply(result) {
+        applyCalls.push(cloneDraft(result))
+      },
+    }))
+
+    provider.updateDraft({ transform: { blur: 12 } }, { deferAutoApply: true })
+    provider.updateDraft({ transform: { blur: 16 } })
+    provider.requestPreview({ schedule: 'immediate', flush: true })
+
+    await vi.waitFor(() => {
+      expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', { blur: 16 }, {
+        phase: 'commit',
+      })
+    })
+
+    debugCommanderMock.setEffect.mockClear()
+
+    expect(provider.undoDraft()).toBe(true)
+    expect(provider.session?.draft.transform).toEqual({ blur: 8 })
+
+    await vi.waitFor(() => {
+      expect(debugCommanderMock.setEffect).toHaveBeenNthCalledWith(1, 'fig-center', { blur: 8 }, {
+        phase: 'preview',
+      })
+    })
+    await vi.waitFor(() => {
+      expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', { blur: 8 }, {
+        phase: 'commit',
+      })
+    })
+    await vi.waitFor(() => {
+      expect(applyCalls.at(-1)?.transform).toEqual({ blur: 8 })
+    })
+
+    debugCommanderMock.setEffect.mockClear()
+
+    expect(provider.redoDraft()).toBe(true)
+    expect(provider.session?.draft.transform).toEqual({ blur: 16 })
+
+    await vi.waitFor(() => {
+      expect(debugCommanderMock.setEffect).toHaveBeenNthCalledWith(1, 'fig-center', { blur: 16 }, {
+        phase: 'preview',
+      })
+    })
+    await vi.waitFor(() => {
+      expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', { blur: 16 }, {
+        phase: 'commit',
+      })
+    })
+    await vi.waitFor(() => {
+      expect(applyCalls.at(-1)?.transform).toEqual({ blur: 16 })
+    })
+  })
+
+  it('自动应用开启时 undo preview 失败不会自动升级为 commit', async () => {
+    const applyCalls: EffectEditorDraft[] = []
+    const provider = createEffectEditorProvider()
+
+    await provider.open(createOpenTarget({
+      baseSentence: createBaseSentence('{"blur":8}'),
+      effectTarget: 'fig-center',
+      onApply(result) {
+        applyCalls.push(cloneDraft(result))
+      },
+    }))
+
+    provider.updateDraft({ transform: { blur: 12 } }, { deferAutoApply: true })
+    provider.updateDraft({ transform: { blur: 16 } })
+    provider.requestPreview({ schedule: 'immediate', flush: true })
+
+    await vi.waitFor(() => {
+      expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', { blur: 16 }, {
+        phase: 'commit',
+      })
+    })
+
+    debugCommanderMock.setEffect.mockImplementation(async (_target, _transform, options) => {
+      if (options?.phase === 'preview') {
+        throw new Error('preview failed')
+      }
+    })
+    debugCommanderMock.setEffect.mockClear()
+
+    expect(provider.undoDraft()).toBe(true)
+
+    await vi.waitFor(() => {
+      expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', { blur: 8 }, {
+        phase: 'preview',
+      })
+    })
+    await Promise.resolve()
+
+    expect(debugCommanderMock.setEffect).not.toHaveBeenCalledWith('fig-center', { blur: 8 }, {
+      phase: 'commit',
+    })
+    expect(applyCalls.at(-1)?.transform).toEqual({ blur: 16 })
   })
 
   it('复制和粘贴当前效果时会克隆完整草稿并记录本地历史', async () => {
@@ -529,11 +2236,11 @@ describe('useEffectEditorProvider', () => {
 
     const provider = createEffectEditorProvider()
 
-    await provider.open({
+    await provider.open(createOpenTarget({
       baseSentence: createBaseSentence('{"blur":8}'),
       effectTarget: 'fig-center',
       onApply: vi.fn(),
-    })
+    }))
 
     provider.updateDraft({
       duration: '300',
@@ -554,6 +2261,64 @@ describe('useEffectEditorProvider', () => {
       duration: '300',
       ease: 'easeInOut',
       transform: { alpha: 0.5, blur: 12 },
+    })
+  })
+
+  it('自动应用开启时 paste 会先同步 preview 再自动提交', async () => {
+    const applyCalls: EffectEditorDraft[] = []
+    const provider = createEffectEditorProvider()
+
+    await provider.open(createOpenTarget({
+      baseSentence: createBaseSentence('{"blur":8}'),
+      effectTarget: 'fig-center',
+      onApply(result) {
+        applyCalls.push(cloneDraft(result))
+      },
+    }))
+
+    provider.updateDraft({
+      duration: '300',
+      ease: 'easeInOut',
+      transform: { alpha: 0.5, blur: 12 },
+    })
+
+    await vi.waitFor(() => {
+      expect(applyCalls.at(-1)?.transform).toEqual({ alpha: 0.5, blur: 12 })
+    })
+
+    expect(provider.copyCurrentEffect()).toBe(true)
+
+    provider.updateDraft({
+      duration: '100',
+      ease: '',
+      transform: { blur: 2 },
+    })
+
+    await vi.waitFor(() => {
+      expect(applyCalls.at(-1)?.transform).toEqual({ blur: 2 })
+    })
+
+    debugCommanderMock.setEffect.mockClear()
+
+    expect(provider.pasteCurrentEffect()).toBe(true)
+    expect(provider.session?.draft).toEqual({
+      duration: '300',
+      ease: 'easeInOut',
+      transform: { alpha: 0.5, blur: 12 },
+    })
+
+    await vi.waitFor(() => {
+      expect(debugCommanderMock.setEffect).toHaveBeenNthCalledWith(1, 'fig-center', { alpha: 0.5, blur: 12 }, {
+        phase: 'preview',
+      })
+    })
+    await vi.waitFor(() => {
+      expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', { alpha: 0.5, blur: 12 }, {
+        phase: 'commit',
+      })
+    })
+    await vi.waitFor(() => {
+      expect(applyCalls.at(-1)?.transform).toEqual({ alpha: 0.5, blur: 12 })
     })
   })
 })

--- a/src/features/editor/effect-editor/__tests__/useEffectEditorProvider-queue.test.ts
+++ b/src/features/editor/effect-editor/__tests__/useEffectEditorProvider-queue.test.ts
@@ -33,6 +33,7 @@ const previewSyncStoreMock = vi.hoisted(() => ({
 
 const loggerWarnMock = vi.hoisted(() => vi.fn())
 const loggerErrorMock = vi.hoisted(() => vi.fn())
+const notifyWarningMock = vi.hoisted(() => vi.fn())
 const modalOpenMock = vi.hoisted(() => vi.fn((
   _name: string,
   payload: { onApply?: () => void, onDiscard?: () => void, onCancel?: () => void },
@@ -57,6 +58,12 @@ vi.mock('~/stores/modal', () => ({
 vi.mock('@tauri-apps/plugin-log', () => ({
   error: loggerErrorMock,
   warn: loggerWarnMock,
+}))
+
+vi.mock('notivue', () => ({
+  push: {
+    warning: notifyWarningMock,
+  },
 }))
 
 function createBaseSentence(transformJson: string = ''): ISentence {
@@ -270,6 +277,7 @@ beforeEach(() => {
   previewSyncStoreMock.isPreviewReady = true
   loggerWarnMock.mockReset()
   loggerErrorMock.mockReset()
+  notifyWarningMock.mockReset()
   previewSyncStoreMock.queryBaseTransform.mockImplementation(async () => ({ status: 'unavailable' }))
   previewSyncStoreMock.queryTransformBaseline.mockImplementation(async () => ({ status: 'unavailable' }))
 })
@@ -1406,6 +1414,39 @@ describe('useEffectEditorProvider', () => {
     expect(provider.session?.draft.transform).toEqual({ blur: 12 })
   })
 
+  it('commit accepted 状态未知后关闭会提示运行时预览未同步', async () => {
+    useEditSettingsStore().autoApplyEffectEditorChanges = false
+
+    const provider = createProvider()
+
+    debugCommanderMock.setEffect.mockImplementation(async (_target, _transform, options) => {
+      if (options?.phase === 'commit') {
+        throw new Error('preview state reset')
+      }
+    })
+
+    await provider.open(createOpenTarget({
+      baseSentence: createBaseSentence('{"blur":8}'),
+    }))
+
+    provider.updateDraft({ transform: { blur: 12 } })
+    expect(await provider.apply()).toBe(false)
+
+    const closed = await provider.close()
+
+    expect(closed).toBe(false)
+    expect(provider.isOpen).toBe(true)
+    expect(notifyWarningMock).toHaveBeenCalledWith({
+      message: 'modals.effectEditor.previewUnsyncedCloseBlockedMessage',
+      title: 'modals.effectEditor.previewUnsyncedCloseBlockedTitle',
+    })
+
+    const forceClosed = await provider.close({ forceDiscard: true })
+
+    expect(forceClosed).toBe(true)
+    expect(provider.isOpen).toBe(false)
+  })
+
   it('commit 普通 timeout 后允许继续预览并基于最新草稿再次应用', async () => {
     useEditSettingsStore().autoApplyEffectEditorChanges = false
 
@@ -1506,11 +1547,11 @@ describe('useEffectEditorProvider', () => {
     })
   })
 
-  it('commit accepted 状态未知后重新打开会废弃旧 preview session 并创建新 session', async () => {
+  it('commit accepted 状态未知且有未保存草稿时重新打开不会废弃旧 session', async () => {
     useEditSettingsStore().autoApplyEffectEditorChanges = false
 
     const provider = createProvider()
-    let failCommit = true
+    const failCommit = true
 
     debugCommanderMock.setEffect.mockImplementation(async (_target, _transform, options) => {
       if (options?.phase === 'commit' && failCommit) {
@@ -1525,7 +1566,8 @@ describe('useEffectEditorProvider', () => {
     provider.updateDraft({ transform: { blur: 12 } })
     expect(await provider.apply()).toBe(false)
 
-    failCommit = false
+    const previousSessionId = provider.session?.sessionId
+    notifyWarningMock.mockClear()
     debugCommanderMock.setEffect.mockClear()
 
     const opened = await provider.open(createOpenTarget({
@@ -1533,18 +1575,14 @@ describe('useEffectEditorProvider', () => {
       effectTarget: 'fig-right',
     }))
 
-    expect(opened).toBe(true)
+    expect(opened).toBe(false)
     expect(provider.isOpen).toBe(true)
-    expect(provider.session?.effectTarget).toBe('fig-right')
-    expect(provider.session?.draft.transform).toEqual({ blur: 4 })
-
-    provider.updateDraft({ transform: { blur: 6 } }, { deferAutoApply: true })
-    provider.requestPreview({ schedule: 'immediate' })
-
-    await vi.waitFor(() => {
-      expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-right', { blur: 6 }, {
-        phase: 'preview',
-      })
+    expect(provider.session?.sessionId).toBe(previousSessionId)
+    expect(provider.session?.effectTarget).toBe('fig-center')
+    expect(provider.session?.draft.transform).toEqual({ blur: 12 })
+    expect(notifyWarningMock).toHaveBeenCalledWith({
+      message: 'modals.effectEditor.previewUnsyncedCloseBlockedMessage',
+      title: 'modals.effectEditor.previewUnsyncedCloseBlockedTitle',
     })
   })
 

--- a/src/features/editor/effect-editor/__tests__/useStatementEffectEditorBridge.test.ts
+++ b/src/features/editor/effect-editor/__tests__/useStatementEffectEditorBridge.test.ts
@@ -185,4 +185,43 @@ describe('useStatementEffectEditorBridge', () => {
       sentenceId: 42,
     }))
   })
+
+  it('视觉模式打开非当前选中语句时会从语句列表计算行号', () => {
+    computeLineNumberFromStatementIdMock.mockReturnValue(7)
+    const parsed = createSentence({
+      command: commandType.changeFigure,
+      content: 'hero.png',
+    })
+    const statements = [
+      { id: 1, rawText: 'say:first;' },
+      { id: 2, rawText: 'changeFigure:hero.png;' },
+    ]
+
+    useEditorStoreMock.mockReturnValue({
+      currentSceneSelection: {
+        lastLineNumber: 42,
+        selectedStatementId: 1,
+      },
+      currentState: {
+        kind: 'scene',
+        path: 'scene/start.txt',
+        projection: 'visual',
+        statements,
+      },
+    })
+
+    const bridge = createApp({}).runWithContext(() => useStatementEffectEditorBridge({
+      parsed,
+      updateTarget: createStatementIdTarget(2),
+      emitUpdate() { /* no-op */ },
+    }))
+
+    bridge.openEffectEditor()
+
+    expect(computeLineNumberFromStatementIdMock).toHaveBeenCalledWith(statements, 2)
+    expect(effectEditorOpenMock).toHaveBeenCalledWith(expect.objectContaining({
+      scenePath: 'scene/start.txt',
+      sentenceId: 7,
+    }))
+  })
 })

--- a/src/features/editor/effect-editor/__tests__/useStatementEffectEditorBridge.test.ts
+++ b/src/features/editor/effect-editor/__tests__/useStatementEffectEditorBridge.test.ts
@@ -1,14 +1,51 @@
 import '~/__tests__/mocks/modal-store'
 
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { commandType } from 'webgal-parser/src/interface/sceneInterface'
 
 import { createSentence } from '~/features/editor/__tests__/statement-editor-test-utils'
 import { serializeTransform } from '~/features/editor/effect-editor/effect-editor-config'
 import { applyEffectEditorResultToSentence } from '~/features/editor/effect-editor/effect-editor-result'
+import { useStatementEffectEditorBridge } from '~/features/editor/effect-editor/useStatementEffectEditorBridge'
+import { createStatementIdTarget } from '~/features/editor/statement-editor/useStatementEditor'
+
+const {
+  computeLineNumberFromStatementIdMock,
+  effectEditorOpenMock,
+  useEditorStoreMock,
+  useInjectedEffectEditorProviderMock,
+} = vi.hoisted(() => ({
+  computeLineNumberFromStatementIdMock: vi.fn(() => 2),
+  effectEditorOpenMock: vi.fn(async () => true),
+  useEditorStoreMock: vi.fn(),
+  useInjectedEffectEditorProviderMock: vi.fn(),
+}))
+
+vi.mock('~/domain/document/scene-selection', () => ({
+  computeLineNumberFromStatementId: computeLineNumberFromStatementIdMock,
+}))
+
+vi.mock('~/features/editor/effect-editor/useEffectEditorProvider', () => ({
+  useInjectedEffectEditorProvider: useInjectedEffectEditorProviderMock,
+}))
+
+vi.mock('~/stores/editor', () => ({
+  isEditableEditor: (state: { projection?: unknown }) => 'projection' in state,
+  useEditorStore: useEditorStoreMock,
+}))
+
+beforeEach(() => {
+  computeLineNumberFromStatementIdMock.mockClear()
+  effectEditorOpenMock.mockClear()
+  useEditorStoreMock.mockReset()
+  useInjectedEffectEditorProviderMock.mockReset()
+  useInjectedEffectEditorProviderMock.mockReturnValue({
+    open: effectEditorOpenMock,
+  })
+})
 
 describe('applyEffectEditorResultToSentence', () => {
-  it('setTransform 命令写入 content 并同步 duration/ease', () => {
+  it('专用变换命令会写入内容并同步时长与缓动', () => {
     const sentence = createSentence({
       command: commandType.setTransform,
       content: '{"alpha":0.2}',
@@ -27,7 +64,7 @@ describe('applyEffectEditorResultToSentence', () => {
     ])
   })
 
-  it('非 setTransform 命令更新 transform 参数并清理空 duration/ease', () => {
+  it('普通命令会更新变换参数并清理空时长与缓动', () => {
     const sentence = createSentence({
       command: commandType.changeFigure,
       content: 'hero.png',
@@ -51,7 +88,7 @@ describe('applyEffectEditorResultToSentence', () => {
     ])
   })
 
-  it('非 setTransform 命令可写入默认值用于重置继承效果', () => {
+  it('普通命令可写入默认值用于重置继承效果', () => {
     const sentence = createSentence({
       command: commandType.changeFigure,
       content: 'hero.png',
@@ -72,7 +109,7 @@ describe('applyEffectEditorResultToSentence', () => {
     ])
   })
 
-  it('非 setTransform 命令在最后一个显式字段被清除后移除 transform 参数', () => {
+  it('普通命令在最后一个显式字段被清除后移除变换参数', () => {
     const sentence = createSentence({
       command: commandType.changeFigure,
       content: 'hero.png',
@@ -93,7 +130,7 @@ describe('applyEffectEditorResultToSentence', () => {
     ])
   })
 
-  it('setTransform 命令在所有显式字段都被清除后写入空 content', () => {
+  it('专用变换命令在所有显式字段都被清除后写入空内容', () => {
     const sentence = createSentence({
       command: commandType.setTransform,
       content: '{"alpha":1}',
@@ -107,5 +144,45 @@ describe('applyEffectEditorResultToSentence', () => {
     })
 
     expect(result.content).toBe('')
+  })
+})
+
+describe('useStatementEffectEditorBridge', () => {
+  it('视觉模式打开当前选中语句时复用已有行号', () => {
+    const parsed = createSentence({
+      command: commandType.changeFigure,
+      content: 'hero.png',
+    })
+    const statements = [
+      { id: 1, rawText: 'say:first;' },
+      { id: 2, rawText: 'changeFigure:hero.png;' },
+    ]
+
+    useEditorStoreMock.mockReturnValue({
+      currentSceneSelection: {
+        lastLineNumber: 42,
+        selectedStatementId: 2,
+      },
+      currentState: {
+        kind: 'scene',
+        path: 'scene/start.txt',
+        projection: 'visual',
+        statements,
+      },
+    })
+
+    const bridge = createApp({}).runWithContext(() => useStatementEffectEditorBridge({
+      parsed,
+      updateTarget: createStatementIdTarget(2),
+      emitUpdate() { /* no-op */ },
+    }))
+
+    bridge.openEffectEditor()
+
+    expect(computeLineNumberFromStatementIdMock).not.toHaveBeenCalled()
+    expect(effectEditorOpenMock).toHaveBeenCalledWith(expect.objectContaining({
+      scenePath: 'scene/start.txt',
+      sentenceId: 42,
+    }))
   })
 })

--- a/src/features/editor/effect-editor/createParamDrag.ts
+++ b/src/features/editor/effect-editor/createParamDrag.ts
@@ -11,6 +11,7 @@ interface ParamDragCallbacks<P, S> {
   onStart: (event: ImmediatePointerDragEvent, param: P) => S | undefined
   onMove: (event: ImmediatePointerDragEvent, state: S & { param: P }) => void
   onEnd: (event: ImmediatePointerDragEvent | undefined, state: S & { param: P }) => void
+  onCancel?: (state: S & { param: P }) => void
 }
 
 export function createParamDrag<P, S>(callbacks: ParamDragCallbacks<P, S>) {
@@ -31,6 +32,7 @@ export function createParamDrag<P, S>(callbacks: ParamDragCallbacks<P, S>) {
     },
     onMove: callbacks.onMove,
     onEnd: callbacks.onEnd,
+    onCancel: callbacks.onCancel,
   })
 
   function start(event: PointerEvent, param: P) {

--- a/src/features/editor/effect-editor/effect-editor-config.ts
+++ b/src/features/editor/effect-editor/effect-editor-config.ts
@@ -1,8 +1,8 @@
-import { Transform } from '~/domain/stage/types'
 import { EASE } from '~/features/editor/command-registry/common-params'
-import { ChoiceField, ColorField, DialField, I18nLike, UNSPECIFIED } from '~/features/editor/command-registry/schema'
+import { UNSPECIFIED } from '~/features/editor/command-registry/schema'
 
-import type { NumberField } from '~/features/editor/command-registry/schema'
+import type { Transform } from '~/domain/stage/types'
+import type { ChoiceField, ColorField, DialField, I18nLike, NumberField } from '~/features/editor/command-registry/schema'
 
 // ─── 效果编辑器参数类型（基于 FieldDef 子集） ───
 

--- a/src/features/editor/effect-editor/transform-rotation-format.ts
+++ b/src/features/editor/effect-editor/transform-rotation-format.ts
@@ -1,0 +1,16 @@
+import { degreeToRadian, radianToDegree, roundByStep, roundToPrecision } from '~/utils/math'
+
+const EFFECT_ROTATION_DEGREE_STEP = 0.01
+const EFFECT_ROTATION_RADIAN_PRECISION = 4
+
+export function formatEffectRotationDegree(degree: number): number {
+  return roundByStep(degree, EFFECT_ROTATION_DEGREE_STEP)
+}
+
+export function effectRotationDegreeToStoredRadian(degree: number): number {
+  return roundToPrecision(degreeToRadian(formatEffectRotationDegree(degree)), EFFECT_ROTATION_RADIAN_PRECISION)
+}
+
+export function normalizeEffectRotationRadian(radian: number): number {
+  return effectRotationDegreeToStoredRadian(radianToDegree(radian))
+}

--- a/src/features/editor/effect-editor/types.ts
+++ b/src/features/editor/effect-editor/types.ts
@@ -9,7 +9,9 @@ export interface EmitTransformOptions {
 export interface EffectControlDeps {
   getFields: () => Record<string, string>
   getFieldValue: (path: string) => string
+  getStoredFieldValue: (path: string) => string | undefined
   getNumberValue: (path: string, fallback: number) => number
   setNumericField: (fields: Record<string, string>, path: string, value: number) => void
   emitTransform: (fields: Record<string, string>, options: EmitTransformOptions) => void
+  cancelPreview?: () => void | Promise<void>
 }

--- a/src/features/editor/effect-editor/useEffectClearControls.ts
+++ b/src/features/editor/effect-editor/useEffectClearControls.ts
@@ -5,7 +5,7 @@ import type {
 
 export function useEffectClearControls(deps: EffectControlDeps) {
   function canClearPaths(paths: readonly string[]): boolean {
-    return paths.some(path => deps.getFieldValue(path) !== '')
+    return paths.some(path => deps.getStoredFieldValue(path) !== undefined)
   }
 
   function clearPaths(paths: readonly string[], options: EmitTransformOptions): void {

--- a/src/features/editor/effect-editor/useEffectColorControl.ts
+++ b/src/features/editor/effect-editor/useEffectColorControl.ts
@@ -61,6 +61,10 @@ export function useEffectColorControl(deps: EffectControlDeps) {
         deferAutoApply: false,
       })
     },
+    onCancel() {
+      pendingColorFlushValue = undefined
+      void deps.cancelPreview?.()
+    },
   })
 
   function handleColorPickerChange(param: EffectColorField, rawValue: unknown) {

--- a/src/features/editor/effect-editor/useEffectContinuousControls.ts
+++ b/src/features/editor/effect-editor/useEffectContinuousControls.ts
@@ -1,6 +1,10 @@
 import { createParamDrag } from '~/features/editor/effect-editor/createParamDrag'
+import {
+  effectRotationDegreeToStoredRadian,
+  formatEffectRotationDegree,
+} from '~/features/editor/effect-editor/transform-rotation-format'
 import { usePreferenceStore } from '~/stores/preference'
-import { applyScrubStepModifier, clamp, degreeToRadian, getPointerAngleDegrees, normalizeAngleDelta, normalizeDegree, radianToDegree, roundByStep, roundToPrecision } from '~/utils/math'
+import { applyScrubStepModifier, clamp, getPointerAngleDegrees, normalizeAngleDelta, normalizeDegree, radianToDegree, roundByStep } from '~/utils/math'
 
 import type { ImmediatePointerDragEvent } from '~/composables/useImmediatePointerDrag'
 import type { DialField, NumberField } from '~/features/editor/command-registry/schema'
@@ -15,8 +19,6 @@ type LinkedNumberField = NumberField & { linkedPairKey: string }
 const SLIDER_CENTER_SNAP_TOLERANCE = 0.02
 // 按住 Shift 时旋钮的角度吸附步进（每 15 度）
 const DIAL_DEGREE_SNAP = 15
-// 弧度值存储精度（4 位小数，约 0.006 度误差）
-const RADIAN_STORAGE_PRECISION = 4
 
 function createContinuousTransformOptions(flush?: boolean): EmitTransformOptions {
   return { schedule: 'continuous', flush, deferAutoApply: !flush }
@@ -73,6 +75,11 @@ export function useEffectContinuousControls(deps: EffectControlDeps) {
       pendingContinuousTransformFrameId = undefined
     }
     pendingContinuousTransformEmit = undefined
+  }
+
+  function cancelCurrentPreviewInteraction() {
+    cancelScheduledContinuousTransformEmit()
+    void deps.cancelPreview?.()
   }
 
   function emitContinuousTransform(
@@ -247,6 +254,9 @@ export function useEffectContinuousControls(deps: EffectControlDeps) {
     onEnd(_event, state) {
       updateNumberFieldValue(state.param, String(state.lastValue), { flush: true, clampValue: true })
     },
+    onCancel() {
+      cancelCurrentPreviewInteraction()
+    },
   })
 
   function handleNumberLabelPointerDown(event: PointerEvent, param: NumberField) {
@@ -268,7 +278,7 @@ export function useEffectContinuousControls(deps: EffectControlDeps) {
   }
 
   function getStoredFieldValue(path: string): string | undefined {
-    const value = deps.getFieldValue(path)
+    const value = deps.getStoredFieldValue(path)
     return value === '' ? undefined : value
   }
 
@@ -461,9 +471,9 @@ export function useEffectContinuousControls(deps: EffectControlDeps) {
 
   function dialDegreeToStoreValue(param: DialField, degree: number): number {
     if (param.dialUnit === 'deg') {
-      return degree
+      return formatEffectRotationDegree(degree)
     }
-    return roundToPrecision(degreeToRadian(degree), RADIAN_STORAGE_PRECISION)
+    return effectRotationDegreeToStoredRadian(degree)
   }
 
   function getDialDegree(param: DialField): number {
@@ -476,7 +486,7 @@ export function useEffectContinuousControls(deps: EffectControlDeps) {
   }
 
   function getDialInputValue(param: DialField): string {
-    return String(roundByStep(getDialDegree(param), 0.01))
+    return String(formatEffectRotationDegree(getDialDegree(param)))
   }
 
   function applyDialSnap(value: number, shiftKey: boolean): number {
@@ -543,7 +553,7 @@ export function useEffectContinuousControls(deps: EffectControlDeps) {
       const pointerAngle = getPointerAngleDegrees(event, state.centerX, state.centerY)
       const deltaAngle = normalizeAngleDelta(pointerAngle - state.lastPointerAngle)
       const rawDegree = state.rawDegree + deltaAngle
-      const snappedDegree = roundByStep(applyDialSnap(rawDegree, event.shiftKey), 0.01)
+      const snappedDegree = formatEffectRotationDegree(applyDialSnap(rawDegree, event.shiftKey))
 
       state.lastPointerAngle = pointerAngle
       state.rawDegree = rawDegree
@@ -556,6 +566,9 @@ export function useEffectContinuousControls(deps: EffectControlDeps) {
     },
     onEnd(_event, state) {
       updateDialField(state.param, String(state.lastDegree), { flush: true })
+    },
+    onCancel() {
+      cancelCurrentPreviewInteraction()
     },
   })
 

--- a/src/features/editor/effect-editor/useEffectEditorProvider.ts
+++ b/src/features/editor/effect-editor/useEffectEditorProvider.ts
@@ -167,6 +167,7 @@ function needsPreviewBaselineReset(
 export function createEffectEditorProvider(options: CreateEffectEditorProviderOptions = {}) {
   const editSettings = useEditSettingsStore()
   const previewSyncStore = usePreviewSyncStore()
+  const { t } = useI18n()
   const baselineClient = options.baselineClient ?? {
     queryBaseTransform: previewSyncStore.queryBaseTransform,
     queryTransformBaseline: previewSyncStore.queryTransformBaseline,
@@ -261,7 +262,11 @@ export function createEffectEditorProvider(options: CreateEffectEditorProviderOp
       return
     }
 
-    logger.warn('效果编辑器运行时预览状态未同步，请先重试应用或重新打开效果编辑器')
+    logger.warn('效果编辑器运行时预览状态未同步，请重新选择目标行，或显式丢弃后重新打开效果编辑器')
+    notify.warning({
+      title: t('modals.effectEditor.previewUnsyncedCloseBlockedTitle'),
+      message: t('modals.effectEditor.previewUnsyncedCloseBlockedMessage'),
+    })
     previewSyncStateWarned = true
   }
 
@@ -1023,6 +1028,10 @@ export function createEffectEditorProvider(options: CreateEffectEditorProviderOp
       clearDraftHistory()
       return true
     }
+    if (isPreviewTerminalUnsynced() && options.forceDiscard) {
+      discardPreviewSession()
+      return true
+    }
     if (isPreviewTerminalUnsynced()) {
       warnPreviewTerminalUnsynced()
       return false
@@ -1133,7 +1142,7 @@ export function createEffectEditorProvider(options: CreateEffectEditorProviderOp
 
   async function open(target: EffectEditorOpenTarget): Promise<boolean> {
     if (isOpen) {
-      if (isPreviewTerminalUnsynced()) {
+      if (isPreviewTerminalUnsynced() && !session?.dirty) {
         discardPreviewSession()
       } else {
         const closed = await close()

--- a/src/features/editor/effect-editor/useEffectEditorProvider.ts
+++ b/src/features/editor/effect-editor/useEffectEditorProvider.ts
@@ -1,17 +1,22 @@
 import { commandType } from 'webgal-parser/src/interface/sceneInterface'
 
 import { readSentenceArgString } from '~/domain/script/sentence'
-import { Transform } from '~/domain/stage/types'
-import { fieldsToTransform, isTransformEqual, parseTransformJson, transformToFields } from '~/features/editor/effect-editor/effect-editor-config'
-import { EmitTransformOptions } from '~/features/editor/effect-editor/types'
+import { serializeSentence } from '~/domain/script/serialize'
+import { fieldsToTransform, isTransformEqual, parseTransformJson } from '~/features/editor/effect-editor/effect-editor-config'
+import { resolveTransformBaselineSession } from '~/features/editor/transform-resolution/baseline-session'
 import { debugCommander } from '~/services/debug-commander'
 import { useEditSettingsStore } from '~/stores/edit-settings'
 import { useModalStore } from '~/stores/modal'
+import { usePreviewSyncStore } from '~/stores/preview-sync'
 import { createAsyncQueue } from '~/utils/async-queue'
 
 import type { ISentence } from 'webgal-parser/src/interface/sceneInterface'
+import type { Transform } from '~/domain/stage/types'
+import type { EmitTransformOptions } from '~/features/editor/effect-editor/types'
+import type { TransformBaselineSessionClient } from '~/features/editor/transform-resolution/baseline-session'
+import type { TransformBaselineSource } from '~/features/editor/transform-resolution/model'
 
-export type EffectEditorPreviewSchedule = 'continuous' | 'color' | 'immediate'
+export type EffectEditorPreviewSchedule = 'continuous' | 'color' | 'frame' | 'immediate'
 
 export interface EffectEditorPreviewPayload {
   schedule: EffectEditorPreviewSchedule
@@ -30,15 +35,23 @@ export interface EffectEditorDraft {
   ease: string
 }
 
+type EffectEditorPreviewTransform = Transform | (() => Transform)
+
 export interface EffectEditorOpenTarget {
   baseSentence: ISentence
   effectTarget?: string
+  scenePath: string
+  sentenceId: number
   onApply: (result: EffectEditorDraft) => void | Promise<void>
 }
 
 export interface EffectEditorSession {
   sessionId: number
+  command: commandType
   effectTarget: string
+  scenePath: string
+  sentenceId: number
+  lineCommandString: string
   draft: EffectEditorDraft
   /** 打开编辑器时的初始草稿快照，用于"重置"操作的目标 */
   initialDraft: EffectEditorDraft
@@ -47,9 +60,15 @@ export interface EffectEditorSession {
   dirty: boolean
   hasApplied: boolean
   missingTargetWarned: boolean
-  previewErrorWarned: boolean
-  previewedTransformFields: Record<string, string>
+  baselineResolved: boolean
+  baselineSource: TransformBaselineSource
+  baselineTransform?: Transform
+  writeDefault: boolean
   onApply: (result: EffectEditorDraft) => void | Promise<void>
+}
+
+interface CreateEffectEditorProviderOptions {
+  baselineClient?: TransformBaselineSessionClient
 }
 
 interface EffectPreviewEmitterOptions {
@@ -59,6 +78,18 @@ interface EffectPreviewEmitterOptions {
 
 const EFFECT_EDITOR_PROVIDER_KEY: InjectionKey<ReturnType<typeof createEffectEditorProvider>> = Symbol('effect-editor-provider')
 type EffectEditorCloseAction = 'save' | 'discard' | 'cancel'
+type EffectPreviewRequestKind = 'preview' | 'commit' | 'restore'
+type PreviewRuntimeSyncState = 'ready' | 'terminal-unsynced'
+const CONTINUOUS_PREVIEW_THROTTLE_MS = 40
+
+interface EffectPreviewOwnerRequest {
+  draftSnapshot: EffectEditorDraft
+  errorMessage: string
+  kind: EffectPreviewRequestKind
+  resolve: (accepted: boolean) => void
+  sessionId: number
+  target: string
+}
 
 function cloneTransform(transform: Transform): Transform {
   return structuredClone(toRaw(transform))
@@ -115,54 +146,83 @@ function resolveEffectTarget(target: EffectEditorOpenTarget): string {
   return target.effectTarget?.trim() || readSentenceArgString(target.baseSentence, 'target').trim()
 }
 
+function resolveWriteDefault(sentence: ISentence): boolean {
+  return sentence.args.some(arg => arg.key === 'writeDefault' && arg.value === true)
+}
+
 function isDraftEqual(left: EffectEditorDraft, right: EffectEditorDraft): boolean {
   return left.duration === right.duration
     && left.ease === right.ease
     && isTransformEqual(left.transform, right.transform)
 }
 
-function areTransformFieldsEqual(
-  left: Record<string, string>,
-  right: Record<string, string>,
+function needsPreviewBaselineReset(
+  previousDraft: EffectEditorDraft,
+  nextDraft: EffectEditorDraft,
+  isVisualPreviewDirty: boolean,
 ): boolean {
-  const leftKeys = Object.keys(left)
-  const rightKeys = Object.keys(right)
-  if (leftKeys.length !== rightKeys.length) {
-    return false
-  }
-
-  return leftKeys.every(key => left[key] === right[key])
+  return isVisualPreviewDirty || !isTransformEqual(previousDraft.transform, nextDraft.transform)
 }
 
-function hasPreviewTransformChanged(session: EffectEditorSession): boolean {
-  return !areTransformFieldsEqual(
-    session.previewedTransformFields,
-    transformToFields(session.initialDraft.transform),
-  )
-}
-
-function needsPreviewBaselineReset(session: EffectEditorSession): boolean {
-  return hasPreviewTransformChanged(session)
-    || !isTransformEqual(session.draft.transform, session.initialDraft.transform)
-}
-
-export function createEffectEditorProvider() {
+export function createEffectEditorProvider(options: CreateEffectEditorProviderOptions = {}) {
   const editSettings = useEditSettingsStore()
+  const previewSyncStore = usePreviewSyncStore()
+  const baselineClient = options.baselineClient ?? {
+    queryBaseTransform: previewSyncStore.queryBaseTransform,
+    queryTransformBaseline: previewSyncStore.queryTransformBaseline,
+    syncScene: debugCommander.syncScene,
+  }
 
   let isOpen = $ref(false)
   let session = $ref<EffectEditorSession>()
-  let colorPreviewFrameId = $ref<number>()
+  let cancelFramePreview: (() => void) | undefined
+  let cancelBaselineResolution = $ref<(() => void) | undefined>()
   let nextSessionId = $ref(0)
   let draftUndoStack: EffectEditorDraft[] = []
   let draftRedoStack: EffectEditorDraft[] = []
   let pendingDraftHistoryBefore: EffectEditorDraft | undefined
   let effectClipboard: EffectEditorDraft | undefined
+  let previewTransformOverride: EffectEditorPreviewTransform | undefined
+  let previewTask: Promise<void> | undefined
+  let previewRequestQueue: EffectPreviewOwnerRequest[] = []
+  let visualPreviewDirty = false
+  let previewSyncState: PreviewRuntimeSyncState = 'ready'
+  let previewSyncStateWarned = false
+  let continuousPreviewTimerId: ReturnType<typeof setTimeout> | undefined
+  let lastContinuousPreviewAt = 0
+  let isClosing = false
 
-  // 40ms 节流（约 25fps）：平衡实时预览流畅度与 IPC 通信开销。
-  // trailing=true 确保拖拽结束时的最终值一定会触发预览
-  const scheduleContinuousPreview = useThrottleFn(() => {
-    previewQueue.enqueue()
-  }, 40, true, true)
+  function clearContinuousPreviewTimer(): void {
+    if (continuousPreviewTimerId === undefined) {
+      return
+    }
+
+    clearTimeout(continuousPreviewTimerId)
+    continuousPreviewTimerId = undefined
+  }
+
+  function sendContinuousPreviewNow(): void {
+    clearContinuousPreviewTimer()
+    lastContinuousPreviewAt = Date.now()
+    scheduleFramePreviewBoundary()
+  }
+
+  function scheduleContinuousPreview(): void {
+    const elapsed = Date.now() - lastContinuousPreviewAt
+    if (elapsed >= CONTINUOUS_PREVIEW_THROTTLE_MS) {
+      sendContinuousPreviewNow()
+      return
+    }
+
+    if (continuousPreviewTimerId !== undefined) {
+      return
+    }
+
+    continuousPreviewTimerId = setTimeout(() => {
+      continuousPreviewTimerId = undefined
+      sendContinuousPreviewNow()
+    }, CONTINUOUS_PREVIEW_THROTTLE_MS - elapsed)
+  }
 
   function canSendPreview(): boolean {
     return editSettings.enableLivePreview
@@ -173,6 +233,47 @@ export function createEffectEditorProvider() {
     return editSettings.autoApplyEffectEditorChanges
   }
 
+  function shouldCommitRuntimeTransform(draftSnapshot: EffectEditorDraft, baseDraft: EffectEditorDraft): boolean {
+    return visualPreviewDirty || !isTransformEqual(draftSnapshot.transform, baseDraft.transform)
+  }
+
+  function markPreviewTerminalUnsynced(): void {
+    previewSyncState = 'terminal-unsynced'
+    previewSyncStateWarned = false
+  }
+
+  function resetPreviewSyncState(): void {
+    previewSyncState = 'ready'
+    previewSyncStateWarned = false
+  }
+
+  function isPreviewTerminalSyncFailure(error: unknown): boolean {
+    const message = error instanceof Error ? error.message : String(error)
+    return message.includes('preview state reset')
+  }
+
+  function isPreviewTerminalUnsynced(): boolean {
+    return previewSyncState === 'terminal-unsynced'
+  }
+
+  function warnPreviewTerminalUnsynced(): void {
+    if (previewSyncStateWarned) {
+      return
+    }
+
+    logger.warn('效果编辑器运行时预览状态未同步，请先重试应用或重新打开效果编辑器')
+    previewSyncStateWarned = true
+  }
+
+  function ensureCanEditPreviewSession(): boolean {
+    if (!isPreviewTerminalUnsynced()) {
+      return true
+    }
+
+    warnPreviewTerminalUnsynced()
+    return false
+  }
+
   function warnMissingEffectTarget(currentSession: EffectEditorSession): void {
     if (!currentSession.missingTargetWarned) {
       logger.warn('效果编辑器缺少 target，跳过实时预览')
@@ -181,16 +282,23 @@ export function createEffectEditorProvider() {
   }
 
   function cancelScheduledPreview() {
-    if (colorPreviewFrameId !== undefined) {
-      cancelAnimationFrame(colorPreviewFrameId)
-      colorPreviewFrameId = undefined
-    }
+    clearContinuousPreviewTimer()
+    cancelFramePreview?.()
+    cancelFramePreview = undefined
   }
 
   function clearDraftHistory(): void {
     draftUndoStack = []
     draftRedoStack = []
     pendingDraftHistoryBefore = undefined
+  }
+
+  function discardSessionState(): void {
+    previewTransformOverride = undefined
+    session = undefined
+    isOpen = false
+    clearDraftHistory()
+    resetPreviewSyncState()
   }
 
   function pushDraftUndoSnapshot(previousDraft: EffectEditorDraft, nextDraft: EffectEditorDraft): void {
@@ -206,24 +314,64 @@ export function createEffectEditorProvider() {
     draftRedoStack = []
   }
 
-  function applyDraftSnapshot(
-    draftSnapshot: EffectEditorDraft,
-    options: { autoApply?: boolean, preview?: boolean } = {},
-  ): void {
+  function applyDraftSnapshot(draftSnapshot: EffectEditorDraft): void {
     if (!session) {
       return
     }
 
+    previewTransformOverride = undefined
     const nextDraft = cloneDraft(draftSnapshot)
     session.draft = nextDraft
     session.dirty = !isDraftEqual(nextDraft, session.baseDraft)
+  }
 
-    if (options.preview) {
-      requestPreview({ schedule: 'immediate', flush: true })
+  function cancelScheduledBaselineResolution(): void {
+    cancelBaselineResolution?.()
+    cancelBaselineResolution = undefined
+  }
+
+  function scheduleSessionBaselineResolution(
+    currentSessionId: number,
+    target: EffectEditorOpenTarget,
+    lineCommandString: string,
+  ): void {
+    cancelScheduledBaselineResolution()
+
+    const run = () => {
+      cancelBaselineResolution = undefined
+      void resolveSessionBaseline(currentSessionId, target, lineCommandString)
     }
-    if (options.autoApply) {
-      autoApplyQueue.enqueue()
+
+    if (typeof requestAnimationFrame === 'function') {
+      const frameId = requestAnimationFrame(run)
+      cancelBaselineResolution = () => cancelAnimationFrame(frameId)
+      return
     }
+
+    const timeoutId = setTimeout(run, 0)
+    cancelBaselineResolution = () => clearTimeout(timeoutId)
+  }
+
+  function scheduleFramePreviewBoundary(): void {
+    if (cancelFramePreview) {
+      return
+    }
+
+    const run = () => {
+      cancelFramePreview = undefined
+      enqueuePreview()
+    }
+
+    const frameId = requestAnimationFrame(run)
+    cancelFramePreview = () => cancelAnimationFrame(frameId)
+  }
+
+  function requestFramePreview(): void {
+    scheduleFramePreviewBoundary()
+  }
+
+  function requestColorPreview(): void {
+    scheduleFramePreviewBoundary()
   }
 
   async function commitDraft(
@@ -251,6 +399,8 @@ export function createEffectEditorProvider() {
     session.baseDraft = nextBaseDraft
     session.dirty = !isDraftEqual(session.draft, nextBaseDraft)
     session.hasApplied = true
+    visualPreviewDirty = false
+    resetPreviewSyncState()
 
     return true
   }
@@ -260,24 +410,241 @@ export function createEffectEditorProvider() {
       if (!session) {
         return
       }
+      if (isPreviewTerminalUnsynced()) {
+        return
+      }
       const currentSessionId = session.sessionId
+      const currentSession = session
       const draftSnapshot = cloneDraft(session.draft)
       if (!isDraftEqual(draftSnapshot, session.baseDraft)) {
+        if (shouldCommitRuntimeTransform(draftSnapshot, session.baseDraft)) {
+          const runtimeCommitted = await commitPreviewAfterIdle(
+            currentSession,
+            draftSnapshot,
+            '自动应用效果编辑器运行时预览提交失败',
+          )
+          if (!runtimeCommitted) {
+            return
+          }
+        }
+
         await commitDraft(currentSessionId, draftSnapshot, '自动应用效果编辑器变更失败')
       }
     },
     () => !!session && isOpen && canAutoApply(),
   )
 
-  async function sendPreviewNow() {
-    if (!session || !isOpen || !canSendPreview()) {
-      return
+  function discardPreviewSession(): void {
+    autoApplyQueue.cancel()
+    cancelQueuedPreview()
+    cancelScheduledPreview()
+    cancelScheduledBaselineResolution()
+    previewTransformOverride = undefined
+    visualPreviewDirty = false
+    discardSessionState()
+  }
+
+  function discardQueuedPreviewRequests(
+    shouldDiscard: (request: EffectPreviewOwnerRequest) => boolean,
+  ): void {
+    const keptRequests: EffectPreviewOwnerRequest[] = []
+    for (const request of previewRequestQueue) {
+      if (shouldDiscard(request)) {
+        request.resolve(false)
+      } else {
+        keptRequests.push(request)
+      }
+    }
+    previewRequestQueue = keptRequests
+  }
+
+  function resolvePhaseForRequest(kind: EffectPreviewRequestKind) {
+    return kind === 'commit' ? 'commit' : 'preview'
+  }
+
+  function handlePreviewRequestFailure(
+    request: EffectPreviewOwnerRequest,
+    error: unknown,
+  ): void {
+    const currentSession = session
+    if (
+      currentSession?.sessionId === request.sessionId
+      && request.kind !== 'preview'
+      && isPreviewTerminalSyncFailure(error)
+    ) {
+      markPreviewTerminalUnsynced()
+    }
+
+    logger.error(`${request.errorMessage}: ${error}`)
+  }
+
+  async function sendPreviewOwnerRequest(request: EffectPreviewOwnerRequest): Promise<boolean> {
+    const currentSession = session
+    if (!currentSession || currentSession.sessionId !== request.sessionId) {
+      return false
+    }
+    if (isPreviewTerminalUnsynced()) {
+      return false
+    }
+
+    const transformSnapshot = cloneTransform(request.draftSnapshot.transform)
+    const phase = resolvePhaseForRequest(request.kind)
+    if (phase === 'preview') {
+      visualPreviewDirty = true
     }
 
     try {
-      const nextPreviewFields = transformToFields(session.draft.transform)
+      await debugCommander.setEffect(request.target, transformSnapshot, { phase })
+    } catch (error) {
+      handlePreviewRequestFailure(request, error)
+      return false
+    }
 
-      if (areTransformFieldsEqual(session.previewedTransformFields, nextPreviewFields)) {
+    if (request.kind === 'restore') {
+      visualPreviewDirty = false
+      resetPreviewSyncState()
+    } else if (request.kind === 'commit' && session?.sessionId === request.sessionId) {
+      visualPreviewDirty = !isTransformEqual(request.draftSnapshot.transform, session.baseDraft.transform)
+      resetPreviewSyncState()
+    }
+
+    return true
+  }
+
+  async function consumeQueuedPreview(): Promise<void> {
+    while (previewRequestQueue.length > 0) {
+      const request = previewRequestQueue.shift()!
+      // eslint-disable-next-line no-await-in-loop -- 单发送循环 ordering 是协议语义的一部分
+      const accepted = await sendPreviewOwnerRequest(request)
+      request.resolve(accepted)
+      if (!accepted && request.kind !== 'preview' && isPreviewTerminalUnsynced()) {
+        discardQueuedPreviewRequests(() => true)
+        break
+      }
+    }
+  }
+
+  function runPreviewQueue(): Promise<void> {
+    if (previewTask) {
+      return previewTask
+    }
+
+    previewTask = (async () => {
+      try {
+        await consumeQueuedPreview()
+      } finally {
+        previewTask = undefined
+      }
+    })()
+
+    return previewTask
+  }
+
+  function enqueuePreviewOwnerRequest(
+    request: Omit<EffectPreviewOwnerRequest, 'resolve'>,
+  ): Promise<boolean> {
+    return new Promise<boolean>((resolve) => {
+      const nextRequest: EffectPreviewOwnerRequest = {
+        ...request,
+        resolve,
+      }
+
+      if (nextRequest.kind === 'preview') {
+        discardQueuedPreviewRequests(queuedRequest => queuedRequest.kind === 'preview')
+      } else if (nextRequest.kind === 'commit') {
+        discardQueuedPreviewRequests(queuedRequest => queuedRequest.kind === 'preview')
+      } else {
+        discardQueuedPreviewRequests(() => true)
+      }
+
+      previewRequestQueue.push(nextRequest)
+      void runPreviewQueue()
+    })
+  }
+
+  function enqueuePreview(): void {
+    if (!session || !isOpen || !canSendPreview()) {
+      return
+    }
+    if (!ensureCanEditPreviewSession()) {
+      return
+    }
+    if (!session.effectTarget) {
+      warnMissingEffectTarget(session)
+      return
+    }
+
+    void enqueuePreviewOwnerRequest({
+      draftSnapshot: clonePreviewDraftSnapshot(session),
+      errorMessage: '发送效果实时预览失败',
+      kind: 'preview',
+      sessionId: session.sessionId,
+      target: session.effectTarget,
+    })
+  }
+
+  function syncExplicitHistoryDraft(): void {
+    if (!session || !isOpen || !canSendPreview()) {
+      autoApplyQueue.enqueue()
+      return
+    }
+    if (!ensureCanEditPreviewSession()) {
+      autoApplyQueue.enqueue()
+      return
+    }
+    if (!session.effectTarget) {
+      warnMissingEffectTarget(session)
+      autoApplyQueue.enqueue()
+      return
+    }
+
+    void enqueuePreviewOwnerRequest({
+      draftSnapshot: cloneDraft(session.draft),
+      errorMessage: '发送效果历史操作预览失败',
+      kind: 'preview',
+      sessionId: session.sessionId,
+      target: session.effectTarget,
+    }).then((accepted) => {
+      if (accepted) {
+        autoApplyQueue.enqueue()
+      }
+    })
+  }
+
+  async function waitForPreviewIdle(): Promise<void> {
+    while (previewTask) {
+      // eslint-disable-next-line no-await-in-loop -- rollback 必须排在已发送 preview 之后
+      await previewTask
+    }
+  }
+
+  function cancelQueuedPreview(): void {
+    discardQueuedPreviewRequests(() => true)
+  }
+
+  function requestPreview(payload: EffectEditorPreviewPayload) {
+    if (!session || !isOpen) {
+      return
+    }
+    if (!payload.flush && canAutoApply() && pendingDraftHistoryBefore === undefined && !hasPreviewTransformOverride()) {
+      return
+    }
+    if (!canSendPreview()) {
+      return
+    }
+    if (!ensureCanEditPreviewSession()) {
+      return
+    }
+
+    if (payload.flush) {
+      cancelScheduledPreview()
+      if (canAutoApply()) {
+        autoApplyQueue.enqueue()
+        return
+      }
+
+      const draftSnapshot = cloneDraft(session.draft)
+      if (!shouldCommitRuntimeTransform(draftSnapshot, session.baseDraft)) {
         return
       }
 
@@ -286,56 +653,36 @@ export function createEffectEditorProvider() {
         return
       }
 
-      const target = session.effectTarget
-      const transformSnapshot = cloneTransform(session.draft.transform)
-      await debugCommander.setEffect(target, transformSnapshot)
-      session.previewedTransformFields = nextPreviewFields
-      session.previewErrorWarned = false
-    } catch (error) {
-      if (!session.previewErrorWarned) {
-        logger.error(`发送效果实时预览失败: ${error}`)
-        session.previewErrorWarned = true
-      }
-    }
-  }
-
-  const previewQueue = createAsyncQueue(
-    sendPreviewNow,
-    () => !!session && isOpen && canSendPreview(),
-  )
-
-  function requestPreview(payload: EffectEditorPreviewPayload) {
-    if (!session || !isOpen) {
+      void enqueuePreviewOwnerRequest({
+        draftSnapshot,
+        errorMessage: '提交效果编辑器运行时预览失败',
+        kind: 'commit',
+        sessionId: session.sessionId,
+        target: session.effectTarget,
+      })
       return
     }
 
-    if (payload.flush) {
-      cancelScheduledPreview()
-      previewQueue.enqueue()
-      return
-    }
-
-    // 三种预览调度策略：
-    // - immediate: 立即入队（用于离散操作如 segmented 切换）
+    // 预览调度策略：
+    // - immediate: 进入全局帧边界（用于离散操作如 segmented 切换）
+    // - frame: 通过 rAF 合并同帧内的多次交互态更新（如变换控件拖拽）
     // - color: 通过 rAF 合并同帧内的多次颜色变更（color picker 高频触发）
     // - continuous（default）: 节流发送（用于拖拽滑块等连续操作）
     switch (payload.schedule) {
       case 'immediate': {
-        previewQueue.enqueue()
+        requestFramePreview()
+        break
+      }
+      case 'frame': {
+        requestFramePreview()
         break
       }
       case 'color': {
-        if (colorPreviewFrameId !== undefined) {
-          return
-        }
-        colorPreviewFrameId = requestAnimationFrame(() => {
-          colorPreviewFrameId = undefined
-          previewQueue.enqueue()
-        })
+        requestColorPreview()
         break
       }
       default: {
-        void scheduleContinuousPreview()
+        scheduleContinuousPreview()
         break
       }
     }
@@ -346,6 +693,9 @@ export function createEffectEditorProvider() {
     options: { deferAutoApply?: boolean } = {},
   ) {
     if (!session) {
+      return
+    }
+    if (!ensureCanEditPreviewSession()) {
       return
     }
 
@@ -384,51 +734,118 @@ export function createEffectEditorProvider() {
     }
   }
 
+  function hasPreviewTransformOverride(): boolean {
+    return previewTransformOverride !== undefined
+  }
+
+  function resolvePreviewTransform(currentSession: EffectEditorSession): Transform {
+    const override = previewTransformOverride
+
+    return typeof override === 'function'
+      ? override()
+      : (override ?? currentSession.draft.transform)
+  }
+
+  function clonePreviewDraftSnapshot(currentSession: EffectEditorSession): EffectEditorDraft {
+    return {
+      ...cloneDraft(currentSession.draft),
+      transform: cloneTransform(resolvePreviewTransform(currentSession)),
+    }
+  }
+
+  function updatePreviewTransform(transform: EffectEditorPreviewTransform): void {
+    if (!session) {
+      return
+    }
+    if (!ensureCanEditPreviewSession()) {
+      return
+    }
+
+    previewTransformOverride = typeof transform === 'function'
+      ? transform
+      : cloneTransform(transform)
+  }
+
   function resetToInitialDraft() {
     if (!session) {
       return
     }
+    if (!ensureCanEditPreviewSession()) {
+      return
+    }
 
     const currentSession = session
-    const shouldResetPreview = needsPreviewBaselineReset(currentSession)
     const previousDraft = cloneDraft(currentSession.draft)
     const nextDraft = cloneDraft(currentSession.initialDraft)
+    const shouldResetPreview = needsPreviewBaselineReset(previousDraft, nextDraft, visualPreviewDirty)
 
     pushDraftUndoSnapshot(previousDraft, nextDraft)
     pendingDraftHistoryBefore = undefined
     applyDraftSnapshot(nextDraft)
 
     autoApplyQueue.cancel()
-    previewQueue.cancel()
+    cancelQueuedPreview()
     cancelScheduledPreview()
-
-    if (shouldResetPreview) {
-      void resetPreviewToBaseline(currentSession)
-    }
 
     if (canAutoApply()) {
       autoApplyQueue.enqueue()
+      return
+    }
+
+    if (shouldResetPreview) {
+      void restorePreviewAfterIdle(currentSession, nextDraft, '重置效果预览失败')
     }
   }
 
-  async function resetPreviewToBaseline(currentSession: EffectEditorSession) {
-    if (!currentSession.effectTarget) {
-      warnMissingEffectTarget(currentSession)
+  async function resolveSessionBaseline(
+    currentSessionId: number,
+    target: EffectEditorOpenTarget,
+    lineCommandString: string,
+  ): Promise<void> {
+    const currentSession = session
+    if (!currentSession || currentSession.sessionId !== currentSessionId) {
       return
     }
 
     try {
-      const baselineTransform = cloneTransform(currentSession.initialDraft.transform)
-      await debugCommander.setEffect(currentSession.effectTarget, baselineTransform)
-      currentSession.previewedTransformFields = transformToFields(baselineTransform)
-      currentSession.previewErrorWarned = false
+      const result = await resolveTransformBaselineSession({
+        client: baselineClient,
+        request: {
+          command: currentSession.command,
+          lineCommandString,
+          scenePath: target.scenePath,
+          sentenceId: target.sentenceId,
+          target: currentSession.effectTarget,
+          writeDefault: currentSession.writeDefault,
+        },
+      })
+
+      if (!session || session.sessionId !== currentSessionId) {
+        return
+      }
+
+      session.baselineSource = result.baselineSource
+      session.baselineTransform = result.baselineTransform
     } catch (error) {
-      logger.error(`重置效果预览失败: ${error}`)
+      if (!session || session.sessionId !== currentSessionId) {
+        return
+      }
+
+      logger.warn(`解析效果编辑器 transform baseline 失败，已降级为 unknown: ${error}`)
+      session.baselineSource = 'unknown'
+      session.baselineTransform = undefined
+    } finally {
+      if (session && session.sessionId === currentSessionId) {
+        session.baselineResolved = true
+      }
     }
   }
 
   function undoDraft(): boolean {
     if (!session) {
+      return false
+    }
+    if (!ensureCanEditPreviewSession()) {
       return false
     }
 
@@ -439,12 +856,16 @@ export function createEffectEditorProvider() {
 
     pendingDraftHistoryBefore = undefined
     draftRedoStack.push(cloneDraft(session.draft))
-    applyDraftSnapshot(targetDraft, { autoApply: true, preview: true })
+    applyDraftSnapshot(targetDraft)
+    syncExplicitHistoryDraft()
     return true
   }
 
   function redoDraft(): boolean {
     if (!session) {
+      return false
+    }
+    if (!ensureCanEditPreviewSession()) {
       return false
     }
 
@@ -455,7 +876,8 @@ export function createEffectEditorProvider() {
 
     pendingDraftHistoryBefore = undefined
     draftUndoStack.push(cloneDraft(session.draft))
-    applyDraftSnapshot(targetDraft, { autoApply: true, preview: true })
+    applyDraftSnapshot(targetDraft)
+    syncExplicitHistoryDraft()
     return true
   }
 
@@ -472,6 +894,9 @@ export function createEffectEditorProvider() {
     if (!session || !effectClipboard) {
       return false
     }
+    if (!ensureCanEditPreviewSession()) {
+      return false
+    }
 
     const previousDraft = cloneDraft(session.draft)
     const nextDraft = cloneDraft(effectClipboard)
@@ -481,8 +906,102 @@ export function createEffectEditorProvider() {
 
     pushDraftUndoSnapshot(previousDraft, nextDraft)
     pendingDraftHistoryBefore = undefined
-    applyDraftSnapshot(nextDraft, { autoApply: true, preview: true })
+    applyDraftSnapshot(nextDraft)
+    syncExplicitHistoryDraft()
     return true
+  }
+
+  function cancelDraftHistoryBatch(): EffectEditorDraft | undefined {
+    const currentSession = session
+    if (!currentSession || !pendingDraftHistoryBefore) {
+      return undefined
+    }
+
+    const rollbackDraft = cloneDraft(pendingDraftHistoryBefore)
+    pendingDraftHistoryBefore = undefined
+    applyDraftSnapshot(rollbackDraft)
+    return rollbackDraft
+  }
+
+  async function restorePreviewAfterIdle(
+    currentSession: EffectEditorSession,
+    draftSnapshot: EffectEditorDraft,
+    errorMessage: string,
+  ): Promise<boolean> {
+    cancelScheduledPreview()
+    cancelQueuedPreview()
+    await waitForPreviewIdle()
+    return restoreEffectPreview(currentSession, draftSnapshot, errorMessage)
+  }
+
+  async function commitPreviewAfterIdle(
+    currentSession: EffectEditorSession,
+    draftSnapshot: EffectEditorDraft,
+    errorMessage: string,
+  ): Promise<boolean> {
+    cancelScheduledPreview()
+    cancelQueuedPreview()
+    await waitForPreviewIdle()
+    return commitEffectPreview(currentSession, draftSnapshot, errorMessage)
+  }
+
+  async function commitEffectPreview(
+    currentSession: EffectEditorSession,
+    draftSnapshot: EffectEditorDraft,
+    errorMessage: string,
+  ): Promise<boolean> {
+    if (!currentSession.effectTarget) {
+      warnMissingEffectTarget(currentSession)
+      return true
+    }
+
+    return await enqueuePreviewOwnerRequest({
+      draftSnapshot: cloneDraft(draftSnapshot),
+      errorMessage,
+      kind: 'commit',
+      sessionId: currentSession.sessionId,
+      target: currentSession.effectTarget,
+    })
+  }
+
+  async function restoreEffectPreview(
+    currentSession: EffectEditorSession,
+    draftSnapshot: EffectEditorDraft,
+    errorMessage: string,
+  ): Promise<boolean> {
+    if (!currentSession.effectTarget) {
+      warnMissingEffectTarget(currentSession)
+      return false
+    }
+
+    return await enqueuePreviewOwnerRequest({
+      draftSnapshot: cloneDraft(draftSnapshot),
+      errorMessage,
+      kind: 'restore',
+      sessionId: currentSession.sessionId,
+      target: currentSession.effectTarget,
+    })
+  }
+
+  async function cancelPreview(): Promise<void> {
+    const currentSession = session
+    if (!currentSession) {
+      cancelScheduledPreview()
+      cancelQueuedPreview()
+      return
+    }
+
+    cancelScheduledPreview()
+    cancelQueuedPreview()
+    previewTransformOverride = undefined
+    const rollbackDraft = cancelDraftHistoryBatch() ?? cloneDraft(currentSession.draft)
+    if (isClosing) {
+      return
+    }
+
+    if (visualPreviewDirty) {
+      await restoreEffectPreview(currentSession, rollbackDraft, '恢复效果编辑器交互预览失败')
+    }
   }
 
   async function confirmDiscardChanges(): Promise<EffectEditorCloseAction> {
@@ -499,9 +1018,20 @@ export function createEffectEditorProvider() {
 
   async function close(options: { forceDiscard?: boolean, skipPreviewReset?: boolean } = {}): Promise<boolean> {
     if (!session) {
+      cancelScheduledBaselineResolution()
       isOpen = false
       clearDraftHistory()
       return true
+    }
+    if (isPreviewTerminalUnsynced()) {
+      warnPreviewTerminalUnsynced()
+      return false
+    }
+
+    const pendingRollbackDraft = options.skipPreviewReset ? undefined : cancelDraftHistoryBatch()
+    if (pendingRollbackDraft) {
+      cancelQueuedPreview()
+      cancelScheduledPreview()
     }
 
     if (canAutoApply() && !options.forceDiscard) {
@@ -518,6 +1048,9 @@ export function createEffectEditorProvider() {
     if (session.dirty && !options.forceDiscard) {
       const action = await confirmDiscardChanges()
       if (action === 'cancel') {
+        if (pendingRollbackDraft && visualPreviewDirty && session) {
+          await restorePreviewAfterIdle(session, pendingRollbackDraft, '恢复效果编辑器交互预览失败')
+        }
         return false
       }
       if (action === 'save') {
@@ -526,27 +1059,35 @@ export function createEffectEditorProvider() {
     }
 
     const currentSession = session
+    const closeRestoreDraft = cloneDraft(currentSession.baseDraft)
+    isClosing = true
 
-    autoApplyQueue.cancel()
-    previewQueue.cancel()
-    cancelScheduledPreview()
+    try {
+      autoApplyQueue.cancel()
+      cancelQueuedPreview()
+      cancelScheduledPreview()
+      cancelScheduledBaselineResolution()
+      await waitForPreviewIdle()
 
-    if (
-      !options.skipPreviewReset
-      && !currentSession.hasApplied
-      && needsPreviewBaselineReset(currentSession)
-    ) {
-      await resetPreviewToBaseline(currentSession)
+      if (!options.skipPreviewReset && visualPreviewDirty) {
+        const restored = await restoreEffectPreview(currentSession, closeRestoreDraft, '恢复效果编辑器关闭后的预览失败')
+        if (!restored) {
+          return false
+        }
+      }
+
+      discardSessionState()
+      return true
+    } finally {
+      isClosing = false
     }
-
-    session = undefined
-    isOpen = false
-    clearDraftHistory()
-    return true
   }
 
   async function apply(): Promise<boolean> {
     if (!session) {
+      return false
+    }
+    if (!ensureCanEditPreviewSession()) {
       return false
     }
 
@@ -559,8 +1100,19 @@ export function createEffectEditorProvider() {
 
     const currentSessionId = session.sessionId
     const draftSnapshot = cloneDraft(session.draft)
-    const needCommit = !isDraftEqual(draftSnapshot, session.baseDraft)
-    if (needCommit) {
+    const needDraftCommit = !isDraftEqual(draftSnapshot, session.baseDraft)
+    if (needDraftCommit) {
+      if (shouldCommitRuntimeTransform(draftSnapshot, session.baseDraft)) {
+        const runtimeCommitted = await commitPreviewAfterIdle(
+          session,
+          draftSnapshot,
+          '提交效果编辑器运行时预览失败',
+        )
+        if (!runtimeCommitted) {
+          return false
+        }
+      }
+
       const committed = await commitDraft(
         currentSessionId,
         draftSnapshot,
@@ -571,14 +1123,23 @@ export function createEffectEditorProvider() {
       }
     }
 
+    if (session && !isDraftEqual(session.draft, draftSnapshot)) {
+      enqueuePreview()
+      return false
+    }
+
     return await close({ forceDiscard: true, skipPreviewReset: true })
   }
 
   async function open(target: EffectEditorOpenTarget): Promise<boolean> {
     if (isOpen) {
-      const closed = await close()
-      if (!closed) {
-        return false
+      if (isPreviewTerminalUnsynced()) {
+        discardPreviewSession()
+      } else {
+        const closed = await close()
+        if (!closed) {
+          return false
+        }
       }
     }
 
@@ -590,26 +1151,52 @@ export function createEffectEditorProvider() {
     }
     const effectTarget = resolveEffectTarget(target)
     const sessionId = ++nextSessionId
+    const lineCommandString = serializeSentence(baseSentence)
 
     session = {
       sessionId,
+      command: baseSentence.command,
       effectTarget,
+      scenePath: target.scenePath,
+      sentenceId: target.sentenceId,
+      lineCommandString,
       draft: cloneDraft(initialDraft),
       initialDraft: cloneDraft(initialDraft),
       baseDraft: cloneDraft(initialDraft),
       dirty: false,
       hasApplied: false,
       missingTargetWarned: false,
-      previewErrorWarned: false,
-      previewedTransformFields: transformToFields(initialDraft.transform),
+      baselineResolved: false,
+      baselineSource: 'unknown',
+      writeDefault: resolveWriteDefault(baseSentence),
       onApply: target.onApply,
     }
 
     autoApplyQueue.cancel()
-    previewQueue.cancel()
     clearDraftHistory()
+    cancelQueuedPreview()
     isOpen = true
+    previewTransformOverride = undefined
+    visualPreviewDirty = false
+    resetPreviewSyncState()
+    clearContinuousPreviewTimer()
+    lastContinuousPreviewAt = 0
+    isClosing = false
+    scheduleSessionBaselineResolution(sessionId, target, lineCommandString)
     return true
+  }
+
+  async function dispose(): Promise<void> {
+    const closed = await close({ forceDiscard: true })
+    if (!closed) {
+      discardPreviewSession()
+    }
+  }
+
+  if (getCurrentScope()) {
+    onScopeDispose(() => {
+      void dispose()
+    })
   }
 
   return {
@@ -629,18 +1216,25 @@ export function createEffectEditorProvider() {
     close,
     apply,
     updateDraft,
+    updatePreviewTransform,
     resetToInitialDraft,
     requestPreview,
     undoDraft,
     redoDraft,
     copyCurrentEffect,
     pasteCurrentEffect,
+    cancelPreview,
   }
 }
 
 export type EffectEditorProvider = ReturnType<typeof createEffectEditorProvider>
 
 export function useEffectEditorProvider(): EffectEditorProvider {
+  const injectedProvider = useInjectedEffectEditorProvider()
+  if (injectedProvider) {
+    return injectedProvider
+  }
+
   const provider = createEffectEditorProvider()
   provide(EFFECT_EDITOR_PROVIDER_KEY, provider)
   return provider

--- a/src/features/editor/effect-editor/useEffectSegmentedControl.ts
+++ b/src/features/editor/effect-editor/useEffectSegmentedControl.ts
@@ -1,5 +1,7 @@
-import { ChoiceField, EditorDynamicOptionsKey, UNSPECIFIED } from '~/features/editor/command-registry/schema'
-import { EmitTransformOptions } from '~/features/editor/effect-editor/types'
+import { UNSPECIFIED } from '~/features/editor/command-registry/schema'
+
+import type { ChoiceField, EditorDynamicOptionsKey } from '~/features/editor/command-registry/schema'
+import type { EmitTransformOptions } from '~/features/editor/effect-editor/types'
 
 export interface EffectSegmentedOption {
   iconClass: string

--- a/src/features/editor/effect-editor/useStatementEffectEditorBridge.ts
+++ b/src/features/editor/effect-editor/useStatementEffectEditorBridge.ts
@@ -1,5 +1,6 @@
 import { commandType } from 'webgal-parser/src/interface/sceneInterface'
 
+import { computeLineNumberFromStatementId } from '~/domain/document/scene-selection'
 import { hasSentenceTruthyFlag, readSentenceArgString } from '~/domain/script/sentence'
 import { serializeSentence } from '~/domain/script/serialize'
 import { applyEffectEditorResultToSentence, EffectEditorResult } from '~/features/editor/effect-editor/effect-editor-result'
@@ -13,6 +14,11 @@ interface UseStatementEffectEditorBridgeOptions {
   updateTarget?: MaybeRefOrGetter<StatementUpdateTarget | undefined>
   parsed: MaybeRefOrGetter<ISentence | undefined>
   emitUpdate: (payload: StatementUpdatePayload) => void
+}
+
+interface SceneStatementLineLookupEntry {
+  id: number
+  rawText: string
 }
 
 const EFFECT_TARGET_BG_MAIN = 'bg-main'
@@ -57,6 +63,18 @@ export type EffectEditorOpenOverride = (
 
 export const EFFECT_EDITOR_OPEN_OVERRIDE_KEY: InjectionKey<EffectEditorOpenOverride> =
   Symbol('effectEditorOpenOverride')
+
+function resolveVisualStatementLineNumber(
+  statements: readonly SceneStatementLineLookupEntry[],
+  selection: { selectedStatementId?: number, lastLineNumber?: number } | undefined,
+  statementId: number,
+): number | undefined {
+  if (selection?.selectedStatementId === statementId && selection.lastLineNumber !== undefined) {
+    return selection.lastLineNumber
+  }
+
+  return computeLineNumberFromStatementId(statements, statementId)
+}
 
 export function useStatementEffectEditorBridge(options: UseStatementEffectEditorBridgeOptions) {
   const updateTarget = computed(() => toValue(options.updateTarget))
@@ -104,9 +122,23 @@ export function useStatementEffectEditorBridge(options: UseStatementEffectEditor
       return
     }
 
+    const selection = editorStore.currentSceneSelection
+    const statementId = updateTarget.value?.kind === 'statement'
+      ? updateTarget.value.statementId
+      : selection?.selectedStatementId
+    const sentenceId = statementId === undefined || state.projection !== 'visual'
+      ? selection?.lastLineNumber
+      : resolveVisualStatementLineNumber(state.statements, selection, statementId)
+    if (sentenceId === undefined) {
+      logger.warn('无法定位效果编辑器语句行号，跳过打开效果编辑器')
+      return
+    }
+
     void effectEditorProvider.open({
       baseSentence: parsed.value,
       effectTarget: resolveEffectPreviewTarget(parsed.value),
+      scenePath: state.path,
+      sentenceId,
       onApply: applyEffectEditorResult,
     })
   }

--- a/src/features/editor/transform-resolution/__tests__/baseline-session.test.ts
+++ b/src/features/editor/transform-resolution/__tests__/baseline-session.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it, vi } from 'vitest'
+import { commandType } from 'webgal-parser/src/interface/sceneInterface'
+
+import { resolveTransformBaselineSession } from '../baseline-session'
+
+import type {
+  BaseTransformQueryResult,
+  TransformBaselineQueryResult,
+  TransformBaselineSessionClient,
+} from '../baseline-session'
+
+function createClient(options: {
+  baseTransform: BaseTransformQueryResult
+  transformBaselines?: TransformBaselineQueryResult[]
+}): TransformBaselineSessionClient {
+  const baselineQueue = [...(options.transformBaselines ?? [])]
+
+  return {
+    queryBaseTransform: vi.fn(async () => options.baseTransform),
+    queryTransformBaseline: vi.fn(async () => {
+      const result = baselineQueue.shift()
+      if (!result) {
+        throw new Error('transform baseline queue exhausted')
+      }
+
+      return result
+    }),
+    syncScene: vi.fn(async () => { /* no-op */ }),
+  }
+}
+
+describe('resolveTransformBaselineSession', () => {
+  it('普通变换命令只使用基础变换并发送不带修订号的同步请求', async () => {
+    const client = createClient({
+      baseTransform: {
+        status: 'ready',
+        transform: {
+          position: { x: 0, y: 20 },
+        },
+      },
+      transformBaselines: [
+        {
+          status: 'ready',
+          transform: {
+            position: { x: 1000 },
+          },
+        },
+      ],
+    })
+
+    await expect(resolveTransformBaselineSession({
+      client,
+      request: {
+        command: commandType.changeFigure,
+        lineCommandString: 'changeFigure:figure.png;',
+        scenePath: 'scene/start.txt',
+        sentenceId: 3,
+        target: 'fig-center',
+        writeDefault: false,
+      },
+    })).resolves.toEqual({
+      baselineSource: 'base',
+      baselineTransform: {
+        position: { x: 0, y: 20 },
+      },
+    })
+
+    expect(client.syncScene).toHaveBeenCalledWith(
+      'scene/start.txt',
+      3,
+      'changeFigure:figure.png;',
+      {
+        settleMode: 'immediate',
+      },
+    )
+    expect(client.queryTransformBaseline).not.toHaveBeenCalled()
+  })
+
+  it('专用变换命令写入默认值时不会创建目标基线查询', async () => {
+    const client = createClient({
+      baseTransform: {
+        status: 'ready',
+        transform: {
+          scale: { x: 1, y: 1 },
+        },
+      },
+    })
+
+    await expect(resolveTransformBaselineSession({
+      client,
+      request: {
+        command: commandType.setTransform,
+        lineCommandString: 'setTransform:;',
+        scenePath: 'scene/start.txt',
+        sentenceId: 4,
+        target: 'fig-center',
+        writeDefault: true,
+      },
+      createTransformBaselineRevision: () => 'rev-effect-1',
+    })).resolves.toEqual({
+      baselineSource: 'base',
+      baselineTransform: {
+        scale: { x: 1, y: 1 },
+      },
+    })
+
+    expect(client.syncScene).toHaveBeenCalledWith(
+      'scene/start.txt',
+      4,
+      'setTransform:;',
+      {
+        settleMode: 'immediate',
+      },
+    )
+    expect(client.queryTransformBaseline).not.toHaveBeenCalled()
+  })
+
+  it('专用变换命令继承模式会用同一个修订号同步后查询目标并重试加载状态', async () => {
+    const client = createClient({
+      baseTransform: {
+        status: 'ready',
+        transform: {
+          position: { x: 0, y: 20 },
+        },
+      },
+      transformBaselines: [
+        {
+          status: 'loading',
+        },
+        {
+          status: 'ready',
+          transform: {
+            position: { x: 1000 },
+          },
+        },
+      ],
+    })
+
+    await expect(resolveTransformBaselineSession({
+      client,
+      request: {
+        command: commandType.setTransform,
+        lineCommandString: 'setTransform:;',
+        scenePath: 'scene/start.txt',
+        sentenceId: 5,
+        target: 'fig-center',
+        writeDefault: false,
+      },
+      createTransformBaselineRevision: () => 'rev-effect-1',
+    })).resolves.toEqual({
+      baselineSource: 'protocol',
+      baselineTransform: {
+        position: { x: 1000, y: 20 },
+      },
+    })
+
+    expect(client.syncScene).toHaveBeenCalledTimes(1)
+    expect(client.syncScene).toHaveBeenCalledWith(
+      'scene/start.txt',
+      5,
+      'setTransform:;',
+      {
+        transformBaselineRevision: 'rev-effect-1',
+        settleMode: 'immediate',
+      },
+    )
+    expect(client.queryTransformBaseline).toHaveBeenCalledTimes(2)
+    expect(client.queryTransformBaseline).toHaveBeenNthCalledWith(1, 'fig-center', 'rev-effect-1')
+    expect(client.queryTransformBaseline).toHaveBeenNthCalledWith(2, 'fig-center', 'rev-effect-1')
+  })
+
+  it('目标基线加载重试耗尽后会降级为未知来源', async () => {
+    const client = createClient({
+      baseTransform: {
+        status: 'ready',
+        transform: {
+          position: { x: 0, y: 20 },
+        },
+      },
+      transformBaselines: [
+        {
+          status: 'loading',
+        },
+      ],
+    })
+
+    await expect(resolveTransformBaselineSession({
+      client,
+      request: {
+        command: commandType.setTransform,
+        lineCommandString: 'setTransform:;',
+        scenePath: 'scene/start.txt',
+        sentenceId: 5,
+        target: 'fig-center',
+        writeDefault: false,
+      },
+      createTransformBaselineRevision: () => 'rev-effect-1',
+      maxTargetLoadingRetries: 0,
+    })).resolves.toEqual({
+      baselineSource: 'unknown',
+    })
+  })
+})

--- a/src/features/editor/transform-resolution/__tests__/baseline-session.test.ts
+++ b/src/features/editor/transform-resolution/__tests__/baseline-session.test.ts
@@ -29,6 +29,13 @@ function createClient(options: {
   }
 }
 
+async function flushBaselineQueryMicrotasks(): Promise<void> {
+  await Promise.resolve()
+  await Promise.resolve()
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
 describe('resolveTransformBaselineSession', () => {
   it('普通变换命令只使用基础变换并发送不带修订号的同步请求', async () => {
     const client = createClient({
@@ -167,6 +174,64 @@ describe('resolveTransformBaselineSession', () => {
     expect(client.queryTransformBaseline).toHaveBeenCalledTimes(2)
     expect(client.queryTransformBaseline).toHaveBeenNthCalledWith(1, 'fig-center', 'rev-effect-1')
     expect(client.queryTransformBaseline).toHaveBeenNthCalledWith(2, 'fig-center', 'rev-effect-1')
+  })
+
+  it('目标基线 loading 重试前会等待短暂退避', async () => {
+    vi.useFakeTimers()
+
+    try {
+      const client = createClient({
+        baseTransform: {
+          status: 'ready',
+          transform: {
+            position: { x: 0, y: 20 },
+          },
+        },
+        transformBaselines: [
+          {
+            status: 'loading',
+          },
+          {
+            status: 'ready',
+            transform: {
+              position: { x: 1000 },
+            },
+          },
+        ],
+      })
+
+      const resultPromise = resolveTransformBaselineSession({
+        client,
+        request: {
+          command: commandType.setTransform,
+          lineCommandString: 'setTransform:;',
+          scenePath: 'scene/start.txt',
+          sentenceId: 5,
+          target: 'fig-center',
+          writeDefault: false,
+        },
+        createTransformBaselineRevision: () => 'rev-effect-1',
+      })
+
+      await flushBaselineQueryMicrotasks()
+
+      expect(client.queryTransformBaseline).toHaveBeenCalledTimes(1)
+
+      await vi.advanceTimersByTimeAsync(15)
+      expect(client.queryTransformBaseline).toHaveBeenCalledTimes(1)
+
+      await vi.advanceTimersByTimeAsync(1)
+
+      await expect(resultPromise).resolves.toEqual({
+        baselineSource: 'protocol',
+        baselineTransform: {
+          position: { x: 1000, y: 20 },
+        },
+      })
+      expect(client.queryTransformBaseline).toHaveBeenCalledTimes(2)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('目标基线加载重试耗尽后会降级为未知来源', async () => {

--- a/src/features/editor/transform-resolution/__tests__/model.test.ts
+++ b/src/features/editor/transform-resolution/__tests__/model.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from 'vitest'
+import { commandType } from 'webgal-parser/src/interface/sceneInterface'
+
+import {
+  materializeTransformDraftChange,
+  mergeTransformBaseline,
+  resolveTransformDraftDisplay,
+  selectTransformBaseline,
+} from '../model'
+
+describe('selectTransformBaseline', () => {
+  it('专用变换命令继承模式会深合并基础值与目标覆盖值', () => {
+    const result = selectTransformBaseline({
+      command: commandType.setTransform,
+      writeDefault: false,
+      baseTransform: {
+        position: { x: 0, y: 20 },
+        scale: { x: 1, y: 1 },
+        rotation: 0,
+      },
+      targetTransform: {
+        position: { x: 1000 },
+        rotation: 0.5,
+      },
+    })
+
+    expect(result).toEqual({
+      baselineSource: 'protocol',
+      baselineTransform: {
+        position: { x: 1000, y: 20 },
+        scale: { x: 1, y: 1 },
+        rotation: 0.5,
+      },
+    })
+  })
+
+  it('普通命令会按基础默认值处理', () => {
+    const result = selectTransformBaseline({
+      command: commandType.changeFigure,
+      writeDefault: false,
+      baseTransform: {
+        position: { x: 0, y: 20 },
+      },
+      targetTransform: {
+        position: { x: 1000 },
+      },
+    })
+
+    expect(result).toEqual({
+      baselineSource: 'base',
+      baselineTransform: {
+        position: { x: 0, y: 20 },
+      },
+    })
+  })
+
+  it('缺少基础变换时不会把目标覆盖值伪造成基线', () => {
+    const result = selectTransformBaseline({
+      command: commandType.setTransform,
+      writeDefault: false,
+      targetTransform: {
+        position: { x: 1000 },
+      },
+    })
+
+    expect(result).toEqual({
+      baselineSource: 'unknown',
+    })
+  })
+})
+
+describe('mergeTransformBaseline', () => {
+  it('合并变换基线时不会补齐基础变换未提供的字段', () => {
+    expect(mergeTransformBaseline(
+      { position: { y: 20 } },
+      { position: { x: 1000 } },
+    )).toEqual({
+      position: { y: 20 },
+    })
+  })
+})
+
+describe('resolveTransformDraftDisplay', () => {
+  it('解析变换草稿显示态时会按显式值、基线与编辑器默认值补全注册字段', () => {
+    const result = resolveTransformDraftDisplay({
+      explicitDraftTransform: {
+        alpha: 0.8,
+        colorRed: 128,
+        position: { y: 40 },
+      },
+      baselineTransform: {
+        alpha: 1,
+        blur: 6,
+        colorRed: 255,
+        colorGreen: 64,
+        position: { x: 1000, y: 20 },
+      },
+      editorDefaultTransform: {
+        colorBlue: 255,
+        gamma: 1,
+        position: { x: 0, y: 0 },
+      },
+    })
+
+    expect(result.displayTransform).toEqual({
+      alpha: 0.8,
+      blur: 6,
+      colorRed: 128,
+      colorGreen: 64,
+      colorBlue: 255,
+      gamma: 1,
+      position: { x: 1000, y: 40 },
+    })
+    expect(result.fieldSources).toMatchObject({
+      'alpha': 'explicit',
+      'blur': 'inherited',
+      'colorBlue': 'editor-default',
+      'colorGreen': 'inherited',
+      'colorRed': 'explicit',
+      'gamma': 'editor-default',
+      'position.x': 'inherited',
+      'position.y': 'explicit',
+    })
+  })
+
+  it('解析变换草稿显示态时会区分基础基线字段来源', () => {
+    const result = resolveTransformDraftDisplay({
+      baselineSource: 'base',
+      baselineTransform: {
+        alpha: 1,
+      },
+      explicitDraftTransform: {},
+    })
+
+    expect(result.fieldSources.alpha).toBe('base')
+  })
+})
+
+describe('materializeTransformDraftChange', () => {
+  it('变换草稿变更只写入明确触达的兜底显示字段', () => {
+    expect(materializeTransformDraftChange({
+      explicitDraftTransform: {},
+      change: {
+        type: 'set-field',
+        path: 'alpha',
+        value: 0.8,
+      },
+    })).toEqual({
+      alpha: 0.8,
+    })
+  })
+
+  it('清空显式字段后不会写回基线兜底值', () => {
+    expect(materializeTransformDraftChange({
+      explicitDraftTransform: {
+        alpha: 0.8,
+        position: { x: 1000 },
+      },
+      change: {
+        type: 'clear-field',
+        path: 'position.x',
+      },
+    })).toEqual({
+      alpha: 0.8,
+    })
+  })
+})

--- a/src/features/editor/transform-resolution/baseline-session.ts
+++ b/src/features/editor/transform-resolution/baseline-session.ts
@@ -64,6 +64,7 @@ export interface ResolveTransformBaselineSessionOptions {
 }
 
 const DEFAULT_TARGET_LOADING_RETRIES = 2
+const TARGET_LOADING_RETRY_DELAY_MS = 16
 
 function createDefaultTransformBaselineRevision(): string {
   return globalThis.crypto?.randomUUID?.()
@@ -74,6 +75,16 @@ function isBaseTransformReady(
   result: BaseTransformQueryResult,
 ): result is Extract<BaseTransformQueryResult, { status: 'ready' }> {
   return result.status === 'ready'
+}
+
+function getTargetLoadingRetryDelay(loadingCount: number): number {
+  return TARGET_LOADING_RETRY_DELAY_MS * (loadingCount + 1)
+}
+
+async function waitTargetLoadingRetry(loadingCount: number): Promise<void> {
+  await new Promise<void>((resolve) => {
+    setTimeout(resolve, getTargetLoadingRetryDelay(loadingCount))
+  })
 }
 
 async function queryTransformBaselineWithRetry(
@@ -94,6 +105,8 @@ async function queryTransformBaselineWithRetry(
       reason: 'target transform loading retry exhausted',
     }
   }
+
+  await waitTargetLoadingRetry(loadingCount)
 
   return queryTransformBaselineWithRetry(
     client,

--- a/src/features/editor/transform-resolution/baseline-session.ts
+++ b/src/features/editor/transform-resolution/baseline-session.ts
@@ -1,0 +1,167 @@
+import {
+  isSetTransformCommand,
+  selectTransformBaseline,
+} from './model'
+
+import type { ResolvedTransformBaseline } from './model'
+import type { commandType } from 'webgal-parser/src/interface/sceneInterface'
+import type { Transform } from '~/domain/stage/types'
+
+export type BaseTransformQueryResult =
+  | {
+    status: 'ready'
+    transform: Transform
+  }
+  | {
+    status: 'unavailable'
+    reason?: string
+  }
+
+export type TransformBaselineQueryResult =
+  | {
+    status: 'ready'
+    transform: Transform
+  }
+  | {
+    status: 'loading'
+  }
+  | {
+    status: 'unavailable'
+    reason?: string
+  }
+
+export interface TransformBaselineSessionRequest {
+  command: commandType
+  lineCommandString: string
+  scenePath: string
+  sentenceId: number
+  target?: string
+  writeDefault: boolean
+}
+
+export interface TransformBaselineSessionClient {
+  queryBaseTransform: () => Promise<BaseTransformQueryResult>
+  queryTransformBaseline: (
+    target: string,
+    transformBaselineRevision: string,
+  ) => Promise<TransformBaselineQueryResult>
+  syncScene: (
+    scenePath: string,
+    sentenceId: number,
+    lineCommandString: string,
+    options?: {
+      transformBaselineRevision?: string
+      settleMode?: 'immediate'
+    },
+  ) => Promise<void>
+}
+
+export interface ResolveTransformBaselineSessionOptions {
+  client: TransformBaselineSessionClient
+  request: TransformBaselineSessionRequest
+  createTransformBaselineRevision?: () => string
+  maxTargetLoadingRetries?: number
+}
+
+const DEFAULT_TARGET_LOADING_RETRIES = 2
+
+function createDefaultTransformBaselineRevision(): string {
+  return globalThis.crypto?.randomUUID?.()
+    ?? `effect-transform-${Date.now()}-${Math.random().toString(16).slice(2)}`
+}
+
+function isBaseTransformReady(
+  result: BaseTransformQueryResult,
+): result is Extract<BaseTransformQueryResult, { status: 'ready' }> {
+  return result.status === 'ready'
+}
+
+async function queryTransformBaselineWithRetry(
+  client: TransformBaselineSessionClient,
+  target: string,
+  transformBaselineRevision: string,
+  maxLoadingRetries: number,
+  loadingCount: number = 0,
+): Promise<TransformBaselineQueryResult> {
+  const result = await client.queryTransformBaseline(target, transformBaselineRevision)
+  if (result.status !== 'loading') {
+    return result
+  }
+
+  if (loadingCount >= maxLoadingRetries) {
+    return {
+      status: 'unavailable',
+      reason: 'target transform loading retry exhausted',
+    }
+  }
+
+  return queryTransformBaselineWithRetry(
+    client,
+    target,
+    transformBaselineRevision,
+    maxLoadingRetries,
+    loadingCount + 1,
+  )
+}
+
+export async function resolveTransformBaselineSession(
+  options: ResolveTransformBaselineSessionOptions,
+): Promise<ResolvedTransformBaseline> {
+  const {
+    client,
+    request,
+  } = options
+  const maxTargetLoadingRetries = options.maxTargetLoadingRetries ?? DEFAULT_TARGET_LOADING_RETRIES
+  const baseTransformResult = await client.queryBaseTransform()
+  const readyBaseTransform = isBaseTransformReady(baseTransformResult)
+    ? baseTransformResult.transform
+    : undefined
+
+  if (
+    !isSetTransformCommand(request.command)
+    || request.writeDefault
+    || !request.target
+    || !readyBaseTransform
+  ) {
+    await client.syncScene(
+      request.scenePath,
+      request.sentenceId,
+      request.lineCommandString,
+      {
+        settleMode: 'immediate',
+      },
+    )
+    return selectTransformBaseline({
+      baseTransform: readyBaseTransform,
+      command: request.command,
+      writeDefault: request.writeDefault,
+    })
+  }
+
+  const transformBaselineRevision = options.createTransformBaselineRevision?.() ?? createDefaultTransformBaselineRevision()
+  await client.syncScene(
+    request.scenePath,
+    request.sentenceId,
+    request.lineCommandString,
+    {
+      transformBaselineRevision,
+      settleMode: 'immediate',
+    },
+  )
+
+  const transformBaselineResult = await queryTransformBaselineWithRetry(
+    client,
+    request.target,
+    transformBaselineRevision,
+    maxTargetLoadingRetries,
+  )
+
+  return selectTransformBaseline({
+    baseTransform: readyBaseTransform,
+    command: request.command,
+    targetTransform: transformBaselineResult.status === 'ready'
+      ? transformBaselineResult.transform
+      : undefined,
+    writeDefault: request.writeDefault,
+  })
+}

--- a/src/features/editor/transform-resolution/model.ts
+++ b/src/features/editor/transform-resolution/model.ts
@@ -122,16 +122,21 @@ export function cloneTransform(transform: Transform = {}): Transform {
   return structuredClone(toRaw(transform))
 }
 
+function coerceFieldValue(path: TransformFieldPath, value: string | number): unknown {
+  const partialTransform = fieldsToTransform({ [path]: String(value) })
+
+  return getValueByPath(partialTransform as unknown as Record<string, unknown>, path)
+}
+
 function writeField(
   transform: Transform,
   path: TransformFieldPath,
   value: string | number,
 ): void {
-  const partialTransform = fieldsToTransform({ [path]: String(value) })
   setValueByPath(
     transform as unknown as Record<string, unknown>,
     path,
-    getValueByPath(partialTransform as unknown as Record<string, unknown>, path),
+    coerceFieldValue(path, value),
   )
 }
 
@@ -149,8 +154,7 @@ function writeFieldMapValue(
     return
   }
 
-  const partialTransform = fieldsToTransform({ [path]: String(value) })
-  const nextValue = getValueByPath(partialTransform as unknown as Record<string, unknown>, path)
+  const nextValue = coerceFieldValue(path, value)
 
   if (nextValue === undefined) {
     unsetValueByPath(transform as unknown as Record<string, unknown>, path)

--- a/src/features/editor/transform-resolution/model.ts
+++ b/src/features/editor/transform-resolution/model.ts
@@ -1,0 +1,292 @@
+import { commandType } from 'webgal-parser/src/interface/sceneInterface'
+
+import {
+  EFFECT_CATEGORIES,
+  fieldsToTransform,
+  getValueByPath,
+  setValueByPath,
+  transformToFields,
+  unsetValueByPath,
+} from '~/features/editor/effect-editor/effect-editor-config'
+
+import type { Transform } from '~/domain/stage/types'
+
+export type TransformFieldPath = string
+export type TransformBaselineSource = 'protocol' | 'base' | 'unknown'
+export type TransformFieldSource = 'explicit' | 'inherited' | 'base' | 'editor-default'
+
+export interface SelectTransformBaselineOptions {
+  baseTransform?: Transform
+  command: commandType
+  targetTransform?: Transform
+  writeDefault: boolean
+}
+
+export interface ResolveTransformDraftDisplayOptions {
+  baselineSource?: TransformBaselineSource
+  baselineTransform?: Transform
+  editorDefaultTransform?: Transform
+  explicitDraftTransform: Transform
+}
+
+export interface ResolvedTransformBaseline {
+  baselineSource: TransformBaselineSource
+  baselineTransform?: Transform
+}
+
+export interface ResolvedTransformDraft {
+  baselineSource: TransformBaselineSource
+  baselineTransform?: Transform
+  displayTransform: Transform
+  editorDefaultTransform?: Transform
+  explicitDraftTransform: Transform
+  fieldSources: Partial<Record<TransformFieldPath, TransformFieldSource>>
+}
+
+export type TransformDraftChange =
+  | {
+    path: TransformFieldPath
+    type: 'clear-field'
+  }
+  | {
+    path: TransformFieldPath
+    type: 'set-field'
+    value: number | string
+  }
+  | {
+    fields: Record<TransformFieldPath, number | string | undefined>
+    type: 'set-fields'
+  }
+
+export interface MaterializeTransformDraftChangeOptions {
+  change: TransformDraftChange
+  explicitDraftTransform: Transform
+}
+
+export const TRANSFORM_FIELD_PATHS = Object.freeze(resolveTransformFieldPaths())
+const EDITOR_DEFAULT_TRANSFORM = createEditorDefaultTransform()
+
+export function isSetTransformCommand(command: commandType): boolean {
+  return command === commandType.setTransform
+}
+
+function resolveTransformFieldPaths(): TransformFieldPath[] {
+  const paths = new Set<TransformFieldPath>()
+
+  for (const category of EFFECT_CATEGORIES) {
+    for (const param of category.params) {
+      if (param.type === 'color') {
+        for (const path of param.colorPaths ?? []) {
+          paths.add(path)
+        }
+        continue
+      }
+
+      paths.add(param.key)
+      if ('linkedPairKey' in param && param.linkedPairKey) {
+        paths.add(param.linkedPairKey)
+      }
+    }
+  }
+
+  return [...paths]
+}
+
+function createEditorDefaultTransform(): Transform {
+  const fields: Record<string, string> = {}
+
+  for (const category of EFFECT_CATEGORIES) {
+    for (const param of category.params) {
+      if (param.type === 'color') {
+        const paths = param.colorPaths ?? []
+        const defaults = param.colorDefaults ?? []
+        for (const [index, path] of paths.entries()) {
+          const value = defaults[index]
+          if (value !== undefined) {
+            fields[path] = String(value)
+          }
+        }
+        continue
+      }
+
+      if ('defaultValue' in param && param.defaultValue !== undefined) {
+        fields[param.key] = String(param.defaultValue)
+      }
+    }
+  }
+
+  return fieldsToTransform(fields)
+}
+
+export function cloneTransform(transform: Transform = {}): Transform {
+  return structuredClone(toRaw(transform))
+}
+
+function writeField(
+  transform: Transform,
+  path: TransformFieldPath,
+  value: string | number,
+): void {
+  const partialTransform = fieldsToTransform({ [path]: String(value) })
+  setValueByPath(
+    transform as unknown as Record<string, unknown>,
+    path,
+    getValueByPath(partialTransform as unknown as Record<string, unknown>, path),
+  )
+}
+
+function getTransformFields(transform: Transform | undefined): Record<string, string> {
+  return transform ? transformToFields(transform) : {}
+}
+
+function writeFieldMapValue(
+  transform: Transform,
+  path: TransformFieldPath,
+  value: number | string | undefined,
+): void {
+  if (value === undefined || value === '') {
+    unsetValueByPath(transform as unknown as Record<string, unknown>, path)
+    return
+  }
+
+  const partialTransform = fieldsToTransform({ [path]: String(value) })
+  const nextValue = getValueByPath(partialTransform as unknown as Record<string, unknown>, path)
+
+  if (nextValue === undefined) {
+    unsetValueByPath(transform as unknown as Record<string, unknown>, path)
+    return
+  }
+
+  setValueByPath(
+    transform as unknown as Record<string, unknown>,
+    path,
+    nextValue,
+  )
+}
+
+export function mergeTransformBaseline(
+  baseTransform: Transform,
+  targetTransform: Transform,
+): Transform {
+  const baselineTransform: Transform = {}
+  const baseFields = transformToFields(baseTransform)
+  const targetFields = transformToFields(targetTransform)
+
+  for (const path of TRANSFORM_FIELD_PATHS) {
+    const baseValue = baseFields[path]
+    if (baseValue === undefined) {
+      continue
+    }
+
+    const targetValue = targetFields[path]
+    if (targetValue !== undefined) {
+      writeField(baselineTransform, path, targetValue)
+      continue
+    }
+
+    writeField(baselineTransform, path, baseValue)
+  }
+
+  return baselineTransform
+}
+
+export function selectTransformBaseline(
+  options: SelectTransformBaselineOptions,
+): ResolvedTransformBaseline {
+  if (!isSetTransformCommand(options.command) || options.writeDefault) {
+    return {
+      baselineSource: options.baseTransform ? 'base' : 'unknown',
+      baselineTransform: options.baseTransform ? cloneTransform(options.baseTransform) : undefined,
+    }
+  }
+
+  if (!options.baseTransform || !options.targetTransform) {
+    return {
+      baselineSource: 'unknown',
+    }
+  }
+
+  return {
+    baselineSource: 'protocol',
+    baselineTransform: mergeTransformBaseline(options.baseTransform, options.targetTransform),
+  }
+}
+
+export function getEditorDefaultTransform(): Transform {
+  return cloneTransform(EDITOR_DEFAULT_TRANSFORM)
+}
+
+export function resolveTransformDraftDisplay(
+  options: ResolveTransformDraftDisplayOptions,
+): ResolvedTransformDraft {
+  const explicitFields = getTransformFields(options.explicitDraftTransform)
+  const baselineFields = getTransformFields(options.baselineTransform)
+  const editorDefaultFields = getTransformFields(options.editorDefaultTransform ?? EDITOR_DEFAULT_TRANSFORM)
+  const displayFields: Record<string, string> = {}
+  const fieldSources: Partial<Record<TransformFieldPath, TransformFieldSource>> = {}
+  const baselineSource = options.baselineSource ?? 'unknown'
+
+  for (const path of TRANSFORM_FIELD_PATHS) {
+    const explicitValue = explicitFields[path]
+    if (explicitValue !== undefined) {
+      displayFields[path] = explicitValue
+      fieldSources[path] = 'explicit'
+      continue
+    }
+
+    const baselineValue = baselineFields[path]
+    if (baselineValue !== undefined) {
+      displayFields[path] = baselineValue
+      fieldSources[path] = baselineSource === 'base' ? 'base' : 'inherited'
+      continue
+    }
+
+    const editorDefaultValue = editorDefaultFields[path]
+    if (editorDefaultValue !== undefined) {
+      displayFields[path] = editorDefaultValue
+      fieldSources[path] = 'editor-default'
+    }
+  }
+
+  return {
+    baselineSource,
+    baselineTransform: options.baselineTransform
+      ? cloneTransform(options.baselineTransform)
+      : undefined,
+    displayTransform: fieldsToTransform(displayFields),
+    editorDefaultTransform: options.editorDefaultTransform
+      ? cloneTransform(options.editorDefaultTransform)
+      : undefined,
+    explicitDraftTransform: cloneTransform(options.explicitDraftTransform),
+    fieldSources,
+  }
+}
+
+export function materializeTransformDraftChange(
+  options: MaterializeTransformDraftChangeOptions,
+): Transform {
+  const nextDraft = cloneTransform(options.explicitDraftTransform)
+
+  switch (options.change.type) {
+    case 'clear-field': {
+      writeFieldMapValue(nextDraft, options.change.path, undefined)
+      break
+    }
+    case 'set-field': {
+      writeFieldMapValue(nextDraft, options.change.path, options.change.value)
+      break
+    }
+    case 'set-fields': {
+      for (const [path, value] of Object.entries(options.change.fields)) {
+        writeFieldMapValue(nextDraft, path, value)
+      }
+      break
+    }
+    default: {
+      const neverChange: never = options.change
+      return neverChange
+    }
+  }
+
+  return nextDraft
+}

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -470,6 +470,8 @@ modals:
     description: Edit visual transform, filter and effect parameters
     apply: Apply
     reset: Reset
+    previewUnsyncedCloseBlockedTitle: Runtime preview is out of sync
+    previewUnsyncedCloseBlockedMessage: The current effect may already be committed to the preview runtime, but the editor could not confirm the sync state. Select the target line again, or explicitly discard before reopening the effect editor.
     clearProperty: Clear {name}
     categories:
       transform: Transform

--- a/src/locales/ja.yml
+++ b/src/locales/ja.yml
@@ -470,6 +470,8 @@ modals:
     description: ビジュアル変換、フィルター、エフェクトパラメータを編集
     apply: 適用
     reset: リセット
+    previewUnsyncedCloseBlockedTitle: ランタイムプレビューが同期されていません
+    previewUnsyncedCloseBlockedMessage: 現在のエフェクトはプレビュー実行環境に反映済みの可能性がありますが、エディターは同期状態を確認できませんでした。対象行を選び直すか、明示的に破棄してからエフェクトエディターを開き直してください。
     clearProperty: "{name} の指定を削除"
     categories:
       transform: 変換

--- a/src/locales/zh-Hans.yml
+++ b/src/locales/zh-Hans.yml
@@ -470,6 +470,8 @@ modals:
     description: 编辑视觉变换、滤镜和效果参数
     apply: 应用
     reset: 还原
+    previewUnsyncedCloseBlockedTitle: 运行时预览未同步
+    previewUnsyncedCloseBlockedMessage: 当前效果可能已经提交到预览运行时，但编辑器尚未确认同步状态。请重新选择目标行，或显式丢弃后重新打开效果编辑器。
     clearProperty: 清除{name}
     categories:
       transform: 变换

--- a/src/locales/zh-Hant.yml
+++ b/src/locales/zh-Hant.yml
@@ -470,6 +470,8 @@ modals:
     description: 編輯視覺變換、濾鏡和效果參數
     apply: 套用
     reset: 還原
+    previewUnsyncedCloseBlockedTitle: 執行時預覽未同步
+    previewUnsyncedCloseBlockedMessage: 目前效果可能已提交到預覽執行時，但編輯器尚未確認同步狀態。請重新選擇目標行，或明確捨棄後重新開啟效果編輯器。
     clearProperty: 清除{name}
     categories:
       transform: 變換


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [ ] 错误修复
- [x] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [x] 代码重构
- [x] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

让效果编辑器能够区分“显式写入的 transform 字段”和“从运行时基线继承的显示值”，并为实时预览增加可靠的 preview / commit / restore 流程。

主要改动：

- 新增 transform baseline resolution 模型和 session 协调逻辑。
- 打开效果编辑器时查询 base transform / transform baseline，并在不可用时降级为 unknown。
- effect editor provider 串行化 preview owner request，支持 preview、commit、restore 阶段。
- 表单控件使用 display value 渲染，但清除和提交只作用于 stored value。
- 拖拽、颜色和旋钮交互取消时回滚运行时预览。
- 修正效果编辑器桥接到可视化语句行号的解析。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

变换编辑需要基于预览运行时的真实目标状态，否则 `setTransform` 和普通效果命令会把继承值、默认值和显式草稿混在一起，导致表单显示和最终写回不一致。该 PR 先把效果编辑器的基线与预览语义稳定下来，供后续浮层复用。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
