### PR TITLE
✨ 支持 Android Web 导出产物发布到公共下载目录

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5627,6 +5627,7 @@ dependencies = [
  "tower",
  "tower-http",
  "trash",
+ "zip",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1260,6 +1260,7 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -6571,15 +6572,35 @@ checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
 dependencies = [
  "arbitrary",
  "crc32fast",
+ "flate2",
  "indexmap 2.14.0",
  "memchr",
+ "zopfli",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
 
 [[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
 
 [[package]]
 name = "zune-core"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -35,6 +35,7 @@ tempfile = "3.27"
 percent-encoding = "2.3"
 sha2 = "0.11"
 chrono = { version = "0.4", default-features = false, features = ["clock", "serde"] }
+zip = { version = "4.6", default-features = false }
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-single-instance = "2.4"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -35,7 +35,7 @@ tempfile = "3.27"
 percent-encoding = "2.3"
 sha2 = "0.11"
 chrono = { version = "0.4", default-features = false, features = ["clock", "serde"] }
-zip = { version = "4.6", default-features = false }
+zip = { version = "4.6", default-features = false, features = ["deflate"] }
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-single-instance = "2.4"

--- a/src-tauri/gen/android/app/build.gradle.kts
+++ b/src-tauri/gen/android/app/build.gradle.kts
@@ -28,6 +28,7 @@ android {
         applicationId = "com.akirami.webgalcraft"
         minSdk = 29
         targetSdk = 36
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         versionCode = tauriProperties.getProperty("tauri.android.versionCode", "1").toInt()
         versionName = tauriProperties.getProperty("tauri.android.versionName", "1.0")
     }

--- a/src-tauri/gen/android/app/src/androidTest/java/com/akirami/webgalcraft/AndroidExportRecoveryInstrumentationTest.kt
+++ b/src-tauri/gen/android/app/src/androidTest/java/com/akirami/webgalcraft/AndroidExportRecoveryInstrumentationTest.kt
@@ -1,0 +1,108 @@
+package com.akirami.webgalcraft
+
+import android.content.ContentValues
+import android.net.Uri
+import android.provider.MediaStore
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import java.io.File
+import java.util.UUID
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class AndroidExportRecoveryInstrumentationTest {
+  private val context = InstrumentationRegistry.getInstrumentation().targetContext
+  private val sessions = AndroidExportSessionStore(context)
+  private val cleanup = AndroidExportSessionCleanup(context, sessions)
+
+  @Test
+  fun recoveryDeletesPendingMediaEntryAndPrivateStaging() {
+    val sessionId = UUID.randomUUID().toString()
+    val staging = ManagedStoragePaths.exportStaging(context.filesDir, sessionId)
+    val contentUri = insertDownload("webgal-craft-pending-$sessionId.zip", pending = true)
+    try {
+      assertTrue(staging.mkdirs())
+      File(staging, "export.zip").writeText("fixture")
+      sessions.create(sessionId).also { session ->
+        session.status = AndroidExportStatus.MEDIA_PENDING
+        session.contentUri = contentUri.toString()
+        sessions.save(session)
+      }
+
+      cleanup.recoverAll()
+
+      assertFalse(staging.exists())
+      assertNull(sessions.find(sessionId))
+      assertFalse(mediaEntryExists(contentUri))
+    } finally {
+      context.contentResolver.delete(contentUri, null, null)
+      staging.deleteRecursively()
+    }
+  }
+
+  @Test
+  fun recoveryPreservesPublishedMediaEntryAndCleansPrivateState() {
+    val sessionId = UUID.randomUUID().toString()
+    val staging = ManagedStoragePaths.exportStaging(context.filesDir, sessionId)
+    val contentUri = insertDownload("webgal-craft-published-$sessionId.zip", pending = false)
+    try {
+      assertTrue(staging.mkdirs())
+      File(staging, "export.zip").writeText("fixture")
+      sessions.create(sessionId).also { session ->
+        session.status = AndroidExportStatus.PUBLISHED
+        session.contentUri = contentUri.toString()
+        sessions.save(session)
+      }
+
+      cleanup.recoverAll()
+
+      assertFalse(staging.exists())
+      assertNull(sessions.find(sessionId))
+      assertTrue(mediaEntryExists(contentUri))
+    } finally {
+      context.contentResolver.delete(contentUri, null, null)
+      staging.deleteRecursively()
+    }
+  }
+
+  @Test
+  fun publishedUriMustBelongToManagedExportDirectory() {
+    val contentUri = insertDownload(
+      "webgal-craft-unmanaged-${UUID.randomUUID()}.zip",
+      pending = false,
+      relativePath = "Download/",
+    )
+    try {
+      val error = runCatching {
+        requirePublishedExportUri(context, contentUri.toString())
+      }.exceptionOrNull()
+
+      assertTrue(error is IllegalArgumentException)
+    } finally {
+      context.contentResolver.delete(contentUri, null, null)
+    }
+  }
+
+  private fun insertDownload(
+    displayName: String,
+    pending: Boolean,
+    relativePath: String = ANDROID_EXPORT_RELATIVE_PATH,
+  ): Uri =
+    requireNotNull(context.contentResolver.insert(
+      MediaStore.Downloads.EXTERNAL_CONTENT_URI,
+      ContentValues().apply {
+        put(MediaStore.Downloads.DISPLAY_NAME, displayName)
+        put(MediaStore.Downloads.MIME_TYPE, ANDROID_EXPORT_MIME_TYPE)
+        put(MediaStore.Downloads.RELATIVE_PATH, relativePath)
+        put(MediaStore.Downloads.IS_PENDING, if (pending) 1 else 0)
+      },
+    ))
+
+  private fun mediaEntryExists(uri: Uri): Boolean =
+    context.contentResolver.query(uri, arrayOf(MediaStore.Downloads._ID), null, null, null)
+      ?.use { it.moveToFirst() } == true
+}

--- a/src-tauri/gen/android/app/src/main/java/com/akirami/webgalcraft/AndroidExportPlugin.kt
+++ b/src-tauri/gen/android/app/src/main/java/com/akirami/webgalcraft/AndroidExportPlugin.kt
@@ -1,0 +1,220 @@
+package com.akirami.webgalcraft
+
+import android.app.Activity
+import android.content.ContentValues
+import android.content.Intent
+import android.net.Uri
+import android.provider.MediaStore
+import app.tauri.annotation.Command
+import app.tauri.annotation.InvokeArg
+import app.tauri.plugin.Invoke
+import app.tauri.plugin.Plugin
+import java.io.FileInputStream
+import java.io.IOException
+import java.util.concurrent.Executors
+
+private const val EXPORT_BUFFER_SIZE = 64 * 1024
+
+@InvokeArg
+private class ExportPublishArgs {
+  lateinit var exportSessionId: String
+  lateinit var suggestedFileName: String
+}
+
+@InvokeArg
+private class ExportSessionArgs {
+  lateinit var exportSessionId: String
+}
+
+@InvokeArg
+private class PublishedUriArgs {
+  lateinit var contentUri: String
+}
+
+class AndroidExportPlugin(private val activity: Activity) : Plugin(activity) {
+  private val executor = Executors.newSingleThreadExecutor()
+  private val sessions = AndroidExportSessionStore(activity)
+  private val sessionCleanup = AndroidExportSessionCleanup(activity, sessions)
+
+  @Command
+  fun resolveWebExportStaging(invoke: Invoke) {
+    try {
+      val args = invoke.parseArgs(ExportSessionArgs::class.java)
+      sessions.create(args.exportSessionId)
+      invoke.resolveObject(mapOf(
+        "sessionPath" to ManagedStoragePaths.exportStaging(activity.filesDir, args.exportSessionId).absolutePath,
+      ))
+    } catch (error: Exception) {
+      invoke.reject(error.message ?: "unable to resolve export staging")
+    }
+  }
+
+  @Command
+  fun publishWebExport(invoke: Invoke) {
+    executor.execute {
+      var publishedUri: Uri? = null
+      var session: AndroidExportSession? = null
+      try {
+        val args = invoke.parseArgs(ExportPublishArgs::class.java)
+        session = sessions.require(args.exportSessionId)
+        require(session.status == AndroidExportStatus.GENERATING) { "export session is not publishable" }
+
+        val sessionDirectory = ManagedStoragePaths.exportStaging(activity.filesDir, args.exportSessionId)
+        val zipFile = sessionDirectory.resolve("export.zip")
+        require(zipFile.isFile) { "export ZIP is missing" }
+
+        val displayName = findAvailableExportName(sanitizeZipFileName(args.suggestedFileName))
+        publishedUri = activity.contentResolver.insert(
+          MediaStore.Downloads.EXTERNAL_CONTENT_URI,
+          ContentValues().apply {
+            put(MediaStore.Downloads.DISPLAY_NAME, displayName)
+            put(MediaStore.Downloads.MIME_TYPE, ANDROID_EXPORT_MIME_TYPE)
+            put(MediaStore.Downloads.RELATIVE_PATH, ANDROID_EXPORT_RELATIVE_PATH)
+            put(MediaStore.Downloads.IS_PENDING, 1)
+          },
+        ) ?: throw IOException("unable to create Downloads entry")
+
+        session.contentUri = publishedUri.toString()
+        session.status = AndroidExportStatus.MEDIA_PENDING
+        sessions.save(session)
+
+        activity.contentResolver.openOutputStream(publishedUri, "w").use { output ->
+          requireNotNull(output) { "unable to open Downloads entry" }
+          FileInputStream(zipFile).use { input -> input.copyTo(output, EXPORT_BUFFER_SIZE) }
+        }
+
+        val updated = activity.contentResolver.update(
+          publishedUri,
+          ContentValues().apply { put(MediaStore.Downloads.IS_PENDING, 0) },
+          null,
+          null,
+        )
+        if (updated != 1) {
+          throw IOException("unable to publish Downloads entry")
+        }
+
+        session.status = AndroidExportStatus.PUBLISHED
+        sessions.save(session)
+        invoke.resolveObject(mapOf(
+          "kind" to "published",
+          "contentUri" to publishedUri.toString(),
+          "displayPath" to "Downloads/WebGALCraft/exports/$displayName",
+        ))
+      } catch (error: Exception) {
+        val removed = publishedUri?.let(::deleteMediaEntry) ?: true
+        if (removed && session != null && session.status != AndroidExportStatus.PUBLISHED) {
+          session.contentUri = null
+          session.status = AndroidExportStatus.GENERATING
+          runCatching { sessions.save(session) }
+        }
+        invoke.reject(error.message ?: "unable to publish export", exportErrorCode(error))
+      }
+    }
+  }
+
+  @Command
+  fun cleanupWebExport(invoke: Invoke) {
+    executor.execute {
+      try {
+        val args = invoke.parseArgs(ExportSessionArgs::class.java)
+        sessionCleanup.cleanup(args.exportSessionId)
+        invoke.resolve()
+      } catch (error: Exception) {
+        invoke.reject(error.message ?: "unable to clean export staging")
+      }
+    }
+  }
+
+  @Command
+  fun cleanupRecoverableWebExports(invoke: Invoke) {
+    executor.execute {
+      try {
+        sessionCleanup.recoverAll()
+        invoke.resolve()
+      } catch (error: Exception) {
+        invoke.reject(error.message ?: "unable to recover export session")
+      }
+    }
+  }
+
+  @Command
+  fun openPublishedExport(invoke: Invoke) {
+    launchPublishedUri(invoke, Intent.ACTION_VIEW)
+  }
+
+  @Command
+  fun sharePublishedExport(invoke: Invoke) {
+    try {
+      val uri = requirePublishedExportUri(
+        activity,
+        invoke.parseArgs(PublishedUriArgs::class.java).contentUri,
+      )
+      activity.startActivity(Intent.createChooser(
+        Intent(Intent.ACTION_SEND).apply {
+          type = ANDROID_EXPORT_MIME_TYPE
+          putExtra(Intent.EXTRA_STREAM, uri)
+          addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        },
+        null,
+      ))
+      invoke.resolve()
+    } catch (error: Exception) {
+      invoke.reject(error.message ?: "unable to share export")
+    }
+  }
+
+  private fun deleteMediaEntry(uri: Uri): Boolean =
+    runCatching { activity.contentResolver.delete(uri, null, null) >= 0 }.getOrDefault(false)
+
+  private fun sanitizeZipFileName(value: String): String {
+    val stem = value.removeSuffix(".zip").trim()
+      .replace(Regex("""[\/:*?"<>|\p{Cc}]"""), "_")
+      .trim('.', ' ')
+      .take(100)
+    require(stem.isNotEmpty() && stem != "..") { "invalid export file name" }
+    return "$stem.zip"
+  }
+
+  private fun findAvailableExportName(baseName: String): String {
+    val stem = baseName.removeSuffix(".zip")
+    var candidate = baseName
+    var suffix = 2
+    while (downloadNameExists(candidate)) {
+      candidate = "$stem ($suffix).zip"
+      suffix++
+    }
+    return candidate
+  }
+
+  private fun downloadNameExists(displayName: String): Boolean {
+    activity.contentResolver.query(
+      MediaStore.Downloads.EXTERNAL_CONTENT_URI,
+      arrayOf(MediaStore.Downloads._ID),
+      "${MediaStore.Downloads.DISPLAY_NAME} = ? AND ${MediaStore.Downloads.RELATIVE_PATH} = ?",
+      arrayOf(displayName, ANDROID_EXPORT_RELATIVE_PATH),
+      null,
+    ).use { cursor -> return cursor?.moveToFirst() == true }
+  }
+
+  private fun launchPublishedUri(invoke: Invoke, action: String) {
+    try {
+      val uri = requirePublishedExportUri(
+        activity,
+        invoke.parseArgs(PublishedUriArgs::class.java).contentUri,
+      )
+      activity.startActivity(Intent(action).apply {
+        setDataAndType(uri, ANDROID_EXPORT_MIME_TYPE)
+        addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+      })
+      invoke.resolve()
+    } catch (error: Exception) {
+      invoke.reject(error.message ?: "unable to open export")
+    }
+  }
+
+  private fun exportErrorCode(error: Exception): String = when (error) {
+    is IllegalArgumentException -> "INVALID_EXPORT"
+    is IOException -> "EXPORT_IO_FAILED"
+    else -> "EXPORT_FAILED"
+  }
+}

--- a/src-tauri/gen/android/app/src/main/java/com/akirami/webgalcraft/AndroidExportSession.kt
+++ b/src-tauri/gen/android/app/src/main/java/com/akirami/webgalcraft/AndroidExportSession.kt
@@ -1,0 +1,141 @@
+package com.akirami.webgalcraft
+
+import android.app.Activity
+import android.content.Context
+import android.net.Uri
+import android.provider.MediaStore
+import java.io.IOException
+import org.json.JSONObject
+
+private const val EXPORT_SESSION_PREFERENCES = "android-web-export-sessions"
+internal const val ANDROID_EXPORT_MIME_TYPE = "application/zip"
+internal const val ANDROID_EXPORT_RELATIVE_PATH = "Download/WebGALCraft/exports/"
+
+internal enum class AndroidExportStatus(val value: String) {
+  GENERATING("generating"),
+  MEDIA_PENDING("media-pending"),
+  PUBLISHED("published");
+
+  companion object {
+    fun fromValue(value: String): AndroidExportStatus = entries.first { it.value == value }
+  }
+}
+
+internal data class AndroidExportSession(
+  val sessionId: String,
+  var status: AndroidExportStatus = AndroidExportStatus.GENERATING,
+  var contentUri: String? = null,
+) {
+  fun toJson(): String = JSONObject()
+    .put("sessionId", sessionId)
+    .put("status", status.value)
+    .put("contentUri", contentUri)
+    .toString()
+
+  companion object {
+    fun fromJson(value: String): AndroidExportSession? = runCatching {
+      JSONObject(value).let { json ->
+        AndroidExportSession(
+          sessionId = json.getString("sessionId"),
+          status = AndroidExportStatus.fromValue(json.getString("status")),
+          contentUri = json.optString("contentUri").ifBlank { null },
+        )
+      }
+    }.getOrNull()
+  }
+}
+
+internal class AndroidExportSessionStore(context: Context) {
+  private val preferences = context.getSharedPreferences(
+    EXPORT_SESSION_PREFERENCES,
+    Activity.MODE_PRIVATE,
+  )
+
+  fun create(sessionId: String): AndroidExportSession {
+    require(ManagedStoragePaths.validateSessionId(sessionId)) { "invalid export session id" }
+    require(find(sessionId) == null) { "export session already exists" }
+    return AndroidExportSession(sessionId).also(::save)
+  }
+
+  fun find(sessionId: String): AndroidExportSession? {
+    require(ManagedStoragePaths.validateSessionId(sessionId)) { "invalid export session id" }
+    val value = preferences.getString(sessionId, null) ?: return null
+    return AndroidExportSession.fromJson(value)?.takeIf { it.sessionId == sessionId }
+      ?: throw IllegalStateException("invalid export session state")
+  }
+
+  fun require(sessionId: String): AndroidExportSession =
+    find(sessionId) ?: throw IllegalStateException("unknown export session")
+
+  fun all(): List<AndroidExportSession> = preferences.all.map { (key, value) ->
+    require(value is String) { "invalid export session state" }
+    AndroidExportSession.fromJson(value)?.takeIf { it.sessionId == key }
+      ?: throw IllegalStateException("invalid export session state")
+  }
+
+  fun save(session: AndroidExportSession) {
+    check(preferences.edit().putString(session.sessionId, session.toJson()).commit()) {
+      "unable to persist export session"
+    }
+  }
+
+  fun delete(sessionId: String) {
+    check(preferences.edit().remove(sessionId).commit()) {
+      "unable to delete export session"
+    }
+  }
+}
+
+internal class AndroidExportSessionCleanup(
+  private val context: Context,
+  private val sessions: AndroidExportSessionStore,
+) {
+  fun recoverAll() {
+    sessions.all().forEach { session -> cleanup(session.sessionId) }
+  }
+
+  fun cleanup(sessionId: String) {
+    val session = sessions.find(sessionId)
+    if (session?.status == AndroidExportStatus.MEDIA_PENDING) {
+      val contentUri = requireNotNull(session.contentUri) { "pending export URI is missing" }
+      val deleted = context.contentResolver.delete(parsePublishedExportUri(contentUri), null, null)
+      if (deleted < 0) {
+        throw IOException("unable to delete pending Downloads entry")
+      }
+    }
+
+    val directory = ManagedStoragePaths.exportStaging(context.filesDir, sessionId)
+    if (directory.exists() && !directory.deleteRecursively()) {
+      throw IOException("unable to clean export staging")
+    }
+    if (session != null) {
+      sessions.delete(sessionId)
+    }
+  }
+}
+
+internal fun parsePublishedExportUri(value: String): Uri {
+  val uri = Uri.parse(value)
+  require(uri.scheme == "content" && uri.authority == MediaStore.AUTHORITY) {
+    "invalid published export URI"
+  }
+  return uri
+}
+
+internal fun requirePublishedExportUri(context: Context, value: String): Uri {
+  val uri = parsePublishedExportUri(value)
+  context.contentResolver.query(
+    uri,
+    arrayOf(MediaStore.Downloads.MIME_TYPE, MediaStore.Downloads.RELATIVE_PATH),
+    null,
+    null,
+    null,
+  ).use { cursor ->
+    require(cursor != null && cursor.moveToFirst()) { "published export does not exist" }
+    require(cursor.getString(0) == ANDROID_EXPORT_MIME_TYPE) { "published export is not a ZIP" }
+    require(cursor.getString(1) == ANDROID_EXPORT_RELATIVE_PATH) {
+      "published export is outside the managed export directory"
+    }
+  }
+  return uri
+}

--- a/src-tauri/src/commands/android_export.rs
+++ b/src-tauri/src/commands/android_export.rs
@@ -208,9 +208,6 @@ pub async fn android_export_cleanup_recoverable<R: Runtime>(
 mod tests {
     use std::{fs, io::Read};
 
-    #[cfg(unix)]
-    use std::path::Path;
-
     use tempfile::tempdir;
     use zip::ZipArchive;
 

--- a/src-tauri/src/commands/android_export.rs
+++ b/src-tauri/src/commands/android_export.rs
@@ -1,0 +1,270 @@
+use std::{
+    fs,
+    io::{Read, Write},
+    path::{Path, PathBuf},
+};
+
+use serde_json::{json, Value};
+use tauri::{AppHandle, Runtime};
+use zip::{write::SimpleFileOptions, ZipWriter};
+
+use super::{
+    export::{
+        cleanup_export_work_directory, emit_web_export_progress, export_error,
+        export_web_to_directory, STEP_FINISHED,
+    },
+    AppError, AppResult,
+};
+
+const STEP_COMPRESSING: &str = "export.progress.compressing";
+
+fn validate_export_session_id(session_id: &str) -> AppResult<()> {
+    if session_id.is_empty()
+        || session_id == "."
+        || session_id == ".."
+        || !session_id
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || character == '-')
+    {
+        return Err(export_error("无效的导出会话 ID"));
+    }
+    Ok(())
+}
+
+fn collect_zip_entries(directory: &Path, entries: &mut Vec<PathBuf>) -> AppResult<()> {
+    let mut children = fs::read_dir(directory)?.collect::<Result<Vec<_>, _>>()?;
+    children.sort_by_key(std::fs::DirEntry::file_name);
+    for child in children {
+        let path = child.path();
+        let file_type = child.file_type()?;
+        if file_type.is_symlink() {
+            return Err(export_error("导出产物包含不受支持的符号链接"));
+        }
+        entries.push(path.clone());
+        if file_type.is_dir() {
+            collect_zip_entries(&path, entries)?;
+        } else if !file_type.is_file() {
+            return Err(export_error("导出产物包含不受支持的文件类型"));
+        }
+    }
+    Ok(())
+}
+
+fn zip_directory(source: &Path, destination: &Path) -> AppResult<()> {
+    let file = fs::File::create(destination)?;
+    let mut archive = ZipWriter::new(file);
+    let options = SimpleFileOptions::default();
+    let mut entries = Vec::new();
+    collect_zip_entries(source, &mut entries)?;
+
+    for path in entries {
+        let relative = path
+            .strip_prefix(source)
+            .map_err(|error| export_error(format!("无法生成 ZIP 相对路径: {error}")))?;
+        let name = relative.to_string_lossy().replace('\\', "/");
+        if path.is_dir() {
+            archive
+                .add_directory(format!("{name}/"), options)
+                .map_err(|error| export_error(format!("写入 ZIP 目录失败: {error}")))?;
+            continue;
+        }
+
+        archive
+            .start_file(name, options)
+            .map_err(|error| export_error(format!("写入 ZIP 文件失败: {error}")))?;
+        let mut input = fs::File::open(path)?;
+        let mut buffer = [0_u8; 64 * 1024];
+        loop {
+            let read = input.read(&mut buffer)?;
+            if read == 0 {
+                break;
+            }
+            archive
+                .write_all(&buffer[..read])
+                .map_err(|error| export_error(format!("写入 ZIP 数据失败: {error}")))?;
+        }
+    }
+
+    archive
+        .finish()
+        .map_err(|error| export_error(format!("完成 ZIP 失败: {error}")))?;
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn export_android_web_zip(
+    app: AppHandle,
+    export_id: String,
+    export_session_id: String,
+    engine_path: String,
+    game_path: String,
+    template_path: Option<String>,
+    game_name: String,
+) -> AppResult<()> {
+    validate_export_session_id(&export_session_id)?;
+    let session_directory =
+        crate::mobile::android_export::resolve_staging(&app, &export_session_id)
+            .await
+            .map_err(export_error)?;
+    tauri::async_runtime::spawn_blocking(move || {
+        if session_directory.exists() {
+            return Err(AppError::TargetConflict(
+                session_directory.display().to_string(),
+            ));
+        }
+        fs::create_dir_all(&session_directory)?;
+        let web_directory = session_directory.join("web");
+        let result = (|| {
+            export_web_to_directory(
+                Path::new(&engine_path),
+                Path::new(&game_path),
+                template_path.as_deref().map(Path::new),
+                &web_directory,
+                &game_name,
+                false,
+                |step, percentage| {
+                    let (step, percentage) = if step == STEP_FINISHED {
+                        (STEP_COMPRESSING, 96)
+                    } else {
+                        (step, percentage.min(95))
+                    };
+                    emit_web_export_progress(&app, &export_id, step, percentage)
+                },
+            )?;
+            zip_directory(&web_directory, &session_directory.join("export.zip"))?;
+            emit_web_export_progress(&app, &export_id, STEP_FINISHED, 100)
+        })();
+        if result.is_err() {
+            cleanup_export_work_directory(&session_directory);
+        }
+        result
+    })
+    .await
+    .map_err(|error| export_error(format!("导出任务执行失败: {error}")))?
+}
+
+#[tauri::command]
+pub async fn cleanup_android_web_export(
+    app: AppHandle,
+    export_session_id: String,
+) -> AppResult<()> {
+    validate_export_session_id(&export_session_id)?;
+    crate::mobile::android_export::cleanup_staging(&app, &export_session_id)
+        .await
+        .map_err(export_error)
+}
+
+#[tauri::command]
+pub async fn android_export_publish<R: Runtime>(
+    app: AppHandle<R>,
+    export_session_id: String,
+    suggested_file_name: String,
+) -> Result<Value, Value> {
+    crate::mobile::android_export::invoke(
+        &app,
+        "publishWebExport",
+        json!({
+            "exportSessionId": export_session_id,
+            "suggestedFileName": suggested_file_name,
+        }),
+    )
+    .await
+}
+
+#[tauri::command]
+pub async fn android_export_open<R: Runtime>(
+    app: AppHandle<R>,
+    content_uri: String,
+) -> Result<Value, Value> {
+    crate::mobile::android_export::invoke(
+        &app,
+        "openPublishedExport",
+        json!({ "contentUri": content_uri }),
+    )
+    .await
+}
+
+#[tauri::command]
+pub async fn android_export_share<R: Runtime>(
+    app: AppHandle<R>,
+    content_uri: String,
+) -> Result<Value, Value> {
+    crate::mobile::android_export::invoke(
+        &app,
+        "sharePublishedExport",
+        json!({ "contentUri": content_uri }),
+    )
+    .await
+}
+
+#[tauri::command]
+pub async fn android_export_cleanup_recoverable<R: Runtime>(
+    app: AppHandle<R>,
+) -> Result<Value, Value> {
+    crate::mobile::android_export::invoke(&app, "cleanupRecoverableWebExports", json!({})).await
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{fs, io::Read};
+
+    #[cfg(unix)]
+    use std::path::Path;
+
+    use tempfile::tempdir;
+    use zip::ZipArchive;
+
+    #[cfg(unix)]
+    use super::{collect_zip_entries, AppError};
+    use super::{validate_export_session_id, zip_directory};
+
+    #[test]
+    fn validates_android_export_session_ids() {
+        assert!(validate_export_session_id("2ee2f25e-4425-4ca8-9240-8ca79ee0b09b").is_ok());
+        for invalid in ["", ".", "..", "../other", "other/session", "other\\session"] {
+            assert!(validate_export_session_id(invalid).is_err(), "{invalid}");
+        }
+    }
+
+    #[test]
+    fn creates_zip_with_relative_directory_structure() {
+        let root = tempdir().expect("temp root should be created");
+        let source = root.path().join("web");
+        fs::create_dir_all(source.join("assets/images")).expect("nested source should be created");
+        fs::write(source.join("index.html"), "index").expect("root file should be created");
+        fs::write(source.join("assets/images/cover.txt"), "cover")
+            .expect("nested file should be created");
+        let destination = root.path().join("export.zip");
+
+        zip_directory(&source, &destination).expect("zip should be created");
+
+        let file = fs::File::open(destination).expect("zip should open");
+        let mut archive = ZipArchive::new(file).expect("zip should parse");
+        let mut index = String::new();
+        archive
+            .by_name("index.html")
+            .expect("root file should exist")
+            .read_to_string(&mut index)
+            .expect("root file should read");
+        assert_eq!(index, "index");
+        assert!(archive.by_name("assets/images/cover.txt").is_ok());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_symbolic_links_in_zip_source() {
+        use std::os::unix::fs::symlink;
+
+        let root = tempdir().expect("temp root should be created");
+        let source = root.path().join("web");
+        fs::create_dir_all(&source).expect("source should be created");
+        let outside = root.path().join("outside.txt");
+        fs::write(&outside, "outside").expect("outside file should be created");
+        symlink(&outside, source.join("linked.txt")).expect("symlink should be created");
+
+        let error =
+            collect_zip_entries(&source, &mut Vec::new()).expect_err("symlink should be rejected");
+
+        assert!(matches!(error, AppError::Export(message) if message.contains("符号链接")));
+    }
+}

--- a/src-tauri/src/commands/export.rs
+++ b/src-tauri/src/commands/export.rs
@@ -1,14 +1,13 @@
 use std::{
     collections::HashSet,
     fs,
-    io::{ErrorKind, Read, Write},
+    io::ErrorKind,
     path::{Path, PathBuf},
     sync::atomic::{AtomicU64, Ordering},
 };
 
 use serde::Serialize;
-use tauri::{AppHandle, Emitter, Manager};
-use zip::{write::SimpleFileOptions, ZipWriter};
+use tauri::{AppHandle, Emitter};
 
 use super::{game::read_game_config, AppError, AppResult};
 use crate::vfs::{CachedCanonicals, OverlayFs, VfsDirEntry, VfsError};
@@ -19,8 +18,7 @@ const STEP_COPYING_ENGINE: &str = "export.progress.copyingEngine";
 const STEP_COPYING_GAME: &str = "export.progress.copyingGame";
 const STEP_COPYING_ICONS: &str = "export.progress.copyingIcons";
 const STEP_UPDATING_MANIFEST: &str = "export.progress.updatingManifest";
-const STEP_FINISHED: &str = "export.progress.finished";
-const STEP_COMPRESSING: &str = "export.progress.compressing";
+pub(super) const STEP_FINISHED: &str = "export.progress.finished";
 const WEB_ICON_FILE_NAMES: [&str; 6] = [
     "apple-touch-icon.png",
     "favicon.ico",
@@ -46,8 +44,26 @@ enum MaterializedNode {
     File { logical_path: PathBuf },
 }
 
-fn export_error(message: impl Into<String>) -> AppError {
+pub(super) fn export_error(message: impl Into<String>) -> AppError {
     AppError::Export(message.into())
+}
+
+pub(super) fn emit_web_export_progress(
+    app: &AppHandle,
+    export_id: &str,
+    step: &str,
+    percentage: u8,
+) -> AppResult<()> {
+    app.emit(
+        "export-progress",
+        ExportProgress {
+            export_id: export_id.into(),
+            platform: PLATFORM_WEB.into(),
+            step: step.into(),
+            percentage,
+        },
+    )?;
+    Ok(())
 }
 
 fn collect_materialized_nodes(
@@ -323,7 +339,7 @@ fn create_export_work_directory(parent: &Path) -> AppResult<PathBuf> {
     Err(export_error("无法创建唯一的导出工作目录"))
 }
 
-fn cleanup_export_work_directory(work_directory: &Path) {
+pub(super) fn cleanup_export_work_directory(work_directory: &Path) {
     if let Err(error) = fs::remove_dir_all(work_directory) {
         log::warn!(
             "清理 Web 导出工作目录失败: {} - {}",
@@ -365,7 +381,7 @@ fn replace_output_directory(
     Ok(())
 }
 
-fn export_web_to_directory<F>(
+pub(super) fn export_web_to_directory<F>(
     engine_path: &Path,
     game_path: &Path,
     template_path: Option<&Path>,
@@ -519,205 +535,25 @@ pub async fn export_web(
             Path::new(&output_path),
             &game_name,
             replace_existing,
-            |step, percentage| {
-                app.emit(
-                    "export-progress",
-                    ExportProgress {
-                        export_id: export_id.clone(),
-                        platform: PLATFORM_WEB.into(),
-                        step: step.into(),
-                        percentage,
-                    },
-                )?;
-                Ok(())
-            },
+            |step, percentage| emit_web_export_progress(&app, &export_id, step, percentage),
         )
     })
     .await
     .map_err(|error| export_error(format!("导出任务执行失败: {error}")))?
 }
 
-fn validate_export_session_id(session_id: &str) -> AppResult<()> {
-    if session_id.is_empty()
-        || session_id == "."
-        || session_id == ".."
-        || !session_id
-            .chars()
-            .all(|character| character.is_ascii_alphanumeric() || character == '-')
-    {
-        return Err(export_error("无效的导出会话 ID"));
-    }
-    Ok(())
-}
-
-fn android_export_session_directory(app: &AppHandle, session_id: &str) -> AppResult<PathBuf> {
-    validate_export_session_id(session_id)?;
-    let root = app
-        .path()
-        .app_data_dir()
-        .map_err(|error| export_error(format!("无法解析应用数据目录: {error}")))?
-        .join("documents/WebGALCraft/exports/.export-staging");
-    Ok(root.join(session_id))
-}
-
-fn collect_zip_entries(directory: &Path, entries: &mut Vec<PathBuf>) -> AppResult<()> {
-    let mut children = fs::read_dir(directory)?.collect::<Result<Vec<_>, _>>()?;
-    children.sort_by_key(std::fs::DirEntry::file_name);
-    for child in children {
-        let path = child.path();
-        let file_type = child.file_type()?;
-        if file_type.is_symlink() {
-            return Err(export_error("导出产物包含不受支持的符号链接"));
-        }
-        entries.push(path.clone());
-        if file_type.is_dir() {
-            collect_zip_entries(&path, entries)?;
-        } else if !file_type.is_file() {
-            return Err(export_error("导出产物包含不受支持的文件类型"));
-        }
-    }
-    Ok(())
-}
-
-fn zip_directory(source: &Path, destination: &Path) -> AppResult<()> {
-    let file = fs::File::create(destination)?;
-    let mut archive = ZipWriter::new(file);
-    let options = SimpleFileOptions::default();
-    let mut entries = Vec::new();
-    collect_zip_entries(source, &mut entries)?;
-
-    for path in entries {
-        let relative = path
-            .strip_prefix(source)
-            .map_err(|error| export_error(format!("无法生成 ZIP 相对路径: {error}")))?;
-        let name = relative.to_string_lossy().replace('\\', "/");
-        if path.is_dir() {
-            archive
-                .add_directory(format!("{name}/"), options)
-                .map_err(|error| export_error(format!("写入 ZIP 目录失败: {error}")))?;
-            continue;
-        }
-
-        archive
-            .start_file(name, options)
-            .map_err(|error| export_error(format!("写入 ZIP 文件失败: {error}")))?;
-        let mut input = fs::File::open(path)?;
-        let mut buffer = [0_u8; 64 * 1024];
-        loop {
-            let read = input.read(&mut buffer)?;
-            if read == 0 {
-                break;
-            }
-            archive
-                .write_all(&buffer[..read])
-                .map_err(|error| export_error(format!("写入 ZIP 数据失败: {error}")))?;
-        }
-    }
-
-    archive
-        .finish()
-        .map_err(|error| export_error(format!("完成 ZIP 失败: {error}")))?;
-    Ok(())
-}
-
-#[tauri::command]
-pub async fn export_android_web_zip(
-    app: AppHandle,
-    export_id: String,
-    export_session_id: String,
-    engine_path: String,
-    game_path: String,
-    template_path: Option<String>,
-    game_name: String,
-) -> AppResult<()> {
-    let session_directory = android_export_session_directory(&app, &export_session_id)?;
-    tauri::async_runtime::spawn_blocking(move || {
-        if session_directory.exists() {
-            return Err(AppError::TargetConflict(
-                session_directory.display().to_string(),
-            ));
-        }
-        fs::create_dir_all(&session_directory)?;
-        let web_directory = session_directory.join("web");
-        let result = (|| {
-            export_web_to_directory(
-                Path::new(&engine_path),
-                Path::new(&game_path),
-                template_path.as_deref().map(Path::new),
-                &web_directory,
-                &game_name,
-                false,
-                |step, percentage| {
-                    let (step, percentage) = if step == STEP_FINISHED {
-                        (STEP_COMPRESSING, 96)
-                    } else {
-                        (step, percentage.min(95))
-                    };
-                    app.emit(
-                        "export-progress",
-                        ExportProgress {
-                            export_id: export_id.clone(),
-                            platform: PLATFORM_WEB.into(),
-                            step: step.into(),
-                            percentage,
-                        },
-                    )?;
-                    Ok(())
-                },
-            )?;
-            zip_directory(&web_directory, &session_directory.join("export.zip"))?;
-            app.emit(
-                "export-progress",
-                ExportProgress {
-                    export_id,
-                    platform: PLATFORM_WEB.into(),
-                    step: STEP_FINISHED.into(),
-                    percentage: 100,
-                },
-            )?;
-            Ok(())
-        })();
-        if result.is_err() {
-            cleanup_export_work_directory(&session_directory);
-        }
-        result
-    })
-    .await
-    .map_err(|error| export_error(format!("导出任务执行失败: {error}")))?
-}
-
-#[tauri::command]
-pub async fn cleanup_android_web_export(
-    app: AppHandle,
-    export_session_id: String,
-) -> AppResult<()> {
-    let session_directory = android_export_session_directory(&app, &export_session_id)?;
-    tauri::async_runtime::spawn_blocking(move || {
-        if session_directory.exists() {
-            fs::remove_dir_all(session_directory)?;
-        }
-        Ok(())
-    })
-    .await
-    .map_err(|error| export_error(format!("清理导出任务失败: {error}")))?
-}
-
 #[cfg(test)]
 mod tests {
     #[cfg(windows)]
     use std::process::Command;
-    use std::{fs, io::Read, path::Path};
+    use std::{fs, path::Path};
 
+    use super::{
+        copy_web_icons, export_web_to_directory, AppError, CachedCanonicals, OverlayFs,
+        STEP_COPYING_ICONS, STEP_FINISHED,
+    };
     use serde_json::Value;
     use tempfile::tempdir;
-    use zip::ZipArchive;
-
-    #[cfg(unix)]
-    use super::collect_zip_entries;
-    use super::{
-        copy_web_icons, export_web_to_directory, validate_export_session_id, zip_directory,
-        AppError, CachedCanonicals, OverlayFs, STEP_COPYING_ICONS, STEP_FINISHED,
-    };
 
     fn write_file(path: &Path, content: &str) {
         fs::create_dir_all(path.parent().expect("fixture file should have parent"))
@@ -1142,55 +978,5 @@ mod tests {
 
         assert!(matches!(error, AppError::Export(message) if message.contains("源目录内部")));
         assert!(!output_parent.exists());
-    }
-
-    #[test]
-    fn validates_android_export_session_ids() {
-        assert!(validate_export_session_id("2ee2f25e-4425-4ca8-9240-8ca79ee0b09b").is_ok());
-        for invalid in ["", ".", "..", "../other", "other/session", "other\\session"] {
-            assert!(validate_export_session_id(invalid).is_err(), "{invalid}");
-        }
-    }
-
-    #[test]
-    fn creates_zip_with_relative_directory_structure() {
-        let root = tempdir().expect("temp root should be created");
-        let source = root.path().join("web");
-        fs::create_dir_all(source.join("assets/images")).expect("nested source should be created");
-        fs::write(source.join("index.html"), "index").expect("root file should be created");
-        fs::write(source.join("assets/images/cover.txt"), "cover")
-            .expect("nested file should be created");
-        let destination = root.path().join("export.zip");
-
-        zip_directory(&source, &destination).expect("zip should be created");
-
-        let file = fs::File::open(destination).expect("zip should open");
-        let mut archive = ZipArchive::new(file).expect("zip should parse");
-        let mut index = String::new();
-        archive
-            .by_name("index.html")
-            .expect("root file should exist")
-            .read_to_string(&mut index)
-            .expect("root file should read");
-        assert_eq!(index, "index");
-        assert!(archive.by_name("assets/images/cover.txt").is_ok());
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn rejects_symbolic_links_in_zip_source() {
-        use std::os::unix::fs::symlink;
-
-        let root = tempdir().expect("temp root should be created");
-        let source = root.path().join("web");
-        fs::create_dir_all(&source).expect("source should be created");
-        let outside = root.path().join("outside.txt");
-        fs::write(&outside, "outside").expect("outside file should be created");
-        symlink(&outside, source.join("linked.txt")).expect("symlink should be created");
-
-        let error =
-            collect_zip_entries(&source, &mut Vec::new()).expect_err("symlink should be rejected");
-
-        assert!(matches!(error, AppError::Export(message) if message.contains("符号链接")));
     }
 }

--- a/src-tauri/src/commands/export.rs
+++ b/src-tauri/src/commands/export.rs
@@ -1,13 +1,14 @@
 use std::{
     collections::HashSet,
     fs,
-    io::ErrorKind,
+    io::{ErrorKind, Read, Write},
     path::{Path, PathBuf},
     sync::atomic::{AtomicU64, Ordering},
 };
 
 use serde::Serialize;
-use tauri::{AppHandle, Emitter};
+use tauri::{AppHandle, Emitter, Manager};
+use zip::{write::SimpleFileOptions, ZipWriter};
 
 use super::{game::read_game_config, AppError, AppResult};
 use crate::vfs::{CachedCanonicals, OverlayFs, VfsDirEntry, VfsError};
@@ -19,6 +20,7 @@ const STEP_COPYING_GAME: &str = "export.progress.copyingGame";
 const STEP_COPYING_ICONS: &str = "export.progress.copyingIcons";
 const STEP_UPDATING_MANIFEST: &str = "export.progress.updatingManifest";
 const STEP_FINISHED: &str = "export.progress.finished";
+const STEP_COMPRESSING: &str = "export.progress.compressing";
 const WEB_ICON_FILE_NAMES: [&str; 6] = [
     "apple-touch-icon.png",
     "favicon.ico",
@@ -535,18 +537,184 @@ pub async fn export_web(
     .map_err(|error| export_error(format!("导出任务执行失败: {error}")))?
 }
 
+fn validate_export_session_id(session_id: &str) -> AppResult<()> {
+    if session_id.is_empty()
+        || session_id == "."
+        || session_id == ".."
+        || !session_id
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric() || character == '-')
+    {
+        return Err(export_error("无效的导出会话 ID"));
+    }
+    Ok(())
+}
+
+fn android_export_session_directory(app: &AppHandle, session_id: &str) -> AppResult<PathBuf> {
+    validate_export_session_id(session_id)?;
+    let root = app
+        .path()
+        .app_data_dir()
+        .map_err(|error| export_error(format!("无法解析应用数据目录: {error}")))?
+        .join("documents/WebGALCraft/exports/.export-staging");
+    Ok(root.join(session_id))
+}
+
+fn collect_zip_entries(directory: &Path, entries: &mut Vec<PathBuf>) -> AppResult<()> {
+    let mut children = fs::read_dir(directory)?.collect::<Result<Vec<_>, _>>()?;
+    children.sort_by_key(std::fs::DirEntry::file_name);
+    for child in children {
+        let path = child.path();
+        let metadata = child.metadata()?;
+        if metadata.is_symlink() {
+            return Err(export_error("导出产物包含不受支持的符号链接"));
+        }
+        entries.push(path.clone());
+        if metadata.is_dir() {
+            collect_zip_entries(&path, entries)?;
+        } else if !metadata.is_file() {
+            return Err(export_error("导出产物包含不受支持的文件类型"));
+        }
+    }
+    Ok(())
+}
+
+fn zip_directory(source: &Path, destination: &Path) -> AppResult<()> {
+    let file = fs::File::create(destination)?;
+    let mut archive = ZipWriter::new(file);
+    let options = SimpleFileOptions::default();
+    let mut entries = Vec::new();
+    collect_zip_entries(source, &mut entries)?;
+
+    for path in entries {
+        let relative = path
+            .strip_prefix(source)
+            .map_err(|error| export_error(format!("无法生成 ZIP 相对路径: {error}")))?;
+        let name = relative.to_string_lossy().replace('\\', "/");
+        if path.is_dir() {
+            archive
+                .add_directory(format!("{name}/"), options)
+                .map_err(|error| export_error(format!("写入 ZIP 目录失败: {error}")))?;
+            continue;
+        }
+
+        archive
+            .start_file(name, options)
+            .map_err(|error| export_error(format!("写入 ZIP 文件失败: {error}")))?;
+        let mut input = fs::File::open(path)?;
+        let mut buffer = [0_u8; 64 * 1024];
+        loop {
+            let read = input.read(&mut buffer)?;
+            if read == 0 {
+                break;
+            }
+            archive
+                .write_all(&buffer[..read])
+                .map_err(|error| export_error(format!("写入 ZIP 数据失败: {error}")))?;
+        }
+    }
+
+    archive
+        .finish()
+        .map_err(|error| export_error(format!("完成 ZIP 失败: {error}")))?;
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn export_android_web_zip(
+    app: AppHandle,
+    export_id: String,
+    export_session_id: String,
+    engine_path: String,
+    game_path: String,
+    template_path: Option<String>,
+    game_name: String,
+) -> AppResult<()> {
+    let session_directory = android_export_session_directory(&app, &export_session_id)?;
+    tauri::async_runtime::spawn_blocking(move || {
+        if session_directory.exists() {
+            return Err(AppError::TargetConflict(
+                session_directory.display().to_string(),
+            ));
+        }
+        fs::create_dir_all(&session_directory)?;
+        let web_directory = session_directory.join("web");
+        let result = (|| {
+            export_web_to_directory(
+                Path::new(&engine_path),
+                Path::new(&game_path),
+                template_path.as_deref().map(Path::new),
+                &web_directory,
+                &game_name,
+                false,
+                |step, percentage| {
+                    let (step, percentage) = if step == STEP_FINISHED {
+                        (STEP_COMPRESSING, 96)
+                    } else {
+                        (step, percentage.min(95))
+                    };
+                    app.emit(
+                        "export-progress",
+                        ExportProgress {
+                            export_id: export_id.clone(),
+                            platform: PLATFORM_WEB.into(),
+                            step: step.into(),
+                            percentage,
+                        },
+                    )?;
+                    Ok(())
+                },
+            )?;
+            zip_directory(&web_directory, &session_directory.join("export.zip"))?;
+            app.emit(
+                "export-progress",
+                ExportProgress {
+                    export_id,
+                    platform: PLATFORM_WEB.into(),
+                    step: STEP_FINISHED.into(),
+                    percentage: 100,
+                },
+            )?;
+            Ok(())
+        })();
+        if result.is_err() {
+            cleanup_export_work_directory(&session_directory);
+        }
+        result
+    })
+    .await
+    .map_err(|error| export_error(format!("导出任务执行失败: {error}")))?
+}
+
+#[tauri::command]
+pub async fn cleanup_android_web_export(
+    app: AppHandle,
+    export_session_id: String,
+) -> AppResult<()> {
+    let session_directory = android_export_session_directory(&app, &export_session_id)?;
+    tauri::async_runtime::spawn_blocking(move || {
+        if session_directory.exists() {
+            fs::remove_dir_all(session_directory)?;
+        }
+        Ok(())
+    })
+    .await
+    .map_err(|error| export_error(format!("清理导出任务失败: {error}")))?
+}
+
 #[cfg(test)]
 mod tests {
     #[cfg(windows)]
     use std::process::Command;
-    use std::{fs, path::Path};
+    use std::{fs, io::Read, path::Path};
 
     use serde_json::Value;
     use tempfile::tempdir;
+    use zip::ZipArchive;
 
     use super::{
-        copy_web_icons, export_web_to_directory, AppError, CachedCanonicals, OverlayFs,
-        STEP_COPYING_ICONS, STEP_FINISHED,
+        copy_web_icons, export_web_to_directory, validate_export_session_id, zip_directory,
+        AppError, CachedCanonicals, OverlayFs, STEP_COPYING_ICONS, STEP_FINISHED,
     };
 
     fn write_file(path: &Path, content: &str) {
@@ -972,5 +1140,37 @@ mod tests {
 
         assert!(matches!(error, AppError::Export(message) if message.contains("源目录内部")));
         assert!(!output_parent.exists());
+    }
+
+    #[test]
+    fn validates_android_export_session_ids() {
+        assert!(validate_export_session_id("2ee2f25e-4425-4ca8-9240-8ca79ee0b09b").is_ok());
+        for invalid in ["", ".", "..", "../other", "other/session", "other\\session"] {
+            assert!(validate_export_session_id(invalid).is_err(), "{invalid}");
+        }
+    }
+
+    #[test]
+    fn creates_zip_with_relative_directory_structure() {
+        let root = tempdir().expect("temp root should be created");
+        let source = root.path().join("web");
+        fs::create_dir_all(source.join("assets/images")).expect("nested source should be created");
+        fs::write(source.join("index.html"), "index").expect("root file should be created");
+        fs::write(source.join("assets/images/cover.txt"), "cover")
+            .expect("nested file should be created");
+        let destination = root.path().join("export.zip");
+
+        zip_directory(&source, &destination).expect("zip should be created");
+
+        let file = fs::File::open(destination).expect("zip should open");
+        let mut archive = ZipArchive::new(file).expect("zip should parse");
+        let mut index = String::new();
+        archive
+            .by_name("index.html")
+            .expect("root file should exist")
+            .read_to_string(&mut index)
+            .expect("root file should read");
+        assert_eq!(index, "index");
+        assert!(archive.by_name("assets/images/cover.txt").is_ok());
     }
 }

--- a/src-tauri/src/commands/export.rs
+++ b/src-tauri/src/commands/export.rs
@@ -565,14 +565,14 @@ fn collect_zip_entries(directory: &Path, entries: &mut Vec<PathBuf>) -> AppResul
     children.sort_by_key(std::fs::DirEntry::file_name);
     for child in children {
         let path = child.path();
-        let metadata = child.metadata()?;
-        if metadata.is_symlink() {
+        let file_type = child.file_type()?;
+        if file_type.is_symlink() {
             return Err(export_error("导出产物包含不受支持的符号链接"));
         }
         entries.push(path.clone());
-        if metadata.is_dir() {
+        if file_type.is_dir() {
             collect_zip_entries(&path, entries)?;
-        } else if !metadata.is_file() {
+        } else if !file_type.is_file() {
             return Err(export_error("导出产物包含不受支持的文件类型"));
         }
     }
@@ -712,6 +712,8 @@ mod tests {
     use tempfile::tempdir;
     use zip::ZipArchive;
 
+    #[cfg(unix)]
+    use super::collect_zip_entries;
     use super::{
         copy_web_icons, export_web_to_directory, validate_export_session_id, zip_directory,
         AppError, CachedCanonicals, OverlayFs, STEP_COPYING_ICONS, STEP_FINISHED,
@@ -1172,5 +1174,23 @@ mod tests {
             .expect("root file should read");
         assert_eq!(index, "index");
         assert!(archive.by_name("assets/images/cover.txt").is_ok());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_symbolic_links_in_zip_source() {
+        use std::os::unix::fs::symlink;
+
+        let root = tempdir().expect("temp root should be created");
+        let source = root.path().join("web");
+        fs::create_dir_all(&source).expect("source should be created");
+        let outside = root.path().join("outside.txt");
+        fs::write(&outside, "outside").expect("outside file should be created");
+        symlink(&outside, source.join("linked.txt")).expect("symlink should be created");
+
+        let error =
+            collect_zip_entries(&source, &mut Vec::new()).expect_err("symlink should be rejected");
+
+        assert!(matches!(error, AppError::Export(message) if message.contains("符号链接")));
     }
 }

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,3 +1,4 @@
+pub mod android_export;
 pub mod backup;
 pub mod engine;
 pub mod error;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -64,6 +64,7 @@ pub fn run() {
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_opener::init())
         .plugin(mobile::managed_directory_import::init())
+        .plugin(mobile::android_export::init())
         .plugin(
             tauri_plugin_log::Builder::new()
                 .target(tauri_plugin_log::Target::new(
@@ -86,8 +87,8 @@ pub fn run() {
             commands::engine::read_engine_manifest,
             // export
             commands::export::export_web,
-            commands::export::export_android_web_zip,
-            commands::export::cleanup_android_web_export,
+            commands::android_export::export_android_web_zip,
+            commands::android_export::cleanup_android_web_export,
             // project config
             commands::project_config::read_project_config_cmd,
             commands::project_config::write_project_config_cmd,
@@ -132,6 +133,10 @@ pub fn run() {
             commands::resource_import::android_resource_import_rollback,
             commands::resource_import::android_resource_import_cancel,
             commands::resource_import::android_resource_import_list_recoverable_sessions,
+            commands::android_export::android_export_publish,
+            commands::android_export::android_export_open,
+            commands::android_export::android_export_share,
+            commands::android_export::android_export_cleanup_recoverable,
             // window
             #[cfg(desktop)]
             commands::window::create_window,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -86,6 +86,8 @@ pub fn run() {
             commands::engine::read_engine_manifest,
             // export
             commands::export::export_web,
+            commands::export::export_android_web_zip,
+            commands::export::cleanup_android_web_export,
             // project config
             commands::project_config::read_project_config_cmd,
             commands::project_config::write_project_config_cmd,

--- a/src-tauri/src/mobile/android_export.rs
+++ b/src-tauri/src/mobile/android_export.rs
@@ -4,7 +4,7 @@ use serde_json::{json, Value};
 use tauri::{plugin::Builder, AppHandle, Runtime};
 
 #[cfg(target_os = "android")]
-use tauri::{plugin::mobile::PluginHandle, Manager};
+use tauri::{plugin::PluginHandle, Manager};
 
 #[cfg(target_os = "android")]
 const ANDROID_PLUGIN_IDENTIFIER: &str = "com.akirami.webgalcraft";

--- a/src-tauri/src/mobile/android_export.rs
+++ b/src-tauri/src/mobile/android_export.rs
@@ -1,0 +1,88 @@
+use std::path::PathBuf;
+
+use serde_json::{json, Value};
+use tauri::{plugin::Builder, AppHandle, Runtime};
+
+#[cfg(target_os = "android")]
+use tauri::{plugin::mobile::PluginHandle, Manager};
+
+#[cfg(target_os = "android")]
+const ANDROID_PLUGIN_IDENTIFIER: &str = "com.akirami.webgalcraft";
+
+pub fn init<R: Runtime>() -> tauri::plugin::TauriPlugin<R> {
+    Builder::new("android-export")
+        .setup(|app, api| {
+            #[cfg(target_os = "android")]
+            {
+                let handle =
+                    api.register_android_plugin(ANDROID_PLUGIN_IDENTIFIER, "AndroidExportPlugin")?;
+                app.manage(AndroidExportPlugin(handle));
+            }
+            #[cfg(not(target_os = "android"))]
+            {
+                let _ = (app, api);
+            }
+            Ok(())
+        })
+        .build()
+}
+
+#[cfg(target_os = "android")]
+pub(crate) struct AndroidExportPlugin<R: Runtime>(PluginHandle<R>);
+
+#[cfg(target_os = "android")]
+pub async fn invoke<R: Runtime>(
+    app: &AppHandle<R>,
+    command: &str,
+    payload: Value,
+) -> Result<Value, Value> {
+    app.state::<AndroidExportPlugin<R>>()
+        .0
+        .run_mobile_plugin_async(command, payload)
+        .await
+        .map_err(|error| super::plugin_error_to_value(error, "Android export failed"))
+}
+
+#[cfg(not(target_os = "android"))]
+pub async fn invoke<R: Runtime>(
+    _app: &AppHandle<R>,
+    _command: &str,
+    _payload: Value,
+) -> Result<Value, Value> {
+    Err(json!({
+        "code": "TAURI_ERROR",
+        "message": "Android export is unavailable on this platform",
+    }))
+}
+
+pub async fn resolve_staging<R: Runtime>(
+    app: &AppHandle<R>,
+    export_session_id: &str,
+) -> Result<PathBuf, String> {
+    let result = invoke(
+        app,
+        "resolveWebExportStaging",
+        json!({ "exportSessionId": export_session_id }),
+    )
+    .await
+    .map_err(|error| error.to_string())?;
+    let path = result
+        .get("sessionPath")
+        .and_then(Value::as_str)
+        .ok_or_else(|| "Android export staging path is missing".to_owned())?;
+    Ok(PathBuf::from(path))
+}
+
+pub async fn cleanup_staging<R: Runtime>(
+    app: &AppHandle<R>,
+    export_session_id: &str,
+) -> Result<(), String> {
+    invoke(
+        app,
+        "cleanupWebExport",
+        json!({ "exportSessionId": export_session_id }),
+    )
+    .await
+    .map(|_| ())
+    .map_err(|error| error.to_string())
+}

--- a/src-tauri/src/mobile/mod.rs
+++ b/src-tauri/src/mobile/mod.rs
@@ -1,3 +1,4 @@
+pub mod android_export;
 pub mod managed_directory_import;
 
 #[cfg(target_os = "android")]

--- a/src/App.vue
+++ b/src/App.vue
@@ -2,6 +2,7 @@
 import { useResourcePreviewPrimer } from '~/composables/useResourcePreviewPrimer'
 import { runAppStartup } from '~/features/app-startup/app-startup'
 import { useAppUpdateController } from '~/features/app-update/useAppUpdateController'
+import { cleanupRecoverableAndroidWebExports } from '~/features/export/android-web-export-workflow'
 import { recoverManagedImportSessions } from '~/features/resource-import/managed-import-recovery'
 import { engineManager } from '~/services/engine-manager'
 import { resolveMissingStorageSavePaths } from '~/services/platform/storage-defaults'
@@ -26,6 +27,7 @@ onMounted(async () => {
 
   await runAppStartup({
     appUpdateController,
+    cleanupRecoverableAndroidWebExports,
     engineManager,
     generalSettingsStore,
     resourceReconcile,

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -12,10 +12,29 @@ export interface WebExportParams {
   templatePath?: AbsPath
 }
 
+export interface AndroidWebExportParams {
+  enginePath: AbsPath
+  exportId: string
+  exportSessionId: string
+  gameName: string
+  gamePath: AbsPath
+  templatePath?: AbsPath
+}
+
 function exportWeb(params: WebExportParams): Promise<void> {
   return safeInvoke('export_web', { ...params })
 }
 
+function exportAndroidWebZip(params: AndroidWebExportParams): Promise<void> {
+  return safeInvoke('export_android_web_zip', { ...params })
+}
+
+function cleanupAndroidWebExport(exportSessionId: string): Promise<void> {
+  return safeInvoke('cleanup_android_web_export', { exportSessionId })
+}
+
 export const exportCmds = {
+  cleanupAndroidWebExport,
+  exportAndroidWebZip,
   exportWeb,
 }

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -33,8 +33,13 @@ function cleanupAndroidWebExport(exportSessionId: string): Promise<void> {
   return safeInvoke('cleanup_android_web_export', { exportSessionId })
 }
 
+function cleanupRecoverableAndroidWebExports(): Promise<void> {
+  return safeInvoke('android_export_cleanup_recoverable')
+}
+
 export const exportCmds = {
   cleanupAndroidWebExport,
+  cleanupRecoverableAndroidWebExports,
   exportAndroidWebZip,
   exportWeb,
 }

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -21,6 +21,12 @@ export interface AndroidWebExportParams {
   templatePath?: AbsPath
 }
 
+export interface PublishedAndroidExport {
+  contentUri: string
+  displayPath: string
+  kind: 'published'
+}
+
 function exportWeb(params: WebExportParams): Promise<void> {
   return safeInvoke('export_web', { ...params })
 }
@@ -37,9 +43,27 @@ function cleanupRecoverableAndroidWebExports(): Promise<void> {
   return safeInvoke('android_export_cleanup_recoverable')
 }
 
+function publishAndroidWebExport(
+  exportSessionId: string,
+  suggestedFileName: string,
+): Promise<PublishedAndroidExport> {
+  return safeInvoke('android_export_publish', { exportSessionId, suggestedFileName })
+}
+
+function openPublishedAndroidWebExport(contentUri: string): Promise<void> {
+  return safeInvoke('android_export_open', { contentUri })
+}
+
+function sharePublishedAndroidWebExport(contentUri: string): Promise<void> {
+  return safeInvoke('android_export_share', { contentUri })
+}
+
 export const exportCmds = {
   cleanupAndroidWebExport,
   cleanupRecoverableAndroidWebExports,
   exportAndroidWebZip,
   exportWeb,
+  openPublishedAndroidWebExport,
+  publishAndroidWebExport,
+  sharePublishedAndroidWebExport,
 }

--- a/src/components/export/ExportDialog.spec.ts
+++ b/src/components/export/ExportDialog.spec.ts
@@ -18,16 +18,36 @@ import ExportDialog from './ExportDialog.vue'
 
 const {
   exportWebMock,
+  androidExportMock,
+  androidOpenMock,
+  androidShareMock,
   confirmExportOverwriteMock,
   openDialogMock,
   openPathMock,
   toastErrorMock,
+  isAndroidRuntimeMock,
 } = vi.hoisted(() => ({
+  androidExportMock: vi.fn(),
+  androidOpenMock: vi.fn(),
+  androidShareMock: vi.fn(),
   exportWebMock: vi.fn(),
   confirmExportOverwriteMock: vi.fn(),
   openDialogMock: vi.fn(),
   openPathMock: vi.fn(),
   toastErrorMock: vi.fn(),
+  isAndroidRuntimeMock: vi.fn(),
+}))
+
+vi.mock('~/services/platform/runtime', () => ({
+  isAndroidRuntime: isAndroidRuntimeMock,
+}))
+
+vi.mock('~/features/export/android-web-export-workflow', () => ({
+  createAndroidWebExportWorkflow: () => ({
+    exportGame: androidExportMock,
+    openPublished: androidOpenMock,
+    sharePublished: androidShareMock,
+  }),
 }))
 
 vi.mock('@tauri-apps/plugin-dialog', () => ({
@@ -133,6 +153,14 @@ describe('ExportDialog', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     exportWebMock.mockResolvedValue(AbsPath.from('/exports/Demo Game/web'))
+    androidExportMock.mockResolvedValue({
+      kind: 'published',
+      contentUri: 'content://media/external/downloads/42',
+      displayPath: 'Downloads/WebGALCraft/exports/Demo_Game-web.zip',
+    })
+    androidOpenMock.mockResolvedValue(undefined)
+    androidShareMock.mockResolvedValue(undefined)
+    isAndroidRuntimeMock.mockReturnValue(false)
     confirmExportOverwriteMock.mockResolvedValue(true)
     openDialogMock.mockResolvedValue('/selected-exports')
     openPathMock.mockResolvedValue(undefined)
@@ -432,5 +460,34 @@ describe('ExportDialog', () => {
     expect(toastErrorMock).not.toHaveBeenCalled()
     await expect.element(page.getByText('export.progress.ready')).toBeInTheDocument()
     await expect.element(page.getByRole('button', { name: 'export.start' })).toBeEnabled()
+  })
+
+  it('Android 使用固定 Downloads 目标并提供打开文件和分享操作', async () => {
+    isAndroidRuntimeMock.mockReturnValue(true)
+    renderExportDialog()
+
+    await navigateToConfigureStep()
+    const outputInput = await page.getByLabelText('export.outputDirectory').element() as HTMLInputElement
+    expect(outputInput.value).toBe('export.androidDestination')
+    await expect.element(page.getByRole('button', { name: 'export.browse' })).not.toBeInTheDocument()
+    expect(openDialogMock).not.toHaveBeenCalled()
+
+    await page.getByRole('button', { name: 'export.next' }).click()
+    await page.getByRole('button', { name: 'export.start' }).click()
+
+    await vi.waitFor(() => expect(androidExportMock).toHaveBeenCalledOnce())
+    await expect.element(page.getByText('export.progress.finished')).toBeInTheDocument()
+    await expect.element(page.getByText('Downloads/WebGALCraft/exports/Demo_Game-web.zip')).toBeInTheDocument()
+    const openFileButton = await page.getByRole('button', { name: 'export.openFile' }).element() as HTMLButtonElement
+    const shareButton = await page.getByRole('button', { name: 'export.share' }).element() as HTMLButtonElement
+    openFileButton.click()
+    shareButton.click()
+
+    await vi.waitFor(() => {
+      expect(androidOpenMock).toHaveBeenCalledWith('content://media/external/downloads/42')
+      expect(androidShareMock).toHaveBeenCalledWith('content://media/external/downloads/42')
+    })
+    expect(openPathMock).not.toHaveBeenCalled()
+    expect(confirmExportOverwriteMock).not.toHaveBeenCalled()
   })
 })

--- a/src/components/export/ExportDialog.vue
+++ b/src/components/export/ExportDialog.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { Check, FolderOpen, Globe2, Loader2 } from '@lucide/vue'
+import { Check, ExternalLink, FolderOpen, Globe2, Loader2, Share2 } from '@lucide/vue'
 import { storeToRefs } from 'pinia'
 
 import { confirmExportOverwrite } from '~/features/export/confirmExportOverwrite'
@@ -33,6 +33,8 @@ const {
   canStart,
   elapsedMs,
   handleOpenChange,
+  hasOutputTarget,
+  isAndroid,
   isBusy,
   isRunning,
   openExportDirectory,
@@ -40,6 +42,7 @@ const {
   outputRoot,
   progress,
   selectOutputRoot,
+  shareExport,
   startExport,
   status,
   stepKey,
@@ -108,7 +111,7 @@ function isStepDisabled(step: number): boolean {
     return !isWebSelected
   }
   if (step === 3) {
-    return !outputRoot
+    return !hasOutputTarget
   }
   return false
 }
@@ -156,6 +159,9 @@ function progressLabel(key: string): string {
     }
     case 'export.progress.updatingManifest': {
       return t('export.progress.updatingManifest')
+    }
+    case 'export.progress.compressing': {
+      return t('export.progress.compressing')
     }
     case 'export.progress.finished': {
       return t('export.progress.finished')
@@ -237,7 +243,8 @@ const startLabel = $computed(() => status === 'failed'
           <ExportOutputDirectoryField
             :disabled="isBusy"
             :output-preview="outputPreview"
-            :output-root="outputRoot"
+            :output-root="isAndroid ? outputPreview : outputRoot"
+            :readonly="isAndroid"
             @select="selectOutputRoot"
           />
         </div>
@@ -282,14 +289,32 @@ const startLabel = $computed(() => status === 'failed'
                         size="icon"
                         class="shrink-0 size-8 transition-opacity"
                         :class="status !== 'completed' ? 'invisible pointer-events-none' : ''"
-                        :aria-label="$t('export.openDirectory')"
+                        :aria-label="isAndroid ? $t('export.openFile') : $t('export.openDirectory')"
                         @click="openExportDirectory"
                       >
-                        <FolderOpen class="size-4" aria-hidden="true" />
+                        <ExternalLink v-if="isAndroid" class="size-4" aria-hidden="true" />
+                        <FolderOpen v-else class="size-4" aria-hidden="true" />
                       </Button>
                     </TooltipTrigger>
                     <TooltipContent side="top">
-                      {{ $t('export.openDirectory') }}
+                      {{ isAndroid ? $t('export.openFile') : $t('export.openDirectory') }}
+                    </TooltipContent>
+                  </Tooltip>
+                  <Tooltip v-if="isAndroid">
+                    <TooltipTrigger as-child>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        class="shrink-0 size-8 transition-opacity"
+                        :class="status !== 'completed' ? 'invisible pointer-events-none' : ''"
+                        :aria-label="$t('export.share')"
+                        @click="shareExport"
+                      >
+                        <Share2 class="size-4" aria-hidden="true" />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent side="top">
+                      {{ $t('export.share') }}
                     </TooltipContent>
                   </Tooltip>
                 </TooltipProvider>
@@ -305,6 +330,13 @@ const startLabel = $computed(() => status === 'failed'
               />
               <span class="text-xs text-muted-foreground text-right shrink-0 w-9 tabular-nums" aria-hidden="true">{{ Math.round(progress) }}%</span>
             </div>
+            <p
+              v-if="isAndroid && status === 'completed'"
+              class="text-xs text-muted-foreground truncate"
+              :title="outputPreview"
+            >
+              {{ outputPreview }}
+            </p>
           </section>
         </div>
       </div>
@@ -327,7 +359,7 @@ const startLabel = $computed(() => status === 'failed'
 
           <Button
             v-if="currentStep < 3"
-            :disabled="currentStep === 1 ? !isWebSelected : !outputRoot"
+            :disabled="currentStep === 1 ? !isWebSelected : !hasOutputTarget"
             @click="goToNextStep"
           >
             {{ $t('export.next') }}

--- a/src/components/export/ExportOutputDirectoryField.vue
+++ b/src/components/export/ExportOutputDirectoryField.vue
@@ -3,6 +3,7 @@ interface Props {
   disabled?: boolean
   outputPreview?: string
   outputRoot?: string
+  readonly?: boolean
 }
 
 defineProps<Props>()
@@ -22,6 +23,7 @@ const emit = defineEmits<{
         disabled
       />
       <Button
+        v-if="!readonly"
         type="button"
         variant="outline"
         class="text-xs font-normal h-8 w-auto shadow-none"

--- a/src/features/app-startup/__tests__/app-startup.test.ts
+++ b/src/features/app-startup/__tests__/app-startup.test.ts
@@ -17,6 +17,7 @@ function createStartupOptions(overrides: Partial<RunAppStartupOptions> = {}): Ru
     appUpdateController: {
       checkForUpdate: vi.fn(),
     },
+    cleanupRecoverableAndroidWebExports: vi.fn(() => Promise.resolve()),
     engineManager: {
       validateAllEngines: vi.fn(async () => ({
         failed: 0,

--- a/src/features/app-startup/app-startup.ts
+++ b/src/features/app-startup/app-startup.ts
@@ -41,6 +41,7 @@ interface AppStartupStorageSettingsStore extends StorageSavePathState {
 
 export interface RunAppStartupOptions {
   appUpdateController: AppStartupUpdateController
+  cleanupRecoverableAndroidWebExports(): Promise<void>
   engineManager: AppStartupEngineManager
   generalSettingsStore: AppStartupGeneralSettingsStore
   resourceReconcile: AppStartupResourceReconcile
@@ -115,6 +116,7 @@ export async function runAppStartup(options: RunAppStartupOptions): Promise<void
   try {
     await initializeStoragePaths(options)
     await options.recoverManagedImportSessions()
+    await options.cleanupRecoverableAndroidWebExports()
     const validationResults = await Promise.all([
       runValidation('引擎校验', () => options.engineManager.validateAllEngines()),
       runValidation('游戏校验', () => options.resourceReconcile.reconcileAllGames()),

--- a/src/features/export/__tests__/android-web-export-workflow.test.ts
+++ b/src/features/export/__tests__/android-web-export-workflow.test.ts
@@ -2,8 +2,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { createTestGame } from '~/__tests__/factories'
 
-const { cleanupMock, exportZipMock, openMock, publishMock, shareMock } = vi.hoisted(() => ({
+const { cleanupMock, cleanupRecoverableMock, exportZipMock, openMock, publishMock, shareMock } = vi.hoisted(() => ({
   cleanupMock: vi.fn(),
+  cleanupRecoverableMock: vi.fn(),
   exportZipMock: vi.fn(),
   openMock: vi.fn(),
   publishMock: vi.fn(),
@@ -17,6 +18,7 @@ vi.mock('@tauri-apps/plugin-log', () => ({
 vi.mock('~/commands/export', () => ({
   exportCmds: {
     cleanupAndroidWebExport: cleanupMock,
+    cleanupRecoverableAndroidWebExports: cleanupRecoverableMock,
   },
 }))
 
@@ -26,12 +28,13 @@ vi.mock('~/services/export-manager', () => ({
   },
 }))
 
-import { createAndroidWebExportWorkflow } from '../android-web-export-workflow'
+import { cleanupRecoverableAndroidWebExports, createAndroidWebExportWorkflow } from '../android-web-export-workflow'
 
 describe('Android Web 导出工作流', () => {
   beforeEach(() => {
     vi.resetAllMocks()
     cleanupMock.mockResolvedValue(undefined)
+    cleanupRecoverableMock.mockResolvedValue(undefined)
     exportZipMock.mockResolvedValue(undefined)
     publishMock.mockResolvedValue({
       kind: 'published',
@@ -105,5 +108,18 @@ describe('Android Web 导出工作流', () => {
 
     expect(openMock).toHaveBeenCalledWith(uri)
     expect(shareMock).toHaveBeenCalledWith(uri)
+  })
+
+  it('启动时仅在 Android 清理遗留导出 session', async () => {
+    await cleanupRecoverableAndroidWebExports(true)
+    await cleanupRecoverableAndroidWebExports(false)
+
+    expect(cleanupRecoverableMock).toHaveBeenCalledOnce()
+  })
+
+  it('遗留导出清理失败不阻断应用启动', async () => {
+    cleanupRecoverableMock.mockRejectedValue(new Error('cleanup failed'))
+
+    await expect(cleanupRecoverableAndroidWebExports(true)).resolves.toBeUndefined()
   })
 })

--- a/src/features/export/__tests__/android-web-export-workflow.test.ts
+++ b/src/features/export/__tests__/android-web-export-workflow.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { createTestGame } from '~/__tests__/factories'
+
+const { cleanupMock, exportZipMock, openMock, publishMock, shareMock } = vi.hoisted(() => ({
+  cleanupMock: vi.fn(),
+  exportZipMock: vi.fn(),
+  openMock: vi.fn(),
+  publishMock: vi.fn(),
+  shareMock: vi.fn(),
+}))
+
+vi.mock('@tauri-apps/plugin-log', () => ({
+  error: vi.fn(),
+}))
+
+vi.mock('~/commands/export', () => ({
+  exportCmds: {
+    cleanupAndroidWebExport: cleanupMock,
+  },
+}))
+
+vi.mock('~/services/export-manager', () => ({
+  exportManager: {
+    exportAndroidWebZip: exportZipMock,
+  },
+}))
+
+import { createAndroidWebExportWorkflow } from '../android-web-export-workflow'
+
+describe('Android Web 导出工作流', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    cleanupMock.mockResolvedValue(undefined)
+    exportZipMock.mockResolvedValue(undefined)
+    publishMock.mockResolvedValue({
+      kind: 'published',
+      contentUri: 'content://media/external/downloads/42',
+      displayPath: 'Downloads/WebGALCraft/exports/Demo-web.zip',
+    })
+  })
+
+  function createWorkflow() {
+    return createAndroidWebExportWorkflow({
+      publisher: {
+        openPublished: openMock,
+        publishZipToDownloads: publishMock,
+        sharePublished: shareMock,
+      },
+    })
+  }
+
+  it('先生成私有 ZIP 再发布到 Downloads 并清理 session', async () => {
+    const game = createTestGame({ engineId: 'engine-1' })
+
+    await expect(createWorkflow().exportGame({
+      game,
+      gameName: 'Demo/Game',
+    })).resolves.toEqual({
+      kind: 'published',
+      contentUri: 'content://media/external/downloads/42',
+      displayPath: 'Downloads/WebGALCraft/exports/Demo-web.zip',
+    })
+
+    const exportSessionId = exportZipMock.mock.calls[0][0].exportSessionId
+    expect(exportZipMock).toHaveBeenCalledWith(expect.objectContaining({
+      exportSessionId,
+      game,
+      gameName: 'Demo/Game',
+    }))
+    expect(publishMock).toHaveBeenCalledWith({
+      exportSessionId,
+      suggestedFileName: 'Demo_Game-web.zip',
+    })
+    expect(cleanupMock).toHaveBeenCalledWith(exportSessionId)
+  })
+
+  it('发布前失败时仍清理私有 staging', async () => {
+    exportZipMock.mockRejectedValue(new Error('export failed'))
+
+    await expect(createWorkflow().exportGame({
+      game: createTestGame({ engineId: 'engine-1' }),
+      gameName: 'Demo',
+    })).rejects.toThrow('export failed')
+
+    expect(publishMock).not.toHaveBeenCalled()
+    expect(cleanupMock).toHaveBeenCalledOnce()
+  })
+
+  it('公共文件发布后清理失败仍返回发布结果', async () => {
+    cleanupMock.mockRejectedValue(new Error('cleanup failed'))
+
+    await expect(createWorkflow().exportGame({
+      game: createTestGame({ engineId: 'engine-1' }),
+      gameName: 'Demo',
+    })).resolves.toMatchObject({ kind: 'published' })
+  })
+
+  it('打开和分享只透传发布器返回的 content URI', async () => {
+    const workflow = createWorkflow()
+    const uri = 'content://media/external/downloads/42'
+
+    await workflow.openPublished(uri)
+    await workflow.sharePublished(uri)
+
+    expect(openMock).toHaveBeenCalledWith(uri)
+    expect(shareMock).toHaveBeenCalledWith(uri)
+  })
+})

--- a/src/features/export/android-export-publisher.ts
+++ b/src/features/export/android-export-publisher.ts
@@ -1,10 +1,8 @@
-import { safeInvoke } from '~/utils/invoke'
+import { exportCmds } from '~/commands/export'
 
-export interface PublishedAndroidExport {
-  kind: 'published'
-  contentUri: string
-  displayPath: string
-}
+import type { PublishedAndroidExport } from '~/commands/export'
+
+export type { PublishedAndroidExport } from '~/commands/export'
 
 export interface AndroidExportPublisher {
   publishZipToDownloads: (input: {
@@ -17,12 +15,12 @@ export interface AndroidExportPublisher {
 
 export const androidExportPublisher: AndroidExportPublisher = {
   publishZipToDownloads(input) {
-    return safeInvoke<PublishedAndroidExport>('android_export_publish', input)
+    return exportCmds.publishAndroidWebExport(input.exportSessionId, input.suggestedFileName)
   },
   openPublished(contentUri) {
-    return safeInvoke<void>('android_export_open', { contentUri })
+    return exportCmds.openPublishedAndroidWebExport(contentUri)
   },
   sharePublished(contentUri) {
-    return safeInvoke<void>('android_export_share', { contentUri })
+    return exportCmds.sharePublishedAndroidWebExport(contentUri)
   },
 }

--- a/src/features/export/android-export-publisher.ts
+++ b/src/features/export/android-export-publisher.ts
@@ -1,0 +1,28 @@
+import { safeInvoke } from '~/utils/invoke'
+
+export interface PublishedAndroidExport {
+  kind: 'published'
+  contentUri: string
+  displayPath: string
+}
+
+export interface AndroidExportPublisher {
+  publishZipToDownloads: (input: {
+    exportSessionId: string
+    suggestedFileName: string
+  }) => Promise<PublishedAndroidExport>
+  openPublished: (contentUri: string) => Promise<void>
+  sharePublished: (contentUri: string) => Promise<void>
+}
+
+export const androidExportPublisher: AndroidExportPublisher = {
+  publishZipToDownloads(input) {
+    return safeInvoke<PublishedAndroidExport>('android_export_publish', input)
+  },
+  openPublished(contentUri) {
+    return safeInvoke<void>('android_export_open', { contentUri })
+  },
+  sharePublished(contentUri) {
+    return safeInvoke<void>('android_export_share', { contentUri })
+  },
+}

--- a/src/features/export/android-web-export-workflow.ts
+++ b/src/features/export/android-web-export-workflow.ts
@@ -1,0 +1,70 @@
+import sanitize from 'sanitize-filename'
+
+import { exportCmds } from '~/commands/export'
+import { exportManager } from '~/services/export-manager'
+
+import { androidExportPublisher } from './android-export-publisher'
+
+import type { AndroidExportPublisher, PublishedAndroidExport } from './android-export-publisher'
+import type { Game } from '~/database/model'
+import type { ExportProgress } from '~/services/export-manager'
+
+interface AndroidWebExportWorkflowOptions {
+  publisher?: AndroidExportPublisher
+}
+
+export interface AndroidWebExportWorkflow {
+  exportGame: (input: {
+    game: Pick<Game, 'engineId' | 'path'>
+    gameName: string
+    onProgress?: (progress: ExportProgress) => void
+  }) => Promise<PublishedAndroidExport>
+  openPublished: (contentUri: string) => Promise<void>
+  sharePublished: (contentUri: string) => Promise<void>
+}
+
+function suggestedZipFileName(gameName: string): string {
+  const safeName = sanitize(gameName.trim(), { replacement: '_' })
+  return `${safeName}-web.zip`
+}
+
+export function createAndroidWebExportWorkflow(
+  options: AndroidWebExportWorkflowOptions = {},
+): AndroidWebExportWorkflow {
+  const publisher = options.publisher ?? androidExportPublisher
+
+  async function exportGame(input: {
+    game: Pick<Game, 'engineId' | 'path'>
+    gameName: string
+    onProgress?: (progress: ExportProgress) => void
+  }): Promise<PublishedAndroidExport> {
+    const exportSessionId = crypto.randomUUID()
+    let published: PublishedAndroidExport | undefined
+    try {
+      await exportManager.exportAndroidWebZip({
+        exportSessionId,
+        game: input.game,
+        gameName: input.gameName,
+        onProgress: input.onProgress,
+      })
+      published = await publisher.publishZipToDownloads({
+        exportSessionId,
+        suggestedFileName: suggestedZipFileName(input.gameName),
+      })
+      return published
+    } finally {
+      try {
+        await exportCmds.cleanupAndroidWebExport(exportSessionId)
+      } catch (error) {
+        const outcome = published ? '已发布' : '未发布'
+        logger.error(`清理 Android Web 导出 staging 失败 (${outcome}): session=${exportSessionId}, error=${error}`)
+      }
+    }
+  }
+
+  return {
+    exportGame,
+    openPublished: publisher.openPublished,
+    sharePublished: publisher.sharePublished,
+  }
+}

--- a/src/features/export/android-web-export-workflow.ts
+++ b/src/features/export/android-web-export-workflow.ts
@@ -2,6 +2,7 @@ import sanitize from 'sanitize-filename'
 
 import { exportCmds } from '~/commands/export'
 import { exportManager } from '~/services/export-manager'
+import { isAndroidRuntime } from '~/services/platform/runtime'
 
 import { androidExportPublisher } from './android-export-publisher'
 
@@ -66,5 +67,18 @@ export function createAndroidWebExportWorkflow(
     exportGame,
     openPublished: publisher.openPublished,
     sharePublished: publisher.sharePublished,
+  }
+}
+
+export async function cleanupRecoverableAndroidWebExports(
+  android: boolean = isAndroidRuntime(),
+): Promise<void> {
+  if (!android) {
+    return
+  }
+  try {
+    await exportCmds.cleanupRecoverableAndroidWebExports()
+  } catch (error) {
+    logger.error(`清理遗留 Android Web 导出 staging 失败: ${error}`)
   }
 }

--- a/src/features/export/useWebExportDialog.ts
+++ b/src/features/export/useWebExportDialog.ts
@@ -1,8 +1,10 @@
-import { open as openDialog } from '@tauri-apps/plugin-dialog'
 import { openPath } from '@tauri-apps/plugin-opener'
 
+import { createAndroidWebExportWorkflow } from '~/features/export/android-web-export-workflow'
+import { desktopDirectoryPicker } from '~/features/resource-import/desktop-directory-picker'
 import { exportManager, resolveWebExportOutputPath } from '~/services/export-manager'
 import { fromExternalAbsPath } from '~/services/platform/path-boundary'
+import { isAndroidRuntime } from '~/services/platform/runtime'
 import { AppError } from '~/types/errors'
 import { handleError } from '~/utils/error-handler'
 
@@ -14,6 +16,7 @@ import type { AbsPath } from '~/domain/path'
 export type WebExportStatus = 'idle' | 'running' | 'completed' | 'failed'
 
 interface UseWebExportDialogOptions {
+  android?: boolean
   confirmOverwrite: (outputPath: AbsPath) => Promise<boolean>
   defaultOutputRoot: MaybeRefOrGetter<string>
   game: MaybeRefOrGetter<Game>
@@ -22,6 +25,8 @@ interface UseWebExportDialogOptions {
 }
 
 export function useWebExportDialog(options: UseWebExportDialogOptions) {
+  const android = options.android ?? isAndroidRuntime()
+  const androidWorkflow = createAndroidWebExportWorkflow()
   const currentGame = computed(() => toValue(options.game))
   const {
     elapsedMs,
@@ -33,6 +38,7 @@ export function useWebExportDialog(options: UseWebExportDialogOptions) {
   const gameName = $computed(() => currentGame.value.metadata.name)
   let outputRoot = $ref<AbsPath>()
   let outputPath = $ref<AbsPath>()
+  let publishedExport = $ref<{ contentUri: string, displayPath: string }>()
   let progress = $ref(0)
   let isConfirmingOverwrite = $ref(false)
   let isSelectingDirectory = $ref(false)
@@ -42,13 +48,21 @@ export function useWebExportDialog(options: UseWebExportDialogOptions) {
 
   const isRunning = $computed(() => status === 'running')
   const isBusy = $computed(() => isConfirmingOverwrite || isSelectingDirectory || isStartingExport || isRunning)
-  const outputPreview = $computed(() => outputRoot
+  const desktopOutputPreview = $computed(() => outputRoot
     ? resolveWebExportOutputPath(outputRoot, gameName)
     : undefined,
   )
-  const canStart = $computed(() => !isBusy && outputPreview !== undefined)
+  const outputPreview = $computed(() => android
+    ? publishedExport?.displayPath ?? options.t('export.androidDestination')
+    : desktopOutputPreview,
+  )
+  const hasOutputTarget = $computed(() => android || outputPreview !== undefined)
+  const canStart = $computed(() => !isBusy && hasOutputTarget)
 
   function configuredOutputRoot(): AbsPath | undefined {
+    if (android) {
+      return
+    }
     const configuredPath = toValue(options.defaultOutputRoot).trim()
     if (!configuredPath) {
       return
@@ -65,6 +79,7 @@ export function useWebExportDialog(options: UseWebExportDialogOptions) {
     resetElapsedTimer()
     outputRoot = configuredOutputRoot()
     outputPath = undefined
+    publishedExport = undefined
     progress = 0
     isConfirmingOverwrite = false
     isSelectingDirectory = false
@@ -94,20 +109,18 @@ export function useWebExportDialog(options: UseWebExportDialogOptions) {
   }
 
   async function selectOutputRoot(): Promise<void> {
-    if (isBusy) {
+    if (android || isBusy) {
       return
     }
 
     isSelectingDirectory = true
     try {
-      const selected = await openDialog({
-        defaultPath: outputRoot,
-        directory: true,
-        multiple: false,
-        title: options.t('export.selectDirectory'),
-      })
-      if (typeof selected === 'string') {
-        outputRoot = fromExternalAbsPath(selected)
+      const selected = await desktopDirectoryPicker.selectDirectory(
+        options.t('export.selectDirectory'),
+        outputRoot,
+      )
+      if (selected) {
+        outputRoot = selected
       }
     } catch (error) {
       logger.error(`选择 Web 导出目录失败: ${error}`)
@@ -118,28 +131,41 @@ export function useWebExportDialog(options: UseWebExportDialogOptions) {
   }
 
   async function startExport(): Promise<void> {
-    if (!canStart || !outputRoot) {
+    if (!canStart || (!android && !outputRoot)) {
       return
     }
 
     const selectedGame = currentGame.value
     const selectedGameName = gameName
-    const selectedOutputPath = outputPreview
+    const selectedOutputPath = desktopOutputPreview
     const selectedOutputRoot = outputRoot
 
     async function runExport(replaceExisting: boolean): Promise<void> {
+      if (android) {
+        publishedExport = await androidWorkflow.exportGame({
+          game: selectedGame,
+          gameName: selectedGameName,
+          onProgress: updateProgress,
+        })
+        return
+      }
+      if (!selectedOutputRoot) {
+        return
+      }
       outputPath = await exportManager.exportWeb({
         game: selectedGame,
         gameName: selectedGameName,
         outputRoot: selectedOutputRoot,
         replaceExisting,
-        onProgress: (nextProgress) => {
-          isStartingExport = false
-          status = 'running'
-          progress = nextProgress.percentage
-          stepKey = nextProgress.step
-        },
+        onProgress: updateProgress,
       })
+    }
+
+    function updateProgress(nextProgress: { percentage: number, step: string }): void {
+      isStartingExport = false
+      status = 'running'
+      progress = nextProgress.percentage
+      stepKey = nextProgress.step
     }
 
     function markCompleted(): void {
@@ -167,7 +193,7 @@ export function useWebExportDialog(options: UseWebExportDialogOptions) {
       await runExport(false)
       markCompleted()
     } catch (error) {
-      if (!(error instanceof AppError) || error.code !== 'TARGET_CONFLICT' || !selectedOutputPath) {
+      if (android || !(error instanceof AppError) || error.code !== 'TARGET_CONFLICT' || !selectedOutputPath) {
         markFailed(error)
         return
       }
@@ -205,6 +231,15 @@ export function useWebExportDialog(options: UseWebExportDialogOptions) {
   }
 
   async function openExportDirectory(): Promise<void> {
+    if (android && publishedExport) {
+      try {
+        await androidWorkflow.openPublished(publishedExport.contentUri)
+      } catch (error) {
+        logger.error(`打开 Android Web 导出文件失败: ${error}`)
+        toast.error(options.t('export.openFileFailed'))
+      }
+      return
+    }
     if (!outputPath) {
       return
     }
@@ -217,10 +252,24 @@ export function useWebExportDialog(options: UseWebExportDialogOptions) {
     }
   }
 
+  async function shareExport(): Promise<void> {
+    if (!publishedExport) {
+      return
+    }
+    try {
+      await androidWorkflow.sharePublished(publishedExport.contentUri)
+    } catch (error) {
+      logger.error(`分享 Android Web 导出文件失败: ${error}`)
+      toast.error(options.t('export.shareFailed'))
+    }
+  }
+
   return $$({
     canStart,
     elapsedMs,
     handleOpenChange,
+    hasOutputTarget,
+    isAndroid: android,
     isBusy,
     isRunning,
     openExportDirectory,
@@ -228,6 +277,7 @@ export function useWebExportDialog(options: UseWebExportDialogOptions) {
     outputRoot,
     progress,
     selectOutputRoot,
+    shareExport,
     startExport,
     status,
     stepKey,

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -645,6 +645,7 @@ export:
   selectDirectoryHint: Select an export folder to continue
   selectDirectory: Select export folder
   selectDirectoryFailed: Failed to select the export folder
+  androidDestination: Downloads/WebGALCraft/exports
   start: Export
   retry: Retry export
   exporting: Exporting
@@ -653,6 +654,10 @@ export:
     total: Took {seconds}s
     separator: ·
   openDirectory: Open folder
+  openFile: Open file
+  openFileFailed: Failed to open the exported file
+  share: Share
+  shareFailed: Failed to share the exported file
   failed: Web export failed
   openDirectoryFailed: Failed to open the export folder
   overwrite:
@@ -666,6 +671,7 @@ export:
     copyingGame: Copying game resources...
     copyingIcons: Copying icons...
     updatingManifest: Updating manifest...
+    compressing: Compressing ZIP...
     finished: Export complete
     failed: Export failed
 

--- a/src/locales/ja.yml
+++ b/src/locales/ja.yml
@@ -645,6 +645,7 @@ export:
   selectDirectoryHint: 続行するには、書き出し先フォルダーを選択してください
   selectDirectory: 書き出し先フォルダーを選択
   selectDirectoryFailed: 書き出し先フォルダーを選択できませんでした
+  androidDestination: Downloads/WebGALCraft/exports
   start: 書き出す
   retry: 再度書き出す
   exporting: 書き出し中
@@ -653,6 +654,10 @@ export:
     total: 所要時間 {seconds} 秒
     separator: ·
   openDirectory: フォルダーを開く
+  openFile: ファイルを開く
+  openFileFailed: 書き出したファイルを開けませんでした
+  share: 共有
+  shareFailed: 書き出したファイルを共有できませんでした
   failed: Web 書き出しに失敗しました
   openDirectoryFailed: 書き出し先フォルダーを開けませんでした
   overwrite:
@@ -666,6 +671,7 @@ export:
     copyingGame: ゲームリソースをコピーしています...
     copyingIcons: アイコンをコピーしています...
     updatingManifest: マニフェストを更新しています...
+    compressing: ZIP を作成しています...
     finished: 書き出しが完了しました
     failed: 書き出しに失敗しました
 

--- a/src/locales/zh-Hans.yml
+++ b/src/locales/zh-Hans.yml
@@ -645,6 +645,7 @@ export:
   selectDirectoryHint: 请先选择导出目录以继续
   selectDirectory: 选择导出目录
   selectDirectoryFailed: 无法选择导出目录
+  androidDestination: 下载/WebGALCraft/exports
   start: 开始导出
   retry: 重新导出
   exporting: 正在导出
@@ -653,6 +654,10 @@ export:
     total: 耗时 {seconds} 秒
     separator: ·
   openDirectory: 打开目录
+  openFile: 打开文件
+  openFileFailed: 无法打开导出文件
+  share: 分享
+  shareFailed: 无法分享导出文件
   failed: Web 导出失败
   openDirectoryFailed: 无法打开导出目录
   overwrite:
@@ -666,6 +671,7 @@ export:
     copyingGame: 正在复制游戏资源...
     copyingIcons: 正在复制图标...
     updatingManifest: 正在更新清单...
+    compressing: 正在生成 ZIP...
     finished: 导出完成
     failed: 导出失败
 

--- a/src/locales/zh-Hant.yml
+++ b/src/locales/zh-Hant.yml
@@ -645,6 +645,7 @@ export:
   selectDirectoryHint: 請先選擇匯出目錄以繼續
   selectDirectory: 選擇匯出目錄
   selectDirectoryFailed: 無法選擇匯出目錄
+  androidDestination: 下載/WebGALCraft/exports
   start: 開始匯出
   retry: 重新匯出
   exporting: 正在匯出
@@ -653,6 +654,10 @@ export:
     total: 耗時 {seconds} 秒
     separator: ·
   openDirectory: 開啟目錄
+  openFile: 開啟檔案
+  openFileFailed: 無法開啟匯出檔案
+  share: 分享
+  shareFailed: 無法分享匯出檔案
   failed: Web 匯出失敗
   openDirectoryFailed: 無法開啟匯出目錄
   overwrite:
@@ -666,6 +671,7 @@ export:
     copyingGame: 正在複製遊戲資源...
     copyingIcons: 正在複製圖示...
     updatingManifest: 正在更新資訊清單...
+    compressing: 正在產生 ZIP...
     finished: 匯出完成
     failed: 匯出失敗
 

--- a/src/services/__tests__/export-manager.test.ts
+++ b/src/services/__tests__/export-manager.test.ts
@@ -10,11 +10,13 @@ import type { ExportProgress } from '~/services/export-manager'
 
 const {
   exportWebCommandMock,
+  exportAndroidWebZipCommandMock,
   listenMock,
   resolvePreviewSiteMock,
   unlistenMock,
 } = vi.hoisted(() => ({
   exportWebCommandMock: vi.fn(),
+  exportAndroidWebZipCommandMock: vi.fn(),
   listenMock: vi.fn(),
   resolvePreviewSiteMock: vi.fn(),
   unlistenMock: vi.fn(),
@@ -28,6 +30,7 @@ vi.mock('@tauri-apps/api/event', () => ({
 
 vi.mock('~/commands/export', () => ({
   exportCmds: {
+    exportAndroidWebZip: exportAndroidWebZipCommandMock,
     exportWeb: exportWebCommandMock,
   },
 }))
@@ -52,6 +55,7 @@ describe('exportManager', () => {
       templatePath: AbsPath.from('/templates/default'),
     })
     exportWebCommandMock.mockResolvedValue(undefined)
+    exportAndroidWebZipCommandMock.mockResolvedValue(undefined)
   })
 
   it('会生成安全目录名并把当前站点三层路径传给导出命令', async () => {
@@ -120,6 +124,42 @@ describe('exportManager', () => {
       outputRoot: AbsPath.from('/exports'),
     })).rejects.toThrow('disk full')
 
+    expect(unlistenMock).toHaveBeenCalledOnce()
+  })
+
+  it('Android 导出把站点写入受控 session 且复用进度事件', async () => {
+    const onProgress = vi.fn()
+    const pending = exportManager.exportAndroidWebZip({
+      exportSessionId: 'session-1',
+      game: createTestGame({ engineId: 'engine-1' }),
+      gameName: 'Demo',
+      onProgress,
+    })
+
+    await vi.waitFor(() => expect(exportAndroidWebZipCommandMock).toHaveBeenCalledOnce())
+    const params = exportAndroidWebZipCommandMock.mock.calls[0][0]
+    progressHandler?.({
+      payload: {
+        exportId: params.exportId,
+        percentage: 96,
+        platform: 'web',
+        step: 'export.progress.compressing',
+      },
+    })
+
+    await expect(pending).resolves.toBeUndefined()
+    expect(exportAndroidWebZipCommandMock).toHaveBeenCalledWith({
+      enginePath: '/engines/webgal',
+      exportId: expect.any(String),
+      exportSessionId: 'session-1',
+      gameName: 'Demo',
+      gamePath: '/games/demo',
+      templatePath: '/templates/default',
+    })
+    expect(onProgress).toHaveBeenCalledWith(expect.objectContaining({
+      percentage: 96,
+      step: 'export.progress.compressing',
+    }))
     expect(unlistenMock).toHaveBeenCalledOnce()
   })
 

--- a/src/services/export-manager.ts
+++ b/src/services/export-manager.ts
@@ -23,6 +23,13 @@ export interface WebExportConfig {
   replaceExisting?: boolean
 }
 
+export interface AndroidWebExportConfig {
+  exportSessionId: string
+  game: Pick<Game, 'engineId' | 'path'>
+  gameName: string
+  onProgress?: (progress: ExportProgress) => void
+}
+
 function createExportDirectoryName(gameName: string): string {
   const trimmed = gameName.trim()
   if (trimmed === '.' || trimmed === '..') {
@@ -83,6 +90,43 @@ async function exportWeb(config: WebExportConfig): Promise<AbsPath> {
   }
 }
 
+async function exportAndroidWebZip(config: AndroidWebExportConfig): Promise<void> {
+  const gameName = config.gameName.trim()
+  if (!gameName || !createExportDirectoryName(gameName)) {
+    throw new AppError('INVALID_CONFIG', '游戏名称不能生成有效的导出文件名')
+  }
+
+  const site = await gameManager.resolvePreviewSite(config.game)
+  if (!site.enginePath) {
+    throw new AppError('ENGINE_EDITOR_INCOMPATIBLE', '当前游戏没有可用的导出引擎')
+  }
+
+  const exportId = crypto.randomUUID()
+  const unlisten = await listen<ExportProgress>('export-progress', (event) => {
+    const progress = event.payload
+    if (progress.exportId === exportId && progress.platform === 'web') {
+      config.onProgress?.({
+        ...progress,
+        percentage: Math.min(100, Math.max(0, progress.percentage)),
+      })
+    }
+  })
+
+  try {
+    await exportCmds.exportAndroidWebZip({
+      enginePath: site.enginePath,
+      exportId,
+      exportSessionId: config.exportSessionId,
+      gameName,
+      gamePath: site.projectPath,
+      templatePath: site.templatePath,
+    })
+  } finally {
+    unlisten()
+  }
+}
+
 export const exportManager = {
+  exportAndroidWebZip,
   exportWeb,
 }


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [ ] 错误修复
- [x] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [x] 代码重构
- [x] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [x] 项目构建
- [x] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

- 增加 Android Web 导出会话和恢复机制。
- 在应用私有 staging 目录生成 Web 导出内容并压缩为 ZIP。
- 通过 Android MediaStore 将 ZIP 发布到：
  `Downloads/WebGALCraft/exports/`
- 使用 pending 状态避免未完成的文件对用户可见。
- 增加安全文件名、冲突处理和导出会话清理。
- 支持打开和分享已发布的公共 ZIP。
- 将 Android 导出能力从资源导入模块中拆出，形成独立的平台边界。
- 保持桌面端可配置导出目录、展开目录导出、覆盖确认和打开路径行为不变。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

Android scoped storage 不允许将公共 Downloads 路径直接当作 Rust 本地路径使用，也不能把 MediaStore URI 转换或伪装成 `AbsPath`。

Android 导出需要明确区分：

1. Rust 在应用私有目录生成导出内容；
2. Android 原生层压缩并发布到 MediaStore；
3. 前端使用 content URI 执行打开和分享。

这样既满足 Android 公共存储约束，也不会污染现有桌面导出模型。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->

这是 stacked PR 的最后一层，依赖 Android 托管目录导入 PR。

本 PR 不包含：

- Android Web 导出的“另存为”或自选目录；
- 将展开后的 Web 目录逐文件发布到公共存储；
- Android 游戏 APK 导出；
- Android 手机响应式 UI；
- iOS/iPadOS 导出适配。

### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
