### PR TITLE
✨ 关于弹窗支持复制并预填反馈环境信息

### DIFF
--- a/src/components/modals/AboutModal.spec.ts
+++ b/src/components/modals/AboutModal.spec.ts
@@ -1,0 +1,201 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { page, userEvent } from 'vitest/browser'
+import { defineComponent, h } from 'vue'
+
+import {
+  createBrowserClickStub,
+  createBrowserContainerStub,
+  renderInBrowser,
+} from '~/__tests__/browser-render'
+import {
+  createBugReportUrl,
+  formatAboutEnvironmentInfo,
+} from '~/features/about/feedback'
+
+import AboutModal from './AboutModal.vue'
+
+import type { AboutEnvironmentInfo } from '~/features/about/feedback'
+
+const { openUrlMock, repositoryUrl } = vi.hoisted(() => ({
+  openUrlMock: vi.fn(),
+  repositoryUrl: 'https://github.com/A-kirami/webgal-craft',
+}))
+
+const environmentInfo: AboutEnvironmentInfo = {
+  appVersion: '1.0.0-alpha.4-build.abc 123',
+  architecture: 'aarch64',
+  osVersion: '15.5 & newer',
+  platform: 'macos',
+}
+const environmentInfoText = formatAboutEnvironmentInfo(environmentInfo)
+
+vi.mock('@tauri-apps/plugin-opener', () => ({
+  openUrl: openUrlMock,
+}))
+
+vi.mock('@tauri-apps/plugin-os', () => ({
+  arch: () => 'aarch64',
+  platform: () => 'macos',
+  version: () => '15.5 & newer',
+}))
+
+vi.mock('~/features/app-update/useAppUpdateController', () => ({
+  useAppUpdateController: () => ({
+    checkForUpdate: vi.fn(),
+    openReleasePage: vi.fn(),
+  }),
+}))
+
+vi.mock('~/utils/metadata', () => ({
+  getVersion: () => ({
+    name: '1.0.0-alpha.4-build.abc 123',
+  }),
+}))
+
+vi.mock('~build/git', () => ({
+  github: repositoryUrl,
+}))
+
+const DialogStub = defineComponent({
+  props: {
+    open: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  setup(props, { slots }) {
+    return () => props.open ? h('div', slots.default?.()) : undefined
+  },
+})
+
+const DialogContentStub = defineComponent({
+  setup(_, { attrs, slots }) {
+    return () => h('section', {
+      ...attrs,
+      'aria-label': 'About WebGAL Craft',
+      'role': 'dialog',
+      'tabindex': -1,
+    }, slots.default?.())
+  },
+})
+
+const globalStubs = {
+  Button: createBrowserClickStub('StubButton'),
+  Dialog: DialogStub,
+  DialogContent: DialogContentStub,
+  DialogDescription: createBrowserContainerStub('StubDialogDescription', 'p'),
+  DialogFooter: createBrowserContainerStub('StubDialogFooter'),
+  DialogTitle: createBrowserContainerStub('StubDialogTitle', 'h2'),
+  Separator: createBrowserContainerStub('StubSeparator', 'hr'),
+}
+
+function renderAboutModal(open: boolean = true) {
+  return renderInBrowser(AboutModal, {
+    props: {
+      open,
+    },
+    browser: {
+      i18nMode: 'lite',
+    },
+    global: {
+      stubs: globalStubs,
+    },
+  })
+}
+
+function createCopyEvent(): { clipboardData: DataTransfer, event: ClipboardEvent } {
+  const clipboardData = new DataTransfer()
+  const event = new ClipboardEvent('copy', {
+    bubbles: true,
+    cancelable: true,
+    clipboardData,
+  })
+
+  return { clipboardData, event }
+}
+
+describe('AboutModal', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+    openUrlMock.mockReset()
+    globalThis.getSelection()?.removeAllRanges()
+  })
+
+  it('弹窗内没有可复制内容时通过复制快捷键写入稳定的版本和环境信息', async () => {
+    renderAboutModal()
+    const dialog = document.querySelector<HTMLElement>('[role="dialog"]')
+    let copyEvent: ClipboardEvent | undefined
+
+    expect(dialog).not.toBeNull()
+    dialog!.addEventListener('copy', (event) => {
+      copyEvent = event
+    })
+    dialog!.focus()
+    await userEvent.copy()
+
+    expect(copyEvent).toBeDefined()
+    expect(copyEvent!.defaultPrevented).toBe(true)
+
+    // Browser Mode 无法读取 userEvent.copy() 触发的受信任事件数据。
+    const copiedData = createCopyEvent()
+    dialog!.dispatchEvent(copiedData.event)
+
+    expect(copiedData.clipboardData.getData('text/plain')).toBe(environmentInfoText)
+  })
+
+  it('弹窗外或弹窗关闭时不接管复制', async () => {
+    const { unmount } = renderAboutModal()
+    const outsideCopy = createCopyEvent()
+
+    document.body.dispatchEvent(outsideCopy.event)
+
+    expect(outsideCopy.event.defaultPrevented).toBe(false)
+    expect(outsideCopy.clipboardData.getData('text/plain')).toBe('')
+
+    await unmount()
+    renderAboutModal(false)
+    const closedCopy = createCopyEvent()
+
+    document.body.dispatchEvent(closedCopy.event)
+
+    expect(document.querySelector('[role="dialog"]')).toBeNull()
+    expect(closedCopy.event.defaultPrevented).toBe(false)
+  })
+
+  it('保留文本选择和可编辑内容的原生复制行为', () => {
+    renderAboutModal()
+    const dialog = document.querySelector<HTMLElement>('[role="dialog"]')!
+    const versionText = [...dialog.querySelectorAll('span')]
+      .find(element => element.textContent === '1.0.0-alpha.4-build.abc 123')!
+    const range = document.createRange()
+    range.selectNodeContents(versionText)
+    globalThis.getSelection()!.addRange(range)
+    const selectionCopy = createCopyEvent()
+
+    versionText.dispatchEvent(selectionCopy.event)
+
+    expect(selectionCopy.event.defaultPrevented).toBe(false)
+    expect(selectionCopy.clipboardData.getData('text/plain')).toBe('')
+
+    globalThis.getSelection()!.removeAllRanges()
+    const input = document.createElement('input')
+    input.value = 'copy me'
+    dialog.append(input)
+    input.select()
+    const inputCopy = createCopyEvent()
+
+    input.dispatchEvent(inputCopy.event)
+
+    expect(inputCopy.event.defaultPrevented).toBe(false)
+    expect(inputCopy.clipboardData.getData('text/plain')).toBe('')
+  })
+
+  it('问题反馈打开错误报告模板并预填对应字段', async () => {
+    renderAboutModal()
+
+    await page.getByRole('button', { name: 'modals.about.issues' }).click()
+
+    expect(openUrlMock).toHaveBeenCalledTimes(1)
+    expect(openUrlMock).toHaveBeenCalledWith(createBugReportUrl(repositoryUrl, environmentInfo))
+  })
+})

