### PR TITLE
✨ 命令面板支持自定义常用分类

### DIFF
--- a/src/__tests__/memory-storage.ts
+++ b/src/__tests__/memory-storage.ts
@@ -1,0 +1,10 @@
+import type { StorageLike } from 'pinia-plugin-persistedstate'
+
+export function createMemoryStorage(seed: Record<string, string> = {}): StorageLike {
+  const state = new Map(Object.entries(seed))
+  return {
+    // eslint-disable-next-line unicorn/no-null -- StorageLike follows the Web Storage contract.
+    getItem: key => state.get(key) ?? null,
+    setItem: (key, value) => state.set(key, value),
+  }
+}

--- a/src/components/editor/CommandPanel.spec.ts
+++ b/src/components/editor/CommandPanel.spec.ts
@@ -151,11 +151,11 @@ describe('CommandPanel', () => {
   }
 
   function getFavoriteButton(commandName: string, actionName: string): HTMLButtonElement {
-    const favoriteButton = [...document.querySelectorAll('button')]
-      .find(button => (
-        button.getAttribute('aria-label') === actionName
-        && button.parentElement?.querySelector('button')?.textContent === commandName
-      ))
+    const commandCard = [...document.querySelectorAll<HTMLButtonElement>('button')]
+      .find(button => button.textContent?.trim() === commandName)
+      ?.parentElement
+    const favoriteButton = [...commandCard?.querySelectorAll<HTMLButtonElement>('button') ?? []]
+      .find(button => button.getAttribute('aria-label') === actionName)
     if (!favoriteButton) {
       throw new TypeError(`expected favorite button for ${commandName}`)
     }

--- a/src/components/editor/CommandPanel.spec.ts
+++ b/src/components/editor/CommandPanel.spec.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { page } from 'vitest/browser'
-import { shallowRef } from 'vue'
+import { page, userEvent } from 'vitest/browser'
+import { nextTick, shallowRef } from 'vue'
+import { commandType } from 'webgal-parser/src/interface/sceneInterface'
 
 import {
   createBrowserActionStub,
@@ -85,12 +86,18 @@ function createCommandPanelBrowserOptions() {
             commandPanel: {
               categories: {
                 all: 'all-category',
+                favorites: 'favorites-category',
+                perform: 'perform-category',
                 groups: 'groups-category',
               },
+              addFavorite: '将此语句加入常用',
+              removeFavorite: '将此语句移出常用',
+              emptyFavorites: 'no-favorite-commands',
               confirmDeleteGroup: 'confirm-delete-group',
               editDefaults: 'edit-defaults',
             },
             commands: {
+              filmMode: 'film-mode-command',
               say: 'dialogue-command',
             },
           },
@@ -143,6 +150,18 @@ describe('CommandPanel', () => {
     return { pinia }
   }
 
+  function getFavoriteButton(commandName: string, actionName: string): HTMLButtonElement {
+    const favoriteButton = [...document.querySelectorAll('button')]
+      .find(button => (
+        button.getAttribute('aria-label') === actionName
+        && button.parentElement?.querySelector('button')?.textContent === commandName
+      ))
+    if (!favoriteButton) {
+      throw new TypeError(`expected favorite button for ${commandName}`)
+    }
+    return favoriteButton
+  }
+
   it('渲染分类标签栏', async () => {
     renderCommandPanel()
 
@@ -151,6 +170,15 @@ describe('CommandPanel', () => {
       exact: true,
     })
     await expect.element(allTab).toBeVisible()
+
+    const favoritesTab = page.getByRole('button', {
+      name: 'favorites-category',
+      exact: true,
+    })
+    await expect.element(favoritesTab).toBeVisible()
+    await expect.element(favoritesTab).toHaveAttribute('aria-pressed', 'false')
+    await favoritesTab.click()
+    await expect.element(favoritesTab).toHaveAttribute('aria-pressed', 'true')
 
     const groupsTab = page.getByRole('button', {
       name: 'groups-category',
@@ -175,10 +203,53 @@ describe('CommandPanel', () => {
     expect(store.activeCategory).toBe('groups')
   })
 
-  it('点击命令卡片会发出 insertCommand 事件', async () => {
+  it('可以跨分类添加、取消并重新添加常用命令', async () => {
+    const { pinia } = renderCommandPanel()
+    const store = useCommandPanelStore(pinia)
+
+    const addDialogueFavorite = getFavoriteButton('dialogue-command', '将此语句加入常用')
+    expect(addDialogueFavorite).toHaveAttribute('aria-pressed', 'false')
+
+    await userEvent.click(addDialogueFavorite)
+    await userEvent.click(getFavoriteButton('film-mode-command', '将此语句加入常用'))
+    expect(store.isFavorite(commandType.say)).toBe(true)
+    expect(store.isFavorite(commandType.filmMode)).toBe(true)
+    expect(addDialogueFavorite).toHaveAttribute('aria-label', '将此语句移出常用')
+    expect(addDialogueFavorite).toHaveAttribute('aria-pressed', 'true')
+
+    await page.getByRole('button', { name: 'favorites-category', exact: true }).click()
+    await expect.element(page.getByRole('button', { name: 'dialogue-command', exact: true })).toBeVisible()
+    await expect.element(page.getByRole('button', { name: 'film-mode-command', exact: true })).toBeVisible()
+
+    await userEvent.click(getFavoriteButton('dialogue-command', '将此语句移出常用'))
+    expect(store.isFavorite(commandType.say)).toBe(false)
+
+    await page.getByRole('button', { name: 'perform-category', exact: true }).click()
+    await userEvent.click(getFavoriteButton('dialogue-command', '将此语句加入常用'))
+    await page.getByRole('button', { name: 'favorites-category', exact: true }).click()
+
+    expect(store.isFavorite(commandType.say)).toBe(true)
+    expect(store.isFavorite(commandType.filmMode)).toBe(true)
+    await expect.element(page.getByRole('button', { name: 'dialogue-command', exact: true })).toBeVisible()
+    await expect.element(page.getByRole('button', { name: 'film-mode-command', exact: true })).toBeVisible()
+  })
+
+  it('常用列表为空或只包含失效项时显示稳定空状态', async () => {
+    const { pinia } = renderCommandPanel()
+    const store = useCommandPanelStore(pinia)
+    store.favoriteCommandIds = ['removed-command']
+    store.setActiveCategory('favorites')
+    await nextTick()
+
+    const emptyState = page.getByRole('status')
+    await expect.element(emptyState).toBeVisible()
+    await expect.element(emptyState).toHaveTextContent('no-favorite-commands')
+  })
+
+  it('从常用分类点击命令卡片会发出 insertCommand 事件', async () => {
     const onInsertCommand = vi.fn()
 
-    renderInBrowser(CommandPanel, {
+    const { pinia } = renderInBrowser(CommandPanel, {
       browser: createCommandPanelBrowserOptions(),
       props: {
         onInsertCommand,
@@ -187,21 +258,28 @@ describe('CommandPanel', () => {
         stubs: globalStubs,
       },
     })
+    if (!pinia) {
+      throw new TypeError('expected browser test pinia')
+    }
+    const store = useCommandPanelStore(pinia)
+    store.toggleFavorite(commandType.say)
+    store.setActiveCategory('favorites')
+    await nextTick()
 
-    await page.getByRole('button', { name: 'dialogue-command' }).click()
+    await page.getByRole('button', { name: 'dialogue-command', exact: true }).click()
 
-    expect(onInsertCommand).toHaveBeenCalledWith(expect.any(Number))
+    expect(onInsertCommand).toHaveBeenCalledWith(commandType.say)
   })
 
-  it('命令卡片拖拽会生成 command-panel-statement payload', () => {
+  it('命令卡片拖拽会使用当前用户默认值生成 payload', () => {
     const { pinia } = renderCommandPanel()
     const store = useCommandPanelStore(pinia)
-    store.saveDefault(0, 'say:custom;')
+    store.saveDefault(commandType.say, 'say:custom;')
     const getData = lastDragSourceOptions.value?.getData
 
     const element = document.createElement('div')
     element.dataset.commandPanelDragKind = 'command'
-    element.dataset.commandPanelCommandType = '0'
+    element.dataset.commandPanelCommandType = String(commandType.say)
     element.dataset.commandPanelDragLabel = 'dialogue-command'
 
     expect(getData?.(element)).toEqual({

--- a/src/components/editor/CommandPanel.vue
+++ b/src/components/editor/CommandPanel.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { Pencil, Star } from '@lucide/vue'
+
 import { useDragSession } from '~/composables/useDragSession'
 import { useDragSource } from '~/composables/useDragTransfer'
 import {
@@ -33,7 +35,11 @@ const activeCategory = $computed(() => commandPanelStore.activeCategory)
 const dragSession = useDragSession()
 
 const isGroupsView = $computed(() => activeCategory === 'groups')
-const visibleCommands = $computed(() => resolveCommandPanelVisibleCommands(activeCategory))
+const visibleCommands = $computed(() => resolveCommandPanelVisibleCommands(
+  activeCategory,
+  commandPanelStore.favoriteCommandIds,
+))
+const isEmptyFavorites = $computed(() => activeCategory === 'favorites' && visibleCommands.length === 0)
 const modalStore = useModalStore()
 
 function openDefaultsModal(type: commandType): void {
@@ -57,6 +63,13 @@ function clearPendingDeleteGroup(): void {
 
 function handleCategoryClick(category: CommandPanelCategory): void {
   commandPanelStore.setActiveCategory(category)
+}
+
+function getFavoriteActionLabel(type: commandType): string {
+  if (commandPanelStore.isFavorite(type)) {
+    return t('edit.visualEditor.commandPanel.removeFavorite')
+  }
+  return t('edit.visualEditor.commandPanel.addFavorite')
 }
 
 function handleDeletePopoverOpenChange(groupId: string, open: boolean): void {
@@ -175,6 +188,7 @@ useShortcutContext({
             size="sm"
             class="px-3 rounded-sm shrink-0 h-6"
             :class="activeCategory === 'all' && 'bg-accent text-accent-foreground'"
+            :aria-pressed="activeCategory === 'all'"
             @click="handleCategoryClick('all')"
           >
             {{ getCategoryLabel('all', t) }}
@@ -186,6 +200,7 @@ useShortcutContext({
             size="sm"
             class="px-3 rounded-sm shrink-0 h-6"
             :class="activeCategory === category && `${categoryTheme[category].bg} ${categoryTheme[category].text} ${categoryTheme[category].hoverBg} ${categoryTheme[category].hoverText}`"
+            :aria-pressed="activeCategory === category"
             @click="handleCategoryClick(category)"
           >
             {{ getCategoryLabel(category, t) }}
@@ -196,20 +211,43 @@ useShortcutContext({
 
       <Separator orientation="vertical" class="h-5" />
 
-      <Button
-        variant="ghost"
-        size="sm"
-        class="px-3 py-1 rounded-sm shrink-0 h-6"
-        :class="activeCategory === 'groups' && 'bg-violet-50 dark:bg-violet-950 text-violet-500 hover:bg-violet-100 dark:hover:bg-violet-900 hover:text-violet-600 dark:hover:text-violet-400'"
-        @click="handleCategoryClick('groups')"
-      >
-        {{ getCategoryLabel('groups', t) }}
-      </Button>
+      <div class="flex gap-1 items-center">
+        <Button
+          variant="ghost"
+          size="sm"
+          class="px-3 py-1 rounded-sm shrink-0 h-6"
+          :class="activeCategory === 'favorites' && 'bg-cyan-50 dark:bg-cyan-950 text-cyan-500 hover:bg-cyan-100 dark:hover:bg-cyan-900 hover:text-cyan-600 dark:hover:text-cyan-400'"
+          :aria-pressed="activeCategory === 'favorites'"
+          @click="handleCategoryClick('favorites')"
+        >
+          {{ getCategoryLabel('favorites', t) }}
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          class="px-3 py-1 rounded-sm shrink-0 h-6"
+          :class="activeCategory === 'groups' && 'bg-violet-50 dark:bg-violet-950 text-violet-500 hover:bg-violet-100 dark:hover:bg-violet-900 hover:text-violet-600 dark:hover:text-violet-400'"
+          :aria-pressed="activeCategory === 'groups'"
+          @click="handleCategoryClick('groups')"
+        >
+          {{ getCategoryLabel('groups', t) }}
+        </Button>
+      </div>
     </div>
 
     <TooltipProvider :skip-delay-duration="0">
       <ScrollArea ref="commandAreaRef" class="flex-1 min-h-0">
         <div
+          v-if="isEmptyFavorites"
+          class="text-muted-foreground p-2 text-center grid inset-0 place-items-center absolute"
+          role="status"
+        >
+          <p class="text-sm">
+            {{ $t('edit.visualEditor.commandPanel.emptyFavorites') }}
+          </p>
+        </div>
+        <div
+          v-else
           class="p-2 gap-1.5 grid"
           style="grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));"
         >
@@ -229,17 +267,34 @@ useShortcutContext({
               :gradient="categoryTheme[entry.category].gradient"
               :icon-bg="categoryTheme[entry.category].bg"
               :icon-text="categoryTheme[entry.category].text"
+              :actions-always-visible="commandPanelStore.isFavorite(entry.type)"
               @click="emit('insertCommand', entry.type)"
             >
-              <template v-if="!entry.locked" #actions>
+              <template #actions>
                 <Button
+                  v-if="!entry.locked"
                   variant="ghost"
                   size="sm"
-                  class="p-0 opacity-60 size-6 hover:opacity-100"
+                  class="p-0 opacity-0 size-6 group-focus-visible:opacity-60 group-has-[:focus-visible]:opacity-60 group-hover:opacity-60 hover:opacity-100 [&_svg]:size-3.5"
                   :title="$t('edit.visualEditor.commandPanel.editDefaults')"
                   @click="openDefaultsModal(entry.type)"
                 >
-                  <div class="i-lucide-pencil size-3" />
+                  <Pencil aria-hidden="true" />
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  class="p-0 size-6 transition-all hover:text-amber-500 hover:opacity-100 [&_svg]:size-3.5"
+                  :class="commandPanelStore.isFavorite(entry.type) ? 'text-amber-500 opacity-100' : 'opacity-60'"
+                  :title="getFavoriteActionLabel(entry.type)"
+                  :aria-label="getFavoriteActionLabel(entry.type)"
+                  :aria-pressed="commandPanelStore.isFavorite(entry.type)"
+                  @click="commandPanelStore.toggleFavorite(entry.type)"
+                >
+                  <Star
+                    :fill="commandPanelStore.isFavorite(entry.type) ? 'currentColor' : 'none'"
+                    aria-hidden="true"
+                  />
                 </Button>
               </template>
             </CommandPanelCard>
@@ -284,11 +339,11 @@ useShortcutContext({
                 <Button
                   variant="ghost"
                   size="sm"
-                  class="p-0 opacity-60 size-6 hover:opacity-100"
+                  class="p-0 opacity-60 size-6 hover:opacity-100 [&_svg]:size-3"
                   :title="$t('common.edit')"
                   @click="openGroupModal(group)"
                 >
-                  <div class="i-lucide-pencil size-3" />
+                  <Pencil aria-hidden="true" />
                 </Button>
                 <Popover :open="pendingDeleteGroupId === group.id" @update:open="value => handleDeletePopoverOpenChange(group.id, value)">
                   <PopoverTrigger as-child>

--- a/src/components/editor/CommandPanelCard.spec.ts
+++ b/src/components/editor/CommandPanelCard.spec.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it, vi } from 'vitest'
-import { page } from 'vitest/browser'
+import { page, userEvent } from 'vitest/browser'
 import { h } from 'vue'
 
 import { createBrowserContainerStub, renderInBrowser } from '~/__tests__/browser-render'
+// @unocss-safelist opacity-0 opacity-100 group-focus-visible:opacity-100 group-has-[:focus-visible]:opacity-100 group-hover:opacity-100
+import 'virtual:uno.css'
 
 import CommandPanelCard from './CommandPanelCard.vue'
 
@@ -13,6 +15,28 @@ const globalStubs = {
 }
 
 describe('CommandPanelCard', () => {
+  it('开启常显动作时动作区保持可见', () => {
+    renderInBrowser(CommandPanelCard, {
+      props: {
+        actionsAlwaysVisible: true,
+        title: 'Dialogue',
+      },
+      slots: {
+        actions: () => h('button', { type: 'button' }, 'favorite-action'),
+      },
+      global: {
+        stubs: globalStubs,
+      },
+    })
+
+    const actionButton = [...document.querySelectorAll('button')]
+      .find(button => button.textContent === 'favorite-action')
+    if (!actionButton?.parentElement) {
+      throw new TypeError('expected favorite action button')
+    }
+    expect(actionButton.parentElement).toHaveStyle({ opacity: '1' })
+  })
+
   it('点击动作区按钮不会触发卡片点击', async () => {
     const handleClick = vi.fn()
 
@@ -29,9 +53,38 @@ describe('CommandPanelCard', () => {
       },
     })
 
+    await page.getByRole('button', { name: 'Dialogue' }).hover()
     await page.getByRole('button', { name: 'edit-action', exact: true }).click()
 
     expect(handleClick).not.toHaveBeenCalled()
+  })
+
+  it('键盘焦点位于卡片或动作按钮时动作区保持可见', async () => {
+    renderInBrowser(CommandPanelCard, {
+      props: {
+        title: 'Dialogue',
+      },
+      slots: {
+        actions: () => h('button', { type: 'button' }, 'edit-action'),
+      },
+      global: {
+        stubs: globalStubs,
+      },
+    })
+
+    const actionButton = page.getByRole('button', { name: 'edit-action', exact: true })
+    const actionElement = actionButton.element()
+    const actions = actionElement.parentElement
+    if (!actions) {
+      throw new TypeError('expected command panel card actions')
+    }
+
+    await userEvent.tab()
+    await expect.poll(() => getComputedStyle(actions).opacity).toBe('1')
+
+    await userEvent.tab()
+    expect(document.activeElement).toBe(actionElement)
+    await expect.poll(() => getComputedStyle(actions).opacity).toBe('1')
   })
 
   it('点击卡片主体仍会触发卡片点击', async () => {

--- a/src/components/editor/CommandPanelCard.vue
+++ b/src/components/editor/CommandPanelCard.vue
@@ -19,6 +19,7 @@ interface Props {
   iconText?: string
   interactive?: boolean
   dashed?: boolean
+  actionsAlwaysVisible?: boolean
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -31,6 +32,7 @@ const props = withDefaults(defineProps<Props>(), {
   iconText: 'text-foreground/80',
   interactive: true,
   dashed: false,
+  actionsAlwaysVisible: false,
 })
 
 const emit = defineEmits<{
@@ -104,7 +106,8 @@ const cardAttrs = $computed(() => ({
         </div>
 
         <div
-          class="pl-3 pr-1.5 opacity-0 flex gap-0.5 transition-opacity items-center right-0 top-1/2 absolute from-card from-65% bg-gradient-to-l group-hover:opacity-100 -translate-y-1/2"
+          class="pl-3 pr-1.5 flex gap-0.5 transition-opacity items-center right-0 top-1/2 absolute from-card from-65% bg-gradient-to-l -translate-y-1/2"
+          :class="actionsAlwaysVisible ? 'opacity-100' : 'opacity-0 group-focus-visible:opacity-100 group-has-[:focus-visible]:opacity-100 group-hover:opacity-100'"
           @click.stop
           @keydown.stop
           @pointerdown.stop

--- a/src/features/editor/command-panel/__tests__/command-panel.test.ts
+++ b/src/features/editor/command-panel/__tests__/command-panel.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it } from 'vitest'
+import { commandType } from 'webgal-parser/src/interface/sceneInterface'
+
+import { commandEntries } from '~/features/editor/command-registry'
 
 import {
   buildCommandPanelGroupTagEntries,
@@ -15,6 +18,19 @@ describe('commandPanel', () => {
     expect(performCommands.length).toBeGreaterThan(0)
     expect(performCommands.every(entry => entry.category === 'perform')).toBe(true)
     expect(performCommands.length).toBeLessThan(allCommands.length)
+  })
+
+  it('常用视图按收藏顺序复用注册项并忽略重复和失效的命令标识', () => {
+    const favoriteCommands = resolveCommandPanelVisibleCommands(
+      'favorites',
+      ['filmMode', 'say', 'filmMode', 'removed-command'],
+    )
+
+    expect(favoriteCommands.map(entry => entry.type)).toEqual([
+      commandType.filmMode,
+      commandType.say,
+    ])
+    expect(favoriteCommands.every(entry => commandEntries.includes(entry))).toBe(true)
   })
 
   it('会按命令标签聚合同类语句组条目', () => {

--- a/src/features/editor/command-panel/command-panel.ts
+++ b/src/features/editor/command-panel/command-panel.ts
@@ -1,5 +1,5 @@
 import { parseSentence } from '~/domain/script/parser'
-import { commandEntries, getCommandConfig } from '~/features/editor/command-registry'
+import { commandEntries, getCommandConfig, getCommandId } from '~/features/editor/command-registry'
 import { resolveI18n } from '~/features/editor/command-registry/schema'
 
 import type { CommandPanelCategory } from '~/features/editor/command-registry'
@@ -13,10 +13,32 @@ export interface CommandPanelGroupTagEntry {
 
 export function resolveCommandPanelVisibleCommands(
   activeCategory: CommandPanelCategory,
+  favoriteCommandIds: readonly string[] = [],
   entries: readonly CommandEntry[] = commandEntries,
 ): readonly CommandEntry[] {
   if (activeCategory === 'all' || activeCategory === 'groups') {
     return entries
+  }
+
+  if (activeCategory === 'favorites') {
+    const entriesById = new Map<string, CommandEntry>()
+    for (const entry of entries) {
+      const id = getCommandId(entry.type)
+      if (id !== undefined) {
+        entriesById.set(id, entry)
+      }
+    }
+
+    const favoriteEntries: CommandEntry[] = []
+    const seenIds = new Set<string>()
+    for (const id of favoriteCommandIds) {
+      const entry = entriesById.get(id)
+      if (entry && !seenIds.has(id)) {
+        favoriteEntries.push(entry)
+        seenIds.add(id)
+      }
+    }
+    return favoriteEntries
   }
 
   return entries.filter(entry => entry.category === activeCategory)

--- a/src/features/editor/command-registry/__tests__/registry.test.ts
+++ b/src/features/editor/command-registry/__tests__/registry.test.ts
@@ -1,10 +1,17 @@
 import { describe, expect, it } from 'vitest'
 import { commandType } from 'webgal-parser/src/interface/sceneInterface'
 
-import { categoryTheme, commandEntries, commandPanelCategories, getCommandConfig } from '../index'
+import { categoryTheme, commandEntries, commandPanelCategories, getCommandConfig, getCommandId } from '../index'
 import { readArgFields, readContentField, readEditorFields, resolveI18n } from '../schema'
 
 describe('命令注册表完整性', () => {
+  it('所有命令注册项都有唯一稳定标识', () => {
+    const commandIds = commandEntries.map(entry => getCommandId(entry.type))
+
+    expect(commandIds).not.toContain(undefined)
+    expect(new Set(commandIds).size).toBe(commandEntries.length)
+  })
+
   it('源条目的命令类型应唯一', () => {
     const seen = new Set<commandType>()
     for (const entry of commandEntries) {

--- a/src/features/editor/command-registry/index.ts
+++ b/src/features/editor/command-registry/index.ts
@@ -36,7 +36,7 @@ export const commandPanelCategories = [
   'system',
 ] as const satisfies readonly CommandCategory[]
 
-export type CommandPanelCategory = (typeof commandPanelCategories)[number] | 'all' | 'groups'
+export type CommandPanelCategory = (typeof commandPanelCategories)[number] | 'all' | 'favorites' | 'groups'
 
 /**
  * 获取命令面板分类的本地化标签
@@ -44,6 +44,7 @@ export type CommandPanelCategory = (typeof commandPanelCategories)[number] | 'al
 export function getCategoryLabel(category: CommandPanelCategory, t: I18nT): string {
   const labelMap: Record<CommandPanelCategory, string> = {
     all: t('edit.visualEditor.commandPanel.categories.all'),
+    favorites: t('edit.visualEditor.commandPanel.categories.favorites'),
     perform: t('edit.visualEditor.commandPanel.categories.perform'),
     effect: t('edit.visualEditor.commandPanel.categories.effect'),
     display: t('edit.visualEditor.commandPanel.categories.display'),
@@ -73,6 +74,14 @@ const scriptStringMap = new Map<commandType, string>(
 
 export function getCommandScriptString(type: commandType): string | undefined {
   return scriptStringMap.get(type)
+}
+
+export function getCommandId(type: commandType): string | undefined {
+  // 注释没有 SCRIPT_CONFIG 脚本关键字，但仍需要稳定的注册项标识。
+  if (type === commandType.comment) {
+    return 'comment'
+  }
+  return getCommandScriptString(type)
 }
 
 const defaultEntry: CommandEntry = {

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -848,8 +848,12 @@ edit:
       moveUp: Move up
       moveDown: Move down
       groupCount: "{count} statements"
+      addFavorite: Add this statement to favorites
+      removeFavorite: Remove this statement from favorites
+      emptyFavorites: No favorite commands yet
       categories:
         all: All
+        favorites: Favorites
         perform: Perform
         effect: Effects
         display: Display

--- a/src/locales/ja.yml
+++ b/src/locales/ja.yml
@@ -848,8 +848,12 @@ edit:
       moveUp: 上へ移動
       moveDown: 下へ移動
       groupCount: "{count} 件のステートメント"
+      addFavorite: このステートメントをお気に入りに追加
+      removeFavorite: このステートメントをお気に入りから削除
+      emptyFavorites: お気に入りのコマンドはまだありません
       categories:
         all: すべて
+        favorites: お気に入り
         perform: 演出
         effect: エフェクト
         display: 表示

--- a/src/locales/zh-Hans.yml
+++ b/src/locales/zh-Hans.yml
@@ -848,8 +848,12 @@ edit:
       moveUp: 上移
       moveDown: 下移
       groupCount: 共 {count} 条语句
+      addFavorite: 将此语句加入常用
+      removeFavorite: 将此语句移出常用
+      emptyFavorites: 暂无常用命令
       categories:
         all: 全部
+        favorites: 常用
         perform: 演出
         effect: 效果
         display: 显示

--- a/src/locales/zh-Hant.yml
+++ b/src/locales/zh-Hant.yml
@@ -848,8 +848,12 @@ edit:
       moveUp: 上移
       moveDown: 下移
       groupCount: 共 {count} 條語句
+      addFavorite: 將此語句加入常用
+      removeFavorite: 將此語句移出常用
+      emptyFavorites: 暫無常用命令
       categories:
         all: 全部
+        favorites: 常用
         perform: 演出
         effect: 效果
         display: 顯示

--- a/src/stores/__tests__/app-update.test.ts
+++ b/src/stores/__tests__/app-update.test.ts
@@ -5,20 +5,8 @@ import { createPersistedState } from 'pinia-plugin-persistedstate'
 import { describe, expect, it } from 'vitest'
 import { createApp, nextTick } from 'vue'
 
+import { createMemoryStorage } from '~/__tests__/memory-storage'
 import { useAppUpdateStore } from '~/stores/app-update'
-
-function createMemoryStorage(seed: Record<string, string> = {}) {
-  const state = new Map(Object.entries(seed))
-  return {
-    getItem(key: string) {
-      // eslint-disable-next-line unicorn/no-null -- persistedstate 遵循 Web Storage 约定。
-      return state.get(key) ?? null
-    },
-    setItem(key: string, value: string) {
-      state.set(key, value)
-    },
-  }
-}
 
 describe('useAppUpdateStore', () => {
   it('记录可用更新时会清理旧版本的跳过状态', () => {

--- a/src/stores/__tests__/command-panel.test.ts
+++ b/src/stores/__tests__/command-panel.test.ts
@@ -1,23 +1,43 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
-
 import '~/__tests__/setup'
 
+import { createPinia, setActivePinia } from 'pinia'
+import { createPersistedState } from 'pinia-plugin-persistedstate'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, nextTick } from 'vue'
+import { commandType } from 'webgal-parser/src/interface/sceneInterface'
+
+import { createMemoryStorage } from '~/__tests__/memory-storage'
 import { parseSentence } from '~/domain/script/parser'
 import { getFactoryDefaultCommandText } from '~/features/editor/command-registry'
 import { useCommandPanelStore } from '~/stores/command-panel'
 
 vi.mock('~/features/editor/command-registry', () => ({
+  getCommandId: vi.fn((type: number) => {
+    if (type === 0) {
+      return 'say'
+    }
+    if (type === 23) {
+      return 'filmMode'
+    }
+  }),
   getFactoryDefaultCommandText: vi.fn((type: number) => `factory:${type}`),
 }))
 vi.mock('~/domain/script/parser', () => ({
   parseSentence: vi.fn(),
 }))
 vi.mock('webgal-parser/src/interface/sceneInterface', () => ({
-  commandType: { say: 0, changeBg: 1 },
+  commandType: { say: 0, changeBg: 1, filmMode: 23 },
 }))
 
 function createParsedSentence(command: number): NonNullable<ReturnType<typeof parseSentence>> {
   return { command } as NonNullable<ReturnType<typeof parseSentence>>
+}
+
+function activatePersistedPinia(storage: ReturnType<typeof createMemoryStorage>): void {
+  const pinia = createPinia()
+  pinia.use(createPersistedState({ storage }))
+  createApp({}).use(pinia)
+  setActivePinia(pinia)
 }
 
 describe('useCommandPanelStore', () => {
@@ -57,6 +77,42 @@ describe('useCommandPanelStore', () => {
     store.resetDefault(1)
     expect(store.defaults[1]).toBeUndefined()
     expect(store.getInsertText(1)).toBe('factory:1')
+  })
+
+  // --- favorites ---
+
+  it('切换常用命令会添加、移除并允许重新添加', () => {
+    store.toggleFavorite(commandType.say)
+    expect(store.favoriteCommandIds).toEqual(['say'])
+    expect(store.isFavorite(commandType.say)).toBe(true)
+
+    store.toggleFavorite(commandType.say)
+    expect(store.favoriteCommandIds).toEqual([])
+    expect(store.isFavorite(commandType.say)).toBe(false)
+
+    store.toggleFavorite(commandType.say)
+    expect(store.favoriteCommandIds).toEqual(['say'])
+  })
+
+  it('拒绝没有稳定标识的未知命令类型', () => {
+    expect(() => store.toggleFavorite(999 as commandType)).toThrow('Unknown command type: 999')
+  })
+
+  it('持久化恢复后保留常用命令类型身份', async () => {
+    const storage = createMemoryStorage()
+    activatePersistedPinia(storage)
+
+    const persistedStore = useCommandPanelStore()
+    persistedStore.toggleFavorite(commandType.say)
+    persistedStore.toggleFavorite(commandType.filmMode)
+    await nextTick()
+
+    const persistedState = JSON.parse(storage.getItem('command-panel') ?? '{}')
+    expect(persistedState.favoriteCommandIds).toEqual(['say', 'filmMode'])
+
+    activatePersistedPinia(storage)
+    const restoredStore = useCommandPanelStore()
+    expect(restoredStore.favoriteCommandIds).toEqual(['say', 'filmMode'])
   })
 
   // --- saveGroup ---

--- a/src/stores/__tests__/storage-settings.test.ts
+++ b/src/stores/__tests__/storage-settings.test.ts
@@ -5,21 +5,8 @@ import { createPersistedState } from 'pinia-plugin-persistedstate'
 import { describe, expect, it } from 'vitest'
 import { createApp } from 'vue'
 
+import { createMemoryStorage } from '~/__tests__/memory-storage'
 import { useStorageSettingsStore } from '~/stores/storage-settings'
-
-function createMemoryStorage(seed: Record<string, string> = {}) {
-  const state = new Map(Object.entries(seed))
-  return {
-    getItem(key: string) {
-      // persistedstate 约定未命中时返回 null，这里显式兼容其接口
-      // eslint-disable-next-line unicorn/no-null
-      return state.get(key) ?? null
-    },
-    setItem(key: string, value: string) {
-      state.set(key, value)
-    },
-  }
-}
 
 describe('useStorageSettingsStore', () => {
   it('默认保存路径为空', () => {

--- a/src/stores/__tests__/tabs.test.ts
+++ b/src/stores/__tests__/tabs.test.ts
@@ -5,6 +5,7 @@ import { createPersistedState } from 'pinia-plugin-persistedstate'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createApp, reactive } from 'vue'
 
+import { createMemoryStorage } from '~/__tests__/memory-storage'
 import { AbsPath } from '~/domain/path'
 import { useTabsStore } from '~/stores/tabs'
 
@@ -22,20 +23,6 @@ const workspaceStoreState = reactive<{ currentGame?: { id: string } }>({
 const editSettingsStoreState = reactive({
   enablePreviewTab: true,
 })
-
-function createMemoryStorage(seed: Record<string, string> = {}) {
-  const state = new Map(Object.entries(seed))
-  return {
-    getItem(key: string) {
-      // persistedstate 约定未命中时返回 null，这里显式兼容其接口
-      // eslint-disable-next-line unicorn/no-null
-      return state.get(key) ?? null
-    },
-    setItem(key: string, value: string) {
-      state.set(key, value)
-    },
-  }
-}
 
 vi.mock('~/stores/workspace', () => ({
   useWorkspaceStore: useWorkspaceStoreMock,

--- a/src/stores/command-panel.ts
+++ b/src/stores/command-panel.ts
@@ -2,7 +2,7 @@ import { defineStore } from 'pinia'
 import { commandType } from 'webgal-parser/src/interface/sceneInterface'
 
 import { parseSentence } from '~/domain/script/parser'
-import { CommandPanelCategory, getFactoryDefaultCommandText } from '~/features/editor/command-registry'
+import { CommandPanelCategory, getCommandId, getFactoryDefaultCommandText } from '~/features/editor/command-registry'
 
 export interface StatementGroup {
   id: string
@@ -20,6 +20,7 @@ export const useCommandPanelStore = defineStore(
   () => {
     let defaults = $ref<Partial<Record<commandType, string>>>({})
     let groups = $ref<StatementGroup[]>([])
+    let favoriteCommandIds = $ref<string[]>([])
     let activeCategory = $ref<CommandPanelCategory>('all')
 
     function getInsertText(type: commandType): string {
@@ -46,6 +47,21 @@ export const useCommandPanelStore = defineStore(
       const nextDefaults = { ...defaults }
       delete nextDefaults[type]
       defaults = nextDefaults
+    }
+
+    function isFavorite(type: commandType): boolean {
+      const commandId = getCommandId(type)
+      return commandId !== undefined && favoriteCommandIds.includes(commandId)
+    }
+
+    function toggleFavorite(type: commandType): void {
+      const commandId = getCommandId(type)
+      if (commandId === undefined) {
+        throw new RangeError(`Unknown command type: ${type}`)
+      }
+      favoriteCommandIds = favoriteCommandIds.includes(commandId)
+        ? favoriteCommandIds.filter(favoriteId => favoriteId !== commandId)
+        : [...favoriteCommandIds, commandId]
     }
 
     function saveGroup(input: Omit<StatementGroup, 'id' | 'createdAt'> & Partial<Pick<StatementGroup, 'id' | 'createdAt'>>) {
@@ -99,10 +115,13 @@ export const useCommandPanelStore = defineStore(
     return $$({
       defaults,
       groups,
+      favoriteCommandIds,
       activeCategory,
       getInsertText,
       saveDefault,
       resetDefault,
+      isFavorite,
+      toggleFavorite,
       saveGroup,
       deleteGroup,
       resetGroup,


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [ ] 错误修复
- [x] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [x] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

- 在命令面板新增“常用”分类，支持从全部命令或任意内置分类添加、取消和重新添加常用命令。
- 将常用命令类型持久化到命令面板 store，并保证重复数据不会生成重复卡片、已失效的命令类型不会阻塞渲染。
- 常用分类直接筛选现有命令注册表，继续复用命令卡片的插入、拖拽、图标、分类配色和当前默认值，不保存命令定义副本。
- 为常用操作和空列表状态补充四种语言的文本及可访问名称；收藏后实心星标保持可见，编辑操作在悬停或键盘焦点下显示。
- 补充 store 单元测试和命令面板浏览器组件测试，覆盖持久化、去重、失效项、分类切换、插入和拖拽。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

制作过程中经常需要在“对话”“电影模式”等不同分类之间切换高频命令，而“全部”分类的信息密度过高。自定义常用分类可以集中这些命令，减少分类切换和查找成本，同时保持原命令行为与默认值实时一致。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->

本次更改只新增可选的常用配置，不改变现有分类的内容、顺序或命令插入语义。

### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
