### PR TITLE
✨ 效果编辑器添加翻转按钮和快捷键

### DIFF
--- a/src/components/editor/effect-editor/EffectDraftCategorySection.spec.ts
+++ b/src/components/editor/effect-editor/EffectDraftCategorySection.spec.ts
@@ -202,7 +202,7 @@ describe('EffectDraftCategorySection', () => {
     })
   })
 
-  it('将翻转按钮放在独立分组中，而不是旋转控件内部', async () => {
+  it('按独立渲染项输出翻转分组并委托对应轴向操作', async () => {
     const { controls } = createControls()
 
     renderInBrowser(EffectDraftCategorySection, {
@@ -212,16 +212,8 @@ describe('EffectDraftCategorySection', () => {
           label: 'Transform',
           items: [
             {
-              kind: 'dial',
-              key: 'rotation',
-              param: {
-                key: 'rotation',
-                type: 'dial',
-                label: 'Rotation',
-                defaultValue: 0,
-                dialUnit: 'rad',
-                compact: true,
-              },
+              kind: 'flip-actions',
+              key: 'transform-flip',
             },
           ],
         },
@@ -235,15 +227,18 @@ describe('EffectDraftCategorySection', () => {
       },
     })
 
-    const rotationGroup = await page.getByRole('group', { name: 'Rotation' }).element()
     const flipGroup = await page.getByRole('group', { name: '翻转' }).element()
     const horizontalFlipButton = await page.getByRole('button', { name: '水平翻转' }).element()
     const verticalFlipButton = await page.getByRole('button', { name: '垂直翻转' }).element()
 
-    expect(rotationGroup.contains(horizontalFlipButton)).toBe(false)
-    expect(rotationGroup.contains(verticalFlipButton)).toBe(false)
     expect(flipGroup.contains(horizontalFlipButton)).toBe(true)
     expect(flipGroup.contains(verticalFlipButton)).toBe(true)
+
+    await page.getByRole('button', { name: '水平翻转' }).click()
+    await page.getByRole('button', { name: '垂直翻转' }).click()
+
+    expect(controls.flipScaleAxis).toHaveBeenNthCalledWith(1, 'x')
+    expect(controls.flipScaleAxis).toHaveBeenNthCalledWith(2, 'y')
   })
 
   it('将固定宽度放在标签与按钮的公共头部容器上，让按钮贴近标签文本', async () => {

--- a/src/components/editor/effect-editor/EffectDraftCategorySection.spec.ts
+++ b/src/components/editor/effect-editor/EffectDraftCategorySection.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import { page } from 'vitest/browser'
 
+import { createBrowserLocalizedI18n } from '~/__tests__/browser'
 import {
   createBrowserClickStub,
   createBrowserContainerStub,
@@ -55,6 +56,7 @@ function createControls() {
     updateDialField: vi.fn(),
     flushDialField: vi.fn(),
     handleDialPointerDown: vi.fn(),
+    flipScaleAxis: vi.fn(),
     getColorPickerValue: () => ({ b: 255, g: 255, r: 255 }),
     handleColorPickerPointerDown: vi.fn(),
     handleColorPickerChange: vi.fn(),
@@ -198,6 +200,50 @@ describe('EffectDraftCategorySection', () => {
       schedule: 'immediate',
       flush: true,
     })
+  })
+
+  it('将翻转按钮放在独立分组中，而不是旋转控件内部', async () => {
+    const { controls } = createControls()
+
+    renderInBrowser(EffectDraftCategorySection, {
+      props: {
+        category: {
+          key: 'transform',
+          label: 'Transform',
+          items: [
+            {
+              kind: 'dial',
+              key: 'rotation',
+              param: {
+                key: 'rotation',
+                type: 'dial',
+                label: 'Rotation',
+                defaultValue: 0,
+                dialUnit: 'rad',
+                compact: true,
+              },
+            },
+          ],
+        },
+        controls,
+        isPanelLayout: false,
+        resolveLabel: (value: string | undefined) => String(value ?? ''),
+      },
+      global: {
+        plugins: [createBrowserLocalizedI18n()],
+        stubs: globalStubs,
+      },
+    })
+
+    const rotationGroup = await page.getByRole('group', { name: 'Rotation' }).element()
+    const flipGroup = await page.getByRole('group', { name: '翻转' }).element()
+    const horizontalFlipButton = await page.getByRole('button', { name: '水平翻转' }).element()
+    const verticalFlipButton = await page.getByRole('button', { name: '垂直翻转' }).element()
+
+    expect(rotationGroup.contains(horizontalFlipButton)).toBe(false)
+    expect(rotationGroup.contains(verticalFlipButton)).toBe(false)
+    expect(flipGroup.contains(horizontalFlipButton)).toBe(true)
+    expect(flipGroup.contains(verticalFlipButton)).toBe(true)
   })
 
   it('将固定宽度放在标签与按钮的公共头部容器上，让按钮贴近标签文本', async () => {

--- a/src/components/editor/effect-editor/EffectDraftCategorySection.vue
+++ b/src/components/editor/effect-editor/EffectDraftCategorySection.vue
@@ -18,7 +18,7 @@ interface Props {
 const props = defineProps<Props>()
 
 type EffectDraftRenderItem = EffectDraftCategoryRenderModel['items'][number]
-type EffectDraftClearableItem = Exclude<EffectDraftRenderItem, { kind: 'choice' | 'position' }>
+type EffectDraftClearableItem = Exclude<EffectDraftRenderItem, { kind: 'choice' | 'flip-actions' | 'position' }>
 
 const CLEAR_IMMEDIATE_OPTIONS = {
   schedule: 'immediate',
@@ -65,10 +65,6 @@ function clearPaths(paths: readonly string[]): void {
 function getClearPropertyLabel(label: Parameters<EffectDraftLabelResolver>[0]): string {
   return props.controls.getClearPropertyLabel(label)
 }
-
-function shouldShowFlipActions(item: EffectDraftRenderItem): boolean {
-  return item.kind === 'dial' && item.param.key === 'rotation'
-}
 </script>
 
 <template>
@@ -80,7 +76,7 @@ function shouldShowFlipActions(item: EffectDraftRenderItem): boolean {
       {{ resolveLabel(category.label) }}
     </legend>
 
-    <div class="flex flex-col gap-2.5">
+    <div class="flex flex-wrap gap-2.5">
       <template
         v-for="item in category.items"
         :key="item.key"
@@ -88,7 +84,7 @@ function shouldShowFlipActions(item: EffectDraftRenderItem): boolean {
         <div
           v-if="item.kind === 'position'"
           class="gap-2 grid"
-          :class="isPanelLayout ? 'w-fit grid-cols-[repeat(2,minmax(0,14rem))]' : 'grid-cols-2'"
+          :class="isPanelLayout ? 'w-fit grid-cols-[repeat(2,minmax(0,14rem))]' : 'w-full grid-cols-2'"
         >
           <div
             v-for="param in item.params"
@@ -132,7 +128,7 @@ function shouldShowFlipActions(item: EffectDraftRenderItem): boolean {
           </div>
         </div>
 
-        <div v-else-if="item.kind === 'number'" class="group/field flex gap-2 items-center">
+        <div v-else-if="item.kind === 'number'" class="group/field flex gap-2 w-full items-center">
           <div class="flex shrink-0 gap-1 min-w-0 w-24 items-center">
             <Label
               :for="controls.numberInputId(item.param.key)"
@@ -169,7 +165,7 @@ function shouldShowFlipActions(item: EffectDraftRenderItem): boolean {
           />
         </div>
 
-        <div v-else-if="item.kind === 'slider'" class="group/field flex gap-2 items-center">
+        <div v-else-if="item.kind === 'slider'" class="group/field flex gap-2 w-full items-center">
           <div class="flex shrink-0 gap-1 min-w-0 w-24 items-center">
             <Label :for="controls.sliderInputId(item.param.key)" class="text-xs text-muted-foreground shrink min-w-0">
               <span class="block truncate">{{ resolveLabel(item.param.label) }}</span>
@@ -210,7 +206,7 @@ function shouldShowFlipActions(item: EffectDraftRenderItem): boolean {
           </div>
         </div>
 
-        <div v-else-if="item.kind === 'linked-slider'" class="group/field px-2.5 py-2 border border-border/60 rounded-md">
+        <div v-else-if="item.kind === 'linked-slider'" class="group/field px-2.5 py-2 border border-border/60 rounded-md w-full">
           <div class="mb-2 flex items-center justify-between" :class="isPanelLayout ? 'max-w-[28rem]' : ''">
             <div class="flex gap-1 min-w-0 items-center">
               <span class="text-xs text-muted-foreground truncate">
@@ -292,7 +288,11 @@ function shouldShowFlipActions(item: EffectDraftRenderItem): boolean {
           </div>
         </div>
 
-        <div v-else-if="item.kind === 'dial'" class="group/field flex flex-wrap gap-2 items-center">
+        <div
+          v-else-if="item.kind === 'dial'"
+          class="group/field flex gap-2 items-center"
+          :class="!item.param.compact && 'w-full'"
+        >
           <div
             :class="item.param.compact ? 'px-2 py-1.5 border border-border/60 rounded-md inline-flex gap-2 items-center' : 'flex flex-1 gap-2 items-center'"
             role="group"
@@ -340,55 +340,56 @@ function shouldShowFlipActions(item: EffectDraftRenderItem): boolean {
               />
             </div>
           </div>
-          <div
-            v-if="shouldShowFlipActions(item)"
-            class="px-2 py-1.5 border border-border/60 rounded-md inline-flex gap-1 items-center"
-            role="group"
-            :aria-label="$t('modals.effectEditor.flip')"
-          >
-            <span class="text-xs text-muted-foreground shrink-0">
-              {{ $t('modals.effectEditor.flip') }}
-            </span>
-            <TooltipProvider :delay-duration="0">
-              <Tooltip>
-                <TooltipTrigger as-child>
-                  <Button
-                    type="button"
-                    size="icon"
-                    variant="ghost"
-                    class="h-7 w-9"
-                    :aria-label="$t('modals.effectEditor.flipHorizontal')"
-                    @click="controls.flipScaleAxis('x')"
-                  >
-                    <div class="i-lucide-flip-horizontal size-3.5" />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent side="top" class="px-2 py-1">
-                  {{ $t('modals.effectEditor.flipHorizontal') }}
-                </TooltipContent>
-              </Tooltip>
-              <Tooltip>
-                <TooltipTrigger as-child>
-                  <Button
-                    type="button"
-                    size="icon"
-                    variant="ghost"
-                    class="h-7 w-9"
-                    :aria-label="$t('modals.effectEditor.flipVertical')"
-                    @click="controls.flipScaleAxis('y')"
-                  >
-                    <div class="i-lucide-flip-vertical size-3.5" />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent side="top" class="px-2 py-1">
-                  {{ $t('modals.effectEditor.flipVertical') }}
-                </TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
-          </div>
         </div>
 
-        <div v-else-if="item.kind === 'color'" class="group/field flex gap-2 items-start">
+        <div
+          v-else-if="item.kind === 'flip-actions'"
+          class="px-2 py-1.5 border border-border/60 rounded-md inline-flex gap-1 items-center"
+          role="group"
+          :aria-label="$t('modals.effectEditor.flip')"
+        >
+          <span class="text-xs text-muted-foreground shrink-0">
+            {{ $t('modals.effectEditor.flip') }}
+          </span>
+          <TooltipProvider :delay-duration="0">
+            <Tooltip>
+              <TooltipTrigger as-child>
+                <Button
+                  type="button"
+                  size="icon"
+                  variant="ghost"
+                  class="h-7 w-9"
+                  :aria-label="$t('modals.effectEditor.flipHorizontal')"
+                  @click="controls.flipScaleAxis('x')"
+                >
+                  <div class="i-lucide-flip-horizontal size-3.5" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="top" class="px-2 py-1">
+                {{ $t('modals.effectEditor.flipHorizontal') }}
+              </TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger as-child>
+                <Button
+                  type="button"
+                  size="icon"
+                  variant="ghost"
+                  class="h-7 w-9"
+                  :aria-label="$t('modals.effectEditor.flipVertical')"
+                  @click="controls.flipScaleAxis('y')"
+                >
+                  <div class="i-lucide-flip-vertical size-3.5" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="top" class="px-2 py-1">
+                {{ $t('modals.effectEditor.flipVertical') }}
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        </div>
+
+        <div v-else-if="item.kind === 'color'" class="group/field flex gap-2 w-full items-start">
           <div class="flex shrink-0 gap-1 min-w-0 w-24 items-start">
             <Label :for="controls.colorControlId(item.param)" class="text-xs text-muted-foreground pt-1 shrink min-w-0">
               <span class="block truncate">{{ resolveLabel(item.param.label) }}</span>
@@ -419,7 +420,7 @@ function shouldShowFlipActions(item: EffectDraftRenderItem): boolean {
           </div>
         </div>
 
-        <div v-else-if="item.kind === 'choice'" class="group/field flex gap-2 items-center">
+        <div v-else-if="item.kind === 'choice'" class="group/field flex gap-2 w-full items-center">
           <div class="flex shrink-0 min-w-0 w-24 items-center">
             <Label :for="controls.segmentedControlId(item.param.key)" class="text-xs text-muted-foreground shrink min-w-0">
               <span class="block truncate">{{ resolveLabel(item.param.label) }}</span>

--- a/src/components/editor/effect-editor/EffectDraftCategorySection.vue
+++ b/src/components/editor/effect-editor/EffectDraftCategorySection.vue
@@ -65,6 +65,10 @@ function clearPaths(paths: readonly string[]): void {
 function getClearPropertyLabel(label: Parameters<EffectDraftLabelResolver>[0]): string {
   return props.controls.getClearPropertyLabel(label)
 }
+
+function shouldShowFlipActions(item: EffectDraftRenderItem): boolean {
+  return item.kind === 'dial' && item.param.key === 'rotation'
+}
 </script>
 
 <template>
@@ -288,28 +292,13 @@ function getClearPropertyLabel(label: Parameters<EffectDraftLabelResolver>[0]): 
           </div>
         </div>
 
-        <div v-else-if="item.kind === 'dial'" class="group/field flex gap-2 items-center">
-          <div v-if="!item.param.compact" class="flex shrink-0 gap-1 min-w-0 w-24 items-center">
-            <Label :for="controls.dialInputId(item.param.key)" class="text-xs text-muted-foreground shrink min-w-0">
-              <span class="block truncate">{{ resolveLabel(item.param.label) }}</span>
-            </Label>
-            <div class="flex shrink-0 size-5 items-center justify-center">
-              <Button
-                variant="ghost"
-                size="icon"
-                :class="getClearButtonClass(getClearPathsForItem(item))"
-                :aria-hidden="!isClearButtonEnabled(getClearPathsForItem(item)) ? 'true' : undefined"
-                :tabindex="!isClearButtonEnabled(getClearPathsForItem(item)) ? -1 : undefined"
-                :title="getClearPropertyLabel(item.param.label)"
-                :aria-label="getClearPropertyLabel(item.param.label)"
-                @click="clearPaths(getClearPathsForItem(item))"
-              >
-                <div class="i-lucide-rotate-ccw size-3" />
-              </Button>
-            </div>
-          </div>
-          <div :class="item.param.compact ? 'px-2 py-1.5 border border-border/60 rounded-md inline-flex gap-2 items-center' : 'flex flex-1 gap-2 items-center'">
-            <div v-if="item.param.compact" class="flex gap-1 min-w-0 items-center">
+        <div v-else-if="item.kind === 'dial'" class="group/field flex flex-wrap gap-2 items-center">
+          <div
+            :class="item.param.compact ? 'px-2 py-1.5 border border-border/60 rounded-md inline-flex gap-2 items-center' : 'flex flex-1 gap-2 items-center'"
+            role="group"
+            :aria-label="resolveLabel(item.param.label)"
+          >
+            <div class="flex shrink-0 gap-1 min-w-0 items-center" :class="!item.param.compact && 'w-24'">
               <Label :for="controls.dialInputId(item.param.key)" class="text-xs text-muted-foreground shrink min-w-0">
                 <span class="block truncate">{{ resolveLabel(item.param.label) }}</span>
               </Label>
@@ -350,6 +339,52 @@ function getClearPropertyLabel(label: Parameters<EffectDraftLabelResolver>[0]): 
                 @keydown.enter="controls.flushDialField(item.param)"
               />
             </div>
+          </div>
+          <div
+            v-if="shouldShowFlipActions(item)"
+            class="px-2 py-1.5 border border-border/60 rounded-md inline-flex gap-1 items-center"
+            role="group"
+            :aria-label="$t('modals.effectEditor.flip')"
+          >
+            <span class="text-xs text-muted-foreground shrink-0">
+              {{ $t('modals.effectEditor.flip') }}
+            </span>
+            <TooltipProvider :delay-duration="0">
+              <Tooltip>
+                <TooltipTrigger as-child>
+                  <Button
+                    type="button"
+                    size="icon"
+                    variant="ghost"
+                    class="h-7 w-9"
+                    :aria-label="$t('modals.effectEditor.flipHorizontal')"
+                    @click="controls.flipScaleAxis('x')"
+                  >
+                    <div class="i-lucide-flip-horizontal size-3.5" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="top" class="px-2 py-1">
+                  {{ $t('modals.effectEditor.flipHorizontal') }}
+                </TooltipContent>
+              </Tooltip>
+              <Tooltip>
+                <TooltipTrigger as-child>
+                  <Button
+                    type="button"
+                    size="icon"
+                    variant="ghost"
+                    class="h-7 w-9"
+                    :aria-label="$t('modals.effectEditor.flipVertical')"
+                    @click="controls.flipScaleAxis('y')"
+                  >
+                    <div class="i-lucide-flip-vertical size-3.5" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="top" class="px-2 py-1">
+                  {{ $t('modals.effectEditor.flipVertical') }}
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
           </div>
         </div>
 

--- a/src/components/editor/effect-editor/EffectDraftForm.spec.ts
+++ b/src/components/editor/effect-editor/EffectDraftForm.spec.ts
@@ -58,6 +58,58 @@ describe('EffectDraftForm', () => {
     expectNoConsoleMessage('Invalid prop: type check failed for prop "modelValue"')
   })
 
+  it('在旋转控件旁提供水平和垂直翻转按钮', async () => {
+    const transformUpdates = vi.fn()
+
+    renderInBrowser(EffectDraftForm, {
+      props: {
+        'duration': '200',
+        'ease': '',
+        'onUpdate:transform': transformUpdates,
+        'transform': {
+          position: { x: 12 },
+          rotation: 0.5,
+          scale: {
+            x: 1.25,
+            y: -0.75,
+          },
+        },
+      },
+      global: {
+        plugins: [createPinia(), createBrowserLocalizedI18n()],
+        stubs: globalStubs,
+      },
+    })
+
+    await page.getByRole('button', { name: '水平翻转' }).click()
+    await page.getByRole('button', { name: '垂直翻转' }).click()
+
+    expect(transformUpdates).toHaveBeenNthCalledWith(1, {
+      value: {
+        position: { x: 12 },
+        rotation: 0.5,
+        scale: {
+          x: -1.25,
+          y: -0.75,
+        },
+      },
+      deferAutoApply: false,
+      flush: true,
+    })
+    expect(transformUpdates).toHaveBeenNthCalledWith(2, {
+      value: {
+        position: { x: 12 },
+        rotation: 0.5,
+        scale: {
+          x: 1.25,
+          y: 0.75,
+        },
+      },
+      deferAutoApply: false,
+      flush: true,
+    })
+  })
+
   it('渲染顶部控件并按分类输出特效参数区域', async () => {
     renderInBrowser(EffectDraftForm, {
       props: {
@@ -77,7 +129,7 @@ describe('EffectDraftForm', () => {
     })
 
     await expect.element(page.getByText('过渡时间')).toBeInTheDocument()
-    expect(page.getByRole('group').elements()).toHaveLength(EFFECT_CATEGORIES.length)
+    expect(page.getByTestId('effect-draft-category-section').elements()).toHaveLength(EFFECT_CATEGORIES.length)
   })
 
   it('显示基线字段后修改其他字段不会把基线写入变换', async () => {

--- a/src/components/editor/effect-editor/EffectDraftForm.vue
+++ b/src/components/editor/effect-editor/EffectDraftForm.vue
@@ -15,6 +15,7 @@ import {
   EFFECT_EASE_OPTIONS,
   transformToFields,
 } from '~/features/editor/effect-editor/effect-editor-config'
+import { flipTransformScaleAxis } from '~/features/editor/effect-editor/transform-flip'
 import { useEffectClearControls } from '~/features/editor/effect-editor/useEffectClearControls'
 import { useEffectColorControl } from '~/features/editor/effect-editor/useEffectColorControl'
 import { useEffectContinuousControls } from '~/features/editor/effect-editor/useEffectContinuousControls'
@@ -33,6 +34,7 @@ import type {
 } from './effectDraftForm.types'
 import type { Transform } from '~/domain/stage/types'
 import type { ColorField, I18nLike } from '~/features/editor/command-registry/schema'
+import type { TransformScaleAxis } from '~/features/editor/effect-editor/transform-flip'
 import type { EffectControlDeps } from '~/features/editor/effect-editor/types'
 import type {
   EffectEditorPreviewPayload,
@@ -225,6 +227,21 @@ function colorControlId(param: ColorField): string {
   return buildControlId(`color-${(param.colorPaths ?? [param.key]).join('-')}`)
 }
 
+function flipScaleAxis(axis: TransformScaleAxis): void {
+  const nextTransform = flipTransformScaleAxis({
+    axis,
+    baselineSource: props.baselineSource,
+    baselineTransform: props.baselineTransform,
+    transform: props.transform,
+  })
+
+  emitTransform(transformToFields(nextTransform), {
+    deferAutoApply: false,
+    flush: true,
+    schedule: 'immediate',
+  })
+}
+
 const categoryControls: EffectDraftCategoryControls = {
   numberInputId,
   sliderInputId,
@@ -254,6 +271,7 @@ const categoryControls: EffectDraftCategoryControls = {
   updateDialField,
   flushDialField,
   handleDialPointerDown,
+  flipScaleAxis,
   getColorPickerValue,
   handleColorPickerPointerDown,
   handleColorPickerChange,

--- a/src/components/editor/effect-editor/EffectDraftForm.vue
+++ b/src/components/editor/effect-editor/EffectDraftForm.vue
@@ -71,7 +71,7 @@ const emit = defineEmits<{
 const EFFECT_DRAFT_CATEGORY_RENDER_MODELS: EffectDraftCategoryRenderModel[] = EFFECT_CATEGORIES.map((category, index) => ({
   key: `${category.icon}-${index}`,
   label: category.label,
-  items: buildCategoryRenderItems(category.params),
+  items: buildCategoryRenderItems(category),
 }))
 
 const { t } = useI18n()

--- a/src/components/editor/effect-editor/effectDraftForm.types.ts
+++ b/src/components/editor/effect-editor/effectDraftForm.types.ts
@@ -6,6 +6,7 @@ import type {
   NumberField,
 } from '~/features/editor/command-registry/schema'
 import type { EffectRenderItem } from '~/features/editor/effect-editor/effect-editor-config'
+import type { TransformScaleAxis } from '~/features/editor/effect-editor/transform-flip'
 import type { EmitTransformOptions } from '~/features/editor/effect-editor/types'
 import type { EffectSegmentedOption } from '~/features/editor/effect-editor/useEffectSegmentedControl'
 
@@ -58,6 +59,7 @@ export interface EffectDraftCategoryControls {
   updateDialField: (param: DialField, rawDegree: string | number) => void
   flushDialField: (param: DialField) => void
   handleDialPointerDown: (event: PointerEvent, param: DialField) => void
+  flipScaleAxis: (axis: TransformScaleAxis) => void
   getColorPickerValue: (param: EffectDraftColorField) => { b: number, g: number, r: number }
   handleColorPickerPointerDown: (event: PointerEvent, param: EffectDraftColorField) => void
   handleColorPickerChange: (param: EffectDraftColorField, rawValue: unknown) => void

--- a/src/features/editor/effect-editor/__tests__/transform-flip.test.ts
+++ b/src/features/editor/effect-editor/__tests__/transform-flip.test.ts
@@ -32,4 +32,16 @@ describe('flipTransformScaleAxis', () => {
       scale: { y: -0.8 },
     })
   })
+
+  it('无显式缩放和基线时使用编辑器默认展示值翻转指定轴', () => {
+    expect(flipTransformScaleAxis({
+      axis: 'x',
+      transform: {
+        alpha: 0.6,
+      },
+    })).toEqual({
+      alpha: 0.6,
+      scale: { x: -1 },
+    })
+  })
 })

--- a/src/features/editor/effect-editor/__tests__/transform-flip.test.ts
+++ b/src/features/editor/effect-editor/__tests__/transform-flip.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+
+import { flipTransformScaleAxis } from '../transform-flip'
+
+describe('flipTransformScaleAxis', () => {
+  it('按当前显式缩放值翻转指定轴并保留其他字段', () => {
+    expect(flipTransformScaleAxis({
+      axis: 'x',
+      transform: {
+        position: { x: 12 },
+        rotation: 0.5,
+        scale: { x: 1.25, y: -0.75 },
+      },
+    })).toEqual({
+      position: { x: 12 },
+      rotation: 0.5,
+      scale: { x: -1.25, y: -0.75 },
+    })
+  })
+
+  it('未显式设置缩放时使用展示值翻转指定轴', () => {
+    expect(flipTransformScaleAxis({
+      axis: 'y',
+      baselineTransform: {
+        scale: { x: 1.5, y: 0.8 },
+      },
+      transform: {
+        alpha: 0.6,
+      },
+    })).toEqual({
+      alpha: 0.6,
+      scale: { y: -0.8 },
+    })
+  })
+})

--- a/src/features/editor/effect-editor/effect-editor-config.ts
+++ b/src/features/editor/effect-editor/effect-editor-config.ts
@@ -14,11 +14,16 @@ export interface EffectCategory {
   icon: string
   defaultOpen?: boolean
   params: EffectParamDef[]
+  actions?: EffectCategoryAction[]
 }
 
 // ─── EffectRenderItem：判别联合，用于模板类型安全分发 ───
 
+export type EffectCategoryAction =
+  | { kind: 'flip-actions', key: string }
+
 export type EffectRenderItem =
+  | EffectCategoryAction
   | { kind: 'position', key: string, params: NumberField[] }
   | { kind: 'number', key: string, param: NumberField }
   | { kind: 'slider', key: string, param: NumberField }
@@ -37,8 +42,9 @@ export function getEffectParamKey(param: EffectParamDef): string {
   return param.key
 }
 
-export function buildCategoryRenderItems(params: EffectParamDef[]): EffectRenderItem[] {
+export function buildCategoryRenderItems(category: EffectCategory): EffectRenderItem[] {
   const items: EffectRenderItem[] = []
+  const { params } = category
 
   // 收集 position 参数
   const positionParams = params.filter(
@@ -100,6 +106,8 @@ export function buildCategoryRenderItems(params: EffectParamDef[]): EffectRender
     }
   }
 
+  items.push(...category.actions ?? [])
+
   return items
 }
 
@@ -130,6 +138,9 @@ export const EFFECT_CATEGORIES: EffectCategory[] = [
       { key: 'scale.x', type: 'number', label: t => t('modals.effectEditor.params.scaleX'), linkedGroupLabel: t => t('modals.effectEditor.params.scale'), defaultValue: 1, min: 0, max: 2, step: 0.01, center: 1, linkedPairKey: 'scale.y', variant: 'slider-input' },
       { key: 'scale.y', type: 'number', label: t => t('modals.effectEditor.params.scaleY'), defaultValue: 1, min: 0, max: 2, step: 0.01, center: 1, linkedPairKey: 'scale.x', variant: 'slider-input' },
       { key: 'rotation', type: 'dial', label: t => t('modals.effectEditor.params.rotation'), defaultValue: 0, dialUnit: 'rad', compact: true },
+    ],
+    actions: [
+      { kind: 'flip-actions', key: 'transform-flip' },
     ],
   },
   {

--- a/src/features/editor/effect-editor/transform-flip.ts
+++ b/src/features/editor/effect-editor/transform-flip.ts
@@ -1,0 +1,39 @@
+import {
+  cloneTransform,
+  resolveTransformDraftDisplay,
+} from '~/features/editor/transform-resolution/model'
+
+import type { Transform } from '~/domain/stage/types'
+import type { TransformBaselineSource } from '~/features/editor/transform-resolution/model'
+
+export type TransformScaleAxis = 'x' | 'y'
+
+interface FlipTransformScaleAxisOptions {
+  axis: TransformScaleAxis
+  baselineSource?: TransformBaselineSource
+  baselineTransform?: Transform
+  transform: Transform
+}
+
+function readScaleValue(transform: Transform, axis: TransformScaleAxis): number {
+  const rawValue = transform.scale?.[axis]
+  const value = Number(rawValue)
+
+  return Number.isFinite(value) ? value : 1
+}
+
+export function flipTransformScaleAxis(options: FlipTransformScaleAxisOptions): Transform {
+  const displayTransform = resolveTransformDraftDisplay({
+    baselineSource: options.baselineSource,
+    baselineTransform: options.baselineTransform,
+    explicitDraftTransform: options.transform,
+  }).displayTransform
+  const nextTransform = cloneTransform(options.transform)
+
+  nextTransform.scale = {
+    ...nextTransform.scale,
+    [options.axis]: -readScaleValue(displayTransform, options.axis),
+  }
+
+  return nextTransform
+}

--- a/src/features/editor/shell/__tests__/useEditorPanelShell.test.ts
+++ b/src/features/editor/shell/__tests__/useEditorPanelShell.test.ts
@@ -327,6 +327,19 @@ describe('useEditorPanelShell', () => {
     scope.stop()
   })
 
+  it('effect 翻转快捷键在缺少当前会话时不会更新草稿和预览', () => {
+    const { scope } = createFixture()
+
+    effectEditorProviderMock.session = undefined
+
+    findEffectShortcutBinding('effectEditor', 'effect.flipHorizontal').execute()
+
+    expect(effectEditorProviderMock.updateDraft).not.toHaveBeenCalled()
+    expect(effectEditorProviderMock.requestPreview).not.toHaveBeenCalled()
+
+    scope.stop()
+  })
+
   it('文本模式关闭 effect editor 后会请求重新聚焦文本编辑器', async () => {
     const { scope, shell, tabsStore } = createFixture({
       currentProjection: 'text',

--- a/src/features/editor/shell/__tests__/useEditorPanelShell.test.ts
+++ b/src/features/editor/shell/__tests__/useEditorPanelShell.test.ts
@@ -3,6 +3,9 @@ import { computed, effectScope, reactive, shallowRef } from 'vue'
 
 import { useEditorPanelShell } from '../useEditorPanelShell'
 
+import type { Transform } from '~/domain/stage/types'
+import type { TransformBaselineSource } from '~/features/editor/transform-resolution/model'
+
 interface BindingMock {
   enableFocusStatement: boolean
   getEntry: () => unknown
@@ -23,6 +26,14 @@ interface CommandPanelLike {
 
 interface ReadonlyRefLike<T> {
   readonly value: T
+}
+
+interface EffectEditorSessionMock {
+  baselineSource?: TransformBaselineSource
+  baselineTransform?: Transform
+  draft: {
+    transform: Transform
+  }
 }
 
 const {
@@ -52,7 +63,7 @@ const {
     requestPreview: vi.fn(),
     redoDraft: vi.fn(() => false),
     resetToInitialDraft: vi.fn(),
-    session: undefined,
+    session: undefined as EffectEditorSessionMock | undefined,
     undoDraft: vi.fn(() => false),
     updateDraft: vi.fn(),
   },
@@ -185,8 +196,10 @@ describe('useEditorPanelShell', () => {
     effectEditorProviderMock.close.mockResolvedValue(true)
     effectEditorProviderMock.copyCurrentEffect.mockClear()
     effectEditorProviderMock.pasteCurrentEffect.mockClear()
+    effectEditorProviderMock.requestPreview.mockClear()
     effectEditorProviderMock.redoDraft.mockClear()
     effectEditorProviderMock.redoDraft.mockReturnValue(false)
+    effectEditorProviderMock.session = undefined
     effectEditorProviderMock.undoDraft.mockClear()
     effectEditorProviderMock.undoDraft.mockReturnValue(false)
     effectEditorProviderMock.updateDraft.mockClear()
@@ -245,7 +258,7 @@ describe('useEditorPanelShell', () => {
     scope.stop()
   })
 
-  it('会注册 effect editor 和 transform overlay 焦点下的效果历史与剪贴板快捷键', () => {
+  it('会注册 effect editor 和 transform overlay 焦点下的效果编辑快捷键', () => {
     const { scope } = createFixture()
 
     const effectBindings = collectEffectShortcutBindings()
@@ -254,6 +267,8 @@ describe('useEditorPanelShell', () => {
       ['effect.redo', ['Mod+Shift+Z', 'Mod+Y']],
       ['effect.copy', 'Mod+C'],
       ['effect.paste', 'Mod+V'],
+      ['effect.flipHorizontal', 'Shift+H'],
+      ['effect.flipVertical', 'Shift+V'],
     ]
 
     for (const panelFocus of ['effectEditor', 'transformOverlay']) {
@@ -265,7 +280,15 @@ describe('useEditorPanelShell', () => {
     scope.stop()
   })
 
-  it('effect 历史和剪贴板快捷键会委托给 effect editor provider', async () => {
+  it('effect 历史、剪贴板和翻转快捷键会委托给 effect editor provider', async () => {
+    effectEditorProviderMock.session = {
+      baselineTransform: { scale: { x: 1, y: 0.75 } },
+      draft: {
+        transform: {
+          scale: { x: 1.25 },
+        },
+      },
+    }
     const { scope } = createFixture()
 
     await Promise.all([
@@ -277,12 +300,29 @@ describe('useEditorPanelShell', () => {
       findEffectShortcutBinding('transformOverlay', 'effect.redo').execute(),
       findEffectShortcutBinding('transformOverlay', 'effect.copy').execute(),
       findEffectShortcutBinding('transformOverlay', 'effect.paste').execute(),
+      findEffectShortcutBinding('effectEditor', 'effect.flipHorizontal').execute(),
+      findEffectShortcutBinding('transformOverlay', 'effect.flipVertical').execute(),
     ])
 
     expect(effectEditorProviderMock.undoDraft).toHaveBeenCalledTimes(2)
     expect(effectEditorProviderMock.redoDraft).toHaveBeenCalledTimes(2)
     expect(effectEditorProviderMock.copyCurrentEffect).toHaveBeenCalledTimes(2)
     expect(effectEditorProviderMock.pasteCurrentEffect).toHaveBeenCalledTimes(2)
+    expect(effectEditorProviderMock.updateDraft).toHaveBeenNthCalledWith(1, {
+      transform: {
+        scale: { x: -1.25 },
+      },
+    })
+    expect(effectEditorProviderMock.updateDraft).toHaveBeenNthCalledWith(2, {
+      transform: {
+        scale: { x: 1.25, y: -0.75 },
+      },
+    })
+    expect(effectEditorProviderMock.requestPreview).toHaveBeenCalledTimes(2)
+    expect(effectEditorProviderMock.requestPreview).toHaveBeenCalledWith({
+      flush: true,
+      schedule: 'immediate',
+    })
 
     scope.stop()
   })

--- a/src/features/editor/shell/useEditorPanelShell.ts
+++ b/src/features/editor/shell/useEditorPanelShell.ts
@@ -1,4 +1,5 @@
 import { useStatementAnimationDialog } from '~/features/editor/animation/useStatementAnimationDialog'
+import { flipTransformScaleAxis } from '~/features/editor/effect-editor/transform-flip'
 import { useEffectEditorProvider } from '~/features/editor/effect-editor/useEffectEditorProvider'
 import { readResizablePanelCollapsed } from '~/features/editor/shared/resizable-panel'
 import { useCommandPanelBridgeProvider, useSidebarPanelProvider } from '~/features/editor/shared/useEditorPanelBindings'
@@ -10,6 +11,7 @@ import { useTabsStore } from '~/stores/tabs'
 
 import type { commandType } from 'webgal-parser/src/interface/sceneInterface'
 import type { Transform } from '~/domain/stage/types'
+import type { TransformScaleAxis } from '~/features/editor/effect-editor/transform-flip'
 import type { ShortcutDefinition } from '~/features/editor/shortcut/types'
 
 interface ResizablePanelLike {
@@ -67,6 +69,26 @@ export function useEditorPanelShell(options: UseEditorPanelShellOptions) {
 
   const isCommandPanelCollapsed = computed(() => readResizablePanelCollapsed(options.commandPanelRef.value))
   const effectEditorSession = computed(() => effectEditorProvider.session)
+
+  function flipEffectScaleAxis(axis: TransformScaleAxis): void {
+    const currentSession = effectEditorProvider.session
+    if (!currentSession) {
+      return
+    }
+
+    effectEditorProvider.updateDraft({
+      transform: flipTransformScaleAxis({
+        axis,
+        baselineSource: currentSession.baselineSource,
+        baselineTransform: currentSession.baselineTransform,
+        transform: currentSession.draft.transform,
+      }),
+    })
+    effectEditorProvider.requestPreview({
+      flush: true,
+      schedule: 'immediate',
+    })
+  }
 
   function toggleCommandPanel(): void {
     const panel = options.commandPanelRef.value
@@ -129,6 +151,18 @@ export function useEditorPanelShell(options: UseEditorPanelShellOptions) {
       i18nKey: 'shortcut.effect.paste',
       id: 'effect.paste',
       keys: 'Mod+V',
+    },
+    {
+      action: () => flipEffectScaleAxis('x'),
+      i18nKey: 'shortcut.effect.flipHorizontal',
+      id: 'effect.flipHorizontal',
+      keys: 'Shift+H',
+    },
+    {
+      action: () => flipEffectScaleAxis('y'),
+      i18nKey: 'shortcut.effect.flipVertical',
+      id: 'effect.flipVertical',
+      keys: 'Shift+V',
     },
   ]
 

--- a/src/features/editor/shell/useEditorPanelShell.ts
+++ b/src/features/editor/shell/useEditorPanelShell.ts
@@ -71,7 +71,7 @@ export function useEditorPanelShell(options: UseEditorPanelShellOptions) {
   const effectEditorSession = computed(() => effectEditorProvider.session)
 
   function flipEffectScaleAxis(axis: TransformScaleAxis): void {
-    const currentSession = effectEditorProvider.session
+    const currentSession = effectEditorSession.value
     if (!currentSession) {
       return
     }

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -473,6 +473,9 @@ modals:
     previewUnsyncedCloseBlockedTitle: Runtime preview is out of sync
     previewUnsyncedCloseBlockedMessage: The current effect may already be committed to the preview runtime, but the editor could not confirm the sync state. Select the target line again, or explicitly discard before reopening the effect editor.
     clearProperty: Clear {name}
+    flip: Flip
+    flipHorizontal: Flip Horizontal
+    flipVertical: Flip Vertical
     categories:
       transform: Transform
       effects: Effects

--- a/src/locales/ja.yml
+++ b/src/locales/ja.yml
@@ -473,6 +473,9 @@ modals:
     previewUnsyncedCloseBlockedTitle: ランタイムプレビューが同期されていません
     previewUnsyncedCloseBlockedMessage: 現在のエフェクトはプレビュー実行環境に反映済みの可能性がありますが、エディターは同期状態を確認できませんでした。対象行を選び直すか、明示的に破棄してからエフェクトエディターを開き直してください。
     clearProperty: "{name} の指定を削除"
+    flip: 反転
+    flipHorizontal: 水平方向に反転
+    flipVertical: 垂直方向に反転
     categories:
       transform: 変換
       effects: エフェクト

--- a/src/locales/zh-Hans.yml
+++ b/src/locales/zh-Hans.yml
@@ -473,6 +473,9 @@ modals:
     previewUnsyncedCloseBlockedTitle: 运行时预览未同步
     previewUnsyncedCloseBlockedMessage: 当前效果可能已经提交到预览运行时，但编辑器尚未确认同步状态。请重新选择目标行，或显式丢弃后重新打开效果编辑器。
     clearProperty: 清除{name}
+    flip: 翻转
+    flipHorizontal: 水平翻转
+    flipVertical: 垂直翻转
     categories:
       transform: 变换
       effects: 效果

--- a/src/locales/zh-Hant.yml
+++ b/src/locales/zh-Hant.yml
@@ -473,6 +473,9 @@ modals:
     previewUnsyncedCloseBlockedTitle: 執行時預覽未同步
     previewUnsyncedCloseBlockedMessage: 目前效果可能已提交到預覽執行時，但編輯器尚未確認同步狀態。請重新選擇目標行，或明確捨棄後重新開啟效果編輯器。
     clearProperty: 清除{name}
+    flip: 翻轉
+    flipHorizontal: 水平翻轉
+    flipVertical: 垂直翻轉
     categories:
       transform: 變換
       effects: 效果


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [ ] 错误修复
- [x] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [x] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

为效果编辑器的变换区域新增独立的“翻转”分组，提供水平翻转和垂直翻转按钮，降低通过手动输入负缩放值完成镜像操作的成本。

同时新增 `Shift+H` 和 `Shift+V` 快捷键，分别用于水平翻转和垂直翻转。快捷键同时适用于 effect editor 与 transform overlay 焦点场景。

实现上新增了 `flipTransformScaleAxis` 纯函数，统一处理显式缩放值、基线变换值和默认展示值下的翻转计算，并复用在按钮和快捷键路径中。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

当前镜像操作需要用户手动输入负缩放值，操作成本较高，且不利于高频调整。新增按钮和快捷键后，可以直接完成常用翻转操作，并保持变换编辑器与拖拽变换场景的操作一致性。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
