### PR TITLE
✨ 根据引擎能力诊断 Live2D 与 Spine 引用

### DIFF
--- a/src/components/editor/StatementSpecialContentEditor.spec.ts
+++ b/src/components/editor/StatementSpecialContentEditor.spec.ts
@@ -119,7 +119,7 @@ describe('StatementSpecialContentEditor', () => {
 
     const inputs = document.querySelectorAll<HTMLInputElement>('[placeholder="edit.visualEditor.filePicker.scene"]')
     expect(inputs).toHaveLength(2)
-    expect(inputs[0]).toHaveAttribute('invalid', 'false')
-    expect(inputs[1]).toHaveAttribute('invalid', 'true')
+    expect(inputs[0]).toHaveAttribute('status', 'none')
+    expect(inputs[1]).toHaveAttribute('status', 'error')
   })
 })

--- a/src/components/editor/StatementSpecialContentEditor.vue
+++ b/src/components/editor/StatementSpecialContentEditor.vue
@@ -135,7 +135,7 @@ function choiceStatus(index: number) {
       <StatementDiagnosticTooltip class="flex-1" :diagnostics="getChoiceDiagnostics(index)">
         <FilePicker
           :model-value="item.second"
-          :invalid="choiceStatus(index) === 'error'"
+          :status="choiceStatus(index)"
           :root-path="sceneRootPath"
           :extensions="['.txt']"
           :popover-title="$t('edit.visualEditor.filePicker.scene')"
@@ -150,7 +150,7 @@ function choiceStatus(index: number) {
         <FilePicker
           :input-id="inputId"
           :model-value="item.second"
-          :invalid="choiceStatus(index) === 'error'"
+          :status="choiceStatus(index)"
           :root-path="sceneRootPath"
           :extensions="['.txt']"
           :popover-title="$t('edit.visualEditor.filePicker.scene')"

--- a/src/components/editor/TextEditor.spec.ts
+++ b/src/components/editor/TextEditor.spec.ts
@@ -61,9 +61,10 @@ const {
   }
 })
 
