### PR TITLE
🐛 修复 Combobox 空状态提示

### DIFF
--- a/src/components/primitives/Autocomplete.vue
+++ b/src/components/primitives/Autocomplete.vue
@@ -276,7 +276,7 @@ function handleBeforeInput(event: InputEvent) {
             </template>
           </template>
           <ComboboxEmpty class="text-sm text-muted-foreground px-2 py-6 text-center">
-            {{ $t('edit.visualEditor.noResults') }}
+            {{ $t('common.noResults') }}
           </ComboboxEmpty>
         </ComboboxViewport>
       </ComboboxContent>

--- a/src/components/primitives/CascadingCombobox.spec.ts
+++ b/src/components/primitives/CascadingCombobox.spec.ts
@@ -36,6 +36,11 @@ const flatData = buildCascadingComboboxData([
   { label: 'Sad', value: 'sad' },
 ])
 
+const emptyData = buildCascadingComboboxData([], {
+  grouping: { mode: 'path' },
+  resolvedDelimiter: '/',
+})
+
 const tallGroupedData = buildCascadingComboboxData([
   ...Array.from({ length: 12 }, (_, index) => ({
     label: `root-${String(index + 1).padStart(2, '0')}/default`,
@@ -148,6 +153,28 @@ const FlatHarness = defineComponent({
       :search-documents="flatData.searchDocuments"
       placeholder="Select mood"
       search-placeholder="Search mood"
+    />
+  `,
+})
+
+const EmptyHarness = defineComponent({
+  components: { CascadingCombobox },
+  setup() {
+    const modelValue = ref('example-expression')
+
+    return {
+      emptyData,
+      modelValue,
+    }
+  },
+  template: `
+    <CascadingCombobox
+      v-model="modelValue"
+      data-testid="empty-trigger"
+      :browse-nodes="emptyData.browseNodes"
+      :search-documents="emptyData.searchDocuments"
+      placeholder="Select expression"
+      search-placeholder="Search expression"
     />
   `,
 })
@@ -391,6 +418,16 @@ function findSearchOptionElement(label: string): HTMLElement | undefined {
 }
 
 describe('CascadingCombobox', () => {
+  it('空候选面板显示可播报且不可选择的状态', async () => {
+    renderInBrowser(EmptyHarness)
+
+    await page.getByTestId('empty-trigger').click()
+
+    await expect.element(page.getByRole('status')).toBeVisible()
+    await expect.element(page.getByRole('status')).toHaveTextContent('common.noOptions')
+    await expect.element(page.getByRole('option')).not.toBeInTheDocument()
+  })
+
   it('首次打开已选嵌套值时，根层与级联子层作为独立浮层渲染，并保持向右级联展开', async () => {
     renderInBrowser(GroupedHarness, {
       props: {
@@ -481,6 +518,17 @@ describe('CascadingCombobox', () => {
     expect(searchInput).toBeDefined()
     expect(activeOption).toBeDefined()
     expect(searchInput!.getAttribute('aria-activedescendant')).toBe(activeOption!.id)
+  })
+
+  it('搜索无匹配项时显示可播报且不可选择的空状态', async () => {
+    renderInBrowser(GroupedHarness)
+
+    await page.getByTestId('grouped-trigger').click()
+    await page.getByPlaceholder('Search motion').fill('zzz')
+
+    await expect.element(page.getByRole('status')).toBeVisible()
+    await expect.element(page.getByRole('status')).toHaveTextContent('common.noResults')
+    await expect.element(page.getByRole('option')).not.toBeInTheDocument()
   })
 
   it('会把搜索词按空格拆分并要求所有关键词都命中完整路径文本', async () => {

--- a/src/components/primitives/CascadingCombobox.vue
+++ b/src/components/primitives/CascadingCombobox.vue
@@ -63,6 +63,11 @@ const activeSearchOptionId = $computed(() => (
 const searchResults = $computed(() => {
   return filterSearchOptionDocuments(props.searchDocuments, searchQuery)
 })
+const hasVisibleOptions = $computed(() => (
+  isSearchMode
+    ? searchResults.length > 0
+    : props.browseNodes.length > 0
+))
 
 const selectedLabel = $computed(() => {
   if (!props.modelValue) {
@@ -351,7 +356,7 @@ watch(() => searchQuery, (nextQuery, previousQuery) => {
             ref="inputRef"
             v-model="searchQuery"
             :aria-activedescendant="isSearchMode ? activeSearchOptionId : undefined"
-            :aria-controls="isSearchMode ? searchListboxId : undefined"
+            :aria-controls="isSearchMode && hasVisibleOptions ? searchListboxId : undefined"
             type="text"
             role="searchbox"
             :placeholder="searchPlaceholder"
@@ -360,8 +365,16 @@ watch(() => searchQuery, (nextQuery, previousQuery) => {
           >
         </div>
 
+        <div
+          v-if="!hasVisibleOptions"
+          role="status"
+          class="text-sm text-muted-foreground px-2 py-6 text-center"
+        >
+          {{ isSearchMode ? $t('common.noResults') : $t('common.noOptions') }}
+        </div>
+
         <ScrollAreaRoot
-          v-if="!isSearchMode"
+          v-else-if="!isSearchMode"
           type="auto"
           class="w-full relative overflow-hidden"
         >
@@ -424,12 +437,6 @@ watch(() => searchQuery, (nextQuery, previousQuery) => {
               >
                 <div class="i-lucide-check shrink-0 size-3.5" :class="props.modelValue === result.value ? 'opacity-100' : 'opacity-0'" />
                 <span class="truncate">{{ result.label }}</span>
-              </li>
-              <li
-                v-if="searchResults.length === 0"
-                class="text-sm text-muted-foreground px-2 py-6 text-center"
-              >
-                {{ $t('edit.visualEditor.noResults') }}
               </li>
             </ul>
           </ScrollAreaViewport>

--- a/src/components/primitives/Combobox.spec.ts
+++ b/src/components/primitives/Combobox.spec.ts
@@ -75,26 +75,6 @@ const globalStubs = {
       }, slots.default?.())
     },
   }),
-  ScrollArea: defineComponent({
-    name: 'StubScrollArea',
-    setup(_, { attrs, slots, expose }) {
-      const viewportElement = ref<HTMLElement>()
-
-      expose({
-        viewport: {
-          get viewportElement() {
-            return viewportElement.value
-          },
-        },
-      })
-
-      return () => h('div', {
-        ...attrs,
-        style: 'max-height: 64px; overflow: auto;',
-        ref: viewportElement,
-      }, slots.default?.())
-    },
-  }),
 }
 
 const ComboboxHarness = defineComponent({
@@ -113,6 +93,18 @@ const ComboboxHarness = defineComponent({
       id="motion"
       data-testid="motion-trigger"
       :options="baseOptions"
+      placeholder="Select motion"
+      search-placeholder="Search motion"
+    />
+  `,
+})
+
+const EmptyComboboxHarness = defineComponent({
+  components: { Combobox },
+  template: `
+    <Combobox
+      data-testid="empty-trigger"
+      :options="[]"
       placeholder="Select motion"
       search-placeholder="Search motion"
     />
@@ -162,6 +154,20 @@ const MultiKeywordComboboxHarness = defineComponent({
 })
 
 describe('Combobox', () => {
+  it('候选集合为空时显示无可用选项', async () => {
+    renderInBrowser(EmptyComboboxHarness, {
+      global: {
+        stubs: globalStubs,
+      },
+    })
+
+    await page.getByTestId('empty-trigger').click()
+
+    await expect.element(page.getByRole('status')).toBeVisible()
+    await expect.element(page.getByRole('status')).toHaveTextContent('common.noOptions')
+    await expect.element(page.getByRole('option')).not.toBeInTheDocument()
+  })
+
   it('打开后会把焦点交给搜索框', async () => {
     renderInBrowser(ComboboxHarness, {
       global: {
@@ -230,7 +236,7 @@ describe('Combobox', () => {
     await expect.element(page.getByTestId('motion-trigger')).toHaveTextContent('Joy')
   })
 
-  it('无匹配项时显示空状态', async () => {
+  it('无匹配项时显示可播报且不可选择的空状态', async () => {
     renderInBrowser(ComboboxHarness, {
       global: {
         stubs: globalStubs,
@@ -240,7 +246,9 @@ describe('Combobox', () => {
     await page.getByTestId('motion-trigger').click()
     await page.getByPlaceholder('Search motion').fill('zzz')
 
-    await expect.element(page.getByText('edit.visualEditor.noResults')).toBeInTheDocument()
+    await expect.element(page.getByRole('status')).toBeVisible()
+    await expect.element(page.getByRole('status')).toHaveTextContent('common.noResults')
+    await expect.element(page.getByRole('option')).not.toBeInTheDocument()
   })
 
   it('会把搜索词按空格拆分并要求所有关键词都命中', async () => {

--- a/src/components/primitives/Combobox.vue
+++ b/src/components/primitives/Combobox.vue
@@ -224,7 +224,15 @@ watch(() => searchQuery, async (nextQuery) => {
           >
         </div>
         <ScrollArea ref="scrollAreaRef" class="max-h-40vh" type="auto">
+          <div
+            v-if="filteredDocuments.length === 0"
+            role="status"
+            class="text-sm text-muted-foreground px-2 py-6 text-center"
+          >
+            {{ searchQuery.trim() ? $t('common.noResults') : $t('common.noOptions') }}
+          </div>
           <ul
+            v-else
             ref="listRef"
             role="listbox"
             class="text-xs m-0 p-1 list-none"
@@ -246,12 +254,6 @@ watch(() => searchQuery, async (nextQuery) => {
             >
               <div class="i-lucide-check shrink-0 size-3.5" :class="props.modelValue === option.value ? 'opacity-100' : 'opacity-0'" />
               <span class="truncate">{{ option.label }}</span>
-            </li>
-            <li
-              v-if="filteredDocuments.length === 0"
-              class="text-sm text-muted-foreground px-2 py-6 text-center"
-            >
-              {{ $t('edit.visualEditor.noResults') }}
             </li>
           </ul>
         </ScrollArea>

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -1,5 +1,7 @@
 common:
   loading: Loading...
+  noOptions: No options available
+  noResults: No results found
   cancel: Cancel
   confirm: Confirm
   create: Create
@@ -1101,7 +1103,6 @@ edit:
     effectEditor: Effect Editor
     statementList: Statement list
     noSelection: Select a statement to edit
-    noResults: No results found
   welcome:
     startEditing: Start Editing
     selectOrCreate: Select a file to start editing, or create a new file

--- a/src/locales/ja.yml
+++ b/src/locales/ja.yml
@@ -1,5 +1,7 @@
 common:
   loading: 読み込み中...
+  noOptions: 利用可能な選択肢がありません
+  noResults: 検索結果がありません
   cancel: キャンセル
   confirm: 確認
   create: 作成
@@ -1101,7 +1103,6 @@ edit:
     effectEditor: エフェクトエディター
     statementList: ステートメントリスト
     noSelection: 編集するステートメントを選択してください
-    noResults: 検索結果がありません
   welcome:
     startEditing: 編集を開始
     selectOrCreate: ファイルを選択して編集を開始するか、新しいファイルを作成

--- a/src/locales/zh-Hans.yml
+++ b/src/locales/zh-Hans.yml
@@ -1,5 +1,7 @@
 common:
   loading: 加载中...
+  noOptions: 无可用选项
+  noResults: 未找到结果
   cancel: 取消
   confirm: 确认
   create: 创建
@@ -1101,7 +1103,6 @@ edit:
     effectEditor: 效果编辑器
     statementList: 语句列表
     noSelection: 请选择一条语句进行编辑
-    noResults: 未找到结果
   welcome:
     startEditing: 开始编辑
     selectOrCreate: 选择一个文件开始编辑，或创建新文件

--- a/src/locales/zh-Hant.yml
+++ b/src/locales/zh-Hant.yml
@@ -1,5 +1,7 @@
 common:
   loading: 載入中...
+  noOptions: 無可用選項
+  noResults: 未找到結果
   cancel: 取消
   confirm: 確認
   create: 建立
@@ -1101,7 +1103,6 @@ edit:
     effectEditor: 效果編輯器
     statementList: 語句列表
     noSelection: 請選擇一條語句進行編輯
-    noResults: 未找到結果
   welcome:
     startEditing: 開始編輯
     selectOrCreate: 選擇一個檔案開始編輯，或建立新檔案


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [x] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [ ] 测试用例
- [ ] 性能优化
- [x] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

- 基础 Combobox 搜索无匹配项时显示本地化空状态。
- 级联 Combobox 在初始候选为空和搜索无匹配时显示对应空状态。
- 区分候选集合为空与搜索无匹配：
  - 候选集合为空时显示“无可用选项”。
  - 搜索无匹配时显示“未找到结果”。
- 空状态使用 `status` 播报语义，不会作为可选择的 `listbox` option 暴露。
- 空状态下不再渲染无意义的空 `listbox`，避免产生多余布局。
- 统一级联浏览与搜索模式的可见候选判断。
- 将通用空状态文案迁移至 `common.noOptions` 和 `common.noResults`。
- 同步更新英文、日文、简体中文和繁体中文翻译。
- Autocomplete 同步改用通用的搜索无结果文案。
- 删除 Combobox 测试中的 `ScrollArea` 替身，改为测试真实滚动组件。
- 增加基础与级联 Combobox 的空状态可见性、文案及可访问性回归测试。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

Combobox 没有候选项或搜索无匹配结果时，下拉面板缺少清晰且可访问的反馈，用户无法判断候选内容为空、搜索没有匹配项，还是候选内容仍在加载。

此前未输入搜索词时也显示“未找到结果”，容易让用户误以为已经执行搜索。本次更改将初始空集合与搜索无匹配拆分为不同文案，同时统一基础和级联 Combobox 的空状态语义与布局。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
