### PR TITLE
🐛 修复变换控件方向键长按移动

### DIFF
--- a/src/components/editor/TransformOverlay.spec.ts
+++ b/src/components/editor/TransformOverlay.spec.ts
@@ -58,6 +58,17 @@ function dispatchKeydown(key: string, options: KeyboardEventInit = {}): Keyboard
   return event
 }
 
+function dispatchKeyup(key: string, options: KeyboardEventInit = {}): KeyboardEvent {
+  const event = new KeyboardEvent('keyup', {
+    bubbles: true,
+    cancelable: true,
+    key,
+    ...options,
+  })
+  globalThis.dispatchEvent(event)
+  return event
+}
+
 function findMoveHandle(): HTMLButtonElement | null {
   return document.querySelector('[aria-label="edit.previewPanel.transformOverlay.move"]')
 }
@@ -69,37 +80,61 @@ describe('TransformOverlay', () => {
     vi.unstubAllGlobals()
   })
 
-  it('方向键会按舞台坐标微调位置', async () => {
+  it('方向键会先预览移动并在松开时提交', async () => {
     const onCommit = vi.fn()
     const onPreview = vi.fn()
     renderTransformOverlay({ onCommit, onPreview })
 
-    const event = dispatchKeydown('ArrowRight')
+    const keydownEvent = dispatchKeydown('ArrowRight')
     await nextTick()
 
-    expect(event.defaultPrevented).toBe(true)
-    expect(onPreview).not.toHaveBeenCalled()
+    expect(keydownEvent.defaultPrevented).toBe(true)
+    expect(onCommit).not.toHaveBeenCalled()
+    expect(onPreview).toHaveBeenCalledWith({
+      ...displayTransform,
+      position: { x: 11, y: 20 },
+    })
+
+    const keyupEvent = dispatchKeyup('ArrowRight')
+    await nextTick()
+
+    expect(keyupEvent.defaultPrevented).toBe(true)
+    expect(onCommit).toHaveBeenCalledOnce()
     expect(onCommit).toHaveBeenCalledWith({
       ...displayTransform,
       position: { x: 11, y: 20 },
     })
   })
 
-  it('方向键自动重复时不会重复提交移动', async () => {
+  it('方向键自动重复时会持续预览并只在松开时提交一次', async () => {
     const onCommit = vi.fn()
-    renderTransformOverlay({ onCommit })
+    const onPreview = vi.fn()
+    renderTransformOverlay({ onCommit, onPreview })
 
     const firstEvent = dispatchKeydown('ArrowRight')
     await nextTick()
     const repeatedEvent = dispatchKeydown('ArrowRight', { repeat: true })
     await nextTick()
+    const fastRepeatedEvent = dispatchKeydown('ArrowRight', { repeat: true, shiftKey: true })
+    await nextTick()
 
     expect(firstEvent.defaultPrevented).toBe(true)
     expect(repeatedEvent.defaultPrevented).toBe(true)
+    expect(fastRepeatedEvent.defaultPrevented).toBe(true)
+    expect(onCommit).not.toHaveBeenCalled()
+    expect(onPreview).toHaveBeenCalledTimes(3)
+    expect(onPreview).toHaveBeenLastCalledWith({
+      ...displayTransform,
+      position: { x: 22, y: 20 },
+    })
+
+    dispatchKeyup('ArrowRight')
+    await nextTick()
+
     expect(onCommit).toHaveBeenCalledOnce()
     expect(onCommit).toHaveBeenCalledWith({
       ...displayTransform,
-      position: { x: 11, y: 20 },
+      position: { x: 22, y: 20 },
     })
   })
 
@@ -156,6 +191,48 @@ describe('TransformOverlay', () => {
     expect(onCancel).toHaveBeenCalledOnce()
     expect(onPreview).not.toHaveBeenCalled()
     expect(onCommit).not.toHaveBeenCalled()
+  })
+
+  it('Escape 会取消正在进行的方向键移动而不是提交变换', async () => {
+    const onCancel = vi.fn()
+    const onCommit = vi.fn()
+    const onPreview = vi.fn()
+    renderTransformOverlay({ onCancel, onCommit, onPreview })
+
+    dispatchKeydown('ArrowRight')
+    await nextTick()
+
+    expect(onPreview).toHaveBeenCalledOnce()
+
+    const event = dispatchKeydown('Escape')
+    await nextTick()
+
+    expect(event.defaultPrevented).toBe(true)
+    expect(onCancel).toHaveBeenCalledOnce()
+    expect(onCommit).not.toHaveBeenCalled()
+  })
+
+  it('window blur 会提交正在进行的方向键移动', async () => {
+    const onCancel = vi.fn()
+    const onCommit = vi.fn()
+    const onPreview = vi.fn()
+    renderTransformOverlay({ onCancel, onCommit, onPreview })
+
+    dispatchKeydown('ArrowDown')
+    await nextTick()
+    dispatchKeydown('ArrowDown', { repeat: true })
+    await nextTick()
+
+    globalThis.dispatchEvent(new Event('blur'))
+    await nextTick()
+
+    expect(onCancel).not.toHaveBeenCalled()
+    expect(onPreview).toHaveBeenCalledTimes(2)
+    expect(onCommit).toHaveBeenCalledOnce()
+    expect(onCommit).toHaveBeenCalledWith({
+      ...displayTransform,
+      position: { x: 10, y: 22 },
+    })
   })
 
   it('pointercancel 会取消正在进行的拖拽而不是提交变换', async () => {

--- a/src/components/editor/TransformOverlay.vue
+++ b/src/components/editor/TransformOverlay.vue
@@ -34,6 +34,11 @@ interface Props {
   displayTransform?: DisplayTransform
 }
 
+interface KeyboardMoveSession {
+  activeKey: string
+  latestTransform: DisplayTransform
+}
+
 const props = defineProps<Props>()
 const emit = defineEmits<{
   'cancel:displayTransform': []
@@ -101,6 +106,7 @@ const scaleHandlePlacementStyles: Record<TransformScaleHandle, CSSProperties> = 
   },
 }
 let rotateTooltip = $ref<TransformRotateTooltip>()
+let keyboardMoveSession: KeyboardMoveSession | undefined
 
 const canvasFrame = $computed<TransformFrame | undefined>(() => {
   if (!props.box || !props.displayTransform) {
@@ -306,6 +312,7 @@ function handlePointerDown(event: PointerEvent, handle: TransformControlHandle):
     event.currentTarget.focus({ preventScroll: true })
   }
 
+  commitKeyboardMoveSession()
   control.start({
     event,
     handle,
@@ -352,6 +359,14 @@ function isEditingText(target: EventTarget | null): boolean {
     || target.isContentEditable
 }
 
+function cloneDisplayTransform(transform: DisplayTransform): DisplayTransform {
+  return {
+    position: { ...transform.position },
+    rotation: transform.rotation,
+    scale: { ...transform.scale },
+  }
+}
+
 function resolveKeyboardMoveDelta(key: string): { x: number, y: number } | undefined {
   switch (key) {
     case 'ArrowLeft': {
@@ -372,14 +387,75 @@ function resolveKeyboardMoveDelta(key: string): { x: number, y: number } | undef
   }
 }
 
-function handleGlobalKeydown(event: KeyboardEvent): void {
-  if (!canvasFrame || !props.displayTransform || isEditingText(event.target) || isEditingText(document.activeElement)) {
+function applyKeyboardMoveDelta(
+  transform: DisplayTransform,
+  delta: { x: number, y: number },
+  step: number,
+): DisplayTransform {
+  return {
+    position: {
+      x: transform.position.x + (delta.x * step),
+      y: transform.position.y + (delta.y * step),
+    },
+    rotation: transform.rotation,
+    scale: { ...transform.scale },
+  }
+}
+
+function updateKeyboardMoveSession(event: KeyboardEvent, delta: { x: number, y: number }): void {
+  if (!props.displayTransform) {
     return
   }
 
-  if (event.key === 'Escape' && control.active) {
+  keyboardMoveSession ??= {
+    activeKey: event.key,
+    latestTransform: cloneDisplayTransform(props.displayTransform),
+  }
+
+  if (keyboardMoveSession.activeKey !== event.key) {
+    return
+  }
+
+  const step = event.shiftKey ? KEYBOARD_FAST_MOVE_STEP : KEYBOARD_MOVE_STEP
+  keyboardMoveSession.latestTransform = applyKeyboardMoveDelta(
+    keyboardMoveSession.latestTransform,
+    delta,
+    step,
+  )
+  emitDisplayTransform(keyboardMoveSession.latestTransform, 'preview')
+}
+
+function commitKeyboardMoveSession(): void {
+  if (!keyboardMoveSession) {
+    return
+  }
+
+  const transform = keyboardMoveSession.latestTransform
+  keyboardMoveSession = undefined
+  emitDisplayTransform(transform, 'commit')
+}
+
+function cancelKeyboardMoveSession(): void {
+  if (!keyboardMoveSession) {
+    return
+  }
+
+  keyboardMoveSession = undefined
+  emitCancelDisplayTransform()
+}
+
+function handleGlobalKeydown(event: KeyboardEvent): void {
+  if (event.key === 'Escape' && (control.active || keyboardMoveSession)) {
     event.preventDefault()
-    control.cancel()
+    if (control.active) {
+      control.cancel()
+    } else {
+      cancelKeyboardMoveSession()
+    }
+    return
+  }
+
+  if (!canvasFrame || !props.displayTransform || isEditingText(event.target) || isEditingText(document.activeElement)) {
     return
   }
 
@@ -389,24 +465,23 @@ function handleGlobalKeydown(event: KeyboardEvent): void {
   }
 
   event.preventDefault()
-  if (event.repeat) {
+  updateKeyboardMoveSession(event, delta)
+}
+
+function handleGlobalKeyup(event: KeyboardEvent): void {
+  if (!keyboardMoveSession || keyboardMoveSession.activeKey !== event.key) {
     return
   }
 
-  const step = event.shiftKey ? KEYBOARD_FAST_MOVE_STEP : KEYBOARD_MOVE_STEP
-  emitDisplayTransform({
-    ...props.displayTransform,
-    position: {
-      x: props.displayTransform.position.x + (delta.x * step),
-      y: props.displayTransform.position.y + (delta.y * step),
-    },
-  }, 'commit')
+  event.preventDefault()
+  commitKeyboardMoveSession()
 }
 
 function handleWindowBlur(): void {
   if (control.active) {
     control.cancel()
   }
+  commitKeyboardMoveSession()
 }
 
 function projectFrameToViewport(
@@ -427,6 +502,7 @@ function projectFrameToViewport(
 }
 
 useEventListener(globalThis, 'keydown', handleGlobalKeydown)
+useEventListener(globalThis, 'keyup', handleGlobalKeyup)
 useEventListener(globalThis, 'blur', handleWindowBlur)
 </script>
 


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [x] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [ ] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

修复变换控件在长按方向键时只能移动一次的问题。

方向键移动现在按连续交互处理：

- `keydown` 与自动重复按键持续发送 `preview:displayTransform`
- `keyup` 时发送一次 `commit:displayTransform`
- `Escape` 会取消当前方向键移动并恢复 preview
- `window blur` 会提交当前已经预览到的位置

这样可以复用现有 preview / commit / cancel 管线，并让一次长按移动在历史记录中表现为一次可撤销操作。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

此前 `TransformOverlay` 会忽略 `KeyboardEvent.repeat`，导致长按方向键只移动一次。

如果简单放开 repeat 并在每次 keydown 都 commit，则会产生大量历史记录，不符合编辑器中“连续交互一次撤销”的预期。因此本次改为与拖拽一致的两阶段语义：高频 preview，结束时 commit 一次。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
