### PR TITLE
⬆️ 提升 WebGAL 引擎最低版本到 4.6.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ WebGAL Craft 是一款为 [WebGAL](https://github.com/OpenWebGAL/WebGAL) 游戏�
 ## 快速上手
 
 > [!IMPORTANT]
-> WebGAL Craft 需要 WebGAL `4.6.1` 或以上版本的引擎，可在 [WebGAL Releases](https://github.com/OpenWebGAL/WebGAL/releases) 获取
+> WebGAL Craft 需要 WebGAL `4.6.2` 或以上版本的引擎，可在 [WebGAL Releases](https://github.com/OpenWebGAL/WebGAL/releases) 获取
 
 1. 下载并安装适合你系统的 WebGAL Craft。
 2. 打开 WebGAL Craft，在主页安装游戏引擎。

--- a/bun.lock
+++ b/bun.lock
@@ -39,7 +39,7 @@
         "vue-router": "^5.1.0",
         "vue-sonner": "^2.0.9",
         "wavesurfer.js": "^7.12.7",
-        "webgal-parser": "^4.6.1",
+        "webgal-parser": "^4.6.2",
         "zod": "^4.4.3",
       },
       "devDependencies": {
@@ -165,14 +165,6 @@
     "@cacheable/memory": ["@cacheable/memory@2.0.9", "", { "dependencies": { "@cacheable/utils": "^2.4.1", "@keyv/bigmap": "^1.3.1", "hookified": "^1.15.1", "keyv": "^5.6.0" } }, "sha512-HdMx6DoGywB30vacDbBsITbIX4pgFqj1zsrV58jZBUw3klzkNoXhj7qOqAgledhxG7YZI5rBSJg7Zp8/VG0DuA=="],
 
     "@cacheable/utils": ["@cacheable/utils@2.4.1", "", { "dependencies": { "hashery": "^1.5.1", "keyv": "^5.6.0" } }, "sha512-eiFgzCbIneyMlLOmNG4g9xzF7Hv3Mga4LjxjcSC/ues6VYq2+gUbQI8JqNuw/ZM8tJIeIaBGpswAsqV2V7ApgA=="],
-
-    "@chevrotain/cst-dts-gen": ["@chevrotain/cst-dts-gen@10.5.0", "", { "dependencies": { "@chevrotain/gast": "10.5.0", "@chevrotain/types": "10.5.0", "lodash": "4.17.21" } }, "sha512-lhmC/FyqQ2o7pGK4Om+hzuDrm9rhFYIJ/AXoQBeongmn870Xeb0L6oGEiuR8nohFNL5sMaQEJWCxr1oIVIVXrw=="],
-
-    "@chevrotain/gast": ["@chevrotain/gast@10.5.0", "", { "dependencies": { "@chevrotain/types": "10.5.0", "lodash": "4.17.21" } }, "sha512-pXdMJ9XeDAbgOWKuD1Fldz4ieCs6+nLNmyVhe2gZVqoO7v8HXuHYs5OV2EzUtbuai37TlOAQHrTDvxMnvMJz3A=="],
-
-    "@chevrotain/types": ["@chevrotain/types@10.5.0", "", {}, "sha512-f1MAia0x/pAVPWH/T73BJVyO2XU5tI4/iE7cnxb7tqdNTNhQI3Uq3XkqcoteTmD4t1aM0LbHCJOhgIDn07kl2A=="],
-
-    "@chevrotain/utils": ["@chevrotain/utils@10.5.0", "", {}, "sha512-hBzuU5+JjB2cqNZyszkDHZgOSrUUT8V3dhgRl8Q9Gp6dAj/H5+KILGjbhDpc3Iy9qmqlm/akuOI2ut9VUtzJxQ=="],
 
     "@csstools/css-calc": ["@csstools/css-calc@3.2.1", "", { "peerDependencies": { "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg=="],
 
@@ -836,8 +828,6 @@
 
     "astral-regex": ["astral-regex@2.0.0", "", {}, "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ=="],
 
-    "axios": ["axios@0.24.0", "", { "dependencies": { "follow-redirects": "^1.14.4" } }, "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA=="],
-
     "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.34", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-IMDedajPifLnHNY0X9n8hKxRTQ6/eTHwr5bDo04WnuqxyKw6LYtQywCuuqPZwhl3aBXMvQpJov42GLCwRRdQzw=="],
@@ -872,15 +862,11 @@
 
     "change-case": ["change-case@5.4.4", "", {}, "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w=="],
 
-    "chevrotain": ["chevrotain@10.5.0", "", { "dependencies": { "@chevrotain/cst-dts-gen": "10.5.0", "@chevrotain/gast": "10.5.0", "@chevrotain/types": "10.5.0", "@chevrotain/utils": "10.5.0", "lodash": "4.17.21", "regexp-to-ast": "0.5.0" } }, "sha512-Pkv5rBY3+CsHOYfV5g/Vs5JY9WTHHDEKOlohI2XeygaZhUeqhAlldZ8Hz9cRmxu709bvS08YzxHdTPHhffc13A=="],
-
     "chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
 
     "ci-info": ["ci-info@4.4.0", "", {}, "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg=="],
 
     "class-variance-authority": ["class-variance-authority@0.7.1", "", { "dependencies": { "clsx": "^2.1.1" } }, "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg=="],
-
-    "cloudlogjs": ["cloudlogjs@1.0.12", "", { "dependencies": { "axios": "^0.24.0" } }, "sha512-mAE6QXLAzDj9fg1g3PguXC25MKkve8433hu+Af7BuGT5+7VSB8W9aSeh/LsZW2TscDYOJg/5PLhR9/Q4zxyp+Q=="],
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
@@ -1053,8 +1039,6 @@
     "flat-cache": ["flat-cache@4.0.1", "", { "dependencies": { "flatted": "^3.2.9", "keyv": "^4.5.4" } }, "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw=="],
 
     "flatted": ["flatted@3.4.2", "", {}, "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA=="],
-
-    "follow-redirects": ["follow-redirects@1.16.0", "", { "peerDependencies": { "debug": "*" }, "optionalPeers": ["debug"] }, "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw=="],
 
     "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
 
@@ -1230,8 +1214,6 @@
 
     "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
 
-    "lodash": ["lodash@4.18.1", "", {}, "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="],
-
     "lodash.truncate": ["lodash.truncate@4.4.2", "", {}, "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw=="],
 
     "lru-cache": ["lru-cache@11.5.1", "", {}, "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A=="],
@@ -1405,8 +1387,6 @@
     "radix3": ["radix3@1.1.2", "", {}, "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA=="],
 
     "readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
-
-    "regexp-to-ast": ["regexp-to-ast@0.5.0", "", {}, "sha512-tlbJqcMHnPKI9zSrystikWKwHkBqu2a/Sgw01h3zFjvYrMxEDYHzzoMZnUrbIfpTFEsoRnnviOXNCzFiSc54Qw=="],
 
     "regexp-tree": ["regexp-tree@0.1.27", "", { "bin": { "regexp-tree": "bin/regexp-tree" } }, "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA=="],
 
@@ -1646,7 +1626,7 @@
 
     "wavesurfer.js": ["wavesurfer.js@7.12.7", "", {}, "sha512-TIe7hB6OCZysNOZ2cn2NR8Qpko22POWel6rauNcqOammFoH65NYQUM35unNLLMIlUMVYvjJ6w/TTl/G/m+w0nA=="],
 
-    "webgal-parser": ["webgal-parser@4.6.1", "", { "dependencies": { "chevrotain": "^10.5.0", "cloudlogjs": "^1.0.11", "lodash": "^4.17.23", "tsx": "^3.12.7" } }, "sha512-HGdXqk1sPP7+3pfaorWltQO2A4zncxLIGOQ7ghyhSR/fbn8oUeKbqQbmrQE/UySnUaj6lcsK8pvtI/c+PMD9Gw=="],
+    "webgal-parser": ["webgal-parser@4.6.2", "", {}, "sha512-GGTrama9fUUrXmgpvxwMzk9m7CQZtm38ueZQdXzR8cJaGge0bjmMQZQBmy2Cu6/Mz7wdwg8QPyZ4KOlE1s8+WA=="],
 
     "webpack-virtual-modules": ["webpack-virtual-modules@0.6.2", "", {}, "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ=="],
 
@@ -1700,10 +1680,6 @@
 
     "@cacheable/utils/keyv": ["keyv@5.6.0", "", { "dependencies": { "@keyv/serialize": "^1.1.1" } }, "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw=="],
 
-    "@chevrotain/cst-dts-gen/lodash": ["lodash@4.17.21", "", {}, "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="],
-
-    "@chevrotain/gast/lodash": ["lodash@4.17.21", "", {}, "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="],
-
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
     "@eslint/eslintrc/globals": ["globals@14.0.0", "", {}, "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="],
@@ -1745,8 +1721,6 @@
     "@vue/devtools-api/@vue/devtools-kit": ["@vue/devtools-kit@7.7.9", "", { "dependencies": { "@vue/devtools-shared": "^7.7.9", "birpc": "^2.3.0", "hookable": "^5.5.3", "mitt": "^3.0.1", "perfect-debounce": "^1.0.0", "speakingurl": "^14.0.1", "superjson": "^2.2.2" } }, "sha512-PyQ6odHSgiDVd4hnTP+aDk2X4gl2HmLDfiyEnn3/oV+ckFDuswRs4IbBT7vacMuGdwY/XemxBoh302ctbsptuA=="],
 
     "cacheable/keyv": ["keyv@5.6.0", "", { "dependencies": { "@keyv/serialize": "^1.1.1" } }, "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw=="],
-
-    "chevrotain/lodash": ["lodash@4.17.21", "", {}, "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="],
 
     "cosmiconfig/import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
 

--- a/integration/support/mock-tauri.ts
+++ b/integration/support/mock-tauri.ts
@@ -76,7 +76,7 @@ const defaultSeedEngine: SeedEngine = {
     name: 'Default Engine',
     icon: 'C:/Engines/Default/icons/favicon.ico',
     description: '用于集成测试的默认引擎',
-    webgalVersion: '4.6.1',
+    webgalVersion: '4.6.2',
   },
   previewAssets: {
     icon: { path: 'C:/Engines/Default/icons/favicon.ico' },

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "vue-router": "^5.1.0",
     "vue-sonner": "^2.0.9",
     "wavesurfer.js": "^7.12.7",
-    "webgal-parser": "^4.6.1",
+    "webgal-parser": "^4.6.2",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/src/__tests__/factories.ts
+++ b/src/__tests__/factories.ts
@@ -89,7 +89,7 @@ export function createTestEngine(options: TestEngineFactoryOptions = {}): Engine
     metadata: {
       description: 'Default engine',
       icon: 'icons/favicon.ico',
-      webgalVersion: '4.6.1',
+      webgalVersion: '4.6.2',
       ...metadata,
     },
     previewAssets: {

--- a/src/components/shared/EngineSelector.spec.ts
+++ b/src/components/shared/EngineSelector.spec.ts
@@ -71,7 +71,7 @@ describe('EngineSelector', () => {
               id: 'created-engine',
               engineId: 'open-webgal.webgal',
               name: 'WebGAL',
-              version: '4.6.1',
+              version: '4.6.2',
               status: 'created',
             }),
             createTestEngine({
@@ -112,7 +112,7 @@ describe('EngineSelector', () => {
 
     await expect.poll(() => document.body.textContent ?? '').toContain('WebGAL')
     expect(document.body.textContent ?? '').not.toContain('Legacy')
-    expect(document.body.textContent ?? '').toContain('4.6.1')
+    expect(document.body.textContent ?? '').toContain('4.6.2')
     expect(document.body.textContent ?? '').not.toContain('4.6.0')
     expect(document.body.textContent ?? '').not.toContain('4.4.0')
     await vi.waitFor(() => {

--- a/src/composables/__tests__/useResourcePreviewPrimer.test.ts
+++ b/src/composables/__tests__/useResourcePreviewPrimer.test.ts
@@ -45,7 +45,7 @@ const previewRuntimeStoreState = {
 function createTestEngine(path: string, overrides: Partial<Omit<TestEngine, 'path'>> = {}): TestEngine {
   return {
     availability: 'available',
-    metadata: { webgalVersion: '4.6.1' },
+    metadata: { webgalVersion: '4.6.2' },
     path,
     status: 'created',
     ...overrides,

--- a/src/features/modals/create-game/__tests__/useCreateGameForm.test.ts
+++ b/src/features/modals/create-game/__tests__/useCreateGameForm.test.ts
@@ -111,7 +111,7 @@ describe('useCreateGameForm', () => {
       status: 'created',
       availability: 'available',
       metadata: {
-        webgalVersion: '4.6.1',
+        webgalVersion: '4.6.2',
       },
     })
     existsMock.mockResolvedValue(false)
@@ -226,7 +226,7 @@ describe('useCreateGameForm', () => {
       status: 'created',
       availability: 'broken',
       metadata: {
-        webgalVersion: '4.6.1',
+        webgalVersion: '4.6.2',
       },
     })
     reconcileEngineRecordMock.mockResolvedValue('available')

--- a/src/features/modals/import-dependency-resolution/__tests__/request-game-runtime-rebind.test.ts
+++ b/src/features/modals/import-dependency-resolution/__tests__/request-game-runtime-rebind.test.ts
@@ -46,7 +46,7 @@ describe('requestGameRuntimeRebind', () => {
     const selectedEngine = createTestEngine({
       id: 'engine-new',
       engineId: 'open-webgal.webgal',
-      version: '4.6.1',
+      version: '4.6.2',
     })
     const game = createTestGame({
       engineId: 'engine-old',

--- a/src/services/__tests__/engine-manager.test.ts
+++ b/src/services/__tests__/engine-manager.test.ts
@@ -217,16 +217,16 @@ describe('engineManager', () => {
 
   it('evaluateEngineEditorCompatibility 会按严格三段版本判断编辑器运行时兼容性', () => {
     expect(evaluateEngineEditorCompatibility(createTestEngine({
-      metadata: { webgalVersion: '4.6.1' },
+      metadata: { webgalVersion: '4.6.2' },
     }))).toEqual({ compatible: true })
     expect(evaluateEngineEditorCompatibility(createTestEngine({
       metadata: { webgalVersion: '4.10.0' },
     }))).toEqual({ compatible: true })
     expect(evaluateEngineEditorCompatibility(createTestEngine({
-      metadata: { webgalVersion: '4.6.0' },
+      metadata: { webgalVersion: '4.6.1' },
     }))).toEqual({ compatible: false, issue: 'versionTooOld' })
     expect(evaluateEngineEditorCompatibility(createTestEngine({
-      metadata: { webgalVersion: '4.6.1-beta' },
+      metadata: { webgalVersion: '4.6.2-beta' },
     }))).toEqual({ compatible: false, issue: 'versionTooOld' })
     expect(evaluateEngineEditorCompatibility(createTestEngine({
       metadata: { webgalVersion: undefined },
@@ -250,9 +250,9 @@ describe('engineManager', () => {
         schemaVersion: '1.0.0',
         id: 'open-webgal.webgal',
         name: 'WebGAL',
-        version: '4.6.1',
+        version: '4.6.2',
         engineType: 'official',
-        webgalVersion: '4.6.1',
+        webgalVersion: '4.6.2',
         icon: 'branding/icon.png',
       },
     })
@@ -266,10 +266,10 @@ describe('engineManager', () => {
     await expect(engineManager.importEngine(AbsPath.from('/downloads/webgal'))).resolves.toEqual({ id: 'engine-1', alreadyRegistered: false })
 
     expect(addMock).toHaveBeenCalledWith(expect.objectContaining({
-      path: '/engines/WebGAL/4.6.1',
-      pathLookupKey: '/engines/webgal/4.6.1',
+      path: '/engines/WebGAL/4.6.2',
+      pathLookupKey: '/engines/webgal/4.6.2',
       name: 'WebGAL',
-      version: '4.6.1',
+      version: '4.6.2',
       status: 'creating',
       metadata: expect.objectContaining({
         type: 'official',
@@ -277,7 +277,7 @@ describe('engineManager', () => {
     }))
     expect(copyDirectoryWithProgressMock).toHaveBeenCalledWith(
       '/downloads/webgal',
-      '/engines/WebGAL/4.6.1',
+      '/engines/WebGAL/4.6.2',
       expect.any(Function),
     )
     expect(resourceStoreMock.updateProgress).toHaveBeenNthCalledWith(1, 'engine-1', 0)
@@ -287,10 +287,10 @@ describe('engineManager', () => {
     expect(enginesUpdateMock).toHaveBeenCalledWith('engine-1', expect.objectContaining({
       status: 'created',
       name: 'WebGAL',
-      version: '4.6.1',
+      version: '4.6.2',
       previewAssets: {
         icon: expect.objectContaining({
-          path: '/engines/WebGAL/4.6.1/branding/icon.png',
+          path: '/engines/WebGAL/4.6.2/branding/icon.png',
         }),
       },
     }))
@@ -304,9 +304,9 @@ describe('engineManager', () => {
         schemaVersion: '1.0.0',
         id: 'open-webgal.webgal',
         name: 'WebGAL',
-        version: '4.6.1',
+        version: '4.6.2',
         engineType: 'official',
-        webgalVersion: '4.6.1',
+        webgalVersion: '4.6.2',
         icon: 'branding/icon.png',
       },
     })
@@ -319,12 +319,12 @@ describe('engineManager', () => {
     })
 
     expect(addMock).toHaveBeenCalledWith(expect.objectContaining({
-      path: 'C:/Engines/WebGAL/4.6.1',
-      pathLookupKey: 'c:/engines/webgal/4.6.1',
+      path: 'C:/Engines/WebGAL/4.6.2',
+      pathLookupKey: 'c:/engines/webgal/4.6.2',
     }))
     expect(copyDirectoryWithProgressMock).toHaveBeenCalledWith(
       'C:/downloads/webgal',
-      'C:/Engines/WebGAL/4.6.1',
+      'C:/Engines/WebGAL/4.6.2',
       expect.any(Function),
     )
   })
@@ -337,7 +337,7 @@ describe('engineManager', () => {
         id: 'open-webgal.webgal',
         name: 'WebGAL',
         engineType: 'official',
-        webgalVersion: '4.6.1',
+        webgalVersion: '4.6.2',
         icon: 'branding/icon.png',
       },
     })
@@ -411,7 +411,7 @@ describe('engineManager', () => {
         schemaVersion: '1.0.0',
         id: 'open-webgal.webgal',
         name: 'WebGAL',
-        version: '4.6.1',
+        version: '4.6.2',
         engineType: 'official',
         webgalVersion: '4.6',
       },
@@ -477,7 +477,7 @@ describe('engineManager', () => {
     const existingEngine = createTestEngine({
       id: 'engine-existing-by-ref',
       name: 'WebGAL',
-      version: '4.6.1',
+      version: '4.6.2',
     })
     readEngineManifestMock.mockResolvedValue({
       status: 'ok',
@@ -485,9 +485,9 @@ describe('engineManager', () => {
         schemaVersion: '1.0.0',
         id: 'open-webgal.webgal',
         name: 'WebGAL',
-        version: '4.6.1',
+        version: '4.6.2',
         engineType: 'official',
-        webgalVersion: '4.6.1',
+        webgalVersion: '4.6.2',
       },
     })
     validateDirectoryStructureMock.mockResolvedValue(true)
@@ -499,7 +499,7 @@ describe('engineManager', () => {
           }
 
           const [engineId, version] = value
-          return engineId === 'open-webgal.webgal' && version === '4.6.1'
+          return engineId === 'open-webgal.webgal' && version === '4.6.2'
             ? existingEngine
             : undefined
         },
@@ -551,13 +551,13 @@ describe('engineManager', () => {
         schemaVersion: '1.0.0',
         id: 'open-webgal.webgal',
         name: 'WebGAL',
-        version: '4.6.1',
+        version: '4.6.2',
         engineType: 'official',
-        webgalVersion: '4.6.1',
+        webgalVersion: '4.6.2',
       },
     })
     validateDirectoryStructureMock.mockResolvedValue(true)
-    existsMock.mockImplementation(async (path: string) => path === '/engines/WebGAL/4.6.1')
+    existsMock.mockImplementation(async (path: string) => path === '/engines/WebGAL/4.6.2')
 
     await expect(engineManager.importEngine(AbsPath.from('/downloads/webgal'))).rejects.toEqual(
       new AppError('TARGET_CONFLICT', '目标引擎目录已存在，请先清理后重试'),

--- a/src/services/__tests__/engine-switch.test.ts
+++ b/src/services/__tests__/engine-switch.test.ts
@@ -209,7 +209,7 @@ describe('engineSwitch.switchEngine', () => {
       id: 'engine-new',
       path: AbsPath.from('/engines/new'),
       engineId: 'open-webgal.webgal',
-      version: '4.6.1',
+      version: '4.6.2',
     })
     dbEngineGetMock.mockResolvedValue(oldEngine)
     resolveTemplatePathMock
@@ -220,7 +220,7 @@ describe('engineSwitch.switchEngine', () => {
 
     await expect(engineSwitch.switchEngine(game, newEngine)).resolves.toBeUndefined()
     expect(writeProjectConfigMock).toHaveBeenCalledWith('/games/demo', expect.objectContaining({
-      engine: { id: 'open-webgal.webgal', version: '4.6.1' },
+      engine: { id: 'open-webgal.webgal', version: '4.6.2' },
     }))
   })
 

--- a/src/services/__tests__/game-manager.test.ts
+++ b/src/services/__tests__/game-manager.test.ts
@@ -231,12 +231,12 @@ function mockTemplateLookupByName(templates: Record<string, ReturnType<typeof cr
 
 const importedProjectEngineRef = {
   id: 'default-publisher.default-engine',
-  version: '4.6.1',
+  version: '4.6.2',
 }
 
 const selectedProjectEngineRef = {
   id: 'default-publisher.default-engine',
-  version: '4.6.1',
+  version: '4.6.2',
 }
 
 const configuredImportDependencyContext = {
@@ -592,9 +592,9 @@ describe('gameManager', () => {
     dbEngineGetMock.mockResolvedValue(createTestEngine({
       availability: 'broken',
       id: 'engine-broken',
-      metadata: { webgalVersion: '4.6.1' },
+      metadata: { webgalVersion: '4.6.2' },
       name: 'WebGAL',
-      version: '4.6.1',
+      version: '4.6.2',
     }))
 
     await expect(gameManager.createGame('Demo Game', AbsPath.from('/games/demo'), 'engine-broken')).rejects.toMatchObject({
@@ -754,7 +754,7 @@ describe('gameManager', () => {
     dbEngineGetMock.mockResolvedValue(createTestEngine({
       id: 'engine-2',
       name: 'WebGAL',
-      version: '4.6.1',
+      version: '4.6.2',
       status: 'created',
     }))
     const resolveDependencies = vi.fn().mockResolvedValue({
@@ -791,7 +791,7 @@ describe('gameManager', () => {
     engineFindByRefMock.mockResolvedValue(createTestEngine({
       id: 'engine-1',
       name: 'WebGAL',
-      version: '4.6.1',
+      version: '4.6.2',
     }))
 
     await expect(gameManager.importGame(AbsPath.from('/games/vfs'))).resolves.toEqual({ id: 'game-1', alreadyRegistered: false })
@@ -823,7 +823,7 @@ describe('gameManager', () => {
     dbEngineGetMock.mockResolvedValue(createTestEngine({
       id: 'engine-2',
       name: 'WebGAL',
-      version: '4.6.1',
+      version: '4.6.2',
       status: 'created',
     }))
     const resolveDependencies = vi.fn().mockResolvedValue({
@@ -871,7 +871,7 @@ describe('gameManager', () => {
     engineFindByRefMock.mockResolvedValue(createTestEngine({
       id: 'engine-1',
       name: 'WebGAL',
-      version: '4.6.1',
+      version: '4.6.2',
     }))
     resolveTemplatePathMock.mockResolvedValue(undefined)
     const selectedTemplateBinding = {
@@ -971,11 +971,11 @@ describe('gameManager', () => {
       },
     })
     engineFindByRefMock.mockImplementation(async (ref: { version?: string }) => {
-      if (ref.version === '4.6.1') {
+      if (ref.version === '4.6.2') {
         return createTestEngine({
           id: 'engine-1',
           name: 'WebGAL',
-          version: '4.6.1',
+          version: '4.6.2',
         })
       }
       return
@@ -1042,11 +1042,11 @@ describe('gameManager', () => {
       },
     })
     engineFindByRefMock.mockImplementation(async (ref: { version?: string }) => {
-      if (ref.version === '4.6.1') {
+      if (ref.version === '4.6.2') {
         return createTestEngine({
           id: 'engine-1',
           name: 'WebGAL',
-          version: '4.6.1',
+          version: '4.6.2',
         })
       }
       if (ref.version === '4.4.0') {
@@ -1120,7 +1120,7 @@ describe('gameManager', () => {
     dbEngineGetMock.mockResolvedValue(createTestEngine({
       id: 'engine-2',
       name: 'WebGAL',
-      version: '4.6.1',
+      version: '4.6.2',
       status: 'created',
     }))
     mockTemplateLookupByName({
@@ -1195,7 +1195,7 @@ describe('gameManager', () => {
     dbEngineGetMock.mockResolvedValue(createTestEngine({
       id: 'engine-2',
       name: 'WebGAL',
-      version: '4.6.1',
+      version: '4.6.2',
       status: 'created',
     }))
     const resolveDependencies = vi.fn().mockResolvedValue({
@@ -1241,13 +1241,13 @@ describe('gameManager', () => {
     engineFindByRefMock.mockResolvedValue(createTestEngine({
       id: 'engine-error',
       name: 'WebGAL',
-      version: '4.6.1',
+      version: '4.6.2',
       status: 'error',
     }))
     dbEngineGetMock.mockResolvedValue(createTestEngine({
       id: 'engine-2',
       name: 'WebGAL',
-      version: '4.6.1',
+      version: '4.6.2',
       status: 'created',
     }))
 
@@ -1292,7 +1292,7 @@ describe('gameManager', () => {
     dbEngineGetMock.mockResolvedValue(createTestEngine({
       id: 'engine-2',
       name: 'WebGAL',
-      version: '4.6.1',
+      version: '4.6.2',
       status: 'created',
     }))
 
@@ -1371,7 +1371,7 @@ describe('gameManager', () => {
     dbEngineGetMock.mockResolvedValue(createTestEngine({
       id: 'engine-2',
       name: 'WebGAL',
-      version: '4.6.1',
+      version: '4.6.2',
       status: 'created',
     }))
     const resolveDependencies = vi.fn().mockResolvedValue({
@@ -1399,9 +1399,9 @@ describe('gameManager', () => {
     dbEngineGetMock.mockResolvedValue(createTestEngine({
       availability: 'broken',
       id: 'engine-broken',
-      metadata: { webgalVersion: '4.6.1' },
+      metadata: { webgalVersion: '4.6.2' },
       name: 'WebGAL',
-      version: '4.6.1',
+      version: '4.6.2',
     }))
 
     await expect(gameManager.importGame(AbsPath.from('/games/no-engine'), {
@@ -1546,7 +1546,7 @@ describe('gameManager', () => {
       version: 1,
       engine: {
         id: 'default-publisher.default-engine',
-        version: '4.6.1',
+        version: '4.6.2',
       },
     })
 
@@ -1614,25 +1614,25 @@ describe('gameManager', () => {
   it('resolveStaticAssetSite 会在绑定引擎兼容时保留 VFS 静态资源上下文', async () => {
     dbEngineGetMock.mockResolvedValue(createTestEngine({
       id: 'engine-1',
-      path: AbsPath.from('/engines/WebGAL/4.6.1'),
-      metadata: { webgalVersion: '4.6.1' },
+      path: AbsPath.from('/engines/WebGAL/4.6.2'),
+      metadata: { webgalVersion: '4.6.2' },
     }))
     readProjectConfigMock.mockResolvedValue({
       version: 1,
       engine: {
         id: 'default-publisher.default-engine',
-        version: '4.6.1',
+        version: '4.6.2',
       },
     })
-    resolveTemplatePathMock.mockResolvedValue(AbsPath.from('/engines/WebGAL/4.6.1/game/template'))
+    resolveTemplatePathMock.mockResolvedValue(AbsPath.from('/engines/WebGAL/4.6.2/game/template'))
 
     await expect(gameManager.resolveStaticAssetSite({
       path: AbsPath.from('/games/demo'),
       engineId: 'engine-1',
     })).resolves.toEqual({
       projectPath: '/games/demo',
-      enginePath: '/engines/WebGAL/4.6.1',
-      templatePath: '/engines/WebGAL/4.6.1/game/template',
+      enginePath: '/engines/WebGAL/4.6.2',
+      templatePath: '/engines/WebGAL/4.6.2/game/template',
     })
   })
 
@@ -1674,7 +1674,7 @@ describe('gameManager', () => {
       version: 1,
       engine: {
         id: 'default-publisher.default-engine',
-        version: '4.6.1',
+        version: '4.6.2',
       },
     })
 

--- a/src/services/engine-manager.ts
+++ b/src/services/engine-manager.ts
@@ -50,7 +50,7 @@ interface DeleteEngineCheckResult {
   reason?: 'ENGINE_HAS_ASSOCIATED_GAMES'
 }
 
-export const MIN_WEBGAL_EDITOR_RUNTIME_VERSION = '4.6.1'
+export const MIN_WEBGAL_EDITOR_RUNTIME_VERSION = '4.6.2'
 
 export type EngineEditorCompatibilityIssue =
   | 'unavailable'


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [ ] 错误修复
- [ ] 新功能
- [x] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [x] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [x] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [x] 是的，并已在 issue #___ 号中获得批准
- [ ] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

将 `MIN_WEBGAL_EDITOR_RUNTIME_VERSION` 从 `4.6.1` 提升到 `4.6.2`。

同步更新内容：
- 将 `webgal-parser` 依赖升级到 `^4.6.2`
- 更新默认测试引擎、集成测试 mock 和相关单测数据
- 更新兼容性测试边界，确保 `4.6.2` 可用、`4.6.1` 会被判定为版本过旧
- 更新 README 中的最低 WebGAL 引擎版本说明

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

WebGAL Craft 现在要求 WebGAL `4.6.2` 或以上版本作为编辑器运行时。此变更让运行时兼容性门禁、测试数据、文档和 parser 依赖版本保持一致。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->

这是运行时版本门槛提升。使用 WebGAL `4.6.1` 的用户需要升级引擎到 `4.6.2` 或以上版本后再作为编辑器运行时使用。

### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [x] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
