### PR TITLE
✨ 支持通过 Home 和 End 选择可视化编辑器首尾语句

### DIFF
--- a/src/components/editor/VisualEditorScene.spec.ts
+++ b/src/components/editor/VisualEditorScene.spec.ts
@@ -303,6 +303,28 @@ describe('VisualEditorScene', () => {
     await expect.element(page.getByRole('option')).not.toBeInTheDocument()
   })
 
+  it('快捷键上下文会反映场景是否存在语句', async () => {
+    const state = reactive(createSceneState())
+    const result = renderInBrowser(VisualEditorScene, {
+      props: {
+        state,
+      },
+      global: {
+        plugins: [createPinia()],
+        stubs: globalStubs,
+      },
+    })
+    const editorSurface = result.container.firstElementChild as HTMLElement
+
+    editorSurface.focus()
+    await nextTick()
+    expect(useShortcutContextRegistry().resolveContext().hasStatements).toBe(true)
+
+    state.statements = []
+    await nextTick()
+    expect(useShortcutContextRegistry().resolveContext().hasStatements).toBe(false)
+  })
+
   it('空场景会把空状态区域注册为首条语句投放目标', async () => {
     const registerDroppable = vi.fn()
     handleCommandDropMock.mockReturnValue(true)

--- a/src/components/editor/VisualEditorScene.vue
+++ b/src/components/editor/VisualEditorScene.vue
@@ -282,6 +282,7 @@ function handleOverlayCollapsedUpdate(collapsed: boolean) {
 }
 
 useShortcutContext({
+  hasStatements: computed(() => !isSceneEmpty.value),
   panelFocus: 'editor',
 }, {
   target: editorSurfaceRef,

--- a/src/components/editor/VisualEditorStatementCard.vue
+++ b/src/components/editor/VisualEditorStatementCard.vue
@@ -117,7 +117,7 @@ function paramBadgeClass(param: StatementCardPreviewParam): string {
       role="option"
       :aria-selected="selected"
       tabindex="-1"
-      class="group px-3 py-1 border border-border rounded-lg bg-card transition-[border-color,background-color,box-shadow] duration-150 relative hover:border-primary/25 hover:shadow-sm"
+      class="group px-3 py-1 border border-border rounded-lg bg-card transition-[border-color,background-color,box-shadow] duration-150 relative focus-visible:outline-none hover:border-primary/25 hover:shadow-sm"
       :class="{
         'border-primary/45 ring-1 ring-primary/20 shadow-sm': selected,
       }"

--- a/src/features/editor/visual-editor/__tests__/useVisualEditorSceneRuntime.test.ts
+++ b/src/features/editor/visual-editor/__tests__/useVisualEditorSceneRuntime.test.ts
@@ -10,6 +10,7 @@ import { useVisualEditorSceneRuntime } from '../useVisualEditorSceneRuntime'
 import type { SceneVisualProjectionState } from '~/stores/editor'
 
 const {
+  findSelectedVisualEditorStatementCardMock,
   restoreSelectionAndScrollMock,
   scrollToSelectedStatementMock,
   useCommandPanelBridgeBindingMock,
@@ -23,6 +24,7 @@ const {
   useVisualEditorSceneViewportMock,
   useWorkspaceStoreMock,
 } = vi.hoisted(() => ({
+  findSelectedVisualEditorStatementCardMock: vi.fn(),
   restoreSelectionAndScrollMock: vi.fn(async () => undefined),
   scrollToSelectedStatementMock: vi.fn(async () => undefined),
   useCommandPanelBridgeBindingMock: vi.fn(),
@@ -68,7 +70,7 @@ vi.mock('~/features/editor/visual-editor/useVisualEditorSceneViewport', () => ({
 
 vi.mock('~/features/editor/visual-editor/visual-editor-focus', () => ({
   canRestoreVisualEditorCardFocus: vi.fn(() => true),
-  findSelectedVisualEditorStatementCard: vi.fn(() => undefined),
+  findSelectedVisualEditorStatementCard: findSelectedVisualEditorStatementCardMock,
 }))
 
 vi.mock('~/stores/command-panel', () => ({
@@ -124,6 +126,8 @@ describe('useVisualEditorSceneRuntime', () => {
   })
 
   beforeEach(() => {
+    findSelectedVisualEditorStatementCardMock.mockReset()
+    findSelectedVisualEditorStatementCardMock.mockReturnValue(undefined)
     restoreSelectionAndScrollMock.mockReset()
     scrollToSelectedStatementMock.mockReset()
     useCommandPanelBridgeBindingMock.mockReset()
@@ -236,6 +240,91 @@ describe('useVisualEditorSceneRuntime', () => {
         visualType: 'scene',
       },
     }))
+
+    scope.stop()
+  })
+
+  it('Home 和 End 会选择场景首尾语句并按边界滚动，且不在输入框中放行', async () => {
+    const scope = effectScope()
+    const state = createState([
+      {
+        id: 1,
+        parseError: false,
+        parsed: undefined,
+        rawText: 'say:first',
+      },
+      {
+        id: 2,
+        parseError: false,
+        parsed: undefined,
+        rawText: 'say:second',
+      },
+      {
+        id: 3,
+        parseError: false,
+        parsed: undefined,
+        rawText: 'say:last',
+      },
+    ])
+    const editorStore = useEditorStoreMock()
+    const focus = vi.fn()
+    class HTMLElementMock {
+      focus = focus
+    }
+    const selectedCard = new HTMLElementMock()
+    const viewportElement = {}
+
+    vi.stubGlobal('document', {
+      activeElement: undefined,
+    })
+    vi.stubGlobal('HTMLElement', HTMLElementMock)
+    findSelectedVisualEditorStatementCardMock.mockReturnValue(selectedCard)
+
+    scope.run(() => useVisualEditorSceneRuntime({
+      getScrollArea: () => ({
+        viewport: {
+          viewportElement,
+        },
+      }) as never,
+      getState: () => state,
+    }))
+
+    const homeShortcut = useShortcutMock.mock.calls.find(([shortcut]) => shortcut.id === 'visual.selectFirst')?.[0]
+    const endShortcut = useShortcutMock.mock.calls.find(([shortcut]) => shortcut.id === 'visual.selectLast')?.[0]
+
+    expect(homeShortcut).toMatchObject({
+      keys: 'Home',
+      when: {
+        hasStatements: true,
+        panelFocus: 'editor',
+        visualType: 'scene',
+      },
+    })
+    expect(endShortcut).toMatchObject({
+      keys: 'End',
+      when: {
+        hasStatements: true,
+        panelFocus: 'editor',
+        visualType: 'scene',
+      },
+    })
+    expect(homeShortcut).not.toHaveProperty('allowInInput')
+    expect(endShortcut).not.toHaveProperty('allowInInput')
+
+    await homeShortcut?.execute()
+    expect(scrollToSelectedStatementMock).toHaveBeenCalledWith('start')
+    expect(focus).toHaveBeenCalledWith({ preventScroll: true })
+    expect(editorStore.syncSceneSelectionFromStatement).toHaveBeenLastCalledWith('/project/scene.txt', 1, {
+      lastEditedStatementId: 1,
+      lineNumber: 1,
+    })
+
+    await endShortcut?.execute()
+    expect(scrollToSelectedStatementMock).toHaveBeenCalledWith('end')
+    expect(editorStore.syncSceneSelectionFromStatement).toHaveBeenLastCalledWith('/project/scene.txt', 3, {
+      lastEditedStatementId: 3,
+      lineNumber: 3,
+    })
 
     scope.stop()
   })

--- a/src/features/editor/visual-editor/__tests__/useVisualEditorSceneViewport.test.ts
+++ b/src/features/editor/visual-editor/__tests__/useVisualEditorSceneViewport.test.ts
@@ -38,6 +38,7 @@ function createScrollArea(viewportElement: HTMLElement): InstanceType<typeof Scr
 describe('useVisualEditorSceneViewport', () => {
   afterEach(() => {
     vi.clearAllMocks()
+    vi.unstubAllGlobals()
   })
 
   beforeEach(() => {
@@ -74,6 +75,44 @@ describe('useVisualEditorSceneViewport', () => {
     expect(virtualizer.measure).not.toHaveBeenCalled()
     expect(virtualizer.measureElement).toHaveBeenCalledWith(firstRow)
     expect(virtualizer.measureElement).toHaveBeenCalledWith(secondRow)
+
+    scope.stop()
+  })
+
+  it('滚动到首尾语句时会保留列表边界对齐方式', async () => {
+    const scope = effectScope()
+    let selectedIndex = 0
+    const viewportElement = {
+      querySelectorAll: vi.fn(() => []),
+    } as unknown as HTMLElement
+    const virtualizer = {
+      getTotalSize: vi.fn(() => 200),
+      getVirtualItems: vi.fn(() => []),
+      measure: vi.fn(),
+      measureElement: vi.fn(),
+      scrollOffset: 0,
+      scrollToIndex: vi.fn(),
+    }
+
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      callback(0)
+      return 0
+    })
+    useVirtualizerMock.mockReturnValue(shallowRef(virtualizer))
+
+    const viewport = scope.run(() => useVisualEditorSceneViewport({
+      getScrollArea: () => createScrollArea(viewportElement),
+      getSelectedIndex: () => selectedIndex,
+      getState: createState,
+      restoreSelection: vi.fn(),
+    }))
+
+    await viewport?.scrollToSelectedStatement('start')
+    expect(virtualizer.scrollToIndex).toHaveBeenLastCalledWith(0, { align: 'start' })
+
+    selectedIndex = 1
+    await viewport?.scrollToSelectedStatement('end')
+    expect(virtualizer.scrollToIndex).toHaveBeenLastCalledWith(1, { align: 'end' })
 
     scope.stop()
   })

--- a/src/features/editor/visual-editor/useVisualEditorSceneRuntime.ts
+++ b/src/features/editor/visual-editor/useVisualEditorSceneRuntime.ts
@@ -188,13 +188,13 @@ export function useVisualEditorSceneRuntime(options: UseVisualEditorSceneRuntime
 
     const selectedCard = findSelectedVisualEditorStatementCard(viewportElement)
     if (selectedCard instanceof HTMLElement) {
-      selectedCard.focus()
+      selectedCard.focus({ preventScroll: true })
     }
   }
 
   async function restoreSelectedStatementPresentation(
     options_: {
-      align?: 'center' | 'auto'
+      align?: 'center' | 'auto' | 'start' | 'end'
       focus?: boolean
     } = {},
   ) {
@@ -522,6 +522,21 @@ export function useVisualEditorSceneRuntime(options: UseVisualEditorSceneRuntime
     }
   }
 
+  function selectBoundaryStatement(boundary: 'first' | 'last'): Promise<void> | undefined {
+    const statement = boundary === 'first'
+      ? state.value.statements[0]
+      : state.value.statements.at(-1)
+    if (!statement) {
+      return
+    }
+
+    handleSelect(statement.id)
+    return restoreSelectedStatementPresentation({
+      align: boundary === 'first' ? 'start' : 'end',
+      focus: true,
+    })
+  }
+
   function handlePlayTo(id: number) {
     syncStatementPreview(id, true)
   }
@@ -634,6 +649,28 @@ export function useVisualEditorSceneRuntime(options: UseVisualEditorSceneRuntime
     when: {
       ...sceneShortcutWhen,
       hasSelection: true,
+    },
+  })
+
+  useShortcut({
+    execute: () => selectBoundaryStatement('first'),
+    i18nKey: 'shortcut.visual.selectFirst',
+    id: 'visual.selectFirst',
+    keys: 'Home',
+    when: {
+      ...sceneShortcutWhen,
+      hasStatements: true,
+    },
+  })
+
+  useShortcut({
+    execute: () => selectBoundaryStatement('last'),
+    i18nKey: 'shortcut.visual.selectLast',
+    id: 'visual.selectLast',
+    keys: 'End',
+    when: {
+      ...sceneShortcutWhen,
+      hasStatements: true,
     },
   })
 

--- a/src/features/editor/visual-editor/useVisualEditorSceneViewport.ts
+++ b/src/features/editor/visual-editor/useVisualEditorSceneViewport.ts
@@ -59,7 +59,7 @@ export function useVisualEditorSceneViewport(options: UseVisualEditorSceneViewpo
   let scrollRequestId = 0
 
   function scrollToSelectedStatement(
-    align: 'center' | 'auto' = 'center',
+    align: 'center' | 'auto' | 'start' | 'end' = 'center',
     options_: {
       trackPositioning?: boolean
     } = {},


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [ ] 错误修复
- [x] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [x] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

- 为可视化场景编辑器添加 `Home` 和 `End` 快捷键，分别选择首条和末条语句。
- 选择首尾语句后，将虚拟列表滚动到对应边界并恢复语句卡片焦点。
- 聚焦卡片时使用 `preventScroll`，避免焦点行为覆盖虚拟列表的边界滚动位置。
- 空场景下不启用首尾选择快捷键，在输入控件中也不会拦截按键。
- 移除语句卡片的默认焦点轮廓，保持现有选中态样式。
- 补充快捷键上下文、首尾选择、滚动对齐和焦点行为测试。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

完善可视化编辑器的键盘导航能力，使用户能够快速跳转到场景的第一条或最后一条语句，同时确保虚拟列表滚动与焦点恢复行为一致。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
