### PR TITLE
✨ 在编辑器状态栏显示资源索引状态

### DIFF
--- a/src/components/editor/EditorStatusBar.spec.ts
+++ b/src/components/editor/EditorStatusBar.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { page } from 'vitest/browser'
 
 import { createBrowserLocalizedI18n } from '~/__tests__/browser'
@@ -82,6 +82,14 @@ vi.mock('~/stores/workspace', () => ({
   useWorkspaceStore: useWorkspaceStoreMock,
 }))
 
+const resourceIndexStatus = shallowRef<'idle' | 'building' | 'ready' | 'degraded'>('idle')
+
+vi.mock('~/services/resource-index/service', () => ({
+  useResourceIndex: () => ({
+    status: resourceIndexStatus,
+  }),
+}))
+
 vi.mock('~/utils/error-handler', () => ({
   handleError: vi.fn(),
 }))
@@ -104,6 +112,8 @@ function createEditorStatusBarLocalizedI18n() {
           },
           statusBar: {
             frames: '{count} 帧',
+            resourceIndexBuilding: '正在构建资源索引',
+            resourceIndexUnavailable: '资源索引不可用',
             statements: '{count} 条语句',
           },
           textEditor: {
@@ -129,9 +139,18 @@ function createEditorStore() {
   })
 }
 
