### PR TITLE
✨ 效果编辑器缩放关联按钮添加状态提示

### DIFF
--- a/src/components/editor/effect-editor/EffectDraftCategorySection.spec.ts
+++ b/src/components/editor/effect-editor/EffectDraftCategorySection.spec.ts
@@ -14,7 +14,11 @@ import EffectDraftCategorySection from './EffectDraftCategorySection.vue'
 
 import type { EffectDraftCategoryControls } from './effectDraftForm.types'
 
-function createControls() {
+interface CreateControlsOptions {
+  linkedSliderLockByPath?: Record<string, boolean>
+}
+
+function createControls(options: CreateControlsOptions = {}) {
   const clearPaths = vi.fn()
   const clearablePathKeys = new Set([
     'position.x',
@@ -42,7 +46,7 @@ function createControls() {
     getSliderInputValue: () => '1',
     updateSliderField: vi.fn(),
     flushSliderField: vi.fn(),
-    isLinkedSliderLocked: () => true,
+    isLinkedSliderLocked: (param: { key: string }) => options.linkedSliderLockByPath?.[param.key] ?? true,
     toggleLinkedSliderLock: vi.fn(),
     getLinkedSliderLabel: () => 'Scale',
     getAxisCompactLabel: (path: string) => path.endsWith('.x') ? 'X' : 'Y',
@@ -82,6 +86,14 @@ const globalStubs = {
   Label: createBrowserContainerStub('StubLabel', 'label'),
   SegmentedControl: createBrowserValueStub('StubSegmentedControl'),
   Slider: createBrowserValueStub('StubSlider'),
+}
+
+const globalStubsWithTooltip = {
+  ...globalStubs,
+  Tooltip: createBrowserContainerStub('StubTooltip'),
+  TooltipContent: createBrowserContainerStub('StubTooltipContent'),
+  TooltipProvider: createBrowserContainerStub('StubTooltipProvider'),
+  TooltipTrigger: createBrowserContainerStub('StubTooltipTrigger'),
 }
 
 describe('EffectDraftCategorySection', () => {
@@ -239,6 +251,68 @@ describe('EffectDraftCategorySection', () => {
 
     expect(controls.flipScaleAxis).toHaveBeenNthCalledWith(1, 'x')
     expect(controls.flipScaleAxis).toHaveBeenNthCalledWith(2, 'y')
+  })
+
+  it('根据缩放关联状态显示对应的切换提示', async () => {
+    const { controls } = createControls({
+      linkedSliderLockByPath: {
+        'locked-scale.x': true,
+        'unlocked-scale.x': false,
+      },
+    })
+
+    renderInBrowser(EffectDraftCategorySection, {
+      props: {
+        category: {
+          key: 'transform',
+          label: 'Transform',
+          items: [
+            {
+              kind: 'linked-slider',
+              key: 'locked-scale',
+              param: {
+                key: 'locked-scale.x',
+                linkedPairKey: 'locked-scale.y',
+                type: 'number',
+                label: 'Scale X',
+                linkedGroupLabel: 'Scale',
+                min: 0,
+                max: 2,
+                step: 0.01,
+                defaultValue: 1,
+              },
+            },
+            {
+              kind: 'linked-slider',
+              key: 'unlocked-scale',
+              param: {
+                key: 'unlocked-scale.x',
+                linkedPairKey: 'unlocked-scale.y',
+                type: 'number',
+                label: 'Scale X',
+                linkedGroupLabel: 'Scale',
+                min: 0,
+                max: 2,
+                step: 0.01,
+                defaultValue: 1,
+              },
+            },
+          ],
+        },
+        controls,
+        isPanelLayout: false,
+        resolveLabel: (value: string | undefined) => String(value ?? ''),
+      },
+      global: {
+        plugins: [createBrowserLocalizedI18n()],
+        stubs: globalStubsWithTooltip,
+      },
+    })
+
+    await expect.element(page.getByRole('button', { name: '解除缩放关联' })).toBeInTheDocument()
+    await expect.element(page.getByText('解除缩放关联')).toBeInTheDocument()
+    await expect.element(page.getByRole('button', { name: '关联 X/Y 缩放' })).toBeInTheDocument()
+    await expect.element(page.getByText('关联 X/Y 缩放')).toBeInTheDocument()
   })
 
   it('将固定宽度放在标签与按钮的公共头部容器上，让按钮贴近标签文本', async () => {

--- a/src/components/editor/effect-editor/EffectDraftCategorySection.vue
+++ b/src/components/editor/effect-editor/EffectDraftCategorySection.vue
@@ -227,16 +227,29 @@ function getClearPropertyLabel(label: Parameters<EffectDraftLabelResolver>[0]): 
                 </Button>
               </div>
             </div>
-            <Button
-              size="icon"
-              variant="ghost"
-              :aria-label="controls.getLinkedSliderLabel(item.param)"
-              :aria-pressed="controls.isLinkedSliderLocked(item.param)"
-              :class="['h-7 w-7', controls.isLinkedSliderLocked(item.param) && 'bg-accent text-accent-foreground hover:bg-accent/80']"
-              @click="controls.toggleLinkedSliderLock(item.param)"
-            >
-              <div :class="controls.isLinkedSliderLocked(item.param) ? 'i-lucide-link' : 'i-lucide-unlink'" class="size-3.5" />
-            </Button>
+            <TooltipProvider :delay-duration="0">
+              <Tooltip>
+                <TooltipTrigger as-child>
+                  <Button
+                    size="icon"
+                    variant="ghost"
+                    :aria-label="controls.isLinkedSliderLocked(item.param) ? $t('modals.effectEditor.unlinkScale') : $t('modals.effectEditor.linkScale')"
+                    :aria-pressed="controls.isLinkedSliderLocked(item.param)"
+                    :class="['h-7 w-7', controls.isLinkedSliderLocked(item.param) && 'bg-accent text-accent-foreground hover:bg-accent/80']"
+                    @click="controls.toggleLinkedSliderLock(item.param)"
+                  >
+                    <div :class="controls.isLinkedSliderLocked(item.param) ? 'i-lucide-link' : 'i-lucide-unlink'" class="size-3.5" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent side="top" class="px-2 py-1">
+                  {{
+                    controls.isLinkedSliderLocked(item.param)
+                      ? $t('modals.effectEditor.unlinkScale')
+                      : $t('modals.effectEditor.linkScale')
+                  }}
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
           </div>
 
           <div class="flex flex-col gap-2" :class="isPanelLayout ? 'max-w-[28rem]' : 'max-w-76'">

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -476,6 +476,8 @@ modals:
     flip: Flip
     flipHorizontal: Flip Horizontal
     flipVertical: Flip Vertical
+    linkScale: Link X/Y Scale
+    unlinkScale: Unlink X/Y Scale
     categories:
       transform: Transform
       effects: Effects

--- a/src/locales/ja.yml
+++ b/src/locales/ja.yml
@@ -476,6 +476,8 @@ modals:
     flip: 反転
     flipHorizontal: 水平方向に反転
     flipVertical: 垂直方向に反転
+    linkScale: X/Y スケールを連動
+    unlinkScale: スケール連動を解除
     categories:
       transform: 変換
       effects: エフェクト

--- a/src/locales/zh-Hans.yml
+++ b/src/locales/zh-Hans.yml
@@ -476,6 +476,8 @@ modals:
     flip: 翻转
     flipHorizontal: 水平翻转
     flipVertical: 垂直翻转
+    linkScale: 关联 X/Y 缩放
+    unlinkScale: 解除缩放关联
     categories:
       transform: 变换
       effects: 效果

--- a/src/locales/zh-Hant.yml
+++ b/src/locales/zh-Hant.yml
@@ -476,6 +476,8 @@ modals:
     flip: 翻轉
     flipHorizontal: 水平翻轉
     flipVertical: 垂直翻轉
+    linkScale: 連結 X/Y 縮放
+    unlinkScale: 解除縮放連結
     categories:
       transform: 變換
       effects: 效果


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [ ] 错误修复
- [x] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [x] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

为效果编辑器中 X/Y 缩放关联按钮添加 tooltip，并根据当前关联状态显示不同文案：

- 已关联时显示“解除缩放关联”
- 未关联时显示“关联 X/Y 缩放”

同时将按钮的 `aria-label` 改为同一套状态文案，避免图标按钮只暴露低信息量的 `Scale` 名称。已同步更新 en、ja、zh-Hans、zh-Hant 四套语言文件，并添加浏览器测试覆盖两种状态。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

缩放关联按钮是纯图标按钮，原先缺少 tooltip，且可访问名称不能表达点击后的动作。补充状态相关提示后，用户能更明确地判断当前按钮会关联还是解除关联 X/Y 缩放。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
