### PR TITLE
✨ 删除游戏时将文件移入回收站

### DIFF
--- a/src/components/modals/DeleteGameModal.spec.ts
+++ b/src/components/modals/DeleteGameModal.spec.ts
@@ -13,6 +13,7 @@ import DeleteGameModal from './DeleteGameModal.vue'
 
 const {
   deleteGameMock,
+  isDesktopRuntimeMock,
   loggerErrorMock,
   modalOpenMock,
   toastErrorMock,
@@ -20,6 +21,7 @@ const {
   useModalStoreMock,
 } = vi.hoisted(() => ({
   deleteGameMock: vi.fn(),
+  isDesktopRuntimeMock: vi.fn(),
   loggerErrorMock: vi.fn(),
   modalOpenMock: vi.fn(),
   toastErrorMock: vi.fn(),
@@ -34,6 +36,9 @@ function translate(key: string): string {
     }
     case 'common.confirm': {
       return '确认'
+    }
+    case 'common.moveToTrash': {
+      return '移到回收站'
     }
     case 'modals.deleteGame.deleteFiles': {
       return '同时删除游戏文件'
@@ -50,6 +55,9 @@ function translate(key: string): string {
     case 'modals.deleteGame.title': {
       return '删除游戏'
     }
+    case 'modals.deleteGame.moveFilesToTrash': {
+      return '同时将游戏文件移到回收站'
+    }
     default: {
       return key
     }
@@ -60,6 +68,10 @@ vi.mock('~/services/game-manager', () => ({
   gameManager: {
     deleteGame: deleteGameMock,
   },
+}))
+
+vi.mock('~/services/platform/runtime', () => ({
+  isDesktopRuntime: isDesktopRuntimeMock,
 }))
 
 vi.mock('@tauri-apps/plugin-log', () => ({
@@ -90,13 +102,13 @@ vi.mock('vue-i18n', async importOriginal => ({
 
 const globalStubs = {
   'AlertDialog': createBrowserContainerStub('StubAlertDialog'),
-  'AlertDialogAction': createBrowserClickStub('StubAlertDialogAction'),
   'AlertDialogCancel': createBrowserClickStub('StubAlertDialogCancel'),
   'AlertDialogContent': createBrowserContainerStub('StubAlertDialogContent'),
   'AlertDialogDescription': createBrowserContainerStub('StubAlertDialogDescription'),
   'AlertDialogFooter': createBrowserContainerStub('StubAlertDialogFooter'),
   'AlertDialogHeader': createBrowserContainerStub('StubAlertDialogHeader'),
   'AlertDialogTitle': createBrowserContainerStub('StubAlertDialogTitle', 'h2'),
+  'Button': createBrowserClickStub('StubButton'),
   'Checkbox': createBrowserCheckboxStub('StubCheckbox'),
   'i18n-t': createBrowserContainerStub('MockI18nT', 'span'),
 }
@@ -127,12 +139,13 @@ describe('DeleteGameModal', () => {
     vi.resetAllMocks()
 
     deleteGameMock.mockResolvedValue(undefined)
+    isDesktopRuntimeMock.mockReturnValue(true)
     useModalStoreMock.mockReturnValue({
       open: modalOpenMock,
     })
   })
 
-  it('默认确认会直接删除游戏并关闭模态框', async () => {
+  it('默认确认只移除游戏记录并关闭模态框', async () => {
     const { game, updateOpen } = renderDeleteGameModal()
 
     await page.getByRole('button', { name: '确认' }).click()
@@ -142,7 +155,18 @@ describe('DeleteGameModal', () => {
     expect(updateOpen).toHaveBeenCalledWith(false)
   })
 
-  it('勾选删除文件后会先打开二次确认模态框', async () => {
+  it('桌面端勾选删除文件后会直接移到回收站并关闭模态框', async () => {
+    const { game, updateOpen } = renderDeleteGameModal()
+
+    await page.getByRole('checkbox').click()
+    await page.getByRole('button', { name: '移到回收站' }).click()
+
+    expect(deleteGameMock).toHaveBeenCalledWith(game, true)
+    expect(updateOpen).toHaveBeenCalledWith(false)
+  })
+
+  it('移动端勾选删除文件后会打开二次确认模态框', async () => {
+    isDesktopRuntimeMock.mockReturnValue(false)
     const { game } = renderDeleteGameModal()
 
     await page.getByRole('checkbox').click()
@@ -155,7 +179,7 @@ describe('DeleteGameModal', () => {
     }))
   })
 
-  it('直接删除失败时记录原因、展示兜底消息且保持模态框打开', async () => {
+  it('移除可用游戏记录失败时记录原因、展示兜底消息且保持模态框打开', async () => {
     deleteGameMock.mockRejectedValueOnce(new Error('permission denied'))
     const { updateOpen } = renderDeleteGameModal()
 
@@ -184,9 +208,10 @@ describe('DeleteGameModal', () => {
     expect(updateOpen).not.toHaveBeenCalledWith(false)
   })
 
-  it('二次确认删除失败时展示兜底消息并返回失败结果', async () => {
+  it('移动端二次确认删除失败时展示兜底消息并保持两个模态框打开', async () => {
+    isDesktopRuntimeMock.mockReturnValue(false)
     deleteGameMock.mockRejectedValueOnce('unknown failure')
-    const { game } = renderDeleteGameModal()
+    const { game, updateOpen } = renderDeleteGameModal()
 
     await page.getByRole('checkbox').click()
     await page.getByRole('button', { name: '确认' }).click()
@@ -197,5 +222,6 @@ describe('DeleteGameModal', () => {
     await expect(confirmProps.onConfirm()).resolves.toBe(false)
     expect(deleteGameMock).toHaveBeenCalledWith(game, true)
     expect(toastErrorMock).toHaveBeenCalledWith('游戏删除失败')
+    expect(updateOpen).not.toHaveBeenCalledWith(false)
   })
 })

--- a/src/components/modals/DeleteGameModal.vue
+++ b/src/components/modals/DeleteGameModal.vue
@@ -2,6 +2,7 @@
 import { TriangleAlert } from '@lucide/vue'
 
 import { gameManager } from '~/services/game-manager'
+import { isDesktopRuntime } from '~/services/platform/runtime'
 import { useModalStore } from '~/stores/modal'
 
 import type { Game } from '~/database/model'
@@ -18,6 +19,10 @@ let isConfirming = $ref(false)
 const modalStore = useModalStore()
 
 const isUnavailable = $computed(() => game.availability !== 'available')
+const isDesktop = isDesktopRuntime()
+const removeFilesLabel = isDesktop
+  ? t('modals.deleteGame.moveFilesToTrash')
+  : t('modals.deleteGame.deleteFiles')
 
 async function performDelete(removeFiles: boolean): Promise<boolean> {
   try {
@@ -47,13 +52,13 @@ async function handleConfirm() {
       return
     }
 
-    if (removeFiles) {
+    if (removeFiles && !isDesktop) {
       modalStore.open('DeleteGameConfirmModal', {
         game,
         onConfirm: () => performDelete(true),
       })
     } else {
-      if (await performDelete(false)) {
+      if (await performDelete(removeFiles)) {
         open = false
       }
     }
@@ -97,7 +102,7 @@ async function handleConfirm() {
                 for="removeFiles"
                 class="text-sm leading-none font-medium peer-disabled:opacity-70 peer-disabled:cursor-not-allowed"
               >
-                {{ $t('modals.deleteGame.deleteFiles') }}
+                {{ removeFilesLabel }}
               </label>
             </div>
           </AlertDialogDescription>
@@ -105,9 +110,9 @@ async function handleConfirm() {
       </div>
       <AlertDialogFooter>
         <AlertDialogCancel>{{ $t('common.cancel') }}</AlertDialogCancel>
-        <AlertDialogAction variant="destructive" :disabled="isConfirming" @click="handleConfirm">
-          {{ $t('common.confirm') }}
-        </AlertDialogAction>
+        <Button variant="destructive" :disabled="isConfirming" @click="handleConfirm">
+          {{ removeFiles && isDesktop ? $t('common.moveToTrash') : $t('common.confirm') }}
+        </Button>
       </AlertDialogFooter>
     </AlertDialogContent>
   </AlertDialog>

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -235,6 +235,7 @@ modals:
     title: Delete Game
     description: Are you sure you want to delete the game {name}?
     deleteFiles: Delete game files as well
+    moveFilesToTrash: Move game files to the recycle bin as well
     deleteFailed: Failed to delete game
     removeTitle: Remove Game Record
     removeDescription: Are you sure you want to remove the record for {name}?

--- a/src/locales/ja.yml
+++ b/src/locales/ja.yml
@@ -235,6 +235,7 @@ modals:
     title: ゲームを削除
     description: ゲーム {name} を削除してもよろしいですか？
     deleteFiles: ゲームファイルも削除
+    moveFilesToTrash: ゲームファイルもゴミ箱に移動
     deleteFailed: ゲームの削除に失敗しました
     removeTitle: ゲーム記録を削除
     removeDescription: ゲーム {name} の記録を削除してもよろしいですか？

--- a/src/locales/zh-Hans.yml
+++ b/src/locales/zh-Hans.yml
@@ -235,6 +235,7 @@ modals:
     title: 删除游戏
     description: 确定要删除游戏 {name} 吗？
     deleteFiles: 同时删除游戏文件
+    moveFilesToTrash: 同时将游戏文件移到回收站
     deleteFailed: 游戏删除失败
     removeTitle: 移除游戏记录
     removeDescription: 确定要移除游戏 {name} 的记录吗？

--- a/src/locales/zh-Hant.yml
+++ b/src/locales/zh-Hant.yml
@@ -235,6 +235,7 @@ modals:
     title: 刪除遊戲
     description: 確定要刪除遊戲 {name} 嗎？
     deleteFiles: 同時刪除遊戲檔案
+    moveFilesToTrash: 同時將遊戲檔案移到資源回收桶
     deleteFailed: 遊戲刪除失敗
     removeTitle: 移除遊戲記錄
     removeDescription: 確定要移除遊戲 {name} 的記錄嗎？

--- a/src/services/__tests__/game-manager.test.ts
+++ b/src/services/__tests__/game-manager.test.ts
@@ -2015,17 +2015,28 @@ describe('gameManager', () => {
     vi.useRealTimers()
   })
 
-  it('deleteGame 在 removeFiles=true 时会通过 fs 命令删除游戏目录后再删除记录', async () => {
+  it('deleteGame 在 removeFiles=true 时会将游戏目录移到回收站后再删除记录', async () => {
     await gameManager.deleteGame(createTestGame({
       id: 'game-1',
       path: AbsPath.from('/games/demo'),
     }), true)
 
-    expect(deleteFileMock).toHaveBeenCalledWith('/games/demo', true)
+    expect(deleteFileMock).toHaveBeenCalledWith('/games/demo')
     expect(dbGameDeleteMock).toHaveBeenCalledWith('game-1')
     expect(deleteFileMock.mock.invocationCallOrder[0]).toBeLessThan(
       dbGameDeleteMock.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
     )
+  })
+
+  it('deleteGame 在移动游戏目录失败时会保留游戏记录', async () => {
+    deleteFileMock.mockRejectedValueOnce(new Error('trash unavailable'))
+
+    await expect(gameManager.deleteGame(createTestGame({
+      id: 'game-1',
+      path: AbsPath.from('/games/demo'),
+    }), true)).rejects.toThrow('trash unavailable')
+
+    expect(dbGameDeleteMock).not.toHaveBeenCalled()
   })
 
   it('touchGameLastModified 只更新时间戳，不刷新预览资源快照', async () => {

--- a/src/services/game-manager.ts
+++ b/src/services/game-manager.ts
@@ -893,7 +893,7 @@ async function createGame(gameName: string, gamePath: AbsPath, engineId: string,
 
 async function deleteGame(game: Game, removeFiles: boolean = false): Promise<void> {
   if (removeFiles) {
-    await fsCmds.deleteFile(game.path, true)
+    await fsCmds.deleteFile(game.path)
   }
   await db.games.delete(game.id)
 }


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [ ] 错误修复
- [x] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [x] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

- 桌面端删除游戏时，勾选游戏文件后会将整个游戏目录移动到系统回收站，不再永久删除。
- 桌面端将删除文件流程收敛为单次确认，并使用“移动到回收站”文案明确操作结果。
- 移动端保留要求输入游戏名称的二次确认；由于移动端暂不支持系统回收站，确认后保持删除失败，不实际删除游戏文件或本地记录。
- 删除操作成功后才关闭确认弹窗；移动到回收站或移除记录失败时保留弹窗并展示错误信息。
- 游戏目录不可用时仍只移除本地游戏记录，不尝试操作文件系统。
- 补充桌面端直接移动到回收站、移动端二次确认和文件操作失败保护的测试。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

桌面端原先使用不可恢复的永久删除，同时要求用户进行两次确认。该流程与文件、引擎和模板等其他删除操作不一致，也增加了误删风险和操作阻力。

桌面端改为移动到系统回收站后，用户仍可恢复游戏文件，因此可以在保留明确确认和失败保护的前提下移除重复确认步骤。移动端尚不具备等价的回收站能力，暂时保留二次确认和失败结果，避免引入不可恢复的永久删除分支。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
