### PR TITLE
✨ TransformOverlay 支持效果编辑器快捷键

### DIFF
--- a/src/components/editor/PreviewPanel.spec.ts
+++ b/src/components/editor/PreviewPanel.spec.ts
@@ -11,6 +11,8 @@ import {
   WEBGAL_PREVIEW_VIEWPORT_SPACE_KEY,
   WEBGAL_PREVIEW_VIEWPORT_WHEEL,
 } from '~/features/editor/preview/embedded-preview-messages'
+import { useShortcutContextRegistry } from '~/features/editor/shortcut/shortcut-context-registry'
+import { TRANSFORM_OVERLAY_BRIDGE_KEY } from '~/features/editor/transform-overlay/context'
 
 const {
   copyMock,
@@ -119,6 +121,10 @@ vi.mock('notivue', () => ({
 
 import PreviewPanel from './PreviewPanel.vue'
 
+import type { DisplayTransform } from '~/features/editor/transform-overlay/model'
+import type { useTransformOverlayBridge } from '~/features/editor/transform-overlay/useTransformOverlayBridge'
+import type { ReferenceBox } from '~/types/editorPreviewProtocol'
+
 const globalStubs = {
   Button: createBrowserClickStub('StubButton'),
   Tooltip: createBrowserContainerStub('StubTooltip'),
@@ -141,6 +147,22 @@ let previewSessionStoreState: {
   currentGameServeUrl: string
   reloadVersion: number
   refresh: () => void
+}
+
+const transformOverlayReferenceBox: ReferenceBox = {
+  originX: 640,
+  originY: 360,
+  width: 200,
+  height: 100,
+  anchorX: 0.5,
+  anchorY: 0.5,
+  stageWidth: 1280,
+  stageHeight: 720,
+}
+const transformOverlayDisplayTransform: DisplayTransform = {
+  position: { x: 0, y: 0 },
+  scale: { x: 1, y: 1 },
+  rotation: 0,
 }
 
 async function flushPreviewWatchers() {
@@ -173,6 +195,18 @@ function createPreviewPanelLiteI18n() {
       },
     },
   })
+}
+
+function createTransformOverlayBridge(): ReturnType<typeof useTransformOverlayBridge> {
+  return {
+    displayTransform: ref(transformOverlayDisplayTransform),
+    enabled: ref(true),
+    formDisplayTransform: ref(transformOverlayDisplayTransform),
+    referenceBox: ref(transformOverlayReferenceBox),
+    cancelDisplayTransform: vi.fn(),
+    handlePanelTransformUpdate: vi.fn(),
+    updateDisplayTransform: vi.fn(),
+  } as unknown as ReturnType<typeof useTransformOverlayBridge>
 }
 
 function parsePreviewTransform(transform: string): {
@@ -561,6 +595,43 @@ describe('PreviewPanel', () => {
     expect(copyMock).toHaveBeenCalledTimes(1)
     expect(notifySuccessMock).toHaveBeenCalledWith('edit.previewPanel.copyUrlSuccess')
     expect(openUrlMock).toHaveBeenCalledWith('http://127.0.0.1:8899')
+  })
+
+  it('变换浮层开启时点击预览空白区域和底部工具栏会保持浮层快捷键上下文', async () => {
+    renderInBrowser(PreviewPanel, {
+      global: {
+        plugins: [createPreviewPanelLiteI18n()],
+        provide: {
+          [TRANSFORM_OVERLAY_BRIDGE_KEY as symbol]: createTransformOverlayBridge(),
+        },
+        stubs: globalStubs,
+      },
+    })
+
+    await expect.element(page.getByTestId('transform-overlay')).toBeVisible()
+
+    const externalInput = document.createElement('input')
+    document.body.append(externalInput)
+
+    try {
+      externalInput.focus()
+
+      document.querySelector<HTMLElement>('[data-testid="transform-overlay"]')?.dispatchEvent(new PointerEvent('pointerdown', {
+        bubbles: true,
+        button: 0,
+      }))
+      await nextTick()
+
+      expect(useShortcutContextRegistry().resolveContext().panelFocus).toBe('transformOverlay')
+
+      externalInput.focus()
+
+      await page.getByRole('button', { name: 'edit.previewPanel.zoomOut' }).click()
+
+      expect(useShortcutContextRegistry().resolveContext().panelFocus).toBe('transformOverlay')
+    } finally {
+      externalInput.remove()
+    }
   })
 
   it('点击刷新按钮会重新读取游戏配置并刷新内嵌预览槽位', async () => {

--- a/src/components/editor/PreviewPanel.vue
+++ b/src/components/editor/PreviewPanel.vue
@@ -141,7 +141,7 @@ function resolvePreviewInteractionCursor(): 'auto' | 'grab' | 'grabbing' | undef
 }
 
 function isPointerFocusManagedByTarget(target: EventTarget | null): boolean {
-  return target instanceof HTMLElement
+  return target instanceof Element
     && target.closest(PREVIEW_WORKSPACE_FOCUSABLE_SELECTOR) !== null
 }
 

--- a/src/components/editor/PreviewPanel.vue
+++ b/src/components/editor/PreviewPanel.vue
@@ -19,6 +19,7 @@ import {
   resolvePreviewPanelStageSize,
 } from '~/features/editor/preview/preview-panel'
 import { resolvePreviewReadySyncTarget } from '~/features/editor/preview/preview-ready-sync-target'
+import { useShortcutContext } from '~/features/editor/shortcut/useShortcutContext'
 import { TRANSFORM_OVERLAY_BRIDGE_KEY } from '~/features/editor/transform-overlay/context'
 import { debugCommander } from '~/services/debug-commander'
 import { useEditorStore } from '~/stores/editor'
@@ -42,6 +43,7 @@ const previewSessionStore = usePreviewSessionStore()
 const previewSyncStore = usePreviewSyncStore()
 const workspaceStore = useWorkspaceStore()
 const iframeRef = useTemplateRef<HTMLIFrameElement>('iframeRef')
+const previewWorkspaceRef = useTemplateRef<HTMLElement>('previewWorkspace')
 const viewportRef = useTemplateRef<HTMLElement>('viewportRef')
 const transformOverlayBridge = inject(TRANSFORM_OVERLAY_BRIDGE_KEY, undefined)
 const transformOverlayEnabled = $computed(() => transformOverlayBridge?.enabled.value ?? false)
@@ -55,6 +57,8 @@ const { t } = useI18n()
 const { copy, copied } = useClipboard({ source: $$(previewUrl) })
 const previewTitle = $computed(() => t('edit.previewPanel.previewTitle', { name: workspaceStore.currentGame?.metadata.name }))
 const resolutionLabel = $computed(() => `${stageWidth} x ${stageHeight}`)
+
+const PREVIEW_WORKSPACE_FOCUSABLE_SELECTOR = 'a[href], button, input, textarea, select, [contenteditable="true"], [tabindex]:not([tabindex="-1"])'
 
 let aspectRatio = $ref(DEFAULT_PREVIEW_PANEL_ASPECT_RATIO)
 let stageWidth = $ref(DEFAULT_PREVIEW_PANEL_STAGE_WIDTH)
@@ -134,6 +138,21 @@ function resolvePreviewInteractionCursor(): 'auto' | 'grab' | 'grabbing' | undef
   }
 
   return undefined
+}
+
+function isPointerFocusManagedByTarget(target: EventTarget | null): boolean {
+  return target instanceof HTMLElement
+    && target.closest(PREVIEW_WORKSPACE_FOCUSABLE_SELECTOR) !== null
+}
+
+function handlePreviewWorkspacePointerDown(event: PointerEvent): void {
+  if (!transformOverlayEnabled || isPointerFocusManagedByTarget(event.target)) {
+    return
+  }
+
+  if (event.currentTarget instanceof HTMLElement) {
+    event.currentTarget.focus({ preventScroll: true })
+  }
 }
 
 function applyStageSize(nextStageSize: PreviewPanelStageSize) {
@@ -475,6 +494,14 @@ watch(
   },
 )
 
+useShortcutContext({
+  panelFocus: 'transformOverlay',
+}, {
+  active: computed(() => transformOverlayEnabled),
+  target: previewWorkspaceRef,
+  trackFocus: true,
+})
+
 onMounted(() => {
   void fitViewportToCurrentStage()
 })
@@ -530,7 +557,13 @@ onBeforeUnmount(() => {
         </div>
       </TooltipProvider>
     </div>
-    <div data-effect-editor-interactive-region class="flex flex-1 flex-col min-h-0 divide-y">
+    <div
+      ref="previewWorkspace"
+      data-effect-editor-interactive-region
+      tabindex="-1"
+      class="outline-none flex flex-1 flex-col min-h-0 divide-y"
+      @pointerdown="handlePreviewWorkspacePointerDown"
+    >
       <div
         ref="viewportRef"
         data-testid="preview-viewport"

--- a/src/features/editor/shell/__tests__/useEditorPanelShell.test.ts
+++ b/src/features/editor/shell/__tests__/useEditorPanelShell.test.ts
@@ -163,6 +163,17 @@ function collectEffectShortcutBindings() {
     .filter(binding => String(binding.id).startsWith('effect.'))
 }
 
+function findEffectShortcutBinding(panelFocus: string, id: string) {
+  const binding = collectEffectShortcutBindings()
+    .find(item => item.id === id && item.when.panelFocus === panelFocus)
+
+  if (!binding) {
+    throw new Error(`缺少 ${panelFocus} 焦点下的 ${id} 快捷键`)
+  }
+
+  return binding
+}
+
 describe('useEditorPanelShell', () => {
   beforeEach(() => {
     commandPanelBridgeMock.activeBinding.value = undefined
@@ -234,51 +245,44 @@ describe('useEditorPanelShell', () => {
     scope.stop()
   })
 
-  it('只会注册 effect editor 焦点下的效果历史和剪贴板快捷键', () => {
+  it('会注册 effect editor 和 transform overlay 焦点下的效果历史与剪贴板快捷键', () => {
     const { scope } = createFixture()
 
-    expect(useShortcutMock).toHaveBeenCalledWith(expect.objectContaining({
-      id: 'effect.undo',
-      keys: 'Mod+Z',
-      when: {
-        panelFocus: 'effectEditor',
-      },
-    }))
-    expect(useShortcutMock).toHaveBeenCalledWith(expect.objectContaining({
-      id: 'effect.copy',
-      keys: 'Mod+C',
-      when: {
-        panelFocus: 'effectEditor',
-      },
-    }))
     const effectBindings = collectEffectShortcutBindings()
-
-    expect(effectBindings.map(binding => [binding.id, binding.keys])).toEqual([
+    const expectedBindings = [
       ['effect.undo', 'Mod+Z'],
       ['effect.redo', ['Mod+Shift+Z', 'Mod+Y']],
       ['effect.copy', 'Mod+C'],
       ['effect.paste', 'Mod+V'],
-    ])
+    ]
+
+    for (const panelFocus of ['effectEditor', 'transformOverlay']) {
+      const focusedBindings = effectBindings.filter(binding => binding.when.panelFocus === panelFocus)
+      expect(focusedBindings.map(binding => [binding.id, binding.keys])).toEqual(expectedBindings)
+    }
     expect(effectBindings.every(binding => binding.allowInInput !== true)).toBe(true)
-    expect(effectBindings.every(binding => binding.when.panelFocus === 'effectEditor')).toBe(true)
 
     scope.stop()
   })
 
   it('effect 历史和剪贴板快捷键会委托给 effect editor provider', async () => {
     const { scope } = createFixture()
-    const effectBindings = new Map(collectEffectShortcutBindings()
-      .map(binding => [binding.id, binding]))
 
-    await effectBindings.get('effect.undo')?.execute()
-    await effectBindings.get('effect.redo')?.execute()
-    await effectBindings.get('effect.copy')?.execute()
-    await effectBindings.get('effect.paste')?.execute()
+    await Promise.all([
+      findEffectShortcutBinding('effectEditor', 'effect.undo').execute(),
+      findEffectShortcutBinding('effectEditor', 'effect.redo').execute(),
+      findEffectShortcutBinding('effectEditor', 'effect.copy').execute(),
+      findEffectShortcutBinding('effectEditor', 'effect.paste').execute(),
+      findEffectShortcutBinding('transformOverlay', 'effect.undo').execute(),
+      findEffectShortcutBinding('transformOverlay', 'effect.redo').execute(),
+      findEffectShortcutBinding('transformOverlay', 'effect.copy').execute(),
+      findEffectShortcutBinding('transformOverlay', 'effect.paste').execute(),
+    ])
 
-    expect(effectEditorProviderMock.undoDraft).toHaveBeenCalledOnce()
-    expect(effectEditorProviderMock.redoDraft).toHaveBeenCalledOnce()
-    expect(effectEditorProviderMock.copyCurrentEffect).toHaveBeenCalledOnce()
-    expect(effectEditorProviderMock.pasteCurrentEffect).toHaveBeenCalledOnce()
+    expect(effectEditorProviderMock.undoDraft).toHaveBeenCalledTimes(2)
+    expect(effectEditorProviderMock.redoDraft).toHaveBeenCalledTimes(2)
+    expect(effectEditorProviderMock.copyCurrentEffect).toHaveBeenCalledTimes(2)
+    expect(effectEditorProviderMock.pasteCurrentEffect).toHaveBeenCalledTimes(2)
 
     scope.stop()
   })

--- a/src/features/editor/shell/useEditorPanelShell.ts
+++ b/src/features/editor/shell/useEditorPanelShell.ts
@@ -104,6 +104,7 @@ export function useEditorPanelShell(options: UseEditorPanelShellOptions) {
     when: { panelFocus: 'statementEditor' },
   })
 
+  const effectEditorShortcutPanelFocuses = ['effectEditor', 'transformOverlay'] as const
   const effectEditorShortcutDefinitions: EffectEditorShortcutDefinition[] = [
     {
       action: effectEditorProvider.undoDraft,
@@ -131,14 +132,16 @@ export function useEditorPanelShell(options: UseEditorPanelShellOptions) {
     },
   ]
 
-  for (const shortcut of effectEditorShortcutDefinitions) {
-    useShortcut({
-      execute: shortcut.action,
-      i18nKey: shortcut.i18nKey,
-      id: shortcut.id,
-      keys: shortcut.keys,
-      when: { panelFocus: 'effectEditor' },
-    })
+  for (const panelFocus of effectEditorShortcutPanelFocuses) {
+    for (const shortcut of effectEditorShortcutDefinitions) {
+      useShortcut({
+        execute: shortcut.action,
+        i18nKey: shortcut.i18nKey,
+        id: shortcut.id,
+        keys: shortcut.keys,
+        when: { panelFocus },
+      })
+    }
   }
 
   function focusTextEditorAfterEffectEditorClose(): void {


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [ ] 错误修复
- [x] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [x] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

这个 PR 让效果编辑器的 `Mod+Z`、`Mod+Shift+Z` / `Mod+Y`、`Mod+C`、`Mod+V` 在 TransformOverlay 焦点上下文下也能生效。

主要改动：

- 将效果编辑器的撤销、重做、复制、粘贴快捷键同时注册到 `effectEditor` 和 `transformOverlay`。
- 在 TransformOverlay 启用时，让预览工作区维持 `transformOverlay` 快捷键上下文。
- 点击预览空白区域时聚焦预览工作区，避免快捷键上下文丢失。
- 点击底部工具栏等可聚焦控件时保留正常浏览器焦点行为。
- 补充单元测试和浏览器测试覆盖对应行为。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

TransformOverlay 已经承担效果编辑器中的可视化变换拖拽交互，但原先只有变换控件自身获得焦点时，部分快捷键上下文才会生效。用户在拖拽、点击预览空白区域或操作底部工具栏后，仍处于同一个变换编辑流程中，此时也应该可以继续使用效果编辑器的撤销、重做、复制、粘贴快捷键。

这个 PR 补齐 TransformOverlay 作为效果编辑器扩展交互面时的快捷键能力，让变换拖拽和表单编辑拥有一致的效果编辑器操作体验。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
