### PR TITLE
🐛 修复效果编辑器颜色选择器点击无响应

### DIFF
--- a/src/components/editor/effect-editor/EffectDraftCategorySection.spec.ts
+++ b/src/components/editor/effect-editor/EffectDraftCategorySection.spec.ts
@@ -66,7 +66,7 @@ function createControls(options: CreateControlsOptions = {}) {
     handleDialPointerDown: vi.fn(),
     flipScaleAxis: vi.fn(),
     getColorPickerValue: () => ({ b: 255, g: 255, r: 255 }),
-    handleColorPickerPointerDown: vi.fn(),
+    handleColorPickerOpenChange: vi.fn(),
     handleColorPickerChange: vi.fn(),
     getSegmentedValue: () => '__unspecified__',
     getSegmentedOptions: () => [],

--- a/src/components/editor/effect-editor/EffectDraftCategorySection.vue
+++ b/src/components/editor/effect-editor/EffectDraftCategorySection.vue
@@ -423,12 +423,13 @@ function getLinkedSliderPath(param: EffectDraftLinkedNumberField, index: 0 | 1):
               </Button>
             </div>
           </div>
-          <div class="flex flex-1 gap-2 items-center" @pointerdown="controls.handleColorPickerPointerDown($event, item.param)">
+          <div class="flex flex-1 gap-2 items-center">
             <ColorPicker
               :id="controls.colorControlId(item.param)"
               :model-value="controls.getColorPickerValue(item.param)"
               disable-alpha
               class="h-7 w-24"
+              @update:open="controls.handleColorPickerOpenChange(item.param, $event)"
               @update:model-value="controls.handleColorPickerChange(item.param, $event)"
             />
           </div>

--- a/src/components/editor/effect-editor/EffectDraftForm.vue
+++ b/src/components/editor/effect-editor/EffectDraftForm.vue
@@ -176,10 +176,9 @@ const {
 
 const {
   getColorPickerValue,
-  handleColorPickerPointerDown,
+  handleColorPickerOpenChange,
   handleColorPickerChange,
-  clearPendingColorFlush,
-  colorDrag,
+  cancelColorInteraction,
 } = useEffectColorControl(controlDeps)
 
 const { buildControlId } = useControlId(props.idNamespace)
@@ -288,7 +287,7 @@ const categoryControls: EffectDraftCategoryControls = {
   handleDialPointerDown,
   flipScaleAxis,
   getColorPickerValue,
-  handleColorPickerPointerDown,
+  handleColorPickerOpenChange,
   handleColorPickerChange,
   getSegmentedValue,
   getSegmentedOptions,
@@ -301,8 +300,7 @@ onUnmounted(() => {
   stopDurationScrub()
   numberScrub.cancel()
   dialDrag.cancel()
-  colorDrag.cancel()
-  clearPendingColorFlush()
+  cancelColorInteraction()
   resetLinkedSliderState()
 })
 </script>

--- a/src/components/editor/effect-editor/EffectDraftFormColorPicker.spec.ts
+++ b/src/components/editor/effect-editor/EffectDraftFormColorPicker.spec.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from 'vitest'
+import { page } from 'vitest/browser'
+
+import { createBrowserInputStub, createBrowserValueStub, renderInBrowser } from '~/__tests__/browser-render'
+
+vi.mock('~/stores/workspace', () => ({
+  useWorkspaceStore: () => ({ CWD: '/game' }),
+}))
+
+import EffectDraftForm from './EffectDraftForm.vue'
+
+const globalStubs = {
+  Button: createBrowserValueStub('StubButton', 'button'),
+  InputGroup: createBrowserValueStub('StubInputGroup'),
+  InputGroupAddon: createBrowserValueStub('StubInputGroupAddon', 'span'),
+  InputGroupInput: createBrowserInputStub('StubInputGroupInput'),
+  Label: createBrowserValueStub('StubLabel', 'label'),
+  ScrollArea: createBrowserValueStub('StubScrollArea'),
+  SegmentedControl: createBrowserValueStub('StubSegmentedControl'),
+  Select: createBrowserValueStub('StubSelect'),
+  SelectContent: createBrowserValueStub('StubSelectContent'),
+  SelectItem: createBrowserValueStub('StubSelectItem'),
+  SelectTrigger: createBrowserValueStub('StubSelectTrigger', 'button'),
+  SelectValue: createBrowserValueStub('StubSelectValue', 'span'),
+  Slider: createBrowserValueStub('StubSlider'),
+}
+
+describe('EffectDraftForm', () => {
+  it('点击颜色按钮会打开真实颜色选择器', async () => {
+    renderInBrowser(EffectDraftForm, {
+      props: {
+        duration: '300',
+        ease: '',
+        transform: {},
+      },
+      global: { stubs: globalStubs },
+      browser: { i18nMode: 'localized', locale: 'zh-Hans' },
+    })
+
+    const trigger = page.getByRole('button', { name: '颜色' }).first()
+    await trigger.click()
+
+    await expect.element(trigger).toHaveAttribute('aria-expanded', 'true')
+    await expect.element(page.getByRole('application', { name: 'Chrome Color Picker' })).toBeVisible()
+  })
+
+  it('在真实色板交互期间延迟更新并在选择器关闭后刷新最终颜色', async () => {
+    const transformUpdates = vi.fn()
+    renderInBrowser(EffectDraftForm, {
+      props: {
+        'duration': '300',
+        'ease': '',
+        'onUpdate:transform': transformUpdates,
+        'transform': {},
+      },
+      global: { stubs: globalStubs },
+      browser: { i18nMode: 'localized', locale: 'zh-Hans' },
+    })
+
+    const trigger = page.getByRole('button', { name: '颜色' }).first()
+    await trigger.click()
+    await page.getByRole('application', { name: 'Saturation and brightness picker' }).click({
+      position: { x: 32, y: 24 },
+    })
+
+    expect(transformUpdates).toHaveBeenCalled()
+    expect(transformUpdates.mock.calls.some(([payload]) => payload.deferAutoApply === true)).toBe(true)
+    expect(transformUpdates.mock.calls.some(([payload]) => payload.flush === true)).toBe(false)
+
+    await trigger.click()
+
+    await expect.element(trigger).toHaveAttribute('aria-expanded', 'false')
+    expect(transformUpdates.mock.calls.filter(([payload]) => payload.flush === true)).toHaveLength(1)
+    expect(transformUpdates.mock.lastCall?.[0]).toMatchObject({
+      deferAutoApply: false,
+      flush: true,
+    })
+  })
+})

--- a/src/components/editor/effect-editor/effectDraftForm.types.ts
+++ b/src/components/editor/effect-editor/effectDraftForm.types.ts
@@ -61,7 +61,7 @@ export interface EffectDraftCategoryControls {
   handleDialPointerDown: (event: PointerEvent, param: EffectDialField) => void
   flipScaleAxis: (axis: TransformScaleAxis) => void
   getColorPickerValue: (param: EffectDraftColorField) => { b: number, g: number, r: number }
-  handleColorPickerPointerDown: (event: PointerEvent, param: EffectDraftColorField) => void
+  handleColorPickerOpenChange: (param: EffectDraftColorField, open: boolean) => void
   handleColorPickerChange: (param: EffectDraftColorField, rawValue: unknown) => void
   getSegmentedValue: (param: ChoiceField) => string
   getSegmentedOptions: (param: ChoiceField) => EffectSegmentedOption[]

--- a/src/components/primitives/ColorPicker.vue
+++ b/src/components/primitives/ColorPicker.vue
@@ -21,6 +21,7 @@ const {
 } = defineProps<Props>()
 
 const color = defineModel<ColorPickerValue>({ default: '#000000' })
+const open = defineModel<boolean>('open', { default: false })
 
 function isRgbLike(value: unknown): value is { a?: number, b: number | string, g: number | string, r: number | string } {
   if (!value || typeof value !== 'object') {
@@ -75,7 +76,7 @@ function resolvePreviewColor(value: ColorPickerValue): string {
 </script>
 
 <template>
-  <Popover>
+  <Popover ::open="open">
     <PopoverTrigger as-child>
       <button
         :id="id"

--- a/src/features/editor/effect-editor/__tests__/useEffectColorControl.test.ts
+++ b/src/features/editor/effect-editor/__tests__/useEffectColorControl.test.ts
@@ -1,69 +1,10 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { reactive } from 'vue'
 
 import { useEffectColorControl } from '~/features/editor/effect-editor/useEffectColorControl'
 
-import type { ImmediatePointerDragEvent } from '~/composables/useImmediatePointerDrag'
 import type { ColorField } from '~/features/editor/command-registry/schema'
 import type { EffectControlDeps } from '~/features/editor/effect-editor/types'
-
-const { createParamDragModule, dragController } = vi.hoisted(() => {
-  const dragController = {
-    active: false,
-    param: undefined as unknown,
-  }
-
-  function createParamDragModule() {
-    return {
-      createParamDrag<P, S>(callbacks: {
-        onCancel?: (state: S & { param: P }) => void
-        onStart: (event: ImmediatePointerDragEvent, param: P) => unknown
-        // 这些测试只覆盖开始/结束语义；保留 onMove 是为了让 mock 签名贴近真实 API。
-        onMove: (event: ImmediatePointerDragEvent, state: S & { param: P }) => unknown
-        onEnd: (event: ImmediatePointerDragEvent | undefined, state: S & { param: P }) => void
-      }) {
-        return {
-          drag: {
-            get active() {
-              return dragController.active
-            },
-            get state() {
-              return dragController.active ? { param: dragController.param as P } as S & { param: P } : undefined
-            },
-            stop(event?: ImmediatePointerDragEvent) {
-              if (!dragController.active) {
-                return
-              }
-              callbacks.onEnd(event, { param: dragController.param as P } as S & { param: P })
-              dragController.active = false
-              dragController.param = undefined
-            },
-            cancel() {
-              if (!dragController.active) {
-                return
-              }
-              callbacks.onCancel?.({ param: dragController.param as P } as S & { param: P })
-              dragController.active = false
-              dragController.param = undefined
-            },
-          },
-          start(event: ImmediatePointerDragEvent, param: P) {
-            callbacks.onStart(event, param)
-            dragController.active = true
-            dragController.param = param
-          },
-        }
-      },
-    }
-  }
-
-  return {
-    createParamDragModule,
-    dragController,
-  }
-})
-
-vi.mock('~/features/editor/effect-editor/createParamDrag', createParamDragModule)
 
 function createDeps(initialFields: Record<string, string> = {}) {
   const fields = reactive({ ...initialFields }) as Record<string, string>
@@ -86,29 +27,6 @@ function createDeps(initialFields: Record<string, string> = {}) {
   return { deps, emitTransform, fields }
 }
 
-function createPointerEvent(overrides?: Partial<PointerEvent>): PointerEvent {
-  return {
-    altKey: false,
-    button: 0,
-    buttons: 1,
-    clientX: 10,
-    clientY: 10,
-    currentTarget: {
-      getBoundingClientRect: () => ({
-        left: 0,
-        top: 0,
-        width: 20,
-        height: 20,
-      }),
-    },
-    pointerId: 1,
-    pointerType: 'mouse',
-    preventDefault: vi.fn(),
-    shiftKey: false,
-    ...overrides,
-  } as PointerEvent
-}
-
 function createColorField(
   overrides: Partial<ColorField & {
     colorPaths: [string, string, string]
@@ -129,11 +47,6 @@ function createColorField(
 }
 
 describe('useEffectColorControl', () => {
-  beforeEach(() => {
-    dragController.active = false
-    dragController.param = undefined
-  })
-
   it('读取颜色值时会归一化通道并生成 picker payload', () => {
     const { deps } = createDeps({
       r: '300',
@@ -149,7 +62,7 @@ describe('useEffectColorControl', () => {
     expect(control.getColorPickerValue(field)).toEqual({ r: 255, g: 0, b: 128 })
   })
 
-  it('非拖拽状态下 handleColorPickerChange 会立即 flush', () => {
+  it('选择器未打开时变更颜色会立即 flush', () => {
     const { deps, emitTransform, fields } = createDeps()
     const control = useEffectColorControl(deps)
     const field = createColorField()
@@ -168,39 +81,27 @@ describe('useEffectColorControl', () => {
     })
   })
 
-  it('颜色选择器打开时回传当前默认颜色不会写入缺失字段', () => {
+  it('颜色选择器打开期间回传当前默认颜色不会写入缺失字段', () => {
     const { deps, emitTransform, fields } = createDeps()
     const control = useEffectColorControl(deps)
     const field = createColorField({
       colorDefaults: [255, 255, 255],
     })
 
+    control.handleColorPickerOpenChange(field, true)
     control.handleColorPickerChange(field, { rgba: { r: 255, g: 255, b: 255 } })
+    control.handleColorPickerOpenChange(field, false)
 
     expect(fields).toEqual({})
     expect(emitTransform).not.toHaveBeenCalled()
   })
 
-  it('颜色触发按钮仅 pointerdown/up 时不会写入缺失字段', () => {
-    const { deps, emitTransform, fields } = createDeps()
-    const control = useEffectColorControl(deps)
-    const field = createColorField({
-      colorDefaults: [255, 255, 255],
-    })
-
-    control.handleColorPickerPointerDown(createPointerEvent(), field)
-    control.colorDrag.stop?.(createPointerEvent())
-
-    expect(fields).toEqual({})
-    expect(emitTransform).not.toHaveBeenCalled()
-  })
-
-  it('拖拽期间只做 deferred preview，结束时才 flush 最终颜色', () => {
+  it('选择器打开期间只做 deferred preview，关闭时才 flush 最终颜色', () => {
     const { deps, emitTransform, fields } = createDeps()
     const control = useEffectColorControl(deps)
     const field = createColorField()
 
-    control.handleColorPickerPointerDown(createPointerEvent(), field)
+    control.handleColorPickerOpenChange(field, true)
     control.handleColorPickerChange(field, { rgba: { r: 10, g: 20, b: 30 } })
 
     expect(emitTransform).toHaveBeenLastCalledWith(fields, {
@@ -208,8 +109,9 @@ describe('useEffectColorControl', () => {
       deferAutoApply: true,
     })
 
-    control.colorDrag.stop?.(createPointerEvent())
+    control.handleColorPickerOpenChange(field, false)
 
+    expect(emitTransform).toHaveBeenCalledTimes(2)
     expect(emitTransform).toHaveBeenLastCalledWith(fields, {
       schedule: 'color',
       flush: true,
@@ -222,17 +124,16 @@ describe('useEffectColorControl', () => {
     })
   })
 
-  it('颜色拖拽取消时会取消当前预览交互并丢弃 pending flush', () => {
+  it('颜色交互取消时会取消当前预览并丢弃 pending flush', () => {
     const { deps, emitTransform } = createDeps()
     const cancelPreview = vi.fn()
-    const depsWithCancel = deps as EffectControlDeps & { cancelPreview: () => void }
-    depsWithCancel.cancelPreview = cancelPreview
-    const control = useEffectColorControl(depsWithCancel)
+    deps.cancelPreview = cancelPreview
+    const control = useEffectColorControl(deps)
     const field = createColorField()
 
-    control.handleColorPickerPointerDown(createPointerEvent(), field)
+    control.handleColorPickerOpenChange(field, true)
     control.handleColorPickerChange(field, { rgba: { r: 10, g: 20, b: 30 } })
-    control.colorDrag.cancel?.()
+    control.cancelColorInteraction()
 
     expect(cancelPreview).toHaveBeenCalledOnce()
     expect(emitTransform).toHaveBeenCalledTimes(1)

--- a/src/features/editor/effect-editor/useEffectColorControl.ts
+++ b/src/features/editor/effect-editor/useEffectColorControl.ts
@@ -1,5 +1,4 @@
 import { ColorField } from '~/features/editor/command-registry/schema'
-import { createParamDrag } from '~/features/editor/effect-editor/createParamDrag'
 import { EffectControlDeps } from '~/features/editor/effect-editor/types'
 import { extractRgbColor, normalizeColorChannel } from '~/utils/color'
 
@@ -7,10 +6,10 @@ import { extractRgbColor, normalizeColorChannel } from '~/utils/color'
 type EffectColorField = ColorField & { colorPaths: [string, string, string], colorDefaults: [number, number, number] }
 
 export function useEffectColorControl(deps: EffectControlDeps) {
-  // 颜色拖拽期间暂存最终颜色值。
-  // color picker 在拖拽过程中高频触发 onChange，每次都 flush 会导致大量 IPC 调用；
-  // 拖拽期间仅做 deferred 预览，拖拽结束时（onEnd）才用暂存值执行一次 flush
-  let pendingColorFlushValue = $ref<[number, number, number]>()
+  // 选择器打开期间暂存最终颜色值，关闭时才执行一次 flush。
+  // 以 Popover 生命周期为界可同时覆盖色板拖拽、触摸和键盘输入。
+  let activeColorParam: EffectColorField | undefined
+  let pendingColorFlushValue: [number, number, number] | undefined
 
   function isColorEqual(left: [number, number, number], right: [number, number, number]): boolean {
     return left[0] === right[0] && left[1] === right[1] && left[2] === right[2]
@@ -41,31 +40,36 @@ export function useEffectColorControl(deps: EffectControlDeps) {
     deps.emitTransform(fields, { schedule: 'color', ...options })
   }
 
-  const { drag: colorDrag, start: startColorDrag } = createParamDrag<
-    EffectColorField,
-    Record<string, never>
-  >({
-    onStart() {
-      pendingColorFlushValue = undefined
-      return {}
-    },
-    onMove() { /* noop */ },
-    onEnd(_event, state) {
-      if (!pendingColorFlushValue) {
-        return
-      }
-      const targetColor = pendingColorFlushValue
-      pendingColorFlushValue = undefined
-      updateColorField(state.param, targetColor, {
-        flush: true,
-        deferAutoApply: false,
-      })
-    },
-    onCancel() {
-      pendingColorFlushValue = undefined
-      void deps.cancelPreview?.()
-    },
-  })
+  function flushColorInteraction(param: EffectColorField) {
+    if (activeColorParam !== param) {
+      return
+    }
+
+    activeColorParam = undefined
+    if (!pendingColorFlushValue) {
+      return
+    }
+
+    const targetColor = pendingColorFlushValue
+    pendingColorFlushValue = undefined
+    updateColorField(param, targetColor, {
+      flush: true,
+      deferAutoApply: false,
+    })
+  }
+
+  function handleColorPickerOpenChange(param: EffectColorField, open: boolean) {
+    if (!open) {
+      flushColorInteraction(param)
+      return
+    }
+
+    if (activeColorParam && activeColorParam !== param) {
+      flushColorInteraction(activeColorParam)
+    }
+    activeColorParam = param
+    pendingColorFlushValue = undefined
+  }
 
   function handleColorPickerChange(param: EffectColorField, rawValue: unknown) {
     const parsed = extractRgbColor(rawValue)
@@ -77,8 +81,7 @@ export function useEffectColorControl(deps: EffectControlDeps) {
       return
     }
 
-    const isDraggingCurrentParam = colorDrag.active && colorDrag.state?.param === param
-    if (!isDraggingCurrentParam) {
+    if (activeColorParam !== param) {
       updateColorField(param, parsed, {
         flush: true,
         deferAutoApply: false,
@@ -90,17 +93,21 @@ export function useEffectColorControl(deps: EffectControlDeps) {
     updateColorField(param, parsed, { deferAutoApply: true })
   }
 
-  function clearPendingColorFlush() {
+  function cancelColorInteraction() {
+    const wasActive = activeColorParam !== undefined
+    activeColorParam = undefined
     pendingColorFlushValue = undefined
+    if (wasActive) {
+      void deps.cancelPreview?.()
+    }
   }
 
   return {
     getColorValue,
     getColorPickerValue,
     updateColorField,
-    handleColorPickerPointerDown: startColorDrag,
+    handleColorPickerOpenChange,
     handleColorPickerChange,
-    clearPendingColorFlush,
-    colorDrag,
+    cancelColorInteraction,
   }
 }


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [x] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [x] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

修复效果编辑器中颜色选择器点击后无响应的问题。

原实现会在颜色控件外层处理 `pointerdown` 并捕获指针，导致内部颜色选择器按钮无法收到完整的点击事件，Popover 因此不能打开。

本次修改：

- 移除颜色选择器外层的指针事件捕获。
- 为通用颜色选择器暴露 Popover 打开状态。
- 使用 Popover 的打开和关闭作为颜色交互会话边界。
- 选择器打开期间仅发送延迟预览更新，避免高频刷新。
- 选择器关闭时提交最终颜色，并确保只执行一次刷新。
- 组件卸载时取消尚未完成的颜色预览交互。
- 删除已经失效的指针拖拽 mock 和重复测试。
- 添加真实 Chromium 组件测试，覆盖点击打开、延迟预览和关闭提交。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

效果编辑器的颜色选择器点击后没有反应，同时不会产生错误或日志。

根因是外层指针拖拽逻辑调用了指针捕获，内部 Popover 触发按钮无法收到后续 `click`。直接调整指针结束时机仍无法可靠处理 `vue-color` 在 `mouseup` 后发送最终颜色值的事件顺序。

因此，本次修复不再将颜色选择器复用为指针拖拽控件，而是以 Popover 生命周期定义完整的颜色编辑事务。该方案同时适用于鼠标、触摸和键盘输入，并避免对共享拖拽实现增加兼容参数或特殊分支。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
