### PR TITLE
🐛 修复图标编辑器退出时未确认修改

### DIFF
--- a/src/components/modals/game-config/IconEditorDialog.spec.ts
+++ b/src/components/modals/game-config/IconEditorDialog.spec.ts
@@ -333,6 +333,28 @@ describe('IconEditorDialog', () => {
     expect(updateOpen).toHaveBeenCalledWith(false)
   })
 
+  it('生成期间忽略关闭请求', async () => {
+    const save = createDeferred<void>()
+    saveIconEditorOutputsMock.mockReturnValueOnce(save.promise)
+    const updateOpen = renderOpenIconEditorDialog()
+
+    await page.getByTestId('icon-editor-select-foreground').click()
+    await page.getByTestId('icon-editor-generate').click()
+    await vi.waitFor(() => {
+      expect(saveIconEditorOutputsMock).toHaveBeenCalled()
+    })
+
+    await page.getByTestId('icon-editor-close-request').click()
+
+    expect(updateOpen).not.toHaveBeenCalledWith(false)
+    expect(modalOpenMock).not.toHaveBeenCalled()
+
+    save.resolve()
+    await vi.waitFor(() => {
+      expect(updateOpen).toHaveBeenCalledWith(false)
+    })
+  })
+
   it('打开时使用 icon-data 初始化编辑状态', async () => {
     loadIconEditorSourceDataMock.mockResolvedValue({
       backgroundBytes: new Uint8Array([8, 9]),

--- a/src/components/modals/game-config/IconEditorDialog.spec.ts
+++ b/src/components/modals/game-config/IconEditorDialog.spec.ts
@@ -5,6 +5,7 @@ import { page } from 'vitest/browser'
 import { defineComponent, h, nextTick } from 'vue'
 
 import {
+  createBrowserActionStub,
   createBrowserClickStub,
   createBrowserContainerStub,
   createBrowserInputStub,
@@ -27,6 +28,7 @@ const {
   buildIconExportOutputsMock,
   handleErrorMock,
   loadIconEditorSourceDataMock,
+  modalOpenMock,
   openDialogMock,
   readFileMock,
   refreshRegisteredGameSnapshotMock,
@@ -37,6 +39,7 @@ const {
   fromExternalAbsPathMock: vi.fn(),
   handleErrorMock: vi.fn(),
   loadIconEditorSourceDataMock: vi.fn(),
+  modalOpenMock: vi.fn(),
   openDialogMock: vi.fn(),
   readFileMock: vi.fn(),
   refreshRegisteredGameSnapshotMock: vi.fn(),
@@ -70,6 +73,12 @@ vi.mock('~/services/platform/path-boundary', () => ({
   fromExternalAbsPath: fromExternalAbsPathMock,
 }))
 
+vi.mock('~/stores/modal', () => ({
+  useModalStore: () => ({
+    open: modalOpenMock,
+  }),
+}))
+
 vi.mock('~/utils/error-handler', () => ({
   handleError: handleErrorMock,
 }))
@@ -77,7 +86,12 @@ vi.mock('~/utils/error-handler', () => ({
 const globalStubs = {
   Button: createBrowserClickStub('StubButton'),
   ColorPicker: createBrowserValueStub('StubColorPicker', 'button'),
-  Dialog: createBrowserContainerStub('StubDialog'),
+  Dialog: createBrowserActionStub('StubDialog', {
+    eventName: 'update:open',
+    includeDefaultSlot: true,
+    payload: false,
+    testId: 'icon-editor-close-request',
+  }),
   DialogContent: createBrowserContainerStub('StubDialogContent', 'section'),
   DialogDescription: createBrowserContainerStub('StubDialogDescription'),
   DialogFooter: createBrowserContainerStub('StubDialogFooter'),
@@ -181,6 +195,38 @@ function createDeferred<T>(): Deferred<T> {
   }
 }
 
+function renderOpenIconEditorDialog() {
+  const updateOpen = vi.fn()
+
+  renderInBrowser(IconEditorDialog, {
+    browser: {
+      i18nMode: 'lite',
+    },
+    props: {
+      'open': true,
+      'gamePath': '/games/demo',
+      'onUpdate:open': updateOpen,
+    },
+    global: {
+      stubs: globalStubs,
+    },
+  })
+
+  return updateOpen
+}
+
+function getSaveChangesCallbacks() {
+  const call = modalOpenMock.mock.calls.find(([name]) => name === 'SaveChangesModal')
+  if (!call) {
+    throw new Error('未打开 SaveChangesModal')
+  }
+
+  return call[1] as {
+    onDontSave: () => void
+    onSave: () => Promise<void>
+  }
+}
+
 describe('IconEditorDialog', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -221,6 +267,70 @@ describe('IconEditorDialog', () => {
     await expect.element(page.getByTestId('icon-editor-preview-grid')).toBeVisible()
     await expect.element(page.getByTestId('icon-editor-generate-hint')).toBeVisible()
     await expect.element(page.getByTestId('icon-editor-generate')).toBeDisabled()
+  })
+
+  it('修改后请求关闭会二次确认而不是直接退出', async () => {
+    const updateOpen = renderOpenIconEditorDialog()
+
+    await page.getByTestId('icon-editor-select-foreground').click()
+    await page.getByTestId('icon-editor-close-request').click()
+
+    expect(updateOpen).not.toHaveBeenCalledWith(false)
+    expect(modalOpenMock).toHaveBeenCalledWith('SaveChangesModal', expect.objectContaining({
+      onDontSave: expect.any(Function),
+      onSave: expect.any(Function),
+    }))
+
+    getSaveChangesCallbacks().onDontSave()
+
+    expect(updateOpen).toHaveBeenCalledWith(false)
+  })
+
+  it('未修改时请求关闭会直接退出', async () => {
+    const updateOpen = renderOpenIconEditorDialog()
+
+    await page.getByTestId('icon-editor-close-request').click()
+
+    expect(modalOpenMock).not.toHaveBeenCalled()
+    expect(updateOpen).toHaveBeenCalledWith(false)
+  })
+
+  it('恢复已有图标配置后未修改会直接退出', async () => {
+    loadIconEditorSourceDataMock.mockResolvedValue({
+      foregroundBytes: new Uint8Array([6, 7]),
+      state: {
+        backgroundColor: '#112233',
+        backgroundOffsetRatio: { x: 0, y: 0 },
+        backgroundScale: 1,
+        backgroundType: 'color',
+        foregroundOffsetRatio: { x: 0.1, y: 0.2 },
+        foregroundScale: 1.4,
+        iconShape: 'rounded',
+        version: 1,
+      },
+    } satisfies IconEditorSourceData)
+
+    const updateOpen = renderOpenIconEditorDialog()
+
+    await vi.waitFor(() => {
+      expect(page.getByTestId('icon-editor-generate').element()).not.toBeDisabled()
+    })
+    await page.getByTestId('icon-editor-close-request').click()
+
+    expect(modalOpenMock).not.toHaveBeenCalled()
+    expect(updateOpen).toHaveBeenCalledWith(false)
+  })
+
+  it('修改后确认保存会生成图标并关闭编辑器', async () => {
+    const updateOpen = renderOpenIconEditorDialog()
+
+    await page.getByTestId('icon-editor-select-foreground').click()
+    await page.getByTestId('icon-editor-close-request').click()
+
+    await getSaveChangesCallbacks().onSave()
+
+    expect(saveIconEditorOutputsMock).toHaveBeenCalledWith('/games/demo', expect.any(Array))
+    expect(updateOpen).toHaveBeenCalledWith(false)
   })
 
   it('打开时使用 icon-data 初始化编辑状态', async () => {

--- a/src/components/modals/game-config/IconEditorDialog.vue
+++ b/src/components/modals/game-config/IconEditorDialog.vue
@@ -34,6 +34,7 @@ const {
   foregroundTransformControls,
   generate,
   isDirty,
+  isSaving,
   previewVersion,
   selectBackgroundImage,
   selectForeground,
@@ -52,6 +53,10 @@ function closeDialog() {
 }
 
 function requestClose() {
+  if (isSaving.value) {
+    return
+  }
+
   if (!isDirty.value) {
     closeDialog()
     return

--- a/src/components/modals/game-config/IconEditorDialog.vue
+++ b/src/components/modals/game-config/IconEditorDialog.vue
@@ -5,6 +5,7 @@ import { Button } from '~/components/ui/button'
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '~/components/ui/dialog'
 import { AbsPath } from '~/domain/path'
 import { useIconEditorSession } from '~/features/modals/game-config/icon-editor/useIconEditorSession'
+import { useModalStore } from '~/stores/modal'
 
 import type { IconPreviewKind } from '~/features/modals/game-config/icon-editor/icon-editor-render'
 
@@ -21,6 +22,7 @@ const props = defineProps<Props>()
 const open = defineModel<boolean>('open', { default: false })
 
 const { t } = useI18n()
+const modalStore = useModalStore()
 
 const {
   backgroundName,
@@ -31,6 +33,7 @@ const {
   foregroundSelectLabel,
   foregroundTransformControls,
   generate,
+  isDirty,
   previewVersion,
   selectBackgroundImage,
   selectForeground,
@@ -44,6 +47,35 @@ const {
   t,
 })
 
+function closeDialog() {
+  open.value = false
+}
+
+function requestClose() {
+  if (!isDirty.value) {
+    closeDialog()
+    return
+  }
+
+  modalStore.open('SaveChangesModal', {
+    title: t('modals.saveChanges.title', {
+      name: t('modals.gameConfig.iconEditor.title'),
+    }),
+    saveLabel: t('modals.gameConfig.iconEditor.generate'),
+    onSave: generate,
+    onDontSave: closeDialog,
+  })
+}
+
+function handleDialogOpenChange(nextOpen: boolean) {
+  if (nextOpen) {
+    open.value = true
+    return
+  }
+
+  requestClose()
+}
+
 const previewItems = $computed((): PreviewItem[] => [
   { key: 'web', label: t('modals.gameConfig.iconEditor.preview.web') },
   { key: 'web-maskable', label: t('modals.gameConfig.iconEditor.preview.webMaskable') },
@@ -55,7 +87,7 @@ const previewItems = $computed((): PreviewItem[] => [
 </script>
 
 <template>
-  <Dialog :open="open" @update:open="open = $event">
+  <Dialog :open="open" @update:open="handleDialogOpenChange">
     <DialogContent
       data-testid="icon-editor-dialog"
       class="grid grid-rows-[auto_minmax(0,1fr)_auto] h-38rem max-w-228 overflow-hidden"

--- a/src/features/modals/game-config/icon-editor/useIconEditorSession.ts
+++ b/src/features/modals/game-config/icon-editor/useIconEditorSession.ts
@@ -1,6 +1,6 @@
 import { open as openDialog } from '@tauri-apps/plugin-dialog'
 import { readFile } from '@tauri-apps/plugin-fs'
-import { computed, markRaw, ref, toValue, watch } from 'vue'
+import { computed, markRaw, ref, shallowRef, toValue, watch } from 'vue'
 
 import { AbsPath } from '~/domain/path'
 import { gameManager } from '~/services/game-manager'
@@ -36,7 +36,7 @@ import type {
   IconEditorTransformControlValue,
   IconEditorTransformUpdateOptions,
 } from './icon-editor-controls'
-import type { IconEditorImageSource } from './icon-editor-state'
+import type { IconEditorImageSource, IconEditorState } from './icon-editor-state'
 import type { MaybeRefOrGetter, Ref } from 'vue'
 import type { I18nT } from '~/utils/i18n-like'
 
@@ -46,10 +46,33 @@ interface UseIconEditorSessionOptions {
   t: I18nT
 }
 
+function createIconEditorStateSnapshot(state: IconEditorState): IconEditorState {
+  return {
+    ...state,
+    backgroundOffsetRatio: { ...state.backgroundOffsetRatio },
+    foregroundOffsetRatio: { ...state.foregroundOffsetRatio },
+  }
+}
+
+function isIconEditorStateEqual(left: IconEditorState, right: IconEditorState): boolean {
+  return left.backgroundColor === right.backgroundColor
+    && left.backgroundImage === right.backgroundImage
+    && left.backgroundOffsetRatio.x === right.backgroundOffsetRatio.x
+    && left.backgroundOffsetRatio.y === right.backgroundOffsetRatio.y
+    && left.backgroundScale === right.backgroundScale
+    && left.backgroundType === right.backgroundType
+    && left.foregroundImage === right.foregroundImage
+    && left.foregroundOffsetRatio.x === right.foregroundOffsetRatio.x
+    && left.foregroundOffsetRatio.y === right.foregroundOffsetRatio.y
+    && left.foregroundScale === right.foregroundScale
+    && left.iconShape === right.iconShape
+}
+
 export function useIconEditorSession(options: UseIconEditorSessionOptions) {
   const state = ref(createDefaultIconEditorState())
   const previewVersion = ref(0)
   const isSaving = ref(false)
+  const initialStateSnapshot = shallowRef(createIconEditorStateSnapshot(state.value))
   let restoreVersion = 0
 
   const foregroundName = computed(() => state.value.foregroundImage
@@ -65,6 +88,7 @@ export function useIconEditorSession(options: UseIconEditorSessionOptions) {
     ? options.t('modals.gameConfig.iconEditor.replaceImage')
     : options.t('modals.gameConfig.iconEditor.selectImage'))
   const canGenerate = computed(() => Boolean(toValue(options.gamePath) && state.value.foregroundImage && !isSaving.value))
+  const isDirty = computed(() => !isIconEditorStateEqual(state.value, initialStateSnapshot.value))
 
   const foregroundTransformControls = computed((): IconEditorTransformControl[] => [
     createScaleControl('foreground', state.value.foregroundScale, setForegroundScale),
@@ -159,6 +183,7 @@ export function useIconEditorSession(options: UseIconEditorSessionOptions) {
 
   function resetEditorState() {
     state.value = createDefaultIconEditorState()
+    initialStateSnapshot.value = createIconEditorStateSnapshot(state.value)
     bumpPreviewVersion()
   }
 
@@ -231,6 +256,7 @@ export function useIconEditorSession(options: UseIconEditorSessionOptions) {
       foregroundScale,
       iconShape,
     }
+    initialStateSnapshot.value = createIconEditorStateSnapshot(state.value)
     bumpPreviewVersion()
   }
 
@@ -399,6 +425,7 @@ export function useIconEditorSession(options: UseIconEditorSessionOptions) {
     foregroundSelectLabel,
     foregroundTransformControls,
     generate,
+    isDirty,
     isSaving,
     previewVersion,
     selectBackgroundImage,


### PR DESCRIPTION
图标编辑器此前直接转发 Dialog 关闭状态，且会话未记录打开基线，导致修改后关闭绕过二次确认。为编辑会话增加基线 dirty 判定，并将关闭请求统一接入现有保存改动弹窗。

<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [x] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [x] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

- 为图标编辑会话记录打开或恢复完成时的状态快照，并基于当前状态与快照判断是否存在未保存修改。
- 将图标编辑器的关闭请求统一接入改动确认流程：未修改时直接关闭，存在修改时允许生成图标、放弃修改或取消关闭。
- 保持图标生成、游戏快照刷新和关闭顺序不变，不引入新的共享抽象或依赖。
- 补充关闭流程回归测试，覆盖未修改、修改后放弃、修改后生成以及恢复已有图标配置后未修改的场景。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

图标编辑器此前会直接响应 Dialog 的关闭事件。用户选择图片或调整图标配置后退出时，编辑器会立即关闭并丢失当前修改，没有提供二次确认。

本次更改为编辑会话建立明确的初始状态基线，并让所有界面关闭入口经过同一关闭决策，避免未保存修改被静默丢弃。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
