### PR TITLE
🐛 修复资源根目录缺失时仍可打开文件夹

### DIFF
--- a/src/components/editor/AssetView.spec.ts
+++ b/src/components/editor/AssetView.spec.ts
@@ -19,6 +19,7 @@ const {
   copyFileMock,
   createFileMock,
   createFolderMock,
+  existsMock,
   fileSystemEventHandlers,
   fileSystemEventsOnMock,
   fileViewerScrollToIndexMock,
@@ -34,6 +35,7 @@ const {
   copyFileMock: vi.fn(),
   createFileMock: vi.fn(),
   createFolderMock: vi.fn(),
+  existsMock: vi.fn(),
   fileSystemEventHandlers: new Map<string, ((event: Record<string, unknown>) => void)[]>(),
   fileSystemEventsOnMock: vi.fn(),
   fileViewerScrollToIndexMock: vi.fn(),
@@ -45,6 +47,11 @@ const {
   usePreviewSessionStoreMock: vi.fn(),
   useTabsStoreMock: vi.fn(),
   useWorkspaceStoreMock: vi.fn(),
+}))
+
+vi.mock('@tauri-apps/plugin-fs', async importOriginal => ({
+  ...await importOriginal<typeof import('@tauri-apps/plugin-fs')>(),
+  exists: existsMock,
 }))
 
 function emitFileSystemEvent(type: string, event: Record<string, unknown>): void {
@@ -80,6 +87,10 @@ vi.mock('~/components/editor/FileTreeContextMenuContent.vue', async () => {
           type: Function,
           default: undefined,
         },
+        revealInExplorerDisabled: {
+          type: Boolean,
+          default: false,
+        },
       },
       setup(props) {
         return () => h('div', {
@@ -87,6 +98,7 @@ vi.mock('~/components/editor/FileTreeContextMenuContent.vue', async () => {
           'data-item-name': (props.item as FileViewerItem).name,
           'data-item-path': (props.item as FileViewerItem).path,
           'data-is-root': String(props.isRoot),
+          'data-reveal-in-explorer-disabled': String(props.revealInExplorerDisabled),
         }, [
           h('button', {
             'type': 'button',
@@ -579,6 +591,7 @@ describe('AssetView', () => {
     copyFileMock.mockReset()
     createFileMock.mockReset()
     createFolderMock.mockReset()
+    existsMock.mockReset()
     fileViewerScrollToIndexMock.mockReset()
     getFolderContentsMock.mockReset()
     handleErrorMock.mockReset()
@@ -590,6 +603,7 @@ describe('AssetView', () => {
     useWorkspaceStoreMock.mockReset()
 
     getFolderContentsMock.mockResolvedValue([])
+    existsMock.mockResolvedValue(true)
     copyFileMock.mockResolvedValue('/project/game/background/folder/hero.png')
     createFileMock.mockResolvedValue('/project/game/background/新建文件.json')
     createFolderMock.mockResolvedValue('/project/game/background/新建文件夹')
@@ -1192,6 +1206,25 @@ describe('AssetView', () => {
     await expect.element(page.getByTestId('file-tree-context-menu-root')).toHaveAttribute('data-item-path', '/games/demo/game/background')
     await expect.element(page.getByTestId('file-tree-context-menu-root')).toHaveAttribute('data-item-name', 'background')
     await expect.element(page.getByTestId('file-tree-context-menu-root')).toHaveAttribute('data-is-root', 'true')
+  })
+
+  it('资源根目录不存在时会禁用根目录菜单的打开文件夹操作', async () => {
+    existsMock.mockResolvedValue(false)
+
+    renderInBrowser(createHarness('background'), {
+      global: {
+        stubs: {
+          ...commonGlobalStubs,
+          FileViewer: createContextMenuFileViewerStub(),
+        },
+      },
+    })
+
+    await vi.waitFor(() => {
+      expect(getFolderContentsMock).toHaveBeenCalledOnce()
+    })
+    expect(existsMock).toHaveBeenCalledWith('/games/demo/game/background')
+    await expect.element(page.getByTestId('file-tree-context-menu-root')).toHaveAttribute('data-reveal-in-explorer-disabled', 'true')
   })
 
   it('会把 FileViewer 的 move drop 交给 pathOperation 执行', async () => {

--- a/src/components/editor/AssetView.vue
+++ b/src/components/editor/AssetView.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { File, FileImage, FileJson2, FileMusic, FileVideo, FileVolume, Folder } from '@lucide/vue'
+import { exists } from '@tauri-apps/plugin-fs'
 
 import { canCreateAssetFile, resolveAssetFileNameParts } from '~/components/editor/asset-file-defaults'
 import { useAssetViewItemsLoader } from '~/components/editor/useAssetViewItemsLoader'
@@ -164,12 +165,13 @@ const currentDirectoryPath = $computed(() => {
 const {
   errorMsg: errorMsgRef,
   isLoading: isLoadingRef,
+  isRootDirectoryMissing: isRootDirectoryMissingRef,
   items: itemsRef,
   scheduleItemsRefresh,
 } = useAssetViewItemsLoader({
-  assetBasePath: () => assetBasePath,
   currentDirectoryPath: () => currentDirectoryPath,
   currentPath: () => currentPath,
+  rootDirectoryExists: directoryPath => exists(AbsPath.from(directoryPath)),
   loadDirectory: async (directoryPath) => {
     await fileStore.initialized
     return fileStore.getFolderContents(AbsPath.from(directoryPath))
@@ -180,6 +182,7 @@ const {
 const items = $computed(() => itemsRef.value)
 const isLoading = $computed(() => isLoadingRef.value)
 const errorMsg = $computed(() => errorMsgRef.value)
+const isRootDirectoryMissing = $computed(() => isRootDirectoryMissingRef.value)
 
 const filteredItems = $computed(() => {
   const keyword = searchQuery.trim().toLocaleLowerCase()
@@ -793,6 +796,7 @@ for (const eventType of FILE_SYSTEM_REFRESH_EVENT_TYPES) {
           is-root
           :on-create-file="canCreateFileInCurrentDirectory ? handleContextMenuCreateFile : undefined"
           :on-create-folder="handleContextMenuCreateFolder"
+          :reveal-in-explorer-disabled="isRootDirectoryMissing"
         />
       </template>
     </FileViewer>

--- a/src/components/editor/FileTreeContextMenuContent.spec.ts
+++ b/src/components/editor/FileTreeContextMenuContent.spec.ts
@@ -135,4 +135,24 @@ describe('FileTreeContextMenuContent', () => {
     expect(toastMock.success).not.toHaveBeenCalled()
     expect(toastMock.error).not.toHaveBeenCalled()
   })
+
+  it('根目录打开文件夹操作可按目录状态禁用', async () => {
+    renderInBrowser(FileTreeContextMenuContent, {
+      props: {
+        isRoot: true,
+        item: {
+          isDir: true,
+          name: 'background',
+          path: '/project/game/background',
+        },
+        revealInExplorerDisabled: true,
+      },
+      global: {
+        stubs: globalStubs,
+      },
+    })
+
+    const openFolderItem = page.getByText('edit.fileTree.revealInExplorer')
+    await expect.element(openFolderItem).toBeDisabled()
+  })
 })

--- a/src/components/editor/FileTreeContextMenuContent.vue
+++ b/src/components/editor/FileTreeContextMenuContent.vue
@@ -41,6 +41,7 @@ interface Props {
   onCreateFolder?: (item: FileItem) => void
   clipboardKey?: string
   isRoot?: boolean
+  revealInExplorerDisabled?: boolean
 }
 
 const {
@@ -50,6 +51,7 @@ const {
   onCreateFolder,
   clipboardKey = 'default',
   isRoot = false,
+  revealInExplorerDisabled = false,
 } = defineProps<Props>()
 
 const { clipboard, operationType, canPaste, setClipboard, clearClipboard } = $(useFileClipboard(clipboardKey))
@@ -238,7 +240,12 @@ const menuItems = $computed(() => {
 
   if (item.source !== 'engineLower' && item.source !== 'templateLower') {
     pushSeparator(items)
-    items.push({ icon: FolderOpen, label: t('edit.fileTree.revealInExplorer'), onClick: handleRevealInExplorer })
+    items.push({
+      icon: FolderOpen,
+      label: t('edit.fileTree.revealInExplorer'),
+      onClick: handleRevealInExplorer,
+      disabled: revealInExplorerDisabled,
+    })
   }
 
   return items

--- a/src/components/editor/__tests__/useAssetViewItemsLoader.test.ts
+++ b/src/components/editor/__tests__/useAssetViewItemsLoader.test.ts
@@ -60,15 +60,14 @@ describe('useAssetViewItemsLoader', () => {
     })
     const loadDirectory = vi.fn().mockReturnValue(firstLoad)
 
-    const assetBasePath = ref('/games/demo/assets/bg')
     const currentDirectoryPath = ref('/games/demo/assets/bg')
     const currentPath = ref('')
 
     scope = effectScope()
     const loader = scope.run(() => useAssetViewItemsLoader({
-      assetBasePath,
       currentDirectoryPath,
       currentPath,
+      rootDirectoryExists: vi.fn().mockResolvedValue(true),
       loadDirectory,
       mapItem: toFileViewerItem,
     }))
@@ -103,15 +102,14 @@ describe('useAssetViewItemsLoader', () => {
       .mockResolvedValueOnce([])
       .mockImplementationOnce(() => new Promise<FileSystemItem[]>(() => undefined))
 
-    const assetBasePath = ref('/games/demo/assets/bg')
     const currentDirectoryPath = ref('/games/demo/assets/bg')
     const currentPath = ref('')
 
     scope = effectScope()
     const loader = scope.run(() => useAssetViewItemsLoader({
-      assetBasePath,
       currentDirectoryPath,
       currentPath,
+      rootDirectoryExists: vi.fn().mockResolvedValue(true),
       loadDirectory,
       mapItem: toFileViewerItem,
     }))
@@ -132,5 +130,35 @@ describe('useAssetViewItemsLoader', () => {
     expect(loadDirectory).toHaveBeenCalledTimes(2)
     expect(loadDirectory).toHaveBeenLastCalledWith('/games/demo/assets/bg/chapter-1')
     expect(loader?.isLoading.value).toBe(true)
+  })
+
+  it('根目录不存在时会保留缺失状态，并在物理目录恢复后清除', async () => {
+    const rootDirectoryExists = vi.fn()
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true)
+    const loadDirectory = vi.fn().mockResolvedValue([])
+    const currentDirectoryPath = ref('/games/demo/assets/bg')
+    const currentPath = ref('')
+
+    scope = effectScope()
+    const loader = scope.run(() => useAssetViewItemsLoader({
+      currentDirectoryPath,
+      currentPath,
+      rootDirectoryExists,
+      loadDirectory,
+      mapItem: toFileViewerItem,
+    }))
+
+    await flushLoaderWatchers()
+    await flushLoaderWatchers()
+
+    expect(loader?.isRootDirectoryMissing.value).toBe(true)
+    expect(loader?.errorMsg.value).toBe('')
+
+    loader?.scheduleItemsRefresh(false)
+    await flushLoaderWatchers()
+    await flushLoaderWatchers()
+
+    expect(loader?.isRootDirectoryMissing.value).toBe(false)
   })
 })

--- a/src/components/editor/useAssetViewItemsLoader.ts
+++ b/src/components/editor/useAssetViewItemsLoader.ts
@@ -7,9 +7,9 @@ import type { MaybeRefOrGetter } from 'vue'
 import type { FileViewerItem } from '~/types/file-viewer'
 
 interface UseAssetViewItemsLoaderOptions<TItem> {
-  assetBasePath: MaybeRefOrGetter<string>
   currentDirectoryPath: MaybeRefOrGetter<string>
   currentPath: MaybeRefOrGetter<string>
+  rootDirectoryExists: (directoryPath: string) => Promise<boolean>
   loadDirectory: (directoryPath: string) => Promise<TItem[]>
   mapItem: (item: TItem) => FileViewerItem
 }
@@ -18,6 +18,7 @@ export function useAssetViewItemsLoader<TItem>(options: UseAssetViewItemsLoaderO
   const items = ref<FileViewerItem[]>([])
   const isLoading = ref(false)
   const errorMsg = ref('')
+  const isRootDirectoryMissing = ref(false)
   const itemsRefreshKey = ref(0)
   const nextItemsRefreshIsSilent = ref(false)
   const pendingItemsLoad = ref<{ directoryPath: string, isSilent: boolean }>()
@@ -89,13 +90,18 @@ export function useAssetViewItemsLoader<TItem>(options: UseAssetViewItemsLoaderO
       if (!directoryPath) {
         if (loadToken === latestLoadToken) {
           items.value = []
+          isRootDirectoryMissing.value = false
         }
         return
       }
 
-      const result = await options.loadDirectory(directoryPath)
+      const [result, rootDirectoryExists] = await Promise.all([
+        options.loadDirectory(directoryPath),
+        relativePath ? true : options.rootDirectoryExists(directoryPath),
+      ])
       if (loadToken === latestLoadToken) {
         items.value = result.map(item => options.mapItem(item))
+        isRootDirectoryMissing.value = !rootDirectoryExists
       }
     } catch (error) {
       if (loadToken !== latestLoadToken) {
@@ -104,11 +110,13 @@ export function useAssetViewItemsLoader<TItem>(options: UseAssetViewItemsLoaderO
 
       if (!relativePath && error instanceof AppError && error.code === 'DIR_NOT_FOUND') {
         items.value = []
+        isRootDirectoryMissing.value = true
         return
       }
 
       errorMsg.value = error instanceof Error ? error.message : String(error)
       items.value = []
+      isRootDirectoryMissing.value = false
     } finally {
       if (loadToken === latestLoadToken) {
         isLoading.value = false
@@ -120,6 +128,7 @@ export function useAssetViewItemsLoader<TItem>(options: UseAssetViewItemsLoaderO
     items,
     isLoading,
     errorMsg,
+    isRootDirectoryMissing,
     scheduleItemsRefresh,
   }
 }


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [x] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [x] 代码重构
- [x] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

资源浏览器加载根目录时会在保留 VFS 内容加载的同时检查项目中的物理目录是否存在，并将缺失状态传递给根目录右键菜单。未启用覆盖层且目录读取返回 `DIR_NOT_FOUND` 的场景继续沿用同一状态。

当根目录不存在时，“在文件资源管理器中显示”操作保持可见但处于禁用状态，避免继续调用系统打开不存在的路径。目录恢复并成功加载后，该操作会自动恢复可用。创建文件、创建文件夹等既有空态操作不受影响。

同时移除了资源视图加载器中未使用的参数，并精简了只验证浏览器原生禁用语义的重复测试代码。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

资源根目录缺失属于资源浏览器支持的空态，用户仍可通过创建操作恢复目录。但启用引擎覆盖层时，VFS 可以在项目物理目录不存在的情况下成功返回资源列表；此前右键菜单只依据 VFS 加载结果，仍允许执行打开文件夹，最终只能得到无效的系统调用。

本次修改在现有加载流程中保留这一明确状态，并通过菜单已有的 `disabled` 能力控制操作，不引入额外服务、兼容层或错误兜底路径。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