+function renderEditorStatusBar() {
+  renderInBrowser(EditorStatusBar, {
+    global: {
+      plugins: [createEditorStatusBarLocalizedI18n()],
+    },
+  })
+}
+
 describe('EditorStatusBar', () => {
   beforeEach(() => {
     vi.resetAllMocks()
+    resourceIndexStatus.value = 'idle'
 
     dayjsMock.mockReturnValue({
       fromNow: () => 'just now',
@@ -151,6 +170,10 @@ describe('EditorStatusBar', () => {
     }))
   })
 
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
   it('会显示文本编辑器的保存状态、语言与行词统计', async () => {
     const editorStore = createEditorStore()
     editorStore.currentState = {
@@ -167,11 +190,7 @@ describe('EditorStatusBar', () => {
 
     useEditorStoreMock.mockReturnValue(editorStore)
 
-    renderInBrowser(EditorStatusBar, {
-      global: {
-        plugins: [createEditorStatusBarLocalizedI18n()],
-      },
-    })
+    renderEditorStatusBar()
 
     await expect.element(page.getByText('已保存')).toBeVisible()
     await expect.element(page.getByText('just now')).toBeVisible()
@@ -192,14 +211,52 @@ describe('EditorStatusBar', () => {
     getImageDimensionsMock.mockResolvedValue([1280, 720])
     useEditorStoreMock.mockReturnValue(editorStore)
 
-    renderInBrowser(EditorStatusBar, {
-      global: {
-        plugins: [createEditorStatusBarLocalizedI18n()],
-      },
-    })
+    renderEditorStatusBar()
 
     await expect.element(page.getByText('1280 × 720')).toBeVisible()
     await expect.element(page.getByText('2.0 KiB')).toBeVisible()
     expect(getImageDimensionsMock).toHaveBeenCalledWith('/project/background.png')
+  })
+
+  it('资源索引持续构建超过延迟后才显示状态', async () => {
+    vi.useFakeTimers()
+    resourceIndexStatus.value = 'building'
+    useEditorStoreMock.mockReturnValue(createEditorStore())
+
+    renderEditorStatusBar()
+
+    await expect.element(page.getByText('正在构建资源索引')).not.toBeInTheDocument()
+
+    await vi.advanceTimersByTimeAsync(299)
+    await expect.element(page.getByText('正在构建资源索引')).not.toBeInTheDocument()
+
+    await vi.advanceTimersByTimeAsync(1)
+    await expect.element(page.getByText('正在构建资源索引')).toBeVisible()
+  })
+
+  it('资源索引在显示延迟内就绪时不显示状态', async () => {
+    vi.useFakeTimers()
+    resourceIndexStatus.value = 'building'
+    useEditorStoreMock.mockReturnValue(createEditorStore())
+
+    renderEditorStatusBar()
+
+    resourceIndexStatus.value = 'ready'
+    await nextTick()
+    await vi.advanceTimersByTimeAsync(300)
+
+    await expect.element(page.getByText('正在构建资源索引')).not.toBeInTheDocument()
+  })
+
+  it('资源索引不可用时持续显示警告状态', async () => {
+    resourceIndexStatus.value = 'degraded'
+    useEditorStoreMock.mockReturnValue(createEditorStore())
+
+    renderEditorStatusBar()
+
+    await expect.element(page.getByText('资源索引不可用')).toBeVisible()
+
+    resourceIndexStatus.value = 'ready'
+    await expect.element(page.getByText('资源索引不可用')).not.toBeInTheDocument()
   })
 })

--- a/src/components/editor/EditorStatusBar.vue
+++ b/src/components/editor/EditorStatusBar.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ChartSpline, FileText, Image as ImageIcon, Layers, Link2, Palette } from '@lucide/vue'
+import { ChartSpline, FileText, Image as ImageIcon, Layers, Link2, Loader2, Palette, TriangleAlert } from '@lucide/vue'
 
 import { fsCmds } from '~/commands/fs'
 import { useTemplateLabel } from '~/composables/useTemplateLabel'
@@ -17,6 +17,7 @@ import { formatEngineLabel } from '~/lib/engine-label'
 import dayjs from '~/plugins/dayjs'
 import { getLanguageDisplayName } from '~/plugins/editor'
 import { isEngineUsable } from '~/services/engine-manager'
+import { useResourceIndex } from '~/services/resource-index/service'
 import {
   isEditableEditor,
   useEditorStore,
@@ -31,6 +32,24 @@ const { t, locale } = useI18n()
 const editorStore = useEditorStore()
 const workspaceStore = useWorkspaceStore()
 const modalStore = useModalStore()
+const resourceIndex = useResourceIndex()
+
+const RESOURCE_INDEX_BUILDING_DELAY_MS = 300
+
+let showResourceIndexBuilding = $ref(false)
+watch(() => resourceIndex.status.value, (status, _previousStatus, onCleanup) => {
+  showResourceIndexBuilding = false
+  if (status !== 'building') {
+    return
+  }
+
+  const timer = setTimeout(() => {
+    showResourceIndexBuilding = true
+  }, RESOURCE_INDEX_BUILDING_DELAY_MS)
+  onCleanup(() => clearTimeout(timer))
+}, { immediate: true })
+
+const isResourceIndexDegraded = $computed(() => resourceIndex.status.value === 'degraded')
 
 const currentState = $computed(() => editorStore.currentState)
 
@@ -197,6 +216,24 @@ watchDebounced(() => textContent, updateStats, { debounce: 500, maxWait: 1000 })
             {{ $t('edit.statusBar.selectTemplate') }}
           </TooltipContent>
         </Tooltip>
+
+        <div
+          v-if="showResourceIndexBuilding"
+          role="status"
+          class="text-muted-foreground flex shrink-0 gap-1 items-center"
+        >
+          <Loader2 class="size-3 animate-spin" aria-hidden="true" />
+          <span>{{ $t('edit.statusBar.resourceIndexBuilding') }}</span>
+        </div>
+
+        <div
+          v-else-if="isResourceIndexDegraded"
+          role="status"
+          class="text-yellow-600 flex shrink-0 gap-1 items-center dark:text-yellow-300"
+        >
+          <TriangleAlert class="size-3" aria-hidden="true" />
+          <span>{{ $t('edit.statusBar.resourceIndexUnavailable') }}</span>
+        </div>
       </TooltipProvider>
     </div>
 

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -728,6 +728,8 @@ edit:
     resource: Resource
   statusBar:
     frames: "{count} frames"
+    resourceIndexBuilding: Indexing resources
+    resourceIndexUnavailable: Resource index unavailable
     statements: "{count} statements"
     engineMissing: Engine unavailable
     selectEngine: Select Engine

--- a/src/locales/ja.yml
+++ b/src/locales/ja.yml
@@ -728,6 +728,8 @@ edit:
     resource: リソース
   statusBar:
     frames: "{count} フレーム"
+    resourceIndexBuilding: リソースをインデックスしています
+    resourceIndexUnavailable: リソースインデックスを利用できません
     statements: "{count} ステートメント"
     engineMissing: エンジンが利用できません
     selectEngine: エンジンを選択

--- a/src/locales/zh-Hans.yml
+++ b/src/locales/zh-Hans.yml
@@ -728,6 +728,8 @@ edit:
     resource: 资源
   statusBar:
     frames: "{count} 帧"
+    resourceIndexBuilding: 正在构建资源索引
+    resourceIndexUnavailable: 资源索引不可用
     statements: "{count} 条语句"
     engineMissing: 引擎不可用
     selectEngine: 选择引擎

--- a/src/locales/zh-Hant.yml
+++ b/src/locales/zh-Hant.yml
@@ -728,6 +728,8 @@ edit:
     resource: 資源
   statusBar:
     frames: "{count} 幀"
+    resourceIndexBuilding: 正在建立資源索引
+    resourceIndexUnavailable: 資源索引無法使用
     statements: "{count} 條語句"
     engineMissing: 引擎不可用
     selectEngine: 選擇引擎


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [ ] 错误修复
- [x] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [x] 测试用例
- [ ] 性能优化
- [x] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

在编辑器底部状态栏中展示资源索引的后台状态：

- 资源索引持续构建超过 300ms 后，显示加载图标和“正在构建资源索引”提示。
- 索引进入 `ready` 或 `idle` 状态时隐藏提示。
- 索引进入 `degraded` 状态时，持续显示“资源索引不可用”警告。
- 同步补充英语、日语、简体中文和繁体中文文案。
- 增加组件测试，覆盖延迟显示、快速完成不闪烁和失败状态切换。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

资源索引构建目前只记录后台日志。构建期间，资源诊断等依赖索引的能力暂不可用，但用户无法从界面判断当前状态。

将进行中和不可用状态放入编辑器底部状态栏，可以在不打断工作流的前提下提供必要反馈。正常的 `ready` 状态不常驻显示，以避免增加视觉噪声。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
