### PR TITLE
🐛 修复资源目录为空或缺失时文件选择器无法打开

### DIFF
--- a/src/components/file-picker/FilePicker.spec.ts
+++ b/src/components/file-picker/FilePicker.spec.ts
@@ -130,7 +130,18 @@ const globalStubs = {
       return () => h('div')
     },
   }),
-  Popover: createBrowserContainerStub('StubPopover'),
+  Popover: defineComponent({
+    name: 'StubPopover',
+    props: {
+      open: Boolean,
+    },
+    setup(props, { slots }) {
+      return () => h('div', {
+        'data-testid': 'file-picker-popover',
+        'data-open': String(props.open),
+      }, slots.default?.())
+    },
+  }),
   PopoverContent: createBrowserContainerStub('StubPopoverContent'),
   PopoverTrigger: createBrowserContainerStub('StubPopoverTrigger'),
 }
@@ -256,6 +267,52 @@ describe('FilePicker', () => {
 
     await expect.element(page.getByTestId('file-viewer-preview-context')).toHaveAttribute('data-preview-cwd', '/games/demo')
     await expect.element(page.getByTestId('file-viewer-preview-context')).toHaveAttribute('data-preview-base-url', 'http://127.0.0.1:8899/game/demo/')
+    expectNoConsoleMessage('decodeEntities option is passed but will be ignored in non-browser builds')
+    await result.unmount()
+  })
+
+  it('资源根目录不存在时点击输入框仍会打开选择器且不读取目录', async () => {
+    existsMock.mockResolvedValue(false)
+    const result = await renderInBrowser(FilePickerHarness, {
+      props: {
+        initialValue: '',
+      },
+      browser: {
+        pinia: true,
+      },
+      global: {
+        stubs: globalStubs,
+      },
+    })
+
+    await page.getByRole('textbox', { name: 'File Path' }).click()
+    await nextTick()
+
+    await expect.element(page.getByTestId('file-picker-popover')).toHaveAttribute('data-open', 'true')
+    expect(readDirectoryMock).not.toHaveBeenCalled()
+    expectNoConsoleMessage('decodeEntities option is passed but will be ignored in non-browser builds')
+    await result.unmount()
+  })
+
+  it('资源根目录不存在时通过键盘聚焦输入框仍会打开选择器', async () => {
+    existsMock.mockResolvedValue(false)
+    const result = await renderInBrowser(FilePickerHarness, {
+      props: {
+        initialValue: '',
+      },
+      browser: {
+        pinia: true,
+      },
+      global: {
+        stubs: globalStubs,
+      },
+    })
+
+    await userEvent.tab()
+    await nextTick()
+
+    await expect.element(page.getByRole('textbox', { name: 'File Path' })).toHaveFocus()
+    await expect.element(page.getByTestId('file-picker-popover')).toHaveAttribute('data-open', 'true')
     expectNoConsoleMessage('decodeEntities option is passed but will be ignored in non-browser builds')
     await result.unmount()
   })

--- a/src/features/file-picker/__tests__/useFilePickerController.test.ts
+++ b/src/features/file-picker/__tests__/useFilePickerController.test.ts
@@ -163,10 +163,20 @@ describe('useFilePickerController', () => {
     controller.handlePopoverOpenChange(false)
 
     rootExists = true
+    readDirectory.mockImplementation(async (path: AbsPath, request: { requestId: number }) => ({
+      absolutePath: path,
+      items: [{
+        isDir: false,
+        name: 'opening.png',
+        path: '/assets/opening.png',
+      }],
+      requestId: request.requestId,
+    }))
     await controller.openPopover()
 
     expect(controller.isOpen.value).toBe(true)
     expect(readDirectory).toHaveBeenCalledOnce()
+    expect(controller.filteredItems.value.map(item => item.name)).toEqual(['opening.png'])
 
     scope.stop()
   })
@@ -191,6 +201,7 @@ describe('useFilePickerController', () => {
     expect(controller.isOpen.value).toBe(true)
     expect(controller.filteredItems.value).toEqual([])
     expect(controller.errorMsg.value).toBe('')
+    expect(readDirectory).toHaveBeenCalledOnce()
 
     scope.stop()
   })