-const { updateEditorDiagnosticsMock, useResourceIndexMock } = vi.hoisted(() => ({
+const { updateEditorDiagnosticsMock, useResourceIndexMock, useResourceStoreMock } = vi.hoisted(() => ({
   updateEditorDiagnosticsMock: vi.fn(),
   useResourceIndexMock: vi.fn(),
+  useResourceStoreMock: vi.fn(),
 }))
 
 vi.mock('~/plugins/editor/diagnostics', () => ({
@@ -72,6 +73,10 @@ vi.mock('~/plugins/editor/diagnostics', () => ({
 
 vi.mock('~/services/resource-index/service', () => ({
   useResourceIndex: useResourceIndexMock,
+}))
+
+vi.mock('~/stores/resource', () => ({
+  useResourceStore: useResourceStoreMock,
 }))
 
 vi.mock('~/features/editor/text-editor/useTextEditorRuntime', () => ({
@@ -121,6 +126,11 @@ import TextEditor from './TextEditor.vue'
 import type { TextProjectionState } from '~/stores/editor'
 
 let resourceIndexRevision = shallowRef(0)
+const resourceStoreState = reactive<{
+  currentEngineCapabilities?: { live2d: boolean, spine: boolean }
+}>({
+  currentEngineCapabilities: undefined,
+})
 
 interface EditorStoreMock {
   currentState?: {
@@ -268,8 +278,11 @@ describe('TextEditor', () => {
     useTextEditorRuntimeMock.mockClear()
     updateEditorDiagnosticsMock.mockReset()
     useResourceIndexMock.mockReset()
+    useResourceStoreMock.mockReset()
     resourceIndexRevision = shallowRef(0)
     useResourceIndexMock.mockReturnValue({ revision: resourceIndexRevision })
+    resourceStoreState.currentEngineCapabilities = undefined
+    useResourceStoreMock.mockReturnValue(resourceStoreState)
 
     ensureModelMock.mockReturnValue({
       id: 'model-1',
@@ -645,6 +658,21 @@ describe('TextEditor', () => {
     updateEditorDiagnosticsMock.mockClear()
 
     resourceIndexRevision.value += 1
+    await nextTick()
+
+    expect(updateEditorDiagnosticsMock).toHaveBeenCalledWith(model)
+  })
+
+  it('当前引擎能力变化后会重新诊断当前模型', async () => {
+    const { state } = createHarness('/project/scene-engine-capabilities.txt')
+    const model = createMonacoModel(['changeFigure:hero.json;'])
+    monacoMockState.editorInstance.getModel.mockReturnValue(model)
+
+    renderTextEditor(state)
+    await nextTick()
+    updateEditorDiagnosticsMock.mockClear()
+
+    resourceStoreState.currentEngineCapabilities = { live2d: false, spine: false }
     await nextTick()
 
     expect(updateEditorDiagnosticsMock).toHaveBeenCalledWith(model)

--- a/src/components/editor/TextEditor.vue
+++ b/src/components/editor/TextEditor.vue
@@ -13,6 +13,7 @@ import { updateEditorDiagnostics } from '~/plugins/editor/diagnostics'
 import { useResourceIndex } from '~/services/resource-index/service'
 import { useEditSettingsStore } from '~/stores/edit-settings'
 import { isEditableEditor, useEditorStore } from '~/stores/editor'
+import { useResourceStore } from '~/stores/resource'
 import { useTabsStore } from '~/stores/tabs'
 
 import type { TextProjectionState } from '~/stores/editor'
@@ -58,6 +59,7 @@ const runtime = useTextEditorRuntime({
   getState: () => props.state,
 })
 const resourceIndex = useResourceIndex()
+const resourceStore = useResourceStore()
 
 const currentTheme = $computed(() => colorMode.value === 'dark' ? THEME_DARK : THEME_LIGHT)
 const isCurrentTextProjectionActive = $computed(() => {
@@ -185,11 +187,15 @@ function schedulePlayToLineGlyphSync() {
 
 function handleModelContentChange(event: monaco.editor.IModelContentChangedEvent) {
   runtime.handleContentChange(event)
+  updateCurrentModelDiagnostics()
+  schedulePlayToLineGlyphSync()
+}
+
+function updateCurrentModelDiagnostics(): void {
   const model = editor?.getModel()
   if (model) {
     updateEditorDiagnostics(model)
   }
-  schedulePlayToLineGlyphSync()
 }
 
 function handleCursorPositionChange(event: monaco.editor.ICursorPositionChangedEvent) {
@@ -242,12 +248,10 @@ function createEditor() {
   syncPlayToLineGlyph()
 }
 
-watch(() => resourceIndex.revision.value, () => {
-  const model = editor?.getModel()
-  if (model) {
-    updateEditorDiagnostics(model)
-  }
-})
+watch([
+  () => resourceIndex.revision.value,
+  () => resourceStore.currentEngineCapabilities,
+], updateCurrentModelDiagnostics)
 
 watch(() => currentTheme, (newTheme) => {
   if (editor) {
@@ -274,10 +278,7 @@ watch(
 
 watch(() => locale.value, () => {
   syncPlayToLineGlyph()
-  const model = editor?.getModel()
-  if (model) {
-    updateEditorDiagnostics(model)
-  }
+  updateCurrentModelDiagnostics()
 })
 
 onMounted(() => {
@@ -300,10 +301,7 @@ watch([() => props.state.path, () => props.state.kind], () => {
   }
 
   nextTick(() => {
-    const model = editor?.getModel()
-    if (model) {
-      updateEditorDiagnostics(model)
-    }
+    updateCurrentModelDiagnostics()
   })
 })
 

--- a/src/components/editor/param-renderer/ParamRenderer.spec.ts
+++ b/src/components/editor/param-renderer/ParamRenderer.spec.ts
@@ -20,7 +20,7 @@ import ParamRenderer from './ParamRenderer.vue'
 
 import type { PropType } from 'vue'
 import type { ResolvedAutocompleteOption } from '~/features/editor/command-registry/autocomplete-options'
-import type { AutocompleteTextField, EditorField, NumberField, PlainTextField, SwitchField, ValueChoiceField } from '~/features/editor/command-registry/schema'
+import type { AutocompleteTextField, EditorField, FileField, NumberField, PlainTextField, SwitchField, ValueChoiceField } from '~/features/editor/command-registry/schema'
 import type { EditorFieldDiagnostic } from '~/features/editor/diagnostics/types'
 import type { StatementEditorSurface } from '~/features/editor/statement-editor/surface-context'
 
@@ -122,6 +122,20 @@ function createNumberField(): EditorField {
     unit: 'ms',
   }
   return { key: 'time', storage: 'content', field }
+}
+
+function createFileField(): EditorField {
+  const field: FileField = {
+    key: 'file',
+    label: 'File',
+    type: 'file',
+    fileConfig: {
+      assetType: 'figure',
+      extensions: ['.png', '.json'],
+      title: 'Figure',
+    },
+  }
+  return { key: 'file', storage: 'content', field }
 }
 
 const warningDiagnostic: EditorFieldDiagnostic = {
@@ -229,6 +243,24 @@ function createAutocompleteProbeStub() {
   })
 }
 
+function createFilePickerProbeStub() {
+  return defineComponent({
+    name: 'FilePickerProbeStub',
+    props: {
+      status: {
+        type: String,
+        default: 'none',
+      },
+    },
+    setup(props) {
+      return () => h('input', {
+        'data-status': props.status,
+        'data-testid': 'file-picker',
+      })
+    },
+  })
+}
+
 const globalStubs = {
   Autocomplete: createAutocompleteProbeStub(),
   ColorPicker: createBrowserContainerStub('ColorPickerStub'),
@@ -265,6 +297,7 @@ function renderFieldRenderer(
   surface: StatementEditorSurface,
   field: EditorField,
   stubs: BrowserStubs = globalStubs,
+  diagnostics: readonly EditorFieldDiagnostic[] = [],
 ) {
   return renderInBrowser(ParamRenderer, {
     props: {
@@ -275,7 +308,7 @@ function renderFieldRenderer(
       getDynamicOptions: () => [],
       getFieldSelectValue: () => '',
       getFieldValue: () => '',
-      getFieldDiagnostics: () => [],
+      getFieldDiagnostics: () => diagnostics,
       isFieldVisible: () => true,
     },
     global: {
@@ -517,6 +550,15 @@ describe('ParamRenderer', () => {
       'focus-visible:ring-yellow/30',
     )
     await expect.element(autocomplete).not.toHaveClass('text-destructive!')
+  })
+
+  it('warning 文件字段向 FilePicker 传递 warning 状态', async () => {
+    renderFieldRenderer('panel', createFileField(), {
+      ...globalStubs,
+      FilePicker: createFilePickerProbeStub(),
+    }, [warningDiagnostic])
+
+    await expect.element(page.getByTestId('file-picker')).toHaveAttribute('data-status', 'warning')
   })
 
   it('error autocomplete 使用 destructive 状态样式', async () => {

--- a/src/components/editor/param-renderer/ParamRenderer.vue
+++ b/src/components/editor/param-renderer/ParamRenderer.vue
@@ -383,7 +383,7 @@ const choiceFieldViewModels = $(useParamChoiceFieldViewModel({
             v-else-if="fieldMode(field) === 'file'"
             :input-id="fieldInputId(field)"
             :model-value="String(getFieldValue(field) || '')"
-            :invalid="isFileField(field) && fieldStatus(field) === 'error'"
+            :status="fieldStatus(field)"
             :root-path="fileRootPath(field)"
             :extensions="fileExtensions(field)"
             :exclude="fileExclude(field)"

--- a/src/components/file-picker/FilePicker.spec.ts
+++ b/src/components/file-picker/FilePicker.spec.ts
@@ -54,6 +54,10 @@ vi.mock('~/stores/preview-session', () => ({
 
 import FilePicker from './FilePicker.vue'
 
+import type { PropType } from 'vue'
+
+type FilePickerStatus = 'none' | 'warning' | 'error'
+
 const globalStubs = {
   Button: createBrowserClickStub('StubButton'),
   DropdownMenu: createBrowserContainerStub('StubDropdownMenu'),
@@ -153,6 +157,10 @@ const FilePickerHarness = defineComponent({
       type: String,
       required: true,
     },
+    status: {
+      type: String as PropType<FilePickerStatus>,
+      default: 'none',
+    },
   },
   setup(props) {
     const model = ref(props.initialValue)
@@ -168,6 +176,7 @@ const FilePickerHarness = defineComponent({
         'modelValue': model.value,
         'inputId': 'file-picker-input',
         'rootPath': '/assets',
+        'status': props.status,
         'onUpdate:modelValue': handleUpdate,
       }),
       h('label', { for: 'file-picker-input' }, 'File Path'),
@@ -200,6 +209,35 @@ describe('FilePicker', () => {
     })
     workspaceStoreState.CWD = '/games/demo'
     previewSessionStoreState.currentGameServeUrl = 'http://127.0.0.1:8899/game/demo/'
+  })
+
+  it.each([
+    {
+      buttonClasses: ['text-yellow-700/60', 'hover:text-yellow-700'],
+      inputClasses: ['text-yellow-700!', 'bg-yellow/5', 'border-yellow/50', 'focus-visible:ring-yellow/30'],
+      status: 'warning' as const,
+    },
+    {
+      buttonClasses: ['text-destructive/60', 'hover:text-destructive'],
+      inputClasses: ['text-destructive!', 'bg-destructive/5', 'border-destructive/50', 'focus-visible:ring-destructive/30'],
+      status: 'error' as const,
+    },
+  ])('$status 状态为输入框和清除按钮应用对应样式', async ({ buttonClasses, inputClasses, status }) => {
+    await renderInBrowser(FilePickerHarness, {
+      props: {
+        initialValue: 'figure/model.json',
+        status,
+      },
+      browser: {
+        pinia: true,
+      },
+      global: {
+        stubs: globalStubs,
+      },
+    })
+
+    await expect.element(page.getByRole('textbox', { name: 'File Path' })).toHaveClass(...inputClasses)
+    await expect.element(page.getByRole('button', { name: 'filePicker.clearInput' })).toHaveClass(...buttonClasses)
   })
 
   it('同步外部文件路径中间态时不会立即归一化并回写父层', async () => {

--- a/src/components/file-picker/FilePicker.vue
+++ b/src/components/file-picker/FilePicker.vue
@@ -12,11 +12,12 @@ import { FileViewerSortBy, FileViewerSortOrder } from '~/types/file-viewer'
 
 import type { HTMLAttributes } from 'vue'
 
+type FilePickerStatus = 'none' | 'warning' | 'error'
+
 interface FilePickerProps {
   class?: HTMLAttributes['class']
   inputId?: string
-  /** 仅用于控制输入框错误样式，校验逻辑由外部负责 */
-  invalid?: boolean
+  status?: FilePickerStatus
   rootPath: string
   extensions?: string[]
   exclude?: string[]
@@ -41,13 +42,23 @@ type ViewMode = 'list' | 'grid'
 type ZoomLevel = 'small' | 'medium' | 'large' | 'extraLarge'
 
 const ZOOM_MAP: Record<ZoomLevel, number> = { small: 80, medium: 100, large: 120, extraLarge: 140 }
+const INPUT_STATUS_CLASS: Record<FilePickerStatus, string> = {
+  none: '',
+  warning: 'text-yellow-700! bg-yellow/5 border-yellow/50 focus-visible:ring-yellow/30 dark:text-yellow-300!',
+  error: 'text-destructive! bg-destructive/5 border-destructive/50 focus-visible:ring-destructive/30',
+}
+const CLEAR_BUTTON_STATUS_CLASS: Record<FilePickerStatus, string> = {
+  none: 'text-muted-foreground hover:text-foreground',
+  warning: 'text-yellow-700/60 hover:text-yellow-700 dark:text-yellow-300/60 dark:hover:text-yellow-300',
+  error: 'text-destructive/60 hover:text-destructive',
+}
 
 defineOptions({ inheritAttrs: false })
 
 const {
   class: rootClass,
   inputId,
-  invalid = false,
+  status = 'none',
   rootPath,
   extensions = [],
   exclude = [],
@@ -247,7 +258,7 @@ function handleFileListKeydown(event: KeyboardEvent) {
           :placeholder="placeholder || $t('filePicker.placeholder')"
           :class="[
             inputText ? 'pr-7' : '',
-            invalid ? 'text-destructive! bg-destructive/5 border-destructive/50 focus-visible:ring-destructive/30' : '',
+            INPUT_STATUS_CLASS[status],
           ]"
           @focus="handleInputFocus"
           @blur="handleInputBlur"
@@ -258,7 +269,7 @@ function handleFileListKeydown(event: KeyboardEvent) {
           v-if="inputText"
           type="button"
           class="size-4 right-2 top-1/2 absolute -translate-y-1/2"
-          :class="invalid ? 'text-destructive/60 hover:text-destructive' : 'text-muted-foreground hover:text-foreground'"
+          :class="CLEAR_BUTTON_STATUS_CLASS[status]"
           :aria-label="$t('filePicker.clearInput')"
           @click="handleClear"
         >

--- a/src/domain/engine/__tests__/model-capabilities.test.ts
+++ b/src/domain/engine/__tests__/model-capabilities.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  classifyEngineModelReference,
+  resolveEngineModelCapabilities,
+} from '../model-capabilities'
+
+describe('resolveEngineModelCapabilities', () => {
+  it('只有显式声明为 true 的模型能力才视为受支持', () => {
+    expect(resolveEngineModelCapabilities({})).toEqual({
+      live2d: false,
+      spine: false,
+    })
+    expect(resolveEngineModelCapabilities({
+      live2dSupport: true,
+      spineSupport: false,
+    })).toEqual({
+      live2d: true,
+      spine: false,
+    })
+    expect(resolveEngineModelCapabilities({
+      live2dSupport: false,
+      spineSupport: true,
+    })).toEqual({
+      live2d: false,
+      spine: true,
+    })
+  })
+})
+
+describe('classifyEngineModelReference', () => {
+  it.each([
+    ['figure/hero.json', 'live2d'],
+    ['figure/HERO.JSON?version=1', 'live2d'],
+    ['figure/hero.json?type=spine', 'spine'],
+    ['figure/hero.json?version=1&type=SPINE', 'spine'],
+    ['figure/hero.skel', 'spine'],
+    ['figure/HERO.SKEL?version=1', 'spine'],
+    ['figure/hero.png', undefined],
+  ] as const)('将 %s 分类为 %s', (reference, expected) => {
+    expect(classifyEngineModelReference(reference)).toBe(expected)
+  })
+})

--- a/src/domain/engine/model-capabilities.ts
+++ b/src/domain/engine/model-capabilities.ts
@@ -1,0 +1,36 @@
+export type EngineModelType = 'live2d' | 'spine'
+
+export interface EngineModelCapabilities {
+  live2d: boolean
+  spine: boolean
+}
+
+interface EngineModelCapabilityDeclaration {
+  live2dSupport?: boolean
+  spineSupport?: boolean
+}
+
+export function resolveEngineModelCapabilities(
+  declaration: EngineModelCapabilityDeclaration,
+): EngineModelCapabilities {
+  return {
+    live2d: declaration.live2dSupport === true,
+    spine: declaration.spineSupport === true,
+  }
+}
+
+export function classifyEngineModelReference(reference: string): EngineModelType | undefined {
+  const [rawPath = '', rawQuery = ''] = reference.trim().split('?', 2)
+  const modelType = new URLSearchParams(rawQuery).get('type')?.toLowerCase()
+  if (modelType === 'spine') {
+    return 'spine'
+  }
+
+  const path = rawPath.toLowerCase()
+  if (path.endsWith('.skel')) {
+    return 'spine'
+  }
+  if (path.endsWith('.json')) {
+    return 'live2d'
+  }
+}

--- a/src/features/editor/command-registry/__tests__/monaco-diagnostics-adapter.browser.test.ts
+++ b/src/features/editor/command-registry/__tests__/monaco-diagnostics-adapter.browser.test.ts
@@ -1,15 +1,17 @@
 import * as monaco from 'monaco-editor'
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { useResourceIndex, useWorkspaceStore } = vi.hoisted(() => ({
+const { useResourceIndex, useResourceStore, useWorkspaceStore } = vi.hoisted(() => ({
   useResourceIndex: vi.fn(),
+  useResourceStore: vi.fn(),
   useWorkspaceStore: vi.fn(),
 }))
 
 vi.mock('~/services/resource-index/service', () => ({ useResourceIndex }))
+vi.mock('~/stores/resource', () => ({ useResourceStore }))
 vi.mock('~/stores/workspace', () => ({ useWorkspaceStore }))
 vi.mock('~/plugins/i18n', () => ({
-  i18n: { global: { t: (key: string, params: Record<string, unknown>) => `${key}:${Object.values(params).join(':')}` } },
+  i18n: { global: { t: (key: string, params: Record<string, unknown> = {}) => `${key}:${Object.values(params).join(':')}` } },
 }))
 
 import { updateEditorDiagnostics } from '~/plugins/editor/diagnostics'
@@ -39,7 +41,9 @@ describe('updateEditorDiagnostics', () => {
 
   beforeEach(() => {
     useResourceIndex.mockReset()
+    useResourceStore.mockReset()
     useWorkspaceStore.mockReset()
+    useResourceStore.mockReturnValue({ currentEngineCapabilities: undefined })
     useWorkspaceStore.mockReturnValue({ currentGame: { path: '/game' } })
   })
 
@@ -170,5 +174,40 @@ describe('updateEditorDiagnostics', () => {
       severity: monaco.MarkerSeverity.Error,
       message: 'edit.diagnostics.missingLabel:missing',
     })])
+  })
+
+  it('为当前引擎不支持的 Live2D 与 Spine 引用创建黄色 marker', () => {
+    useResourceIndex.mockReturnValue({
+      status: { value: 'ready' },
+      hasAssetKey: vi.fn(() => true),
+    })
+    useResourceStore.mockReturnValue({
+      currentEngineCapabilities: { live2d: false, spine: false },
+    })
+
+    const model = createModel([
+      'changeFigure:live2d/hero.json;',
+      'changeFigure:spine/hero.json?type=spine;',
+      'changeFigure:spine/hero.skel;',
+    ].join('\n'))
+    updateEditorDiagnostics(model)
+
+    expect(readMarkers(model)).toEqual([
+      expect.objectContaining({
+        startLineNumber: 1,
+        severity: monaco.MarkerSeverity.Warning,
+        message: 'edit.diagnostics.unsupportedLive2d:',
+      }),
+      expect.objectContaining({
+        startLineNumber: 2,
+        severity: monaco.MarkerSeverity.Warning,
+        message: 'edit.diagnostics.unsupportedSpine:',
+      }),
+      expect.objectContaining({
+        startLineNumber: 3,
+        severity: monaco.MarkerSeverity.Warning,
+        message: 'edit.diagnostics.unsupportedSpine:',
+      }),
+    ])
   })
 })

--- a/src/features/editor/command-registry/diagnostics.ts
+++ b/src/features/editor/command-registry/diagnostics.ts
@@ -1,5 +1,6 @@
 import { commandType } from 'webgal-parser/src/interface/sceneInterface'
 
+import { classifyEngineModelReference } from '~/domain/engine/model-capabilities'
 import { parseChooseContent } from '~/domain/script/content'
 import { createReferencedAssetKey } from '~/services/resource-index/values'
 
@@ -7,8 +8,15 @@ import { getCommandConfig } from './index'
 import { deriveArgFieldsFromEditorFields, readEditorFields, readFieldResourceReference } from './schema'
 
 import type { ISentence } from 'webgal-parser/src/interface/sceneInterface'
+import type { EngineModelCapabilities, EngineModelType } from '~/domain/engine/model-capabilities'
 import type { AssetKey } from '~/services/resource-index/keys'
 import type { ResourceReferenceQuery, ResourceReferenceSource } from '~/services/resource-index/reference-query'
+
+export interface UnsupportedEngineModelReference {
+  modelType: EngineModelType
+  source: { kind: 'content' }
+  value: string
+}
 
 export function querySentenceResourceReferences(sentence: ISentence): ResourceReferenceQuery[] {
   const entry = getCommandConfig(sentence.command)
@@ -52,6 +60,35 @@ export function findMissingSentenceResourceReferences(
 ): ResourceReferenceQuery[] {
   return querySentenceResourceReferences(sentence)
     .filter(reference => !hasAssetKey(reference.assetKey))
+}
+
+export function findUnsupportedEngineModelReferences(
+  sentence: ISentence,
+  capabilities: EngineModelCapabilities,
+): UnsupportedEngineModelReference[] {
+  const value = sentence.content.trim()
+  const modelType = classifySentenceEngineModelReference(sentence.command, value)
+  if (!modelType || capabilities[modelType]) {
+    return []
+  }
+
+  return [{
+    modelType,
+    source: { kind: 'content' },
+    value,
+  }]
+}
+
+function classifySentenceEngineModelReference(
+  command: commandType,
+  value: string,
+): EngineModelType | undefined {
+  if (command === commandType.changeFigure) {
+    return classifyEngineModelReference(value)
+  }
+  if (command === commandType.changeBg && value.toLowerCase().endsWith('.skel')) {
+    return 'spine'
+  }
 }
 
 function addReference(result: ResourceReferenceQuery[], assetType: string, value: string, source: ResourceReferenceSource): void {

--- a/src/features/editor/command-registry/perform.ts
+++ b/src/features/editor/command-registry/perform.ts
@@ -1,5 +1,6 @@
 import { commandType } from 'webgal-parser/src/interface/sceneInterface'
 
+import { classifyEngineModelReference } from '~/domain/engine/model-capabilities'
 import { FIGURE_POSITION_TARGET_IDS } from '~/domain/script/types'
 
 import { AUDIO_EXTENSIONS, BACKGROUND_EXTENSIONS, CONTINUE, DEFAULT_ENTER_DURATION, DEFAULT_EXIT_DURATION, EFFECT_DURATION, EFFECT_EASE, EFFECT_TRANSFORM, ENTER_ANIMATION, EXIT_ANIMATION, FIGURE_EXTENSIONS, FIGURE_ID, IGNORE_DEFAULT, IMAGE_EXTENSIONS, NEXT, ORDER, SERIES, SOUND_EFFECT_ID, UNLOCK_NAME, VOLUME } from './common-params'
@@ -8,18 +9,18 @@ import { arg, commandRaw, content, UNSPECIFIED } from './schema'
 import type { CommandEntry } from './schema'
 
 function isLive2dContent(content: string): boolean {
-  return content.endsWith('.json') && !content.includes('?type=spine')
+  return classifyEngineModelReference(content) === 'live2d'
 }
 
 // 判断 content 是否为动画类立绘（Live2D / Spine），用于控制 motion/expression 字段的可见性。
 // 包含 .skel 和 ?type=spine：虽然 .skel 二进制格式无法提供动态选项的自动补全，
 // 但仍需显示字段，确保用户在文本模式下写入的参数在可视化编辑器中可见。
 function isAnimatedContent(content: string): boolean {
-  return content.endsWith('.json') || content.endsWith('.skel') || content.includes('?type=spine')
+  return classifyEngineModelReference(content) !== undefined
 }
 
 function isSpineContent(content: string): boolean {
-  return content.endsWith('.skel') || content.includes('?type=spine')
+  return classifyEngineModelReference(content) === 'spine'
 }
 
 function isImageContent(content: string): boolean {

--- a/src/features/editor/diagnostics/__tests__/scene-diagnostics.test.ts
+++ b/src/features/editor/diagnostics/__tests__/scene-diagnostics.test.ts
@@ -77,6 +77,69 @@ describe('diagnoseScene', () => {
       }),
     ])
   })
+
+  it('根据引擎能力诊断 Live2D 与 Spine 模型引用', () => {
+    const sentences = [
+      parseSentence('changeFigure:live2d/hero.json;'),
+      parseSentence('changeFigure:spine/hero.json?type=spine;'),
+      parseSentence('changeFigure:spine/hero.skel;'),
+      parseSentence('changeFigure:images/hero.png;'),
+      parseSentence('changeAnimation:opening.json;'),
+      parseSentence('unlockCg:gallery/model.skel;'),
+      parseSentence('miniAvatar:avatar.json;'),
+    ]
+
+    expect(diagnoseScene(sentences, {
+      engineCapabilities: { live2d: true, spine: false },
+    })).toEqual([
+      {
+        code: 'unsupported-spine',
+        field: { kind: 'content' },
+        severity: 'warning',
+        source: 'engine',
+        statementIndex: 1,
+        value: 'spine/hero.json?type=spine',
+      },
+      {
+        code: 'unsupported-spine',
+        field: { kind: 'content' },
+        severity: 'warning',
+        source: 'engine',
+        statementIndex: 2,
+        value: 'spine/hero.skel',
+      },
+    ])
+  })
+
+  it('仅将 .skel 背景作为 Spine 模型诊断', () => {
+    const sentences = [
+      parseSentence('changeBg:live2d/background.json;'),
+      parseSentence('changeBg:spine/background.json?type=spine;'),
+      parseSentence('changeBg:spine/background.SKEL;'),
+      parseSentence('changeBg:spine/background.skel?version=1;'),
+      parseSentence('changeBg:images/background.png -enter=transitions/fade.json -exit=transitions/fade.skel;'),
+    ]
+
+    expect(diagnoseScene(sentences, {
+      engineCapabilities: { live2d: false, spine: false },
+    })).toEqual([
+      {
+        code: 'unsupported-spine',
+        field: { kind: 'content' },
+        severity: 'warning',
+        source: 'engine',
+        statementIndex: 2,
+        value: 'spine/background.SKEL',
+      },
+    ])
+  })
+
+  it('没有可用的引擎能力上下文时不生成兼容性诊断', () => {
+    expect(diagnoseScene([
+      parseSentence('changeFigure:live2d/hero.json;'),
+      parseSentence('changeFigure:spine/hero.skel;'),
+    ])).toEqual([])
+  })
 })
 
 describe('diagnoseEditorDocument', () => {

--- a/src/features/editor/diagnostics/__tests__/useEditorDiagnostics.test.ts
+++ b/src/features/editor/diagnostics/__tests__/useEditorDiagnostics.test.ts
@@ -8,11 +8,13 @@ const {
   useEditorDiagnosticsStoreMock,
   useEditorStoreMock,
   useResourceIndexMock,
+  useResourceStoreMock,
   useTabsStoreMock,
 } = vi.hoisted(() => ({
   useEditorDiagnosticsStoreMock: vi.fn(),
   useEditorStoreMock: vi.fn(),
   useResourceIndexMock: vi.fn(),
+  useResourceStoreMock: vi.fn(),
   useTabsStoreMock: vi.fn(),
 }))
 
@@ -28,6 +30,10 @@ vi.mock('~/services/resource-index/service', () => ({
   useResourceIndex: useResourceIndexMock,
 }))
 
+vi.mock('~/stores/resource', () => ({
+  useResourceStore: useResourceStoreMock,
+}))
+
 vi.mock('~/stores/tabs', () => ({
   useTabsStore: useTabsStoreMock,
 }))
@@ -39,7 +45,11 @@ describe('useEditorDiagnostics', () => {
     useEditorDiagnosticsStoreMock.mockReset()
     useEditorStoreMock.mockReset()
     useResourceIndexMock.mockReset()
+    useResourceStoreMock.mockReset()
     useTabsStoreMock.mockReset()
+    useResourceStoreMock.mockReturnValue(reactive({
+      currentEngineCapabilities: undefined,
+    }))
   })
 
   it('只发布已打开文档，并在资源索引变化后使资源诊断失效再重算', async () => {
@@ -133,6 +143,50 @@ describe('useEditorDiagnostics', () => {
     await nextTick()
 
     expect(diagnosticsStore.publish).toHaveBeenLastCalledWith(path, [])
+    scope.stop()
+  })
+
+  it('当前引擎能力变化后重新发布兼容性诊断', async () => {
+    const path = AbsPath.from('/game/scene/start.txt')
+    const diagnosticsStore = {
+      invalidateSource: vi.fn(),
+      publish: vi.fn(),
+    }
+    const resourceStore = reactive<{
+      currentEngineCapabilities?: { live2d: boolean, spine: boolean }
+    }>({
+      currentEngineCapabilities: { live2d: false, spine: false },
+    })
+
+    useEditorDiagnosticsStoreMock.mockReturnValue(diagnosticsStore)
+    useEditorStoreMock.mockReturnValue({
+      getTextProjectionState: vi.fn(() => undefined),
+      getVisualProjectionState: vi.fn(() => reactive({
+        kind: 'scene' as const,
+        statements: buildStatements('changeFigure:hero.json;'),
+      })),
+      peekSceneRevision: vi.fn(() => 'revision-1'),
+    })
+    useResourceIndexMock.mockReturnValue({
+      hasAssetKey: vi.fn(() => true),
+      revision: shallowRef(0),
+      status: shallowRef('ready'),
+    })
+    useResourceStoreMock.mockReturnValue(resourceStore)
+    useTabsStoreMock.mockReturnValue(reactive({ tabs: [{ path }] }))
+
+    const scope = effectScope()
+    scope.run(useEditorDiagnostics)
+
+    expect(diagnosticsStore.publish).toHaveBeenLastCalledWith(path, [
+      expect.objectContaining({ code: 'unsupported-live2d' }),
+    ])
+
+    resourceStore.currentEngineCapabilities = { live2d: true, spine: false }
+    await nextTick()
+
+    expect(diagnosticsStore.publish).toHaveBeenLastCalledWith(path, [])
+    expect(diagnosticsStore.invalidateSource).not.toHaveBeenCalledWith('resource')
     scope.stop()
   })
 })

--- a/src/features/editor/diagnostics/document-diagnostics.ts
+++ b/src/features/editor/diagnostics/document-diagnostics.ts
@@ -2,6 +2,7 @@ import { ensureParsed } from '~/domain/script/sentence'
 import { diagnoseScene } from '~/features/editor/diagnostics/scene-diagnostics'
 
 import type { EditorDiagnostic } from './types'
+import type { EngineModelCapabilities } from '~/domain/engine/model-capabilities'
 import type { StatementEntry } from '~/domain/script/sentence'
 import type { AssetKey } from '~/services/resource-index/keys'
 
@@ -16,6 +17,7 @@ interface EditorDiagnosticVisualProjection {
 }
 
 interface DiagnoseEditorDocumentOptions {
+  engineCapabilities?: EngineModelCapabilities
   hasAssetKey?: (key: AssetKey) => boolean
   textProjection?: EditorDiagnosticTextProjection
   visualProjection?: EditorDiagnosticVisualProjection

--- a/src/features/editor/diagnostics/presentation.ts
+++ b/src/features/editor/diagnostics/presentation.ts
@@ -47,6 +47,12 @@ export function getEditorDiagnosticMessage(
     case 'missing-resource': {
       return t('edit.completion.missingResource', { path: diagnostic.value })
     }
+    case 'unsupported-live2d': {
+      return t('edit.diagnostics.unsupportedLive2d')
+    }
+    case 'unsupported-spine': {
+      return t('edit.diagnostics.unsupportedSpine')
+    }
     default: {
       const exhaustiveCheck: never = diagnostic
       return exhaustiveCheck

--- a/src/features/editor/diagnostics/scene-diagnostics.ts
+++ b/src/features/editor/diagnostics/scene-diagnostics.ts
@@ -1,11 +1,16 @@
 import { diagnoseDuplicateSceneLabels, diagnoseMissingSceneLabels } from '~/domain/script/diagnostics'
-import { findMissingSentenceResourceReferences } from '~/features/editor/command-registry/diagnostics'
+import {
+  findMissingSentenceResourceReferences,
+  findUnsupportedEngineModelReferences,
+} from '~/features/editor/command-registry/diagnostics'
 
 import type { SceneEditorDiagnostic } from './types'
 import type { ISentence } from 'webgal-parser/src/interface/sceneInterface'
+import type { EngineModelCapabilities } from '~/domain/engine/model-capabilities'
 import type { AssetKey } from '~/services/resource-index/keys'
 
 interface DiagnoseSceneOptions {
+  engineCapabilities?: EngineModelCapabilities
   hasAssetKey?: (key: AssetKey) => boolean
 }
 
@@ -48,6 +53,25 @@ export function diagnoseScene(
           field: reference.source,
           severity: 'error',
           source: 'resource',
+          statementIndex,
+          value: reference.value,
+        })
+      }
+    }
+  }
+
+  if (options.engineCapabilities) {
+    for (const [statementIndex, sentence] of sentences.entries()) {
+      if (!sentence) {
+        continue
+      }
+
+      for (const reference of findUnsupportedEngineModelReferences(sentence, options.engineCapabilities)) {
+        diagnostics.push({
+          code: reference.modelType === 'live2d' ? 'unsupported-live2d' : 'unsupported-spine',
+          field: reference.source,
+          severity: 'warning',
+          source: 'engine',
           statementIndex,
           value: reference.value,
         })

--- a/src/features/editor/diagnostics/types.ts
+++ b/src/features/editor/diagnostics/types.ts
@@ -2,7 +2,7 @@ import type { AssetKey } from '~/services/resource-index/keys'
 import type { ResourceReferenceSource } from '~/services/resource-index/reference-query'
 
 export type DiagnosticSeverity = 'error' | 'warning' | 'info' | 'hint'
-export type EditorDiagnosticSource = 'document' | 'scene' | 'resource'
+export type EditorDiagnosticSource = 'document' | 'scene' | 'resource' | 'engine'
 
 interface EditorDiagnosticBase {
   code: string
@@ -40,6 +40,20 @@ export interface MissingResourceEditorDiagnostic extends SceneEditorDiagnosticBa
   value: string
 }
 
+export interface UnsupportedLive2dEditorDiagnostic extends SceneEditorDiagnosticBase {
+  code: 'unsupported-live2d'
+  severity: 'warning'
+  source: 'engine'
+  value: string
+}
+
+export interface UnsupportedSpineEditorDiagnostic extends SceneEditorDiagnosticBase {
+  code: 'unsupported-spine'
+  severity: 'warning'
+  source: 'engine'
+  value: string
+}
+
 export interface InvalidAnimationDocumentDiagnostic extends EditorDiagnosticBase {
   code: 'invalid-animation-json'
   severity: 'error'
@@ -50,11 +64,15 @@ export type SceneEditorDiagnostic =
   | DuplicateLabelEditorDiagnostic
   | MissingLabelEditorDiagnostic
   | MissingResourceEditorDiagnostic
+  | UnsupportedLive2dEditorDiagnostic
+  | UnsupportedSpineEditorDiagnostic
 
 export type EditorFieldDiagnostic =
   | Omit<DuplicateLabelEditorDiagnostic, 'statementIndex'>
   | Omit<MissingLabelEditorDiagnostic, 'statementIndex'>
   | Omit<MissingResourceEditorDiagnostic, 'statementIndex'>
+  | Omit<UnsupportedLive2dEditorDiagnostic, 'statementIndex'>
+  | Omit<UnsupportedSpineEditorDiagnostic, 'statementIndex'>
 
 export type EditorDiagnostic =
   | SceneEditorDiagnostic

--- a/src/features/editor/diagnostics/useEditorDiagnostics.ts
+++ b/src/features/editor/diagnostics/useEditorDiagnostics.ts
@@ -2,12 +2,14 @@ import { diagnoseEditorDocument } from '~/features/editor/diagnostics/document-d
 import { useResourceIndex } from '~/services/resource-index/service'
 import { useEditorStore } from '~/stores/editor'
 import { useEditorDiagnosticsStore } from '~/stores/editor-diagnostics'
+import { useResourceStore } from '~/stores/resource'
 import { useTabsStore } from '~/stores/tabs'
 
 export function useEditorDiagnostics(): void {
   const diagnosticsStore = useEditorDiagnosticsStore()
   const editorStore = useEditorStore()
   const resourceIndex = useResourceIndex()
+  const resourceStore = useResourceStore()
   const tabsStore = useTabsStore()
 
   function publishOpenDocumentDiagnostics(): void {
@@ -23,11 +25,12 @@ export function useEditorDiagnostics(): void {
       }
 
       diagnosticsStore.publish(tab.path, diagnoseEditorDocument({
+        engineCapabilities: resourceStore.currentEngineCapabilities,
+        hasAssetKey: canCheckResources
+          ? key => resourceIndex.hasAssetKey(key)
+          : undefined,
         textProjection,
         visualProjection,
-        ...(canCheckResources
-          ? { hasAssetKey: key => resourceIndex.hasAssetKey(key) }
-          : {}),
       }))
     }
   }
@@ -48,6 +51,10 @@ export function useEditorDiagnostics(): void {
 
   watch(() => resourceIndex.revision.value, () => {
     diagnosticsStore.invalidateSource('resource')
+    publishOpenDocumentDiagnostics()
+  })
+
+  watch(() => resourceStore.currentEngineCapabilities, () => {
     publishOpenDocumentDiagnostics()
   })
 }

--- a/src/features/editor/statement-editor/__tests__/useStatementFieldDiagnostics.test.ts
+++ b/src/features/editor/statement-editor/__tests__/useStatementFieldDiagnostics.test.ts
@@ -7,12 +7,17 @@ import { useStatementFieldDiagnostics } from '~/features/editor/statement-editor
 
 import type { SceneEditorDiagnostic } from '~/features/editor/diagnostics/types'
 
-const { useResourceIndexMock } = vi.hoisted(() => ({
+const { useResourceIndexMock, useResourceStoreMock } = vi.hoisted(() => ({
   useResourceIndexMock: vi.fn(),
+  useResourceStoreMock: vi.fn(),
 }))
 
 vi.mock('~/services/resource-index/service', () => ({
   useResourceIndex: useResourceIndexMock,
+}))
+
+vi.mock('~/stores/resource', () => ({
+  useResourceStore: useResourceStoreMock,
 }))
 
 function missingArgumentDiagnostic(key: string): SceneEditorDiagnostic {
@@ -42,6 +47,7 @@ describe('useStatementFieldDiagnostics', () => {
       hasAssetKey,
       status: resourceIndexStatus,
     })
+    useResourceStoreMock.mockReturnValue({ currentEngineCapabilities: undefined })
   })
 
   it('已发布诊断按完整字段地址解析且不会回退到本地资源检查', () => {
@@ -97,6 +103,26 @@ describe('useStatementFieldDiagnostics', () => {
     const result = useStatementFieldDiagnostics({ parsed })
 
     expect(result.getFieldStatus({ kind: 'content' })).toBe('none')
+    expect(hasAssetKey).not.toHaveBeenCalled()
+  })
+
+  it('临时草稿在资源索引未就绪时仍会诊断不受支持的模型', () => {
+    resourceIndexStatus.value = 'idle'
+    useResourceStoreMock.mockReturnValue({
+      currentEngineCapabilities: { live2d: false, spine: true },
+    })
+    const parsed = computed(() => parseSentence('changeFigure:live2d/hero.json;'))
+
+    const result = useStatementFieldDiagnostics({ parsed })
+
+    expect(result.getFieldDiagnostics({ kind: 'content' })).toEqual([{
+      code: 'unsupported-live2d',
+      field: { kind: 'content' },
+      severity: 'warning',
+      source: 'engine',
+      value: 'live2d/hero.json',
+    }])
+    expect(result.getFieldStatus({ kind: 'content' })).toBe('warning')
     expect(hasAssetKey).not.toHaveBeenCalled()
   })
 })

--- a/src/features/editor/statement-editor/useStatementFieldDiagnostics.ts
+++ b/src/features/editor/statement-editor/useStatementFieldDiagnostics.ts
@@ -1,10 +1,15 @@
-import { findMissingSentenceResourceReferences } from '~/features/editor/command-registry/diagnostics'
+import {
+  findMissingSentenceResourceReferences,
+  findUnsupportedEngineModelReferences,
+} from '~/features/editor/command-registry/diagnostics'
 import { getDiagnosticFieldStatus } from '~/features/editor/diagnostics/presentation'
 import { selectHighestDiagnosticSeverity } from '~/features/editor/diagnostics/types'
 import { isSameResourceReferenceSource } from '~/services/resource-index/reference-query'
 import { useResourceIndex } from '~/services/resource-index/service'
+import { useResourceStore } from '~/stores/resource'
 
 import type { ISentence } from 'webgal-parser/src/interface/sceneInterface'
+import type { UnsupportedEngineModelReference } from '~/features/editor/command-registry/diagnostics'
 import type { DiagnosticFieldStatus } from '~/features/editor/diagnostics/presentation'
 import type { EditorFieldDiagnostic, SceneEditorDiagnostic } from '~/features/editor/diagnostics/types'
 import type { ResourceReferenceQuery, ResourceReferenceSource } from '~/services/resource-index/reference-query'
@@ -26,22 +31,47 @@ function toLocalMissingResourceDiagnostic(reference: ResourceReferenceQuery): Ed
   }
 }
 
+function toLocalUnsupportedEngineModelDiagnostic(
+  reference: UnsupportedEngineModelReference,
+): EditorFieldDiagnostic {
+  return {
+    code: reference.modelType === 'live2d' ? 'unsupported-live2d' : 'unsupported-spine',
+    field: reference.source,
+    severity: 'warning',
+    source: 'engine',
+    value: reference.value,
+  }
+}
+
 export function useStatementFieldDiagnostics(options: UseStatementFieldDiagnosticsOptions) {
   const resourceIndex = useResourceIndex()
+  const resourceStore = useResourceStore()
 
   const publishedDiagnostics = computed(() =>
     options.diagnostics === undefined ? undefined : toValue(options.diagnostics),
   )
   const localDiagnostics = computed<readonly EditorFieldDiagnostic[]>(() => {
     const parsed = toValue(options.parsed)
-    if (!parsed || resourceIndex.status.value !== 'ready') {
+    if (!parsed) {
       return []
     }
 
-    return findMissingSentenceResourceReferences(
-      parsed,
-      key => resourceIndex.hasAssetKey(key),
-    ).map(reference => toLocalMissingResourceDiagnostic(reference))
+    const diagnostics: EditorFieldDiagnostic[] = []
+    if (resourceStore.currentEngineCapabilities) {
+      diagnostics.push(...findUnsupportedEngineModelReferences(
+        parsed,
+        resourceStore.currentEngineCapabilities,
+      ).map(reference => toLocalUnsupportedEngineModelDiagnostic(reference)))
+    }
+
+    if (resourceIndex.status.value === 'ready') {
+      diagnostics.push(...findMissingSentenceResourceReferences(
+        parsed,
+        key => resourceIndex.hasAssetKey(key),
+      ).map(reference => toLocalMissingResourceDiagnostic(reference)))
+    }
+
+    return diagnostics
   })
 
   function getFieldDiagnostics(field: ResourceReferenceSource): readonly EditorFieldDiagnostic[] {

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -665,6 +665,8 @@ edit:
   diagnostics:
     duplicateLabel: 'Label "{label}" is defined {count} times in this scene, so jump targets are ambiguous.'
     missingLabel: 'Label "{label}" is not defined in this scene.'
+    unsupportedLive2d: The current engine does not support Live2D models.
+    unsupportedSpine: The current engine does not support Spine models.
   errors:
     fileSyncFailed: Failed to sync the file. Please try again shortly.
     previewUnavailable: Preview URL is not available. Please start preview first.

--- a/src/locales/ja.yml
+++ b/src/locales/ja.yml
@@ -665,6 +665,8 @@ edit:
   diagnostics:
     duplicateLabel: "ラベル「{label}」は現在のシーンで{count}回定義されているため、ジャンプ先が曖昧です。"
     missingLabel: "ラベル「{label}」は現在のシーンで定義されていません。"
+    unsupportedLive2d: 現在のエンジンは Live2D モデルをサポートしていません。
+    unsupportedSpine: 現在のエンジンは Spine モデルをサポートしていません。
   errors:
     fileSyncFailed: ファイルの同期に失敗しました。しばらくしてからもう一度お試しください。
     previewUnavailable: プレビューURLがありません。先にプレビューを起動してください。

--- a/src/locales/zh-Hans.yml
+++ b/src/locales/zh-Hans.yml
@@ -665,6 +665,8 @@ edit:
   diagnostics:
     duplicateLabel: "标签“{label}”在当前场景中定义了 {count} 次，跳转目标不明确。"
     missingLabel: "标签“{label}”未在当前场景中定义。"
+    unsupportedLive2d: 当前引擎不支持 Live2D 模型。
+    unsupportedSpine: 当前引擎不支持 Spine 模型。
   errors:
     fileSyncFailed: 文件同步失败，请稍后重试
     previewUnavailable: 预览地址不存在，请先启动预览

--- a/src/locales/zh-Hant.yml
+++ b/src/locales/zh-Hant.yml
@@ -665,6 +665,8 @@ edit:
   diagnostics:
     duplicateLabel: "標籤「{label}」在目前場景中定義了 {count} 次，跳轉目標不明確。"
     missingLabel: "標籤「{label}」未在目前場景中定義。"
+    unsupportedLive2d: 目前引擎不支援 Live2D 模型。
+    unsupportedSpine: 目前引擎不支援 Spine 模型。
   errors:
     fileSyncFailed: 檔案同步失敗，請稍後重試
     previewUnavailable: 預覽地址不存在，請先啟動預覽

--- a/src/plugins/editor/diagnostics.ts
+++ b/src/plugins/editor/diagnostics.ts
@@ -5,6 +5,7 @@ import { getEditorDiagnosticMessage } from '~/features/editor/diagnostics/presen
 import { diagnoseScene } from '~/features/editor/diagnostics/scene-diagnostics'
 import { i18n } from '~/plugins/i18n'
 import { useResourceIndex } from '~/services/resource-index/service'
+import { useResourceStore } from '~/stores/resource'
 import { useWorkspaceStore } from '~/stores/workspace'
 
 import type { ResourceReferenceQuery } from '~/services/resource-index/reference-query'
@@ -21,14 +22,18 @@ export function updateEditorDiagnostics(model: monaco.editor.ITextModel): void {
 
   const workspace = useWorkspaceStore()
   const resourceIndex = useResourceIndex()
+  const resourceStore = useResourceStore()
   const canCheckResources = Boolean(workspace.currentGame?.path) && resourceIndex.status.value === 'ready'
   const markers: monaco.editor.IMarkerData[] = []
   const lines = model.getLinesContent()
   const sentences = lines.map(line => parseSceneOrEmpty(line, TEMP_SCENE_NAME, TEMP_SCENE_URL).sentenceList[0])
 
-  const diagnostics = diagnoseScene(sentences, canCheckResources
-    ? { hasAssetKey: key => resourceIndex.hasAssetKey(key) }
-    : {})
+  const diagnostics = diagnoseScene(sentences, {
+    engineCapabilities: resourceStore.currentEngineCapabilities,
+    hasAssetKey: canCheckResources
+      ? key => resourceIndex.hasAssetKey(key)
+      : undefined,
+  })
 
   for (const diagnostic of diagnostics) {
     const lineNumber = diagnostic.statementIndex + 1
@@ -52,6 +57,18 @@ export function updateEditorDiagnostics(model: monaco.editor.ITextModel): void {
       markers.push({
         ...locateContent(lineNumber, line, sentence.commandRaw, diagnostic.label),
         severity: monaco.MarkerSeverity.Error,
+        message,
+      })
+      continue
+    }
+
+    if (diagnostic.code === 'unsupported-live2d' || diagnostic.code === 'unsupported-spine') {
+      markers.push({
+        ...locateReference(lineNumber, line, sentence.commandRaw, {
+          source: diagnostic.field,
+          value: diagnostic.value,
+        }),
+        severity: monaco.MarkerSeverity.Warning,
         message,
       })
       continue

--- a/src/stores/__tests__/resource.test.ts
+++ b/src/stores/__tests__/resource.test.ts
@@ -20,7 +20,11 @@ const {
   useWorkspaceStoreMock: vi.fn(),
 }))
 
-const workspaceStoreState = reactive({
+const workspaceStoreState = reactive<{
+  currentGame?: Game
+  searchQuery: string
+}>({
+  currentGame: undefined,
   searchQuery: '',
 })
 
@@ -79,6 +83,7 @@ describe('useResourceStore', () => {
     vi.resetAllMocks()
 
     workspaceStoreState.searchQuery = ''
+    workspaceStoreState.currentGame = undefined
     gamesRef.value = undefined
     enginesRef.value = undefined
     templatesRef.value = undefined
@@ -128,6 +133,45 @@ describe('useResourceStore', () => {
 
     workspaceStoreState.searchQuery = 'classic'
     expect(store.filteredTemplates.map(template => template.id)).toEqual(['classic'])
+  })
+
+  it('从当前游戏绑定的引擎派生模型能力，并将缺失字段视为不支持', () => {
+    enginesRef.value = [
+      createTestEngine({
+        id: 'engine-with-defaults',
+        metadata: {
+          description: '',
+          icon: 'icons/favicon.ico',
+        },
+      }),
+      createTestEngine({
+        id: 'engine-with-live2d',
+        metadata: {
+          description: '',
+          icon: 'icons/favicon.ico',
+          live2dSupport: true,
+          spineSupport: false,
+        },
+      }),
+    ]
+    workspaceStoreState.currentGame = createTestGame({ engineId: 'engine-with-defaults' })
+
+    const store = useResourceStore()
+
+    expect(store.currentEngineCapabilities).toEqual({ live2d: false, spine: false })
+
+    workspaceStoreState.currentGame = createTestGame({ engineId: 'engine-with-live2d' })
+    expect(store.currentEngineCapabilities).toEqual({ live2d: true, spine: false })
+  })
+
+  it('引擎记录尚未加载或当前绑定无法解析时不提供能力上下文', () => {
+    workspaceStoreState.currentGame = createTestGame({ engineId: 'missing-engine' })
+    const store = useResourceStore()
+
+    expect(store.currentEngineCapabilities).toBeUndefined()
+
+    enginesRef.value = []
+    expect(store.currentEngineCapabilities).toBeUndefined()
   })
 
   it('会把独立模板和引擎内置模板整理为模板族展示模型', () => {

--- a/src/stores/resource.ts
+++ b/src/stores/resource.ts
@@ -1,6 +1,7 @@
 import { defineStore } from 'pinia'
 
 import { useEngines, useGames, useTemplates } from '~/composables/useDatabase'
+import { resolveEngineModelCapabilities } from '~/domain/engine/model-capabilities'
 import { createTemplateGroups } from '~/features/home/templates-tab/template-groups'
 import { isEngineEditorCompatible } from '~/services/engine-manager'
 import { useWorkspaceStore } from '~/stores/workspace'
@@ -54,6 +55,18 @@ export const useResourceStore = defineStore('resource', () => {
     sortedEngines.filter(isEngineEditorCompatible),
   )
 
+  const currentEngineCapabilities = $computed(() => {
+    const currentEngineId = workspaceStore.currentGame?.engineId
+    if (!engines || !currentEngineId) {
+      return
+    }
+
+    const currentEngine = engines.find(engine => engine.id === currentEngineId)
+    return currentEngine
+      ? resolveEngineModelCapabilities(currentEngine.metadata)
+      : undefined
+  })
+
   const filteredTemplates = $computed(() =>
     filterBySearchQuery(sortedTemplates, template => template.metadata.name),
   )
@@ -82,6 +95,7 @@ export const useResourceStore = defineStore('resource', () => {
     engines,
     filteredEngines,
     availableEngines,
+    currentEngineCapabilities,
     // 模板相关
     templates,
     filteredTemplates,


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [ ] 错误修复
- [x] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [x] 代码重构
- [x] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

- 从当前游戏绑定的引擎元数据派生 Live2D 与 Spine 能力，只有 `live2dSupport` 或 `spineSupport` 显式为 `true` 时才视为支持。
- 按命令语义识别模型引用：`changeFigure` 支持 Live2D 与 Spine，`changeBg` 仅支持 `.skel` 格式的 Spine 背景。
- 仅诊断命令主体实际支持的模型路径，不检查动画参数、背景 JSON 或复用相同资源目录的其他命令，避免产生误报。
- 通过现有诊断系统在 Monaco、可视化语句编辑器和未提交的临时语句草稿中显示非阻塞 warning。
- 文件选择字段会以黄色输入框样式呈现 warning，并继续以红色样式呈现 error。
- 当前游戏绑定的引擎发生变化时，自动重新诊断已打开文档和当前 Monaco 模型。
- 补充四种语言的诊断文案，以及模型分类、能力派生、场景诊断、草稿诊断和编辑器刷新测试。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

场景可以引用 Live2D 或 Spine 模型，但不同引擎不一定提供对应运行能力。此前编辑器无法在编写阶段识别这种不匹配，问题通常要到运行时才会暴露。

本次更改利用引擎已有的能力声明，在不修改脚本、不阻止保存且不解析模型文件内容的前提下，提前提示当前引擎不支持的模型引用。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->

- 能力字段缺失与显式为 `false` 的行为一致，均视为不支持。
- 当前引擎尚未加载或游戏绑定的引擎无法解析时，不生成能力诊断。
- 不会过滤文件选择器或项目资源树中的模型资源。
- 不涉及公共协议、持久化格式或迁移。

### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
