### PR TITLE
✨ 在编辑器预览中接入变换浮层

### DIFF
--- a/src/components/editor/EditorPanel.spec.ts
+++ b/src/components/editor/EditorPanel.spec.ts
@@ -1,9 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { page } from 'vitest/browser'
-import { defineComponent, h, reactive } from 'vue'
+import { defineComponent, h, nextTick, reactive, shallowRef } from 'vue'
 
 import { createBrowserLocalizedI18n } from '~/__tests__/browser'
 import { renderInBrowser } from '~/__tests__/browser-render'
+import { shortcutDispatcherRegistryKey } from '~/features/editor/shortcut/useShortcutDispatcher'
+import { TRANSFORM_OVERLAY_BRIDGE_KEY } from '~/features/editor/transform-overlay/context'
+
+import EditorPanel from './EditorPanel.vue'
+
+import type { ShortcutDefinition } from '~/features/editor/shortcut/types'
 
 const {
   commandBridgeMock,
@@ -155,8 +161,6 @@ vi.mock('~/components/ui/resizable', () => {
   }
 })
 
-import EditorPanel from './EditorPanel.vue'
-
 const globalStubs = {
   CommandPanel: defineComponent({
     name: 'StubCommandPanel',
@@ -212,7 +216,20 @@ const globalStubs = {
   FileEditor: defineComponent({
     name: 'StubFileEditor',
     setup() {
-      return () => h('div', 'File Editor')
+      return () => h('div', [
+        h('div', 'File Editor'),
+        h('div', {
+          'data-effect-editor-interactive-region': '',
+          'data-testid': 'preview-interactive-region',
+          'style': {
+            height: '120px',
+            left: '160px',
+            position: 'fixed',
+            top: '120px',
+            width: '240px',
+          },
+        }),
+      ])
     },
   }),
   ResizableHandle: defineComponent({
@@ -248,8 +265,11 @@ const globalStubs = {
   }),
   SheetContent: defineComponent({
     name: 'StubSheetContent',
-    setup(_, { slots }) {
-      return () => h('div', slots.default?.())
+    setup(_, { attrs, slots }) {
+      return () => h('div', {
+        'data-testid': 'effect-editor-sheet',
+        ...attrs,
+      }, slots.default?.())
     },
   }),
   SheetDescription: defineComponent({
@@ -288,13 +308,50 @@ function createEditorPanelI18n() {
   return createBrowserLocalizedI18n()
 }
 
-function renderEditorPanel() {
+function renderEditorPanel(options: {
+  provide?: Record<symbol, unknown>
+} = {}) {
   renderInBrowser(EditorPanel, {
     global: {
       plugins: [createEditorPanelI18n()],
+      provide: options.provide,
       stubs: globalStubs,
     },
   })
+}
+
+function renderEditorPanelWithShortcutRegistry() {
+  const bindings = new Map<symbol, ShortcutDefinition<unknown>>()
+  renderEditorPanel({
+    provide: {
+      [shortcutDispatcherRegistryKey as symbol]: {
+        registerBinding: () => Symbol('shortcut-binding'),
+        unregisterBinding: (token: symbol) => bindings.delete(token),
+        updateBinding: (token: symbol, binding: ShortcutDefinition<unknown>) => {
+          bindings.set(token, binding)
+        },
+      },
+    },
+  })
+
+  return bindings
+}
+
+function createTransformOverlayBridge(enabled: boolean) {
+  return {
+    enabled: shallowRef(enabled),
+    formDisplayTransform: shallowRef(undefined),
+    handlePanelTransformUpdate: vi.fn(),
+  }
+}
+
+async function updateEffectEditorInteractiveRegion(): Promise<void> {
+  globalThis.dispatchEvent(new Event('resize'))
+  await nextTick()
+}
+
+function getEffectEditorDismissLayers(): HTMLElement[] {
+  return [...document.querySelectorAll<HTMLElement>('[data-testid="effect-editor-dismiss-layer"]')]
 }
 
 describe('EditorPanel', () => {
@@ -430,5 +487,60 @@ describe('EditorPanel', () => {
 
     await expect.element(page.getByText('当前存在多个编辑目标，语句编辑已暂停')).toBeVisible()
     await expect.element(page.getByText('Statement Editor Panel')).not.toBeInTheDocument()
+  })
+
+  it('变换浮层聚焦时按下回车或组合回车会应用效果编辑器变更', async () => {
+    effectEditorProviderMock.canApply = true
+    effectEditorProviderMock.apply.mockResolvedValue(true)
+
+    const bindings = renderEditorPanelWithShortcutRegistry()
+    await vi.waitFor(() => {
+      expect(bindings.size).toBeGreaterThan(0)
+    })
+
+    const binding = [...bindings.values()].find(item =>
+      item.when?.panelFocus === 'transformOverlay'
+      && item.keys.includes('Enter')
+      && item.keys.includes('Mod+Enter'),
+    )
+    expect(binding).toBeDefined()
+
+    await binding!.execute(undefined)
+
+    expect(effectEditorProviderMock.apply).toHaveBeenCalledOnce()
+  })
+
+  it('效果编辑器打开但变换框不可用时不会放行预览交互区域', async () => {
+    effectEditorProviderMock.isOpen = true
+
+    renderEditorPanel({
+      provide: {
+        [TRANSFORM_OVERLAY_BRIDGE_KEY as symbol]: createTransformOverlayBridge(false),
+      },
+    })
+
+    const region = document.querySelector<HTMLElement>('[data-testid="preview-interactive-region"]')
+    expect(region?.getBoundingClientRect().width).toBeGreaterThan(0)
+
+    await updateEffectEditorInteractiveRegion()
+
+    expect(getEffectEditorDismissLayers()).toHaveLength(1)
+  })
+
+  it('效果编辑器打开且变换框可用时会保留预览交互区域', async () => {
+    effectEditorProviderMock.isOpen = true
+
+    renderEditorPanel({
+      provide: {
+        [TRANSFORM_OVERLAY_BRIDGE_KEY as symbol]: createTransformOverlayBridge(true),
+      },
+    })
+
+    const region = document.querySelector<HTMLElement>('[data-testid="preview-interactive-region"]')
+    expect(region?.getBoundingClientRect().width).toBeGreaterThan(0)
+
+    await updateEffectEditorInteractiveRegion()
+
+    expect(getEffectEditorDismissLayers().length).toBeGreaterThan(1)
   })
 })

--- a/src/components/editor/EditorPanel.spec.ts
+++ b/src/components/editor/EditorPanel.spec.ts
@@ -543,4 +543,18 @@ describe('EditorPanel', () => {
 
     expect(getEffectEditorDismissLayers().length).toBeGreaterThan(1)
   })
+
+  it('效果编辑器初始打开且变换框可用时会立即保留预览交互区域', async () => {
+    effectEditorProviderMock.isOpen = true
+
+    renderEditorPanel({
+      provide: {
+        [TRANSFORM_OVERLAY_BRIDGE_KEY as symbol]: createTransformOverlayBridge(true),
+      },
+    })
+
+    await nextTick()
+
+    expect(getEffectEditorDismissLayers().length).toBeGreaterThan(1)
+  })
 })

--- a/src/components/editor/EditorPanel.vue
+++ b/src/components/editor/EditorPanel.vue
@@ -3,10 +3,39 @@ import { ResizablePanel } from '~/components/ui/resizable'
 import { useEditorPanelShell } from '~/features/editor/shell/useEditorPanelShell'
 import { useShortcut } from '~/features/editor/shortcut/useShortcut'
 import { useShortcutContext } from '~/features/editor/shortcut/useShortcutContext'
+import { TRANSFORM_OVERLAY_BRIDGE_KEY } from '~/features/editor/transform-overlay/context'
 
 const commandPanelRef = useTemplateRef<InstanceType<typeof ResizablePanel>>('commandPanel')
 const editorPanelRef = $(useTemplateRef('editorPanel'))
 const { t } = useI18n()
+const transformOverlayBridge = inject(TRANSFORM_OVERLAY_BRIDGE_KEY, undefined)
+const EFFECT_EDITOR_INTERACTIVE_REGION_SELECTOR = '[data-effect-editor-interactive-region]'
+const EFFECT_EDITOR_DISMISS_TOP_OFFSET = 28
+
+interface EffectEditorDismissLayerSegment {
+  height: number
+  key: string
+  style: Record<string, string>
+  width?: number
+}
+
+interface EffectEditorInteractiveBounds {
+  bottom: number
+  left: number
+  right: number
+  top: number
+}
+
+const TRANSFORM_OVERLAY_FIELD_PATHS = new Set([
+  'position.x',
+  'position.y',
+  'scale.x',
+  'scale.y',
+  'rotation',
+])
+
+let effectEditorInteractiveRegion = $ref<HTMLElement>()
+let effectEditorInteractiveRect = $ref<DOMRectReadOnly>()
 
 const {
   binding,
@@ -34,6 +63,171 @@ const {
   commandPanelRef,
 })
 
+const canUseEffectEditorPreviewRegion = $computed(() => transformOverlayBridge?.enabled.value === true)
+
+const effectEditorDismissLayerSegments = $computed<EffectEditorDismissLayerSegment[]>(() => {
+  if (!effectEditorProvider.isOpen) {
+    return []
+  }
+
+  if (!canUseEffectEditorPreviewRegion) {
+    return [createFullEffectEditorDismissLayerSegment()]
+  }
+
+  const bounds = resolveEffectEditorInteractiveBounds(effectEditorInteractiveRect)
+  if (!bounds) {
+    return [createFullEffectEditorDismissLayerSegment()]
+  }
+
+  const { bottom, left, right, top } = bounds
+  const segments: EffectEditorDismissLayerSegment[] = [
+    {
+      height: top - EFFECT_EDITOR_DISMISS_TOP_OFFSET,
+      key: 'top',
+      style: {
+        height: `${top - EFFECT_EDITOR_DISMISS_TOP_OFFSET}px`,
+        insetInline: '0',
+        top: `${EFFECT_EDITOR_DISMISS_TOP_OFFSET}px`,
+      },
+      width: globalThis.innerWidth,
+    },
+    {
+      height: bottom - top,
+      key: 'left',
+      style: {
+        height: `${bottom - top}px`,
+        left: '0',
+        top: `${top}px`,
+        width: `${left}px`,
+      },
+      width: left,
+    },
+    {
+      height: bottom - top,
+      key: 'right',
+      style: {
+        height: `${bottom - top}px`,
+        left: `${right}px`,
+        right: '0',
+        top: `${top}px`,
+      },
+      width: globalThis.innerWidth - right,
+    },
+    {
+      height: globalThis.innerHeight - bottom,
+      key: 'bottom',
+      style: {
+        bottom: '0',
+        insetInline: '0',
+        top: `${bottom}px`,
+      },
+      width: globalThis.innerWidth,
+    },
+  ]
+
+  return segments.filter(segment => segment.height > 0 && (segment.width ?? 1) > 0)
+})
+
+function createFullEffectEditorDismissLayerSegment(): EffectEditorDismissLayerSegment {
+  return {
+    height: globalThis.innerHeight - EFFECT_EDITOR_DISMISS_TOP_OFFSET,
+    key: 'full',
+    style: {
+      inset: `${EFFECT_EDITOR_DISMISS_TOP_OFFSET}px 0 0 0`,
+    },
+    width: globalThis.innerWidth,
+  }
+}
+
+function resolveEffectEditorInteractiveBounds(
+  rect: DOMRectReadOnly | undefined,
+): EffectEditorInteractiveBounds | undefined {
+  if (!rect) {
+    return undefined
+  }
+
+  const bounds = {
+    bottom: Math.min(globalThis.innerHeight, rect.bottom),
+    left: Math.max(0, rect.left),
+    right: Math.min(globalThis.innerWidth, rect.right),
+    top: Math.max(EFFECT_EDITOR_DISMISS_TOP_OFFSET, rect.top),
+  }
+
+  return bounds.right > bounds.left && bounds.bottom > bounds.top
+    ? bounds
+    : undefined
+}
+
+function updateEffectEditorInteractiveRegion(): void {
+  if (!effectEditorProvider.isOpen) {
+    effectEditorInteractiveRegion = undefined
+    effectEditorInteractiveRect = undefined
+    return
+  }
+
+  const region = document.querySelector<HTMLElement>(EFFECT_EDITOR_INTERACTIVE_REGION_SELECTOR) ?? undefined
+  effectEditorInteractiveRegion = region
+  effectEditorInteractiveRect = region?.getBoundingClientRect()
+}
+
+function handleEffectEditorTransformUpdate(payload: Parameters<typeof handleEffectTransformUpdate>[0]): void {
+  if (transformOverlayBridge?.enabled.value) {
+    transformOverlayBridge.handlePanelTransformUpdate(payload)
+    return
+  }
+
+  handleEffectTransformUpdate(payload)
+}
+
+function getTransformOverlayFieldValue(path: string): string | undefined {
+  if (!TRANSFORM_OVERLAY_FIELD_PATHS.has(path)) {
+    return undefined
+  }
+
+  const displayTransform = transformOverlayBridge?.formDisplayTransform.value
+  if (!displayTransform) {
+    return undefined
+  }
+
+  switch (path) {
+    case 'position.x': {
+      return String(displayTransform.position.x)
+    }
+    case 'position.y': {
+      return String(displayTransform.position.y)
+    }
+    case 'scale.x': {
+      return String(displayTransform.scale.x)
+    }
+    case 'scale.y': {
+      return String(displayTransform.scale.y)
+    }
+    case 'rotation': {
+      return String(displayTransform.rotation)
+    }
+    default: {
+      return undefined
+    }
+  }
+}
+
+useEventListener(globalThis, 'resize', updateEffectEditorInteractiveRegion)
+useResizeObserver($$(effectEditorInteractiveRegion), updateEffectEditorInteractiveRegion)
+
+watch(
+  () => effectEditorProvider.isOpen,
+  async (isOpen) => {
+    if (!isOpen) {
+      updateEffectEditorInteractiveRegion()
+      return
+    }
+
+    await nextTick()
+    updateEffectEditorInteractiveRegion()
+  },
+  { flush: 'post' },
+)
+
 const sidebarEmptyText = $computed(() => (
   binding.value?.getEmptyState?.() === 'multiple-edit-targets'
     ? t('edit.textEditor.formPanel.multipleEditTargets')
@@ -56,6 +250,16 @@ useShortcut({
   id: 'effect.apply',
   keys: 'Mod+Enter',
   when: { panelFocus: 'effectEditor' },
+})
+
+useShortcut({
+  execute: () => {
+    void handleEffectApply()
+  },
+  i18nKey: 'shortcut.effect.apply',
+  id: 'effect.applyFromTransformOverlay',
+  keys: ['Enter', 'Mod+Enter'],
+  when: { panelFocus: 'transformOverlay' },
 })
 
 useShortcut({
@@ -134,8 +338,11 @@ defineExpose({ toggleCommandPanel })
 
       <Sheet :open="effectEditorProvider.isOpen" :modal="false" @update:open="handleEffectEditorSheetOpenChange">
         <div
-          v-if="effectEditorProvider.isOpen"
-          class="inset-x-0 bottom-0 top-7 fixed z-40"
+          v-for="segment in effectEditorDismissLayerSegments"
+          :key="segment.key"
+          data-testid="effect-editor-dismiss-layer"
+          class="fixed z-40"
+          :style="segment.style"
           aria-hidden="true"
           @click="closeEffectEditor"
         />
@@ -163,14 +370,18 @@ defineExpose({ toggleCommandPanel })
               v-if="effectEditorSession"
               class="flex-1 min-h-0"
               :transform="effectEditorSession.draft.transform"
+              :baseline-source="effectEditorSession.baselineSource"
+              :baseline-transform="effectEditorSession.baselineTransform"
+              :preview-field-value="getTransformOverlayFieldValue"
               :duration="effectEditorSession.draft.duration"
               :ease="effectEditorSession.draft.ease"
               :can-apply="effectEditorProvider.canApply"
               :can-reset="effectEditorProvider.canReset"
-              @update:transform="handleEffectTransformUpdate"
+              @update:transform="handleEffectEditorTransformUpdate"
               @update:duration="effectEditorProvider.updateDraft({ duration: $event })"
               @update:ease="effectEditorProvider.updateDraft({ ease: $event })"
               @preview="effectEditorProvider.requestPreview"
+              @cancel-preview="effectEditorProvider.cancelPreview"
               @apply="handleEffectApply"
               @reset="handleEffectReset"
             />

--- a/src/components/editor/EditorPanel.vue
+++ b/src/components/editor/EditorPanel.vue
@@ -225,7 +225,7 @@ watch(
     await nextTick()
     updateEffectEditorInteractiveRegion()
   },
-  { flush: 'post' },
+  { flush: 'post', immediate: true },
 )
 
 const sidebarEmptyText = $computed(() => (

--- a/src/components/editor/LeftPanel.vue
+++ b/src/components/editor/LeftPanel.vue
@@ -60,7 +60,7 @@ function handlePreviewExpand() {
     <ResizablePanel
       ref="previewPanel"
       size-unit="px"
-      :default-size="270"
+      :default-size="300"
       :min-size="150"
       collapsible
       @collapse="handlePreviewCollapse"

--- a/src/components/editor/PreviewPanel.vue
+++ b/src/components/editor/PreviewPanel.vue
@@ -19,6 +19,7 @@ import {
   resolvePreviewPanelStageSize,
 } from '~/features/editor/preview/preview-panel'
 import { resolvePreviewReadySyncTarget } from '~/features/editor/preview/preview-ready-sync-target'
+import { TRANSFORM_OVERLAY_BRIDGE_KEY } from '~/features/editor/transform-overlay/context'
 import { debugCommander } from '~/services/debug-commander'
 import { useEditorStore } from '~/stores/editor'
 import { useModalStore } from '~/stores/modal'
@@ -28,9 +29,11 @@ import { usePreviewSyncStore } from '~/stores/preview-sync'
 import { useWorkspaceStore } from '~/stores/workspace'
 import { handleError } from '~/utils/error-handler'
 
+import TransformOverlay from './TransformOverlay.vue'
 import ViewportControls from './ViewportControls.vue'
 
 import type { PreviewPanelStageSize } from '~/features/editor/preview/preview-panel'
+import type { DisplayTransform } from '~/features/editor/transform-overlay/model'
 
 const editorStore = useEditorStore()
 const modalStore = useModalStore()
@@ -40,6 +43,10 @@ const previewSyncStore = usePreviewSyncStore()
 const workspaceStore = useWorkspaceStore()
 const iframeRef = useTemplateRef<HTMLIFrameElement>('iframeRef')
 const viewportRef = useTemplateRef<HTMLElement>('viewportRef')
+const transformOverlayBridge = inject(TRANSFORM_OVERLAY_BRIDGE_KEY, undefined)
+const transformOverlayEnabled = $computed(() => transformOverlayBridge?.enabled.value ?? false)
+const transformOverlayReferenceBox = $computed(() => transformOverlayBridge?.referenceBox.value)
+const transformOverlayDisplayTransform = $computed(() => transformOverlayBridge?.displayTransform.value)
 
 const previewUrl = $computed(() => previewSessionStore.currentGameServeUrl ?? '')
 const hasPreviewUrl = $computed(() => !!previewSessionStore.currentGameServeUrl)
@@ -133,6 +140,18 @@ function applyStageSize(nextStageSize: PreviewPanelStageSize) {
   aspectRatio = nextStageSize.aspectRatio
   stageWidth = nextStageSize.stageWidth
   stageHeight = nextStageSize.stageHeight
+}
+
+function previewTransformOverlayDisplayTransform(value: DisplayTransform): void {
+  transformOverlayBridge?.updateDisplayTransform(value)
+}
+
+function commitTransformOverlayDisplayTransform(value: DisplayTransform): void {
+  transformOverlayBridge?.updateDisplayTransform(value, { flush: true })
+}
+
+function cancelTransformOverlayDisplayTransform(): void {
+  transformOverlayBridge?.cancelDisplayTransform()
 }
 
 async function fitViewportToCurrentStage(): Promise<void> {
@@ -511,55 +530,68 @@ onBeforeUnmount(() => {
         </div>
       </TooltipProvider>
     </div>
-    <div
-      ref="viewportRef"
-      data-testid="preview-viewport"
-      class="bg-muted size-full relative overflow-hidden"
-      :class="previewViewportClass"
-      @wheel="previewViewport.handleWheel"
-      @pointerdown="previewViewport.handlePointerDown"
-    >
+    <div data-effect-editor-interactive-region class="flex flex-1 flex-col min-h-0 divide-y">
       <div
-        v-if="hasPreviewUrl"
-        data-testid="preview-canvas"
-        class="bg-background shadow-sm origin-top-left left-0 top-0 absolute"
-        :style="previewCanvasStyle"
+        ref="viewportRef"
+        data-testid="preview-viewport"
+        class="bg-muted flex-1 min-h-0 relative overflow-hidden"
+        :class="previewViewportClass"
+        @wheel="previewViewport.handleWheel"
+        @pointerdown="previewViewport.handlePointerDown"
       >
-        <iframe
-          ref="iframeRef"
-          :key="refreshKey"
-          :src="previewUrl"
-          :title="previewTitle"
-          class="border-0 size-full"
-          :style="previewIframeStyle"
+        <div
+          v-if="hasPreviewUrl"
+          data-testid="preview-canvas"
+          class="bg-background shadow-sm origin-top-left left-0 top-0 absolute"
+          :style="previewCanvasStyle"
+        >
+          <iframe
+            ref="iframeRef"
+            :key="refreshKey"
+            :src="previewUrl"
+            :title="previewTitle"
+            class="border-0 size-full"
+            :style="previewIframeStyle"
+          />
+        </div>
+        <TransformOverlay
+          v-if="hasPreviewUrl && transformOverlayEnabled"
+          :box="transformOverlayReferenceBox"
+          :canvas-height="stageHeight"
+          :canvas-placement="previewViewport.canvasPlacement.value"
+          :canvas-width="stageWidth"
+          :display-transform="transformOverlayDisplayTransform"
+          @cancel:display-transform="cancelTransformOverlayDisplayTransform"
+          @commit:display-transform="commitTransformOverlayDisplayTransform"
+          @preview:display-transform="previewTransformOverlayDisplayTransform"
+        />
+        <div
+          v-if="isPreviewInteractionOverlayVisible"
+          data-testid="preview-interaction-overlay"
+          aria-hidden="true"
+          class="inset-0 absolute z-5"
+          :style="previewInteractionOverlayStyle"
         />
       </div>
       <div
-        v-if="isPreviewInteractionOverlayVisible"
-        data-testid="preview-interaction-overlay"
-        aria-hidden="true"
-        class="inset-0 absolute z-5"
-        :style="previewInteractionOverlayStyle"
-      />
-    </div>
-    <div
-      v-if="hasPreviewUrl"
-      data-testid="preview-bottom-toolbar"
-      class="text-muted-foreground px-2 bg-background/80 flex flex-shrink-0 h-6.5 items-center justify-between"
-    >
-      <output
-        data-testid="preview-resolution"
-        class="text-xs leading-none font-medium font-mono pointer-events-none select-none tabular-nums"
-        :aria-label="$t('edit.previewPanel.resolution')"
+        v-if="hasPreviewUrl"
+        data-testid="preview-bottom-toolbar"
+        class="text-muted-foreground px-2 bg-background/80 flex flex-shrink-0 h-6.5 items-center justify-between"
       >
-        {{ resolutionLabel }}
-      </output>
-      <ViewportControls
-        :zoom-ratio="previewViewport.zoomRatio.value"
-        @zoom-in="previewViewport.zoomIn"
-        @zoom-out="previewViewport.zoomOut"
-        @fit-to-view="previewViewport.fitToView"
-      />
+        <output
+          data-testid="preview-resolution"
+          class="text-xs leading-none font-medium font-mono pointer-events-none select-none tabular-nums"
+          :aria-label="$t('edit.previewPanel.resolution')"
+        >
+          {{ resolutionLabel }}
+        </output>
+        <ViewportControls
+          :zoom-ratio="previewViewport.zoomRatio.value"
+          @zoom-in="previewViewport.zoomIn"
+          @zoom-out="previewViewport.zoomOut"
+          @fit-to-view="previewViewport.fitToView"
+        />
+      </div>
     </div>
   </div>
 </template>

--- a/src/composables/__tests__/usePreviewViewport.test.ts
+++ b/src/composables/__tests__/usePreviewViewport.test.ts
@@ -183,6 +183,11 @@ describe('usePreviewViewport', () => {
     expect(viewport?.zoom.value).toBeCloseTo(0.5)
     expect(viewport?.zoomRatio.value).toBe(1)
     expect(viewport?.viewportTransform.value).toBe('translate(0px, 75px) scale(0.5)')
+    expect(viewport?.canvasPlacement.value).toEqual({
+      left: 0,
+      scale: 0.5,
+      top: 75,
+    })
 
     scope.stop()
   })

--- a/src/composables/usePreviewViewport.ts
+++ b/src/composables/usePreviewViewport.ts
@@ -15,6 +15,12 @@ export interface PreviewViewportPoint {
   y: number
 }
 
+export interface PreviewCanvasPlacement {
+  left: number
+  scale: number
+  top: number
+}
+
 export interface UsePreviewViewportOptions {
   getCanvasSize: () => PreviewViewportSize
   getViewportElement: () => HTMLElement | null | undefined
@@ -73,6 +79,11 @@ export function usePreviewViewport(options: UsePreviewViewportOptions) {
   const viewportTransform = computed(() => {
     return `translate(${formatCssNumber(panX.value)}px, ${formatCssNumber(panY.value)}px) scale(${formatCssNumber(zoom.value)})`
   })
+  const canvasPlacement = computed<PreviewCanvasPlacement>(() => ({
+    left: panX.value,
+    scale: zoom.value,
+    top: panY.value,
+  }))
 
   function getViewportRect(): DOMRect | undefined {
     return options.getViewportElement()?.getBoundingClientRect()
@@ -359,6 +370,7 @@ export function usePreviewViewport(options: UsePreviewViewportOptions) {
   useEventListener(globalThis, 'blur', handleWindowBlur)
 
   return {
+    canvasPlacement,
     fitToView,
     handleForwardedPointerEvent,
     handlePointerDown,

--- a/src/features/editor/transform-overlay/__tests__/useTransformOverlayBridge.test.ts
+++ b/src/features/editor/transform-overlay/__tests__/useTransformOverlayBridge.test.ts
@@ -72,7 +72,7 @@ function createProvider(session: EffectEditorSession | undefined): EffectEditorP
     close: vi.fn(),
     apply: vi.fn(),
     cancelPreview: vi.fn(),
-    updateDraft: vi.fn((patch, options) => {
+    updateDraft: vi.fn((patch, _options) => {
       if (!session) {
         return
       }

--- a/src/features/editor/transform-overlay/__tests__/useTransformOverlayBridge.test.ts
+++ b/src/features/editor/transform-overlay/__tests__/useTransformOverlayBridge.test.ts
@@ -1,0 +1,395 @@
+import '~/__tests__/setup'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { effectScope, reactive } from 'vue'
+import { commandType } from 'webgal-parser/src/interface/sceneInterface'
+
+import { useTransformOverlayBridge } from '../useTransformOverlayBridge'
+
+import type { EffectScope } from 'vue'
+import type { EffectEditorProvider, EffectEditorSession } from '~/features/editor/effect-editor/useEffectEditorProvider'
+import type { ReferenceBoxQueryResultPayload } from '~/types/editorPreviewProtocol'
+
+const previewSyncStore = vi.hoisted(() => ({
+  isPreviewReady: true,
+  queryReferenceBox: vi.fn<(target: string) => Promise<ReferenceBoxQueryResultPayload>>(),
+}))
+
+vi.mock('~/stores/preview-sync', () => ({
+  usePreviewSyncStore: () => previewSyncStore,
+}))
+
+function createSession(options: {
+  baselineResolved?: boolean
+} = {}): EffectEditorSession {
+  return reactive({
+    sessionId: 1,
+    command: commandType.changeFigure,
+    effectTarget: 'fig-center',
+    scenePath: 'scene/start.txt',
+    sentenceId: 3,
+    lineCommandString: 'changeFigure:figure.png;',
+    draft: {
+      duration: '',
+      ease: '',
+      transform: {},
+    },
+    initialDraft: {
+      duration: '',
+      ease: '',
+      transform: {},
+    },
+    baseDraft: {
+      duration: '',
+      ease: '',
+      transform: {},
+    },
+    dirty: false,
+    hasApplied: false,
+    missingTargetWarned: false,
+    baselineResolved: options.baselineResolved ?? true,
+    baselineSource: 'unknown',
+    writeDefault: false,
+    onApply() { /* no-op */ },
+  }) as EffectEditorSession
+}
+
+function createProvider(session: EffectEditorSession | undefined): EffectEditorProvider {
+  return {
+    get isOpen() {
+      return Boolean(session)
+    },
+    get session() {
+      return session
+    },
+    get canApply() {
+      return false
+    },
+    get canReset() {
+      return false
+    },
+    open: vi.fn(),
+    close: vi.fn(),
+    apply: vi.fn(),
+    cancelPreview: vi.fn(),
+    updateDraft: vi.fn((patch, options) => {
+      if (!session) {
+        return
+      }
+      if (patch.transform) {
+        session.draft.transform = patch.transform
+      }
+    }),
+    updatePreviewTransform: vi.fn(),
+    resetToInitialDraft: vi.fn(),
+    requestPreview: vi.fn(),
+  } as unknown as EffectEditorProvider
+}
+
+let scope: EffectScope | undefined
+
+function createBridge(options: Parameters<typeof useTransformOverlayBridge>[0]): ReturnType<typeof useTransformOverlayBridge> {
+  scope?.stop()
+  scope = effectScope()
+  return scope.run(() => useTransformOverlayBridge(options))!
+}
+
+describe('useTransformOverlayBridge', () => {
+  beforeEach(() => {
+    previewSyncStore.isPreviewReady = true
+    previewSyncStore.queryReferenceBox.mockReset()
+    vi.useRealTimers()
+  })
+
+  afterEach(() => {
+    scope?.stop()
+    scope = undefined
+    vi.useRealTimers()
+  })
+
+  it('引用框不可用时不会显示变换控件', async () => {
+    previewSyncStore.queryReferenceBox.mockResolvedValueOnce({
+      target: 'fig-center',
+      status: 'missing',
+    })
+
+    const bridge = createBridge({
+      provider: createProvider(createSession()),
+    })
+
+    await vi.waitFor(() => {
+      expect(previewSyncStore.queryReferenceBox).toHaveBeenCalledWith('fig-center')
+    })
+
+    expect(bridge.referenceBox.value).toBeUndefined()
+    expect(bridge.enabled.value).toBe(false)
+  })
+
+  it('预览未就绪时不会查询引用框', () => {
+    previewSyncStore.isPreviewReady = false
+
+    const bridge = createBridge({
+      provider: createProvider(createSession()),
+    })
+
+    expect(previewSyncStore.queryReferenceBox).not.toHaveBeenCalled()
+    expect(bridge.referenceBox.value).toBeUndefined()
+    expect(bridge.enabled.value).toBe(false)
+  })
+
+  it('基线解析完成前不会显示变换控件', async () => {
+    previewSyncStore.queryReferenceBox.mockResolvedValueOnce({
+      target: 'fig-center',
+      status: 'ready',
+      box: {
+        originX: 640,
+        originY: 360,
+        width: 200,
+        height: 100,
+        anchorX: 0.5,
+        anchorY: 0.5,
+        stageWidth: 1280,
+        stageHeight: 720,
+      },
+    })
+
+    const session = createSession({ baselineResolved: false })
+    const bridge = createBridge({
+      provider: createProvider(session),
+    })
+
+    expect(bridge.displayTransform.value).toBeDefined()
+    expect(previewSyncStore.queryReferenceBox).not.toHaveBeenCalled()
+    expect(bridge.referenceBox.value).toBeUndefined()
+    expect(bridge.enabled.value).toBe(false)
+
+    session.baselineResolved = true
+    await vi.waitFor(() => {
+      expect(bridge.referenceBox.value).toBeDefined()
+    })
+
+    expect(bridge.enabled.value).toBe(true)
+  })
+
+  it('拖拽中的显示变换只更新交互态和预览覆盖，不写入响应式 draft', () => {
+    const provider = createProvider(createSession())
+    const bridge = createBridge({
+      provider,
+    })
+    const firstDisplayTransform = {
+      position: { x: 24, y: 12 },
+      scale: { x: 1, y: 1 },
+      rotation: 0,
+    }
+    const nextDisplayTransform = {
+      position: { x: 48, y: 24 },
+      scale: { x: 1, y: 1 },
+      rotation: 0,
+    }
+
+    bridge.updateDisplayTransform(firstDisplayTransform)
+    bridge.updateDisplayTransform(nextDisplayTransform)
+
+    const previewTransformArg: unknown = vi.mocked(provider.updatePreviewTransform).mock.calls.at(-1)?.[0]
+    expect(provider.updateDraft).not.toHaveBeenCalled()
+    expect(bridge.displayTransform.value).toEqual(nextDisplayTransform)
+    expect(typeof previewTransformArg).toBe('function')
+    expect((previewTransformArg as () => unknown)()).toEqual({
+      position: { x: 48, y: 24 },
+    })
+    expect(provider.requestPreview).toHaveBeenCalledWith({
+      flush: undefined,
+      schedule: 'frame',
+    })
+  })
+
+  it('拖拽中的表单显示变换会节流到最新值但不延迟浮层显示', () => {
+    vi.useFakeTimers()
+
+    const provider = createProvider(createSession())
+    const bridge = createBridge({
+      provider,
+    })
+    const firstDisplayTransform = {
+      position: { x: 24, y: 12 },
+      scale: { x: 1, y: 1 },
+      rotation: 0,
+    }
+    const nextDisplayTransform = {
+      position: { x: 48, y: 24 },
+      scale: { x: 1, y: 1 },
+      rotation: 0,
+    }
+
+    bridge.updateDisplayTransform(firstDisplayTransform)
+
+    expect(bridge.displayTransform.value).toEqual(firstDisplayTransform)
+    expect(bridge.formDisplayTransform.value).toEqual(firstDisplayTransform)
+
+    bridge.updateDisplayTransform(nextDisplayTransform)
+
+    expect(bridge.displayTransform.value).toEqual(nextDisplayTransform)
+    expect(bridge.formDisplayTransform.value).toEqual(firstDisplayTransform)
+
+    vi.advanceTimersByTime(32)
+
+    expect(bridge.formDisplayTransform.value).toEqual(nextDisplayTransform)
+  })
+
+  it('拖拽提交会立即刷新表单显示并丢弃待处理的节流值', () => {
+    vi.useFakeTimers()
+
+    const provider = createProvider(createSession())
+    const bridge = createBridge({
+      provider,
+    })
+    const firstDisplayTransform = {
+      position: { x: 24, y: 12 },
+      scale: { x: 1, y: 1 },
+      rotation: 0,
+    }
+    const pendingDisplayTransform = {
+      position: { x: 48, y: 24 },
+      scale: { x: 1, y: 1 },
+      rotation: 0,
+    }
+    const finalDisplayTransform = {
+      position: { x: 64, y: 32 },
+      scale: { x: 1, y: 1 },
+      rotation: 0,
+    }
+
+    bridge.updateDisplayTransform(firstDisplayTransform)
+    bridge.updateDisplayTransform(pendingDisplayTransform)
+    bridge.updateDisplayTransform(finalDisplayTransform, { flush: true })
+
+    expect(bridge.formDisplayTransform.value).toEqual(finalDisplayTransform)
+
+    vi.advanceTimersByTime(32)
+
+    expect(bridge.formDisplayTransform.value).toEqual(finalDisplayTransform)
+  })
+
+  it('销毁时会取消待处理的表单显示节流任务', () => {
+    vi.useFakeTimers()
+
+    const provider = createProvider(createSession())
+    const bridge = createBridge({
+      provider,
+    })
+    const firstDisplayTransform = {
+      position: { x: 24, y: 12 },
+      scale: { x: 1, y: 1 },
+      rotation: 0,
+    }
+    const nextDisplayTransform = {
+      position: { x: 48, y: 24 },
+      scale: { x: 1, y: 1 },
+      rotation: 0,
+    }
+
+    bridge.updateDisplayTransform(firstDisplayTransform)
+    bridge.updateDisplayTransform(nextDisplayTransform)
+
+    scope?.stop()
+    scope = undefined
+    vi.advanceTimersByTime(32)
+
+    expect(bridge.formDisplayTransform.value).toBeUndefined()
+  })
+
+  it('拖拽提交时才写入正式草稿并清理交互态', () => {
+    const provider = createProvider(createSession())
+    const bridge = createBridge({
+      provider,
+    })
+    const nextDisplayTransform = {
+      position: { x: 24, y: 12 },
+      scale: { x: 1, y: 1 },
+      rotation: 0,
+    }
+
+    bridge.updateDisplayTransform(nextDisplayTransform)
+    bridge.updateDisplayTransform(nextDisplayTransform, { flush: true })
+
+    expect(provider.updateDraft).toHaveBeenCalledTimes(1)
+    expect(provider.updateDraft).toHaveBeenLastCalledWith(
+      { transform: { position: { x: 24, y: 12 } } },
+      { deferAutoApply: false },
+    )
+    expect(bridge.displayTransform.value).toEqual(nextDisplayTransform)
+    expect(provider.updatePreviewTransform).toHaveBeenLastCalledWith({
+      position: { x: 24, y: 12 },
+    })
+    expect(provider.requestPreview).toHaveBeenLastCalledWith({
+      flush: true,
+      schedule: 'immediate',
+    })
+  })
+
+  it('取消拖拽会清理交互态并请求恢复预览场景', () => {
+    const provider = createProvider(createSession())
+    const bridge = createBridge({
+      provider,
+    })
+    const nextDisplayTransform = {
+      position: { x: 24, y: 12 },
+      scale: { x: 1, y: 1 },
+      rotation: 0,
+    }
+
+    bridge.updateDisplayTransform(nextDisplayTransform)
+    expect(bridge.displayTransform.value).toEqual(nextDisplayTransform)
+
+    bridge.cancelDisplayTransform()
+
+    expect(bridge.displayTransform.value).toEqual({
+      position: { x: 0, y: 0 },
+      scale: { x: 1, y: 1 },
+      rotation: 0,
+    })
+    expect(provider.cancelPreview).toHaveBeenCalledOnce()
+  })
+
+  it('没有会话时取消拖拽不会请求恢复预览场景', () => {
+    const provider = createProvider(undefined)
+    const bridge = createBridge({
+      provider,
+    })
+
+    bridge.cancelDisplayTransform()
+
+    expect(provider.cancelPreview).not.toHaveBeenCalled()
+  })
+
+  it('右侧表单更新会写入草稿和预览覆盖，但不重复调度预览', () => {
+    const provider = createProvider(createSession())
+    const bridge = createBridge({
+      provider,
+    })
+
+    bridge.handlePanelTransformUpdate({
+      value: {
+        alpha: 0.8,
+        position: { x: 32, y: 16 },
+      },
+      deferAutoApply: true,
+      flush: false,
+    })
+
+    expect(provider.updateDraft).toHaveBeenCalledWith(
+      {
+        transform: {
+          alpha: 0.8,
+          position: { x: 32, y: 16 },
+        },
+      },
+      { deferAutoApply: true },
+    )
+    expect(provider.updatePreviewTransform).toHaveBeenCalledWith({
+      alpha: 0.8,
+      position: { x: 32, y: 16 },
+    })
+    expect(provider.requestPreview).not.toHaveBeenCalled()
+  })
+})

--- a/src/features/editor/transform-overlay/context.ts
+++ b/src/features/editor/transform-overlay/context.ts
@@ -1,0 +1,6 @@
+import type { useTransformOverlayBridge } from './useTransformOverlayBridge'
+
+type UseTransformOverlayBridgeReturn = ReturnType<typeof useTransformOverlayBridge>
+
+export const TRANSFORM_OVERLAY_BRIDGE_KEY: InjectionKey<UseTransformOverlayBridgeReturn> =
+  Symbol('transform-overlay-bridge')

--- a/src/features/editor/transform-overlay/useTransformOverlayBridge.ts
+++ b/src/features/editor/transform-overlay/useTransformOverlayBridge.ts
@@ -1,0 +1,227 @@
+import { usePreviewSyncStore } from '~/stores/preview-sync'
+
+import {
+  deriveDisplayTransform,
+  materializeDisplayTransform,
+} from './model'
+
+import type { DisplayTransform } from './model'
+import type {
+  EffectEditorProvider,
+  EffectEditorTransformUpdatePayload,
+} from '~/features/editor/effect-editor/useEffectEditorProvider'
+import type { ReferenceBoxQueryResultPayload } from '~/types/editorPreviewProtocol'
+
+export interface UseTransformOverlayBridgeOptions {
+  provider: EffectEditorProvider
+}
+
+const FORM_DISPLAY_THROTTLE_MS = 32
+
+export function useTransformOverlayBridge(options: UseTransformOverlayBridgeOptions) {
+  const previewSyncStore = usePreviewSyncStore()
+
+  let referenceBoxResult = $ref<ReferenceBoxQueryResultPayload>()
+  let liveDisplayTransform = $ref<DisplayTransform>()
+  let formDisplayTransform = $ref<DisplayTransform>()
+  let pendingFormDisplayTransform = $ref<DisplayTransform>()
+  let formDisplayTimeoutId: ReturnType<typeof setTimeout> | undefined
+  let queryRevision = 0
+
+  const session = computed(() => options.provider.session)
+  const referenceBox = computed(() => referenceBoxResult?.status === 'ready' ? referenceBoxResult.box : undefined)
+  const draftDisplayTransform = computed<DisplayTransform | undefined>(() => {
+    const currentSession = session.value
+    if (!currentSession) {
+      return
+    }
+
+    return deriveDisplayTransform({
+      baselineSource: currentSession.baselineSource,
+      baselineTransform: currentSession.baselineTransform,
+      explicitDraftTransform: currentSession.draft.transform,
+    })
+  })
+  const displayTransform = computed<DisplayTransform | undefined>(() => liveDisplayTransform ?? draftDisplayTransform.value)
+  const displayFormTransform = computed<DisplayTransform | undefined>(() => formDisplayTransform)
+  const enabled = computed(() => Boolean(
+    session.value?.effectTarget
+    && session.value.baselineResolved
+    && referenceBox.value
+    && displayTransform.value,
+  ))
+
+  async function queryReferenceBox(): Promise<void> {
+    const currentSession = session.value
+    if (
+      !currentSession?.effectTarget
+      || !currentSession.baselineResolved
+      || !previewSyncStore.isPreviewReady
+    ) {
+      queryRevision++
+      referenceBoxResult = undefined
+      return
+    }
+
+    const revision = ++queryRevision
+    const result = await previewSyncStore.queryReferenceBox(currentSession.effectTarget)
+
+    if (revision !== queryRevision) {
+      return
+    }
+
+    referenceBoxResult = result
+  }
+
+  function cancelScheduledFormDisplayTransform(): void {
+    if (formDisplayTimeoutId === undefined) {
+      return
+    }
+
+    clearTimeout(formDisplayTimeoutId)
+    formDisplayTimeoutId = undefined
+  }
+
+  function resetFormDisplayTransform(): void {
+    cancelScheduledFormDisplayTransform()
+    pendingFormDisplayTransform = undefined
+    formDisplayTransform = undefined
+  }
+
+  function applyFormDisplayTransform(nextDisplayTransform: DisplayTransform): void {
+    cancelScheduledFormDisplayTransform()
+    pendingFormDisplayTransform = undefined
+    formDisplayTransform = nextDisplayTransform
+  }
+
+  function flushPendingFormDisplayTransform(): void {
+    formDisplayTimeoutId = undefined
+    if (!pendingFormDisplayTransform) {
+      return
+    }
+
+    formDisplayTransform = pendingFormDisplayTransform
+    pendingFormDisplayTransform = undefined
+  }
+
+  function scheduleFormDisplayTransform(nextDisplayTransform: DisplayTransform): void {
+    if (!formDisplayTransform) {
+      formDisplayTransform = nextDisplayTransform
+      return
+    }
+
+    pendingFormDisplayTransform = nextDisplayTransform
+    if (formDisplayTimeoutId !== undefined) {
+      return
+    }
+
+    formDisplayTimeoutId = setTimeout(flushPendingFormDisplayTransform, FORM_DISPLAY_THROTTLE_MS)
+  }
+
+  function updateDisplayTransform(
+    nextDisplayTransform: DisplayTransform,
+    options_: { flush?: boolean } = {},
+  ): void {
+    const currentSession = session.value
+    if (!currentSession) {
+      return
+    }
+
+    const baseDisplayTransform = draftDisplayTransform.value
+    if (!baseDisplayTransform) {
+      return
+    }
+
+    if (options_.flush) {
+      const nextDraftTransform = materializeDisplayTransform({
+        currentDisplayTransform: baseDisplayTransform,
+        explicitDraftTransform: currentSession.draft.transform,
+        nextDisplayTransform,
+      })
+      liveDisplayTransform = undefined
+      options.provider.updateDraft(
+        { transform: nextDraftTransform },
+        { deferAutoApply: false },
+      )
+      options.provider.updatePreviewTransform(nextDraftTransform)
+      applyFormDisplayTransform(nextDisplayTransform)
+    } else {
+      liveDisplayTransform = nextDisplayTransform
+      scheduleFormDisplayTransform(nextDisplayTransform)
+      options.provider.updatePreviewTransform(() => {
+        const latestDisplayTransform = liveDisplayTransform ?? nextDisplayTransform
+        return materializeDisplayTransform({
+          currentDisplayTransform: baseDisplayTransform,
+          explicitDraftTransform: currentSession.draft.transform,
+          nextDisplayTransform: latestDisplayTransform,
+        })
+      })
+    }
+
+    options.provider.requestPreview({
+      flush: options_.flush,
+      schedule: options_.flush ? 'immediate' : 'frame',
+    })
+  }
+
+  function handlePanelTransformUpdate(payload: EffectEditorTransformUpdatePayload): void {
+    const currentSession = session.value
+    if (!currentSession) {
+      return
+    }
+
+    liveDisplayTransform = undefined
+    resetFormDisplayTransform()
+    options.provider.updateDraft(
+      { transform: payload.value },
+      { deferAutoApply: payload.deferAutoApply },
+    )
+    options.provider.updatePreviewTransform(payload.value)
+  }
+
+  function cancelDisplayTransform(): void {
+    liveDisplayTransform = undefined
+    resetFormDisplayTransform()
+    if (!session.value) {
+      return
+    }
+
+    void options.provider.cancelPreview()
+  }
+
+  watch(
+    () => [
+      session.value?.sessionId,
+      session.value?.effectTarget,
+      session.value?.baselineResolved,
+      previewSyncStore.isPreviewReady,
+    ],
+    () => {
+      liveDisplayTransform = undefined
+      resetFormDisplayTransform()
+      void queryReferenceBox()
+    },
+    { immediate: true },
+  )
+
+  watch(
+    () => session.value?.draft.transform,
+    () => {
+      liveDisplayTransform = undefined
+      resetFormDisplayTransform()
+    },
+    { deep: true },
+  )
+
+  tryOnScopeDispose(resetFormDisplayTransform)
+
+  return {
+    displayTransform,
+    enabled,
+    formDisplayTransform: displayFormTransform,
+    cancelDisplayTransform,
+    handlePanelTransformUpdate,
+    referenceBox,
+    updateDisplayTransform,
+  }
+}

--- a/src/views/edit/[gameId].vue
+++ b/src/views/edit/[gameId].vue
@@ -1,9 +1,12 @@
 <script setup lang="ts">
 import { ResizablePanel } from '~/components/ui/resizable'
 import { useAnimationTableSyncBootstrap } from '~/features/editor/animation/useAnimationTableSyncBootstrap'
+import { useEffectEditorProvider } from '~/features/editor/effect-editor/useEffectEditorProvider'
 import { createEditorShortcutDefinitions } from '~/features/editor/shortcut/definitions'
 import { useShortcutContext } from '~/features/editor/shortcut/useShortcutContext'
 import { useShortcutDispatcher } from '~/features/editor/shortcut/useShortcutDispatcher'
+import { TRANSFORM_OVERLAY_BRIDGE_KEY } from '~/features/editor/transform-overlay/context'
+import { useTransformOverlayBridge } from '~/features/editor/transform-overlay/useTransformOverlayBridge'
 import { requestGameRuntimeRebind, resolveRuntimeRebindIssue } from '~/features/modals/import-dependency-resolution/request-game-runtime-rebind'
 import { requestImportDependencyResolution } from '~/features/modals/import-dependency-resolution/request-import-dependency-resolution'
 import { gameManager } from '~/services/game-manager'
@@ -26,6 +29,12 @@ const preferenceStore = usePreferenceStore()
 const workspaceStore = useWorkspaceStore()
 const router = useRouter()
 const editorPanelRef = useTemplateRef<EditorPanelHandle>('editorPanel')
+const effectEditorProvider = useEffectEditorProvider()
+const transformOverlayBridge = useTransformOverlayBridge({
+  provider: effectEditorProvider,
+})
+
+provide(TRANSFORM_OVERLAY_BRIDGE_KEY, transformOverlayBridge)
 
 let pendingEditExit: Promise<void> | undefined
 

--- a/src/views/edit/__tests__/game-id.test.ts
+++ b/src/views/edit/__tests__/game-id.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createSSRApp, reactive } from 'vue'
 import { renderToString } from 'vue/server-renderer'
 
+import { createBrowserLiteI18n } from '~/__tests__/browser'
 import { createTestGame } from '~/__tests__/factories'
 import { AppError } from '~/types/errors'
 
@@ -173,6 +174,15 @@ vi.mock('~/stores/workspace', () => ({
 
 const mountedApps: { unmount: () => void }[] = []
 
+async function renderEditView() {
+  const view = await import('../[gameId].vue')
+  const app = createSSRApp(view.default)
+
+  app.use(createBrowserLiteI18n())
+  await renderToString(app)
+  mountedApps.push(app)
+}
+
 describe('edit/[gameId]', () => {
   beforeEach(() => {
     useAnimationTableSyncBootstrapMock.mockReset()
@@ -233,11 +243,7 @@ describe('edit/[gameId]', () => {
   })
 
   it('会在编辑页壳层启动资源索引 bootstrap', async () => {
-    const view = await import('../[gameId].vue')
-    const app = createSSRApp(view.default)
-
-    await renderToString(app)
-    mountedApps.push(app)
+    await renderEditView()
 
     expect(useResourceIndexBootstrapMock).toHaveBeenCalledOnce()
   })
@@ -255,11 +261,7 @@ describe('edit/[gameId]', () => {
       ensureCurrentGameAvailable: vi.fn(async () => true),
     }))
 
-    const view = await import('../[gameId].vue')
-    const app = createSSRApp(view.default)
-
-    await renderToString(app)
-    mountedApps.push(app)
+    await renderEditView()
 
     await vi.waitFor(() => {
       expect(requestGameRuntimeRebindMock).toHaveBeenCalledWith(currentGame, expect.objectContaining({
@@ -295,11 +297,7 @@ describe('edit/[gameId]', () => {
       ensureCurrentGameAvailable: vi.fn(async () => true),
     }))
 
-    const view = await import('../[gameId].vue')
-    const app = createSSRApp(view.default)
-
-    await renderToString(app)
-    mountedApps.push(app)
+    await renderEditView()
 
     await vi.waitFor(() => {
       expect(modalOpenMock).toHaveBeenCalledWith(
@@ -333,11 +331,7 @@ describe('edit/[gameId]', () => {
       ensureCurrentGameAvailable: vi.fn(async () => true),
     }))
 
-    const view = await import('../[gameId].vue')
-    const app = createSSRApp(view.default)
-
-    await renderToString(app)
-    mountedApps.push(app)
+    await renderEditView()
 
     await vi.waitFor(() => {
       expect(routerReplaceMock).toHaveBeenCalledWith('/')


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [ ] 错误修复
- [x] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [x] 测试用例
- [ ] 性能优化
- [x] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

把变换浮层接入编辑器预览和效果编辑器，实现预览画布上的 transform 直接编辑。

主要改动：

- 新增 transform overlay bridge，连接 effect editor provider、preview sync store 和 reference box 查询。
- 编辑页 provide 共享 bridge，PreviewPanel 根据 bridge 状态渲染 TransformOverlay。
- PreviewPanel 暴露 canvas placement，让浮层在缩放 / 平移后的预览画布上保持正确坐标。
- EditorPanel 调整效果编辑器 dismiss layer，允许效果编辑器和预览浮层同时交互。
- 浮层拖拽中的 display transform 会同步回表单预览值，Enter / Mod+Enter 可从浮层焦点提交效果编辑器。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

前面几个 PR 已经提供协议通道、效果编辑器基线语义和浮层组件。本 PR 负责最后的页面级接入，让用户在打开效果编辑器时可以直接在内嵌预览中移动、缩放和旋转目标，并保持表单和运行时预览一致。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
