### PR TITLE
🐛 修复失效游戏仍显示打开文件夹操作

### DIFF
--- a/src/components/home/games-tab/GamesTabCollectionSection.spec.ts
+++ b/src/components/home/games-tab/GamesTabCollectionSection.spec.ts
@@ -132,6 +132,54 @@ describe('GamesTabCollectionSection', () => {
     await expect.element(page.getByRole('button', { name: 'home.games.deleteGame' })).not.toBeInTheDocument()
   })
 
+  it('网格视图只为路径仍可达的游戏显示打开文件夹操作', async () => {
+    const brokenGame = createTestGame({ id: 'game-broken', availability: 'broken' })
+    const missingGame = createTestGame({ id: 'game-missing', availability: 'missing' })
+    const onOpenFolder = vi.fn()
+
+    renderInBrowser(GamesTabCollectionSection, {
+      browser: {
+        i18nMode: 'lite',
+      },
+      props: {
+        items: createItems([brokenGame, missingGame]),
+        getGameProgress: () => 0,
+        hasGameProgress: () => false,
+        onOpenFolder,
+        viewMode: 'grid',
+      },
+      global: {
+        stubs: globalStubs,
+      },
+    })
+
+    const openFolderButtons = page.getByRole('button', { name: 'common.openFolder' })
+    expect(openFolderButtons.elements()).toHaveLength(1)
+
+    await openFolderButtons.click()
+    expect(onOpenFolder).toHaveBeenCalledOnce()
+    expect(onOpenFolder).toHaveBeenCalledWith(brokenGame)
+  })
+
+  it('列表视图不会为路径已失效的游戏显示打开文件夹快捷操作', async () => {
+    renderInBrowser(GamesTabCollectionSection, {
+      browser: {
+        i18nMode: 'lite',
+      },
+      props: {
+        items: createItems([createTestGame({ availability: 'missing' })]),
+        getGameProgress: () => 0,
+        hasGameProgress: () => false,
+        viewMode: 'list',
+      },
+      global: {
+        stubs: globalStubs,
+      },
+    })
+
+    await expect.element(page.getByRole('button', { name: 'common.openFolder' })).not.toBeInTheDocument()
+  })
+
   it('导入入口使用按钮语义并会触发 importClick', async () => {
     const onImportClick = vi.fn()
 

--- a/src/components/home/games-tab/GamesTabCollectionSection.spec.ts
+++ b/src/components/home/games-tab/GamesTabCollectionSection.spec.ts
@@ -69,10 +69,6 @@ const globalStubs = {
   Button: createBrowserClickStub('StubButton'),
   Card: createBrowserContainerStub('StubCard'),
   CardContent: createBrowserContainerStub('StubCardContent'),
-  ContextMenu: createBrowserContainerStub('StubContextMenu'),
-  ContextMenuContent: createBrowserContainerStub('StubContextMenuContent'),
-  ContextMenuItem: createBrowserClickStub('StubContextMenuItem'),
-  ContextMenuTrigger: createBrowserContainerStub('StubContextMenuTrigger'),
   Progress: createBrowserContainerStub('StubProgress'),
   Tooltip: createBrowserContainerStub('StubTooltip'),
   TooltipContent: createBrowserContainerStub('StubTooltipContent'),
@@ -153,12 +149,17 @@ describe('GamesTabCollectionSection', () => {
       },
     })
 
-    const openFolderButtons = page.getByRole('button', { name: 'common.openFolder' })
-    expect(openFolderButtons.elements()).toHaveLength(1)
+    await page.getByTestId(`game-card-${brokenGame.id}`).click({ button: 'right' })
 
-    await openFolderButtons.click()
+    const openFolderMenuItem = page.getByRole('menuitem', { name: 'common.openFolder' })
+    await expect.element(openFolderMenuItem).toBeVisible()
+
+    await openFolderMenuItem.click()
     expect(onOpenFolder).toHaveBeenCalledOnce()
     expect(onOpenFolder).toHaveBeenCalledWith(brokenGame)
+
+    await page.getByTestId(`game-card-${missingGame.id}`).click({ button: 'right' })
+    await expect.element(openFolderMenuItem).not.toBeInTheDocument()
   })
 
   it('列表视图不会为路径已失效的游戏显示打开文件夹快捷操作', async () => {

--- a/src/components/home/games-tab/GamesTabCollectionSection.vue
+++ b/src/components/home/games-tab/GamesTabCollectionSection.vue
@@ -122,7 +122,10 @@ const LIST_COVER_THUMBNAIL: AssetThumbnailOptions = {
           </Card>
         </ContextMenuTrigger>
         <ContextMenuContent class="w-42">
-          <ContextMenuItem @click="emit('openFolder', item.game)">
+          <ContextMenuItem
+            v-if="item.game.availability !== 'missing'"
+            @click="emit('openFolder', item.game)"
+          >
             <Folder class="mr-2 size-3.5" />
             {{ $t('common.openFolder') }}
           </ContextMenuItem>
@@ -208,7 +211,7 @@ const LIST_COVER_THUMBNAIL: AssetThumbnailOptions = {
         </div>
         <div v-if="!hasGameProgress(item.game)" class="flex gap-2 items-center">
           <TooltipProvider>
-            <Tooltip>
+            <Tooltip v-if="item.game.availability !== 'missing'">
               <TooltipTrigger as-child>
                 <Button
                   :aria-label="$t('common.openFolder')"


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [x] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [x] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

- 游戏目录不存在时，隐藏网格右键菜单中的“打开文件夹”操作。
- 同步隐藏列表视图中的“打开文件夹”快捷操作。
- 保留目录仍可访问但游戏内容损坏时的打开文件夹能力，方便用户检查和修复文件。
- 添加浏览器组件测试，覆盖路径失效与目录仍可访问两种状态。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

游戏路径已经失效时，打开文件夹命令必然失败。继续展示该操作会让用户触发无效命令并收到没有实际帮助的错误提示。

本次修改根据游戏目录的可达状态控制操作入口，使上下文菜单和列表快捷操作保持一致。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