--- a/src/features/file-picker/__tests__/useFilePickerController.test.ts
+++ b/src/features/file-picker/__tests__/useFilePickerController.test.ts
@@ -23,6 +23,7 @@ vi.mock('@tauri-apps/plugin-fs', () => ({
 
 interface ControllerFixtureOptions {
   commitInputOnBlur?: boolean
+  extensions?: string[]
   modelValue?: string
   reopenInSelectedParent?: boolean
   rootPath?: string
@@ -59,7 +60,7 @@ function createFixture(options: ControllerFixtureOptions = {}) {
     commitInputOnBlur: () => options.commitInputOnBlur ?? true,
     ensurePathWithinRoot,
     exclude: () => [],
-    extensions: () => [],
+    extensions: () => options.extensions ?? [],
     isRecentHistoryInvalid: () => false,
     modelValue: () => modelValue.value,
     readDirectory,
@@ -101,6 +102,110 @@ describe('useFilePickerController', () => {
   afterEach(() => {
     vi.useRealTimers()
     vi.clearAllMocks()
+  })
+
+  it('根目录为空时仍会打开并显示空列表', async () => {
+    const { controller, readDirectory, scope } = createFixture()
+
+    await flushControllerTasks()
+    await controller.openPopover()
+
+    expect(controller.isOpen.value).toBe(true)
+    expect(controller.filteredItems.value).toEqual([])
+    expect(controller.errorMsg.value).toBe('')
+    expect(readDirectory).toHaveBeenCalledOnce()
+
+    scope.stop()
+  })
+
+  it('根目录不存在时仍会打开为空列表且不读取目录', async () => {
+    existsMock.mockResolvedValue(false)
+    const { controller, readDirectory, scope } = createFixture()
+
+    await flushControllerTasks()
+    await controller.openPopover()
+
+    expect(controller.isOpen.value).toBe(true)
+    expect(controller.filteredItems.value).toEqual([])
+    expect(controller.errorMsg.value).toBe('')
+    expect(readDirectory).not.toHaveBeenCalled()
+
+    scope.stop()
+  })
+
+  it('根目录不存在时仍允许输入子路径并保持空状态', async () => {
+    existsMock.mockResolvedValue(false)
+    const { controller, readDirectory, scope } = createFixture()
+
+    await flushControllerTasks()
+    await controller.openPopover()
+    await nextTick()
+
+    controller.inputText.value = 'images/'
+    await vi.advanceTimersByTimeAsync(300)
+    await flushControllerTasks()
+
+    expect(controller.currentDir.value).toBe('images')
+    expect(controller.filteredItems.value).toEqual([])
+    expect(controller.errorMsg.value).toBe('')
+    expect(readDirectory).not.toHaveBeenCalled()
+
+    scope.stop()
+  })
+
+  it('缺失的根目录随后创建后会在重新打开时读取内容', async () => {
+    let rootExists = false
+    existsMock.mockImplementation(async () => rootExists)
+    const { controller, readDirectory, scope } = createFixture()
+
+    await flushControllerTasks()
+    await controller.openPopover()
+    controller.handlePopoverOpenChange(false)
+
+    rootExists = true
+    await controller.openPopover()
+
+    expect(controller.isOpen.value).toBe(true)
+    expect(readDirectory).toHaveBeenCalledOnce()
+
+    scope.stop()
+  })
+
+  it('根目录只有不支持的文件时仍会打开为空列表', async () => {
+    const { controller, readDirectory, scope } = createFixture({
+      extensions: ['.png'],
+    })
+    readDirectory.mockImplementation(async (path: AbsPath, request: { requestId: number }) => ({
+      absolutePath: path,
+      items: [{
+        isDir: false,
+        name: 'notes.txt',
+        path: '/assets/notes.txt',
+      }],
+      requestId: request.requestId,
+    }))
+
+    await flushControllerTasks()
+    await controller.openPopover()
+
+    expect(controller.isOpen.value).toBe(true)
+    expect(controller.filteredItems.value).toEqual([])
+    expect(controller.errorMsg.value).toBe('')
+
+    scope.stop()
+  })
+
+  it('根路径不是目录时不会打开或尝试读取', async () => {
+    statMock.mockResolvedValue({ isDirectory: false })
+    const { controller, readDirectory, scope } = createFixture()
+
+    await flushControllerTasks()
+    await controller.openPopover()
+
+    expect(controller.isOpen.value).toBe(false)
+    expect(readDirectory).not.toHaveBeenCalled()
+
+    scope.stop()
   })
 
   it('reopenInSelectedParent 打开时会回到当前选中文件的父目录', async () => {
@@ -167,6 +272,20 @@ describe('useFilePickerController', () => {
 
     expect(controller.currentDir.value).toBe('images/bg')
     expect(controller.errorMsg.value).toBe('目录不存在')
+    expect(controller.isLoading.value).toBe(false)
+
+    scope.stop()
+  })
+
+  it('目录读取失败时仍会打开并显示现有错误状态', async () => {
+    const { controller, readDirectory, scope } = createFixture()
+    readDirectory.mockRejectedValue(new AppError('IO_ERROR', '没有目录读取权限'))
+
+    await flushControllerTasks()
+    await controller.openPopover()
+
+    expect(controller.isOpen.value).toBe(true)
+    expect(controller.errorMsg.value).toBe('没有目录读取权限')
     expect(controller.isLoading.value).toBe(false)
 
     scope.stop()

--- a/src/features/file-picker/useFilePickerController.ts
+++ b/src/features/file-picker/useFilePickerController.ts
@@ -68,7 +68,6 @@ export function useFilePickerController(options: UseFilePickerControllerOptions)
   const isLoading = ref(false)
   const errorMsg = ref('')
   const isRootReady = ref(false)
-  const isRootMissing = ref(false)
   const isInputFocused = ref(false)
   const isPopoverFocused = ref(false)
   const suppressBlurCommit = ref(false)
@@ -76,6 +75,7 @@ export function useFilePickerController(options: UseFilePickerControllerOptions)
   let latestReadId = 0
   let latestRootId = 0
   let latestInputSyncId = 0
+  let isRootMissing = false
 
   const canOpen = computed(() => !options.disabled() && isRootReady.value && !!canonicalRootPath.value)
   const filteredItems = computed(() => {
@@ -215,7 +215,6 @@ export function useFilePickerController(options: UseFilePickerControllerOptions)
   async function checkRoot() {
     const requestId = ++latestRootId
     isRootReady.value = false
-    isRootMissing.value = false
     canonicalRootPath.value = ''
 
     try {
@@ -227,7 +226,7 @@ export function useFilePickerController(options: UseFilePickerControllerOptions)
         // 防止旧根目录的在途读取在缺失状态建立后回写过期内容。
         latestReadId += 1
         canonicalRootPath.value = normalizedRoot
-        isRootMissing.value = true
+        isRootMissing = true
         isRootReady.value = true
         setEmptyDirectoryState('', '')
         options.syncRecentHistory()
@@ -237,6 +236,7 @@ export function useFilePickerController(options: UseFilePickerControllerOptions)
       if (requestId !== latestRootId) {
         return
       }
+      isRootMissing = false
       if (!info.isDirectory) {
         isOpen.value = false
         return
@@ -260,7 +260,7 @@ export function useFilePickerController(options: UseFilePickerControllerOptions)
       return
     }
     const normalizedDir = RelPath.from(relativeDir)
-    if (isRootMissing.value) {
+    if (isRootMissing) {
       setEmptyDirectoryState(normalizedDir, keyword)
       return
     }
@@ -285,7 +285,7 @@ export function useFilePickerController(options: UseFilePickerControllerOptions)
         return
       }
       if (error instanceof AppError && error.code === 'DIR_NOT_FOUND' && !normalizedDir) {
-        isRootMissing.value = true
+        isRootMissing = true
         setEmptyDirectoryState('', keyword)
         return
       }
@@ -357,7 +357,7 @@ export function useFilePickerController(options: UseFilePickerControllerOptions)
   }
 
   async function openPopover(openOptions: OpenPopoverOptions = {}) {
-    if (!options.disabled() && (!isRootReady.value || isRootMissing.value)) {
+    if (!options.disabled() && (!isRootReady.value || isRootMissing)) {
       await checkRoot()
     }
     if (!canOpen.value) {

--- a/src/features/file-picker/useFilePickerController.ts
+++ b/src/features/file-picker/useFilePickerController.ts
@@ -68,6 +68,7 @@ export function useFilePickerController(options: UseFilePickerControllerOptions)
   const isLoading = ref(false)
   const errorMsg = ref('')
   const isRootReady = ref(false)
+  const isRootMissing = ref(false)
   const isInputFocused = ref(false)
   const isPopoverFocused = ref(false)
   const suppressBlurCommit = ref(false)
@@ -186,6 +187,14 @@ export function useFilePickerController(options: UseFilePickerControllerOptions)
     return !!ext && extensionSet.value.has(ext)
   }
 
+  function setEmptyDirectoryState(relativeDir: string, keyword: string) {
+    items.value = []
+    currentDir.value = RelPath.from(relativeDir)
+    filterKeyword.value = keyword.trim()
+    errorMsg.value = ''
+    isLoading.value = false
+  }
+
   function toRelativeFromAbsolute(path: string): string {
     // `checkRoot()` 保存的是经过 Tauri 规范化的绝对根路径，调用方传入的路径
     // 也来自同一套 Tauri 路径 API。这里保持精确比较，避免在大小写敏感文件系统上
@@ -206,20 +215,30 @@ export function useFilePickerController(options: UseFilePickerControllerOptions)
   async function checkRoot() {
     const requestId = ++latestRootId
     isRootReady.value = false
+    isRootMissing.value = false
     canonicalRootPath.value = ''
 
     try {
       const normalizedRoot = AbsPath.from(options.rootPath())
       if (!(await exists(normalizedRoot))) {
-        isOpen.value = false
+        if (requestId !== latestRootId) {
+          return
+        }
+        // 防止旧根目录的在途读取在缺失状态建立后回写过期内容。
+        latestReadId += 1
+        canonicalRootPath.value = normalizedRoot
+        isRootMissing.value = true
+        isRootReady.value = true
+        setEmptyDirectoryState('', '')
+        options.syncRecentHistory()
         return
       }
       const info = await stat(normalizedRoot)
-      if (!info.isDirectory) {
-        isOpen.value = false
+      if (requestId !== latestRootId) {
         return
       }
-      if (requestId !== latestRootId) {
+      if (!info.isDirectory) {
+        isOpen.value = false
         return
       }
       isRootReady.value = true
@@ -241,6 +260,10 @@ export function useFilePickerController(options: UseFilePickerControllerOptions)
       return
     }
     const normalizedDir = RelPath.from(relativeDir)
+    if (isRootMissing.value) {
+      setEmptyDirectoryState(normalizedDir, keyword)
+      return
+    }
     const requestId = ++latestReadId
     isLoading.value = true
     errorMsg.value = ''
@@ -259,6 +282,11 @@ export function useFilePickerController(options: UseFilePickerControllerOptions)
       filterKeyword.value = keyword.trim()
     } catch (error) {
       if (requestId !== latestReadId) {
+        return
+      }
+      if (error instanceof AppError && error.code === 'DIR_NOT_FOUND' && !normalizedDir) {
+        isRootMissing.value = true
+        setEmptyDirectoryState('', keyword)
         return
       }
       if (error instanceof AppError && error.code === 'DIR_NOT_FOUND') {
@@ -329,6 +357,9 @@ export function useFilePickerController(options: UseFilePickerControllerOptions)
   }
 
   async function openPopover(openOptions: OpenPopoverOptions = {}) {
+    if (!options.disabled() && (!isRootReady.value || isRootMissing.value)) {
+      await checkRoot()
+    }
     if (!canOpen.value) {
       return
     }


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [x] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [x] 代码重构
- [x] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

- 将不存在的资源根目录视为可展示的空状态，使文件选择器仍可通过输入框点击、焦点和键盘操作打开。
- 保留规范化后的根路径，不隐式创建目录，并允许用户继续输入和浏览相对路径。
- 在重新打开选择器时重新检查缺失的根目录，使目录随后创建后可以正常读取内容。
- 继续沿用现有错误边界：根路径不是目录时不打开，子目录不存在、无权限或其他读取失败时显示错误状态。
- 补充 controller 与 Chromium 组件回归测试，覆盖空目录、缺失目录、不支持文件、路径输入、鼠标点击、键盘聚焦和读取错误。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

可视化编辑器引用的资源目录可能尚未创建，或当前没有可展示的资源。此前根目录不存在时会被判断为不可用，导致用户触发文件选择器后没有任何可见反馈，也无法继续输入目标路径。

此更改将“目录缺失但可以继续操作”与“路径无效或读取失败”明确区分，使空状态、加载状态和错误状态保持一致且可预测。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
