### PR TITLE
🐛 调整效果编辑器翻转为屏幕轴镜像语义

### DIFF
--- a/src/components/editor/effect-editor/EffectDraftForm.spec.ts
+++ b/src/components/editor/effect-editor/EffectDraftForm.spec.ts
@@ -87,7 +87,7 @@ describe('EffectDraftForm', () => {
     expect(transformUpdates).toHaveBeenNthCalledWith(1, {
       value: {
         position: { x: 12 },
-        rotation: 0.5,
+        rotation: -0.5,
         scale: {
           x: -1.25,
           y: -0.75,
@@ -99,7 +99,7 @@ describe('EffectDraftForm', () => {
     expect(transformUpdates).toHaveBeenNthCalledWith(2, {
       value: {
         position: { x: 12 },
-        rotation: 0.5,
+        rotation: -0.5,
         scale: {
           x: 1.25,
           y: 0.75,

--- a/src/features/editor/effect-editor/__tests__/transform-flip.test.ts
+++ b/src/features/editor/effect-editor/__tests__/transform-flip.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest'
 import { flipTransformScaleAxis } from '../transform-flip'
 
 describe('flipTransformScaleAxis', () => {
-  it('按当前显式缩放值翻转指定轴并保留其他字段', () => {
+  it('按屏幕轴翻转指定缩放轴并反转旋转方向', () => {
     expect(flipTransformScaleAxis({
       axis: 'x',
       transform: {
@@ -13,7 +13,7 @@ describe('flipTransformScaleAxis', () => {
       },
     })).toEqual({
       position: { x: 12 },
-      rotation: 0.5,
+      rotation: -0.5,
       scale: { x: -1.25, y: -0.75 },
     })
   })

--- a/src/features/editor/effect-editor/transform-flip.ts
+++ b/src/features/editor/effect-editor/transform-flip.ts
@@ -22,6 +22,12 @@ function readScaleValue(transform: Transform, axis: TransformScaleAxis): number 
   return Number.isFinite(value) ? value : 1
 }
 
+function readRotationValue(transform: Transform): number {
+  const value = Number(transform.rotation)
+
+  return Number.isFinite(value) ? value : 0
+}
+
 export function flipTransformScaleAxis(options: FlipTransformScaleAxisOptions): Transform {
   const displayTransform = resolveTransformDraftDisplay({
     baselineSource: options.baselineSource,
@@ -29,10 +35,14 @@ export function flipTransformScaleAxis(options: FlipTransformScaleAxisOptions): 
     explicitDraftTransform: options.transform,
   }).displayTransform
   const nextTransform = cloneTransform(options.transform)
+  const displayRotation = readRotationValue(displayTransform)
 
   nextTransform.scale = {
     ...nextTransform.scale,
     [options.axis]: -readScaleValue(displayTransform, options.axis),
+  }
+  if (nextTransform.rotation !== undefined || displayRotation !== 0) {
+    nextTransform.rotation = -displayRotation
   }
 
   return nextTransform


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [x] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [x] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

修复效果编辑器的水平/垂直翻转在目标已设置旋转时表现反直觉的问题。

此前翻转只会取反 `scale.x` 或 `scale.y`，并保留 `rotation`，因此实际语义是沿目标自身局部轴翻转。目标旋转后，局部轴也随之旋转，导致“水平翻转”看起来不像设计软件中的屏幕水平翻转。

现在翻转行为调整为屏幕轴镜像语义：

- 水平翻转：取反 `scale.x`，同时取反 `rotation`
- 垂直翻转：取反 `scale.y`，同时取反 `rotation`

这让效果编辑器行为更接近 Figma 等设计工具的翻转体验。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

效果编辑器面向视觉调整场景，翻转按钮的用户预期更接近设计软件中的屏幕轴镜像，而不是数学上的局部轴负缩放。

当目标已旋转时，旧行为会产生视觉上“方向不对”的结果。本 PR 通过同步反转旋转角度，使翻转结果符合设计软件使用习惯。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