--- a/src/components/modals/AboutModal.vue
+++ b/src/components/modals/AboutModal.vue
@@ -10,6 +10,11 @@ import {
 } from '@lucide/vue'
 import { openUrl } from '@tauri-apps/plugin-opener'
 
+import {
+  collectAboutEnvironmentInfo,
+  createBugReportUrl,
+  formatAboutEnvironmentInfo,
+} from '~/features/about/feedback'
 import { useAppUpdateController } from '~/features/app-update/useAppUpdateController'
 import { getVersion } from '~/utils/metadata'
 
@@ -19,6 +24,10 @@ const open = defineModel<boolean>('open')
 
 const version = getVersion()
 const appUpdateController = useAppUpdateController()
+const environmentInfo = collectAboutEnvironmentInfo(version.name)
+const environmentInfoText = formatAboutEnvironmentInfo(environmentInfo)
+const repositoryUrl = github || 'https://github.com/A-kirami/webgal-craft'
+const bugReportUrl = createBugReportUrl(repositoryUrl, environmentInfo)
 
 function handleVersionClick() {
   if (version.link) {
@@ -33,11 +42,34 @@ function handleCheckForUpdate(): void {
 function handleOpenReleaseList(): void {
   void appUpdateController.openReleasePage()
 }
+
+function isEditableCopyTarget(target: EventTarget | null): boolean {
+  return target instanceof Element
+    && target.closest('input, textarea, [contenteditable]:not([contenteditable="false"])') !== null
+}
+
+function handleCopy(event: ClipboardEvent): void {
+  if (
+    event.defaultPrevented
+    || isEditableCopyTarget(event.target)
+    || globalThis.getSelection()?.isCollapsed === false
+    || !event.clipboardData
+  ) {
+    return
+  }
+
+  event.clipboardData.setData('text/plain', environmentInfoText)
+  event.preventDefault()
+}
+
+function handleOpenBugReport(): void {
+  void openUrl(bugReportUrl)
+}
 </script>
 
 <template>
   <Dialog ::open="open">
-    <DialogContent class="sm:max-w-[480px]">
+    <DialogContent class="sm:max-w-[480px]" @copy="handleCopy">
       <div class="mt-4 flex flex-col gap-4 items-center">
         <img src="/webgal-craft-logo.svg" alt="WebGAL Craft Logo" class="size-20">
         <div class="text-center space-y-2">
@@ -105,7 +137,7 @@ function handleOpenReleaseList(): void {
 
         <button
           class="group text-muted-foreground rounded flex gap-1.5 transition-colors items-center hover:text-foreground"
-          @click="github && openUrl(github + '/issues')"
+          @click="handleOpenBugReport"
         >
           <Bug class="size-3.5" />
           <span class="text-xs">{{ $t('modals.about.issues') }}</span>

--- a/src/features/about/__tests__/feedback.test.ts
+++ b/src/features/about/__tests__/feedback.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  createBugReportUrl,
+  formatAboutEnvironmentInfo,
+} from '../feedback'
+
+import type { AboutEnvironmentInfo } from '../feedback'
+
+const environmentInfo: AboutEnvironmentInfo = {
+  appVersion: '1.0.0-alpha.4-build.abc 123',
+  architecture: 'aarch64',
+  osVersion: '15.5 & newer',
+  platform: 'macos',
+}
+
+describe('formatAboutEnvironmentInfo', () => {
+  it('只生成固定三行版本和系统信息', () => {
+    expect(formatAboutEnvironmentInfo(environmentInfo)).toBe([
+      'WebGAL Craft: 1.0.0-alpha.4-build.abc 123',
+      'Operating system: macos 15.5 & newer',
+      'Architecture: aarch64',
+    ].join('\n'))
+  })
+})
+
+describe('createBugReportUrl', () => {
+  it('选择错误报告模板并分别预填版本和运行环境', () => {
+    const url = new URL(createBugReportUrl('https://github.com/A-kirami/webgal-craft', environmentInfo))
+
+    expect(url.origin + url.pathname).toBe('https://github.com/A-kirami/webgal-craft/issues/new')
+    expect(url.searchParams.get('template')).toBe('bug_report.yml')
+    expect(url.searchParams.get('version')).toBe(environmentInfo.appVersion)
+    expect(url.searchParams.get('context')).toBe([
+      'Operating system: macos 15.5 & newer',
+      'Architecture: aarch64',
+    ].join('\n'))
+    expect(url.searchParams.get('context')).not.toContain(environmentInfo.appVersion)
+  })
+})

--- a/src/features/about/feedback.ts
+++ b/src/features/about/feedback.ts
@@ -1,0 +1,41 @@
+import { arch, platform, version as getOsVersion } from '@tauri-apps/plugin-os'
+
+import type { Arch, Platform } from '@tauri-apps/plugin-os'
+
+export interface AboutEnvironmentInfo {
+  appVersion: string
+  architecture: Arch
+  osVersion: string
+  platform: Platform
+}
+
+export function collectAboutEnvironmentInfo(appVersion: string): AboutEnvironmentInfo {
+  return {
+    appVersion,
+    architecture: arch(),
+    osVersion: getOsVersion(),
+    platform: platform(),
+  }
+}
+
+function formatRuntimeEnvironmentInfo(info: AboutEnvironmentInfo): string {
+  return [
+    `Operating system: ${info.platform} ${info.osVersion}`,
+    `Architecture: ${info.architecture}`,
+  ].join('\n')
+}
+
+export function formatAboutEnvironmentInfo(info: AboutEnvironmentInfo): string {
+  return [
+    `WebGAL Craft: ${info.appVersion}`,
+    formatRuntimeEnvironmentInfo(info),
+  ].join('\n')
+}
+
+export function createBugReportUrl(repositoryUrl: string, info: AboutEnvironmentInfo): string {
+  const url = new URL(`${repositoryUrl}/issues/new`)
+  url.searchParams.set('template', 'bug_report.yml')
+  url.searchParams.set('version', info.appVersion)
+  url.searchParams.set('context', formatRuntimeEnvironmentInfo(info))
+  return url.toString()
+}


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [ ] 错误修复
- [x] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [x] 代码重构
- [x] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

- 在“关于”弹窗处于活动状态且没有现有可复制内容时，通过系统复制快捷键写入应用版本、平台、系统版本和架构信息。
- 将复制处理限制在弹窗内容区域，弹窗关闭、焦点位于其他区域、存在文本选择或可编辑内容时保留原生复制行为。
- 抽取关于弹窗专属的环境信息采集、稳定文本格式和错误报告 URL 构造能力，复制与问题反馈入口复用同一份信息。
- “问题反馈”入口直接打开 GitHub 错误报告模板，通过正确编码的 `version` 参数预填应用版本，并在 `context` 参数中仅填写操作系统及架构，避免重复版本信息。
- 环境信息仅包含故障排查所需的应用与系统元数据，不包含用户路径、项目内容、主机名或其他敏感信息。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

用户反馈问题时需要手动查找版本并补充运行环境，信息格式容易缺失或不一致。此次更改在不增加额外采集范围的前提下，为复制反馈信息和创建错误报告提供一致入口，降低用户填写成本，并提高问题信息的可读性和可诊断性。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
