### PR TITLE
🐛 修复高 DPI 下首页外部目录拖放失效

### DIFF
--- a/src/composables/__tests__/useTauriDropZone.browser.test.ts
+++ b/src/composables/__tests__/useTauriDropZone.browser.test.ts
@@ -1,0 +1,121 @@
+import { PhysicalPosition } from '@tauri-apps/api/dpi'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render } from 'vitest-browser-vue'
+import { defineComponent, h, ref } from 'vue'
+
+import { useTauriDropZone } from '../useTauriDropZone'
+
+import type { Event as TauriEvent } from '@tauri-apps/api/event'
+import type { DragDropEvent } from '@tauri-apps/api/webview'
+
+const { webviewMockState } = vi.hoisted(() => ({
+  webviewMockState: {
+    handler: undefined as ((event: TauriEvent<DragDropEvent>) => void) | undefined,
+    unlisten: vi.fn(),
+  },
+}))
+
+vi.mock('@tauri-apps/api/webview', () => ({
+  getCurrentWebview: () => ({
+    onDragDropEvent: vi.fn(async (handler: (event: TauriEvent<DragDropEvent>) => void) => {
+      webviewMockState.handler = handler
+      return webviewMockState.unlisten
+    }),
+  }),
+}))
+
+const originalDevicePixelRatio = Object.getOwnPropertyDescriptor(globalThis, 'devicePixelRatio')
+const standardDpiPath = '/games/standard-dpi'
+const highDpiPath = '/games/high-dpi'
+const outsidePath = '/games/outside'
+
+function setDevicePixelRatio(value: number): void {
+  Object.defineProperty(globalThis, 'devicePixelRatio', {
+    configurable: true,
+    value,
+  })
+}
+
+async function renderDropZone() {
+  const onDrop = vi.fn()
+  const Harness = defineComponent({
+    setup() {
+      const target = ref<HTMLElement>()
+      useTauriDropZone(target, onDrop)
+
+      return () => h('div', {
+        ref: target,
+        style: {
+          height: '50px',
+          left: '50px',
+          position: 'fixed',
+          top: '50px',
+          width: '50px',
+          zIndex: '2147483647',
+        },
+      })
+    },
+  })
+
+  const result = render(Harness)
+  await vi.waitFor(() => expect(webviewMockState.handler).toBeTypeOf('function'))
+
+  return { onDrop, result }
+}
+
+function emitDrop(paths: string[], position: PhysicalPosition): void {
+  webviewMockState.handler?.({
+    event: 'tauri://drag-drop',
+    id: 1,
+    payload: {
+      paths,
+      position,
+      type: 'drop',
+    },
+  })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  webviewMockState.handler = undefined
+})
+
+afterEach(() => {
+  if (originalDevicePixelRatio) {
+    Object.defineProperty(globalThis, 'devicePixelRatio', originalDevicePixelRatio)
+  } else {
+    Reflect.deleteProperty(globalThis, 'devicePixelRatio')
+  }
+})
+
+describe('useTauriDropZone', () => {
+  it('在 1x DPI 下使用原生坐标命中放置区域', async () => {
+    setDevicePixelRatio(1)
+    const { onDrop, result } = await renderDropZone()
+
+    emitDrop([standardDpiPath], new PhysicalPosition(75, 75))
+
+    expect(onDrop).toHaveBeenCalledWith([standardDpiPath])
+    result.unmount()
+  })
+
+  it('在高 DPI 下将物理坐标转换为 CSS 坐标后命中放置区域', async () => {
+    setDevicePixelRatio(2)
+    const { onDrop, result } = await renderDropZone()
+
+    emitDrop([highDpiPath], new PhysicalPosition(150, 150))
+
+    expect(onDrop).toHaveBeenCalledWith([highDpiPath])
+    result.unmount()
+  })
+
+  it('高 DPI 坐标换算后位于区域外时不触发放置', async () => {
+    setDevicePixelRatio(2)
+    const { onDrop, result } = await renderDropZone()
+
+    emitDrop([outsidePath], new PhysicalPosition(250, 250))
+
+    expect(onDrop).not.toHaveBeenCalled()
+    result.unmount()
+  })
+})

--- a/src/composables/useTauriDropZone.ts
+++ b/src/composables/useTauriDropZone.ts
@@ -1,5 +1,6 @@
 import { getCurrentWebview } from '@tauri-apps/api/webview'
 
+import type { PhysicalPosition } from '@tauri-apps/api/dpi'
 import type { DragDropEvent } from '@tauri-apps/api/webview'
 
 export interface UseTauriDropZoneOptions {
@@ -75,8 +76,9 @@ export function useTauriDropZone(
     }
   }
 
-  function elementAtPosition(position: { x: number, y: number }): Element | null {
-    return document.elementFromPoint(position.x, position.y)
+  function elementAtPosition(position: PhysicalPosition): Element | null {
+    const logicalPosition = position.toLogical(globalThis.devicePixelRatio || 1)
+    return document.elementFromPoint(logicalPosition.x, logicalPosition.y)
   }
 
   function handleDragDropEvent(payload: DragDropEvent): void {


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [x] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [x] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

修复首页从外部拖入目录时，在高 DPI 或非 100% 系统缩放环境下没有任何反应的问题。

Tauri 的拖放事件使用物理像素坐标，而浏览器的 `document.elementFromPoint` 使用 CSS 逻辑像素。此前代码直接使用 Tauri 坐标执行命中检测，导致高 DPI 环境下无法正确命中拖放区域。

本次修改在 `useTauriDropZone` 中通过当前 `devicePixelRatio` 将 `PhysicalPosition` 转换为逻辑坐标，再执行拖放区域命中检测。游戏、引擎和模板首页共用该 composable，因此会统一获得修复。

同时新增浏览器回归测试，覆盖：

- 1x DPI 下正常命中拖放区域；
- 2x DPI 下物理坐标转换后正常触发拖放；
- 高 DPI 坐标转换后位于区域外时不会误触发。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

首页的游戏、引擎和模板导入都依赖 Tauri 原生拖放事件。在高 DPI 显示器或 Windows 缩放比例不为 100% 时，物理坐标与 CSS 坐标不一致，导致目录虽然被拖入应用，但导入回调没有执行，也没有任何界面反馈。

本修改统一修正拖放基础设施中的坐标边界，避免在各首页组件中重复处理平台坐标。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
