### PR TITLE
🐛 修复按钮与开关默认尺寸被全局样式覆盖

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -36,14 +36,6 @@ body {
     display: none;
     appearance: none;
   }
-
-  @media (any-pointer: coarse) {
-    button:not(:disabled),
-    [role="button"]:not(:disabled) {
-      min-width: 44px;
-      min-height: 44px;
-    }
-  }
 }
 
 .bg-checkerboard {


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [x] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [ ] 测试用例
- [ ] 性能优化
- [x] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

移除 `src/styles/main.css` 中针对 `any-pointer: coarse` 的全局最小尺寸规则。

该规则会匹配所有启用的 `button`，包括 Reka UI `SwitchRoot` 渲染出的 `button[role="switch"]`，从而覆盖按钮和开关自身的 `h-9`、`h-5` 等尺寸。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

部分桌面 WebView 环境也可能匹配 `any-pointer: coarse`，因此该规则并不只影响 Android 或触摸屏设备。

全局设置 `min-height: 44px` 会导致默认按钮和开关尺寸异常。本次移除该全局覆盖，恢复由组件自身 variant 和 class 控制尺寸。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->

本次不涉及组件 API、IPC 或持久化数据。

如果后续需要满足触控目标尺寸，应针对具体交互控件显式设置，避免全局覆盖基础控件。

### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
