### PR TITLE
🐛 修正 next 与 continue 参数互斥

### DIFF
--- a/src/domain/script/__tests__/command-node-update-param.test.ts
+++ b/src/domain/script/__tests__/command-node-update-param.test.ts
@@ -204,6 +204,28 @@ describe('命令节点参数更新器', () => {
     expect(serialized.args).toEqual([{ key: 'skipOff', value: true }])
   })
 
+  it('开启 next 时会关闭 generic 命令的 continue', () => {
+    const node = parseCommandNode(mustParse('changeBg: bg.jpg -continue -x=1;'))
+    const updated = updateCommandNodeParam(node, makeParamDef('next', 'switch'), true)
+
+    expect(updated).toBeDefined()
+    expect(serializeCommandNode(updated!).args).toEqual([
+      { key: 'next', value: true },
+      { key: 'x', value: 1 },
+    ])
+  })
+
+  it('开启 continue 时会关闭 generic 命令的 next', () => {
+    const node = parseCommandNode(mustParse('changeBg: bg.jpg -next -x=1;'))
+    const updated = updateCommandNodeParam(node, makeParamDef('continue', 'switch'), true)
+
+    expect(updated).toBeDefined()
+    expect(serializeCommandNode(updated!).args).toEqual([
+      { key: 'continue', value: true },
+      { key: 'x', value: 1 },
+    ])
+  })
+
   it('可关闭 say concat 标志', () => {
     const sentence = mustParse('Alice: hello -concat -x=1;')
     const node = parseCommandNode(sentence)

--- a/src/domain/script/update.ts
+++ b/src/domain/script/update.ts
@@ -10,6 +10,17 @@ import type { arg } from 'webgal-parser/src/interface/sceneInterface'
 
 const NOT_HANDLED = Symbol('command-param-not-handled')
 
+type ControlFlagKey = 'next' | 'continue'
+
+function getOppositeControlFlag(key: string): ControlFlagKey | undefined {
+  if (key === 'next') {
+    return 'continue'
+  }
+  if (key === 'continue') {
+    return 'next'
+  }
+}
+
 type ParamUpdateValue = string | boolean | number
 
 // 判断新值是否等效于"未设置"：
@@ -187,6 +198,10 @@ function updateFromFieldTable(
       case 'boolean': {
         removeArgByKey(nextArgs, paramDef.key)
         if (newValue === true) {
+          const oppositeKey = getOppositeControlFlag(paramDef.key)
+          if (oppositeKey) {
+            removeArgByKey(nextArgs, oppositeKey)
+          }
           upsertArgValue(nextArgs, paramDef.key, true, knownKeys)
         }
         return { ...node, args: nextArgs }


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [x] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [x] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

可视化编辑器更新语句参数时，`next` 和 `continue` 现在视为互斥开关：

- 开启 `next` 会移除 `continue`。
- 开启 `continue` 会移除 `next`。
- 关闭任一开关不会改变另一个开关的状态。
- 更新时继续保留其他已知参数、额外参数及其序列化顺序。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

`next` 与 `continue` 同时存在时会产生相互冲突的语句控制状态。可视化编辑器应在用户开启其中一个参数时立即清理另一个参数，避免保存出含冲突控制 flag 的语句。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->

互斥处理放在统一的命令参数更新路径中，因此命令面板和语句编辑器共用同一行为。已有脚本文本仍可正常读取，只有通过可视化编辑器开启控制 flag 时会应用互斥规则。

### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
