### PR TITLE
🐛 修复预览面板关闭时仍发送预览请求

### DIFF
--- a/src/features/editor/effect-editor/__tests__/useEffectEditorProvider-queue.test.ts
+++ b/src/features/editor/effect-editor/__tests__/useEffectEditorProvider-queue.test.ts
@@ -12,6 +12,7 @@ import {
 } from '~/features/editor/effect-editor/effect-editor-config'
 import { createEffectEditorProvider, useEffectEditorProvider } from '~/features/editor/effect-editor/useEffectEditorProvider'
 import { useEditSettingsStore } from '~/stores/edit-settings'
+import { usePreferenceStore } from '~/stores/preference'
 
 import type { ISentence } from 'webgal-parser/src/interface/sceneInterface'
 import type { Transform } from '~/domain/stage/types'
@@ -287,6 +288,27 @@ afterEach(() => {
 })
 
 describe('useEffectEditorProvider', () => {
+  it('预览面板关闭时会丢弃运行时请求但仍允许应用脚本变更', async () => {
+    usePreferenceStore().showPreviewPanel = false
+    useEditSettingsStore().autoApplyEffectEditorChanges = false
+    const applyMock = vi.fn()
+    const provider = createProvider()
+
+    await provider.open(createOpenTarget({ onApply: applyMock }))
+    provider.updateDraft({ transform: { blur: 12 } })
+    provider.requestPreview({ schedule: 'immediate' })
+    await vi.waitFor(() => {
+      expect(provider.canApply).toBe(true)
+    })
+
+    expect(debugCommanderMock.setEffect).not.toHaveBeenCalled()
+    await expect(provider.apply()).resolves.toBe(true)
+    expect(applyMock).toHaveBeenCalledWith(expect.objectContaining({
+      transform: { blur: 12 },
+    }))
+    expect(debugCommanderMock.setEffect).not.toHaveBeenCalled()
+  })
+
   it('未产生 visual preview 时关闭效果编辑器不会重复恢复场景预览', async () => {
     useEditSettingsStore().autoApplyEffectEditorChanges = false
     const provider = createEffectEditorProvider()

--- a/src/features/editor/effect-editor/useEffectEditorProvider.ts
+++ b/src/features/editor/effect-editor/useEffectEditorProvider.ts
@@ -5,6 +5,7 @@ import { serializeSentence } from '~/domain/script/serialize'
 import { fieldsToTransform, isTransformEqual, parseTransformJson } from '~/features/editor/effect-editor/effect-editor-config'
 import { resolveTransformBaselineSession } from '~/features/editor/transform-resolution/baseline-session'
 import { debugCommander } from '~/services/debug-commander'
+import { isPreviewPanelOpen } from '~/services/preview-protocol-client'
 import { useEditSettingsStore } from '~/stores/edit-settings'
 import { useModalStore } from '~/stores/modal'
 import { usePreviewSyncStore } from '~/stores/preview-sync'
@@ -483,6 +484,10 @@ export function createEffectEditorProvider(options: CreateEffectEditorProviderOp
     const currentSession = session
     if (!currentSession || currentSession.sessionId !== request.sessionId) {
       return false
+    }
+    if (!isPreviewPanelOpen()) {
+      // 面板关闭时跳过运行时请求，但不阻止脚本层提交效果编辑器草稿。
+      return true
     }
     if (isPreviewTerminalUnsynced()) {
       return false

--- a/src/services/preview-protocol-client.ts
+++ b/src/services/preview-protocol-client.ts
@@ -1,4 +1,5 @@
 import { serverCmds } from '~/commands/server'
+import { usePreferenceStore } from '~/stores/preference'
 import { createRequestEnvelope } from '~/types/editorPreviewProtocol'
 
 import type {
@@ -7,6 +8,16 @@ import type {
   RequestEnvelopeByType,
   RequestPayloadByType,
 } from '~/types/editorPreviewProtocol'
+
+export const PREVIEW_STATE_RESET_REASON = 'preview state reset'
+
+export function isPreviewPanelOpen(): boolean {
+  return usePreferenceStore().showPreviewPanel
+}
+
+export function isPreviewStateResetError(error: unknown): boolean {
+  return error instanceof Error && error.message === PREVIEW_STATE_RESET_REASON
+}
 
 function createPreviewRequestId(): string {
   return globalThis.crypto?.randomUUID?.()
@@ -31,6 +42,10 @@ export function createPreviewRequestEnvelope<TType extends PreviewRequestType>(
 export async function sendPreviewRequestEnvelope<TType extends PreviewRequestType>(
   request: RequestEnvelopeByType<TType>,
 ): Promise<void> {
+  if (!isPreviewPanelOpen()) {
+    throw new Error(PREVIEW_STATE_RESET_REASON)
+  }
+
   await serverCmds.sendPreviewCommand(JSON.stringify(request))
 }
 
@@ -42,6 +57,18 @@ export async function sendPreviewCommandRequest<TType extends PreviewCommandType
   type: TType,
   payload: RequestPayloadByType[TType],
 ): Promise<void> {
+  if (!isPreviewPanelOpen()) {
+    return
+  }
+
   const request = createPreviewRequestEnvelope(type, payload)
-  await sendPreviewRequestEnvelope(request)
+  try {
+    await sendPreviewRequestEnvelope(request)
+  } catch (error) {
+    if (isPreviewStateResetError(error)) {
+      return
+    }
+
+    throw error
+  }
 }

--- a/src/stores/__tests__/preview-sync.test.ts
+++ b/src/stores/__tests__/preview-sync.test.ts
@@ -2,6 +2,7 @@ import '~/__tests__/setup'
 
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { usePreferenceStore } from '../preference'
 import { usePreviewSyncStore } from '../preview-sync'
 
 const {
@@ -412,5 +413,73 @@ describe('usePreviewSyncStore', () => {
     }))
 
     await expect(pending).rejects.toThrow('set effect failed')
+  })
+
+  it('预览面板关闭时会丢弃请求，重新打开后恢复发送', async () => {
+    const preferenceStore = usePreferenceStore()
+    preferenceStore.showPreviewPanel = false
+    const store = usePreviewSyncStore()
+
+    await expect(store.queryReferenceBox('fig-center')).resolves.toEqual({
+      target: 'fig-center',
+      status: 'unsupported',
+      reason: 'preview state reset',
+    })
+    await expect(store.sendPreviewCommand('preview.command.set-effect', {
+      target: 'fig-center',
+      transform: { blur: 12 },
+    })).rejects.toThrow('preview state reset')
+    expect(sendPreviewCommandMock).not.toHaveBeenCalled()
+
+    preferenceStore.showPreviewPanel = true
+    const pending = store.queryReferenceBox('fig-center')
+    expect(sendPreviewCommandMock).toHaveBeenCalledTimes(1)
+    const request = JSON.parse(sendPreviewCommandMock.mock.calls[0][0])
+    store.consumeHostEvent(JSON.stringify({
+      kind: 'response',
+      type: 'preview.query.reference-box',
+      requestId: request.requestId,
+      payload: {
+        target: 'fig-center',
+        status: 'unsupported',
+        reason: 'not ready',
+      },
+    }))
+
+    await expect(pending).resolves.toEqual({
+      target: 'fig-center',
+      status: 'unsupported',
+      reason: 'not ready',
+    })
+  })
+
+  it('预览面板关闭时不会继续使用缓存的基础变换', async () => {
+    const store = usePreviewSyncStore()
+    const pending = store.queryBaseTransform()
+    const request = JSON.parse(sendPreviewCommandMock.mock.calls[0][0])
+
+    store.consumeHostEvent(JSON.stringify({
+      kind: 'response',
+      type: 'preview.query.base-transform',
+      requestId: request.requestId,
+      payload: {
+        baseTransform: {
+          position: { x: 12 },
+        },
+      },
+    }))
+    await expect(pending).resolves.toEqual({
+      status: 'ready',
+      transform: {
+        position: { x: 12 },
+      },
+    })
+
+    usePreferenceStore().showPreviewPanel = false
+    await expect(store.queryBaseTransform()).resolves.toEqual({
+      status: 'unavailable',
+      reason: 'preview state reset',
+    })
+    expect(sendPreviewCommandMock).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/stores/__tests__/preview-sync.test.ts
+++ b/src/stores/__tests__/preview-sync.test.ts
@@ -417,10 +417,17 @@ describe('usePreviewSyncStore', () => {
 
   it('预览面板关闭时会丢弃请求，重新打开后恢复发送', async () => {
     const preferenceStore = usePreferenceStore()
-    preferenceStore.showPreviewPanel = false
     const store = usePreviewSyncStore()
+    const pendingBeforeClose = store.queryReferenceBox('fig-center')
+
+    preferenceStore.showPreviewPanel = false
 
     await expect(store.queryReferenceBox('fig-center')).resolves.toEqual({
+      target: 'fig-center',
+      status: 'unsupported',
+      reason: 'preview state reset',
+    })
+    await expect(pendingBeforeClose).resolves.toEqual({
       target: 'fig-center',
       status: 'unsupported',
       reason: 'preview state reset',
@@ -429,12 +436,12 @@ describe('usePreviewSyncStore', () => {
       target: 'fig-center',
       transform: { blur: 12 },
     })).rejects.toThrow('preview state reset')
-    expect(sendPreviewCommandMock).not.toHaveBeenCalled()
+    expect(sendPreviewCommandMock).toHaveBeenCalledTimes(1)
 
     preferenceStore.showPreviewPanel = true
     const pending = store.queryReferenceBox('fig-center')
-    expect(sendPreviewCommandMock).toHaveBeenCalledTimes(1)
-    const request = JSON.parse(sendPreviewCommandMock.mock.calls[0][0])
+    expect(sendPreviewCommandMock).toHaveBeenCalledTimes(2)
+    const request = JSON.parse(sendPreviewCommandMock.mock.calls[1][0])
     store.consumeHostEvent(JSON.stringify({
       kind: 'response',
       type: 'preview.query.reference-box',

--- a/src/stores/preview-sync.ts
+++ b/src/stores/preview-sync.ts
@@ -2,6 +2,9 @@ import { defineStore } from 'pinia'
 
 import {
   createPreviewRequestEnvelope,
+  isPreviewPanelOpen,
+  isPreviewStateResetError,
+  PREVIEW_STATE_RESET_REASON,
   sendPreviewRequestEnvelope,
 } from '~/services/preview-protocol-client'
 import {
@@ -207,7 +210,7 @@ export const usePreviewSyncStore = defineStore('previewSync', () => {
     stageSnapshot = undefined
     fastPreviewTimeout = undefined
     cachedBaseTransform = undefined
-    settlePendingPreviewResponses('preview state reset')
+    settlePendingPreviewResponses(PREVIEW_STATE_RESET_REASON)
   }
 
   function consumePreviewResponse(message: ResponseEnvelopeByType<PreviewResponseType>): void {
@@ -257,8 +260,11 @@ export const usePreviewSyncStore = defineStore('previewSync', () => {
       }
 
       clearTimeout(pending.timeoutId)
-      logger.error(`发送 ${request.type} 查询失败: ${error}`)
-      pending.settleFailure(failureReason)
+      const isReset = isPreviewStateResetError(error)
+      if (!isReset) {
+        logger.error(`发送 ${request.type} 查询失败: ${error}`)
+      }
+      pending.settleFailure(isReset ? PREVIEW_STATE_RESET_REASON : failureReason)
     })
   }
 
@@ -267,6 +273,10 @@ export const usePreviewSyncStore = defineStore('previewSync', () => {
     payload: RequestPayloadByType[TType],
     options: PreviewCommandOptions = {},
   ): Promise<void> {
+    if (!isPreviewPanelOpen()) {
+      return Promise.reject(new Error(PREVIEW_STATE_RESET_REASON))
+    }
+
     const request = createPreviewRequestEnvelope(type, payload)
     const { requestId } = request
 
@@ -295,7 +305,10 @@ export const usePreviewSyncStore = defineStore('previewSync', () => {
         }
 
         clearTimeout(timeoutId)
-        logger.error(`发送 ${request.type} command 失败: ${error}`)
+        const isReset = isPreviewStateResetError(error)
+        if (!isReset) {
+          logger.error(`发送 ${request.type} command 失败: ${error}`)
+        }
         reject(error instanceof Error ? error : new Error(String(error)))
       })
     })
@@ -306,6 +319,14 @@ export const usePreviewSyncStore = defineStore('previewSync', () => {
     options: ReferenceBoxQueryOptions = {},
   ): Promise<ReferenceBoxQueryResultPayload> {
     const type = 'preview.query.reference-box'
+    if (!isPreviewPanelOpen()) {
+      return Promise.resolve({
+        target,
+        status: 'unsupported',
+        reason: PREVIEW_STATE_RESET_REASON,
+      })
+    }
+
     const request = createPreviewRequestEnvelope(
       type,
       { target },
@@ -346,6 +367,13 @@ export const usePreviewSyncStore = defineStore('previewSync', () => {
   }
 
   function queryBaseTransform(options: PreviewQueryOptions = {}): Promise<BaseTransformQueryResult> {
+    if (!isPreviewPanelOpen()) {
+      return Promise.resolve({
+        status: 'unavailable',
+        reason: PREVIEW_STATE_RESET_REASON,
+      })
+    }
+
     const cachedTransform = cloneCachedBaseTransform()
     if (cachedTransform) {
       return Promise.resolve({
@@ -395,6 +423,13 @@ export const usePreviewSyncStore = defineStore('previewSync', () => {
     options: PreviewQueryOptions = {},
   ): Promise<TransformBaselineQueryResult> {
     const type = 'preview.query.transform-baseline'
+    if (!isPreviewPanelOpen()) {
+      return Promise.resolve({
+        status: 'unavailable',
+        reason: PREVIEW_STATE_RESET_REASON,
+      })
+    }
+
     const request = createPreviewRequestEnvelope(
       type,
       { target, transformBaselineRevision },

--- a/src/stores/preview-sync.ts
+++ b/src/stores/preview-sync.ts
@@ -320,6 +320,7 @@ export const usePreviewSyncStore = defineStore('previewSync', () => {
   ): Promise<ReferenceBoxQueryResultPayload> {
     const type = 'preview.query.reference-box'
     if (!isPreviewPanelOpen()) {
+      resetEmbeddedPreviewState()
       return Promise.resolve({
         target,
         status: 'unsupported',


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [x] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [x] 代码重构
- [x] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

当预览面板关闭时，前端不再向 Tauri/Rust 发送场景同步、效果预览、命令或查询请求，避免预览目标不存在时产生无效请求和警告。

本次更改包括：

- 在预览协议客户端增加统一的面板状态检查，覆盖直接命令和同步 store 发起的请求。
- 面板关闭时跳过已排队但尚未发送的运行时预览请求，清理待处理预览响应，并阻止查询使用过期的基础变换缓存。
- 面板重新打开后恢复正常预览请求发送。
- 效果编辑器在面板关闭时仍可点击应用并写入脚本，仅跳过运行时预览请求。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

预览面板关闭后仍可能触发预览协议请求，Rust 端会报告没有可用预览目标。关闭面板意味着当前没有可用的运行时预览目标，因此这些请求应在前端被忽略，同时不能影响效果编辑器将草稿应用到脚本。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [x] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
