### PR TITLE
🐛 修复托管资源卸载的平台回收站策略

### DIFF
--- a/src/components/home/engines-tab/EnginesTab.spec.ts
+++ b/src/components/home/engines-tab/EnginesTab.spec.ts
@@ -47,6 +47,7 @@ vi.mock('@tauri-apps/plugin-dialog', () => ({
 
 vi.mock('~/services/platform/runtime', () => ({
   isAndroidRuntime: () => false,
+  isDesktopRuntime: () => true,
 }))
 
 vi.mock('@tauri-apps/plugin-opener', () => ({

--- a/src/components/home/games-tab/GamesTab.spec.ts
+++ b/src/components/home/games-tab/GamesTab.spec.ts
@@ -94,6 +94,7 @@ vi.mock('@tauri-apps/plugin-dialog', () => ({
 
 vi.mock('~/services/platform/runtime', () => ({
   isAndroidRuntime: () => false,
+  isDesktopRuntime: () => true,
 }))
 
 vi.mock('@tauri-apps/plugin-opener', () => ({

--- a/src/components/home/templates-tab/TemplatesTab.spec.ts
+++ b/src/components/home/templates-tab/TemplatesTab.spec.ts
@@ -41,6 +41,7 @@ vi.mock('@tauri-apps/plugin-dialog', () => ({
 
 vi.mock('~/services/platform/runtime', () => ({
   isAndroidRuntime: () => false,
+  isDesktopRuntime: () => true,
 }))
 
 vi.mock('@tauri-apps/plugin-opener', () => ({

--- a/src/services/__tests__/engine-manager.test.ts
+++ b/src/services/__tests__/engine-manager.test.ts
@@ -5,6 +5,8 @@ import { AbsPath } from '~/domain/path'
 import { engineManager, evaluateEngineEditorCompatibility } from '~/services/engine-manager'
 import { AppError } from '~/types/errors'
 
+import type { Platform } from '@tauri-apps/plugin-os'
+
 const {
   addMock,
   copyDirectoryWithProgressMock,
@@ -29,6 +31,7 @@ const {
   useResourceStoreMock,
   useStorageSettingsStoreMock,
   validateDirectoryStructureMock,
+  platformMock,
 } = vi.hoisted(() => ({
   addMock: vi.fn(),
   copyDirectoryWithProgressMock: vi.fn(),
@@ -56,6 +59,11 @@ const {
   useResourceStoreMock: vi.fn(),
   useStorageSettingsStoreMock: vi.fn(),
   validateDirectoryStructureMock: vi.fn(),
+  platformMock: vi.fn((): Platform => 'windows'),
+}))
+
+vi.mock('@tauri-apps/plugin-os', () => ({
+  platform: platformMock,
 }))
 
 vi.mock('@tauri-apps/plugin-fs', () => ({
@@ -137,10 +145,12 @@ describe('engineManager', () => {
     useResourceStoreMock.mockReset()
     useStorageSettingsStoreMock.mockReset()
     validateDirectoryStructureMock.mockReset()
+    platformMock.mockReset()
 
     iconPathMock.mockImplementation((enginePath: string) => `${enginePath}/icons/favicon.ico`)
     useResourceStoreMock.mockReturnValue(resourceStoreMock)
     useStorageSettingsStoreMock.mockReturnValue({ engineSavePath: '/engines' })
+    platformMock.mockReturnValue('windows')
     engineWhereMock.mockReturnValue({
       equals: engineWhereEqualsMock,
     })
@@ -294,6 +304,31 @@ describe('engineManager', () => {
         }),
       },
     }))
+  })
+
+  it('importEngine 复制失败时会永久清理目标目录', async () => {
+    readEngineManifestMock.mockResolvedValue({
+      status: 'ok',
+      manifest: {
+        schemaVersion: '1.0.0',
+        id: 'open-webgal.webgal',
+        name: 'WebGAL',
+        version: '4.6.2',
+        engineType: 'official',
+        webgalVersion: '4.6.2',
+      },
+    })
+    validateDirectoryStructureMock.mockResolvedValue(true)
+    addMock.mockResolvedValue('engine-1')
+    enginesUpdateMock.mockResolvedValue(undefined)
+    deleteFileMock.mockResolvedValue(undefined)
+    copyDirectoryWithProgressMock.mockRejectedValue(new Error('disk full'))
+    existsMock.mockResolvedValueOnce(false).mockResolvedValueOnce(true)
+
+    await expect(engineManager.importEngine(AbsPath.from('/downloads/webgal'))).rejects.toThrow('disk full')
+
+    expect(enginesUpdateMock).toHaveBeenCalledWith('engine-1', { status: 'error' })
+    expect(deleteFileMock).toHaveBeenCalledWith('/engines/WebGAL/4.6.2', true)
   })
 
   it('managed import 预检只读并在发布后直接注册最终目录', async () => {
@@ -939,7 +974,7 @@ describe('engineManager', () => {
 
     await engineManager.uninstallEngine(createTestEngine())
 
-    expect(deleteFileMock).toHaveBeenCalledWith('/engines/default', true)
+    expect(deleteFileMock).toHaveBeenCalledWith('/engines/default', false)
     expect(enginesDeleteMock).toHaveBeenCalledWith('engine-1')
   })
 
@@ -949,11 +984,47 @@ describe('engineManager', () => {
 
     await expect(engineManager.uninstallEngine(createTestEngine())).resolves.toBeUndefined()
 
-    expect(deleteFileMock).toHaveBeenCalledWith('/engines/default', true)
+    expect(deleteFileMock).toHaveBeenCalledWith('/engines/default', false)
     expect(enginesDeleteMock).toHaveBeenCalledWith('engine-1')
   })
 
   it('uninstallEngineGroup 会删除整组版本并清理记录', async () => {
+    enginesDeleteMock.mockResolvedValue(undefined)
+    engineWhereToArrayMock.mockResolvedValue([
+      createTestEngine({
+        id: 'engine-1',
+        name: 'WebGAL',
+        path: AbsPath.from('/engines/WebGAL/4.5.0'),
+        version: '4.5.0',
+      }),
+      createTestEngine({
+        id: 'engine-2',
+        name: 'WebGAL',
+        path: AbsPath.from('/engines/WebGAL/4.4.0'),
+        version: '4.4.0',
+      }),
+    ])
+
+    await engineManager.uninstallEngineGroup('open-webgal.webgal')
+
+    expect(deleteFileMock).toHaveBeenNthCalledWith(1, '/engines/WebGAL/4.5.0', false)
+    expect(deleteFileMock).toHaveBeenNthCalledWith(2, '/engines/WebGAL/4.4.0', false)
+    expect(enginesDeleteMock).toHaveBeenNthCalledWith(1, 'engine-1')
+    expect(enginesDeleteMock).toHaveBeenNthCalledWith(2, 'engine-2')
+  })
+
+  it('uninstallEngine 在 Android 上永久删除托管目录', async () => {
+    platformMock.mockReturnValue('android')
+    enginesDeleteMock.mockResolvedValue(undefined)
+
+    await engineManager.uninstallEngine(createTestEngine())
+
+    expect(deleteFileMock).toHaveBeenCalledWith('/engines/default', true)
+    expect(enginesDeleteMock).toHaveBeenCalledWith('engine-1')
+  })
+
+  it('uninstallEngineGroup 在 Android 上永久删除所有版本', async () => {
+    platformMock.mockReturnValue('android')
     enginesDeleteMock.mockResolvedValue(undefined)
     engineWhereToArrayMock.mockResolvedValue([
       createTestEngine({

--- a/src/services/__tests__/template-manager.test.ts
+++ b/src/services/__tests__/template-manager.test.ts
@@ -5,6 +5,8 @@ import { AbsPath } from '~/domain/path'
 import { templateManager } from '~/services/template-manager'
 import { AppError } from '~/types/errors'
 
+import type { Platform } from '@tauri-apps/plugin-os'
+
 const {
   copyDirectoryWithProgressMock,
   dbGamesToArrayMock,
@@ -24,6 +26,7 @@ const {
   useResourceStoreMock,
   useStorageSettingsStoreMock,
   validateDirectoryStructureMock,
+  platformMock,
 } = vi.hoisted(() => ({
   copyDirectoryWithProgressMock: vi.fn(),
   dbGamesToArrayMock: vi.fn(),
@@ -46,6 +49,11 @@ const {
   useResourceStoreMock: vi.fn(),
   useStorageSettingsStoreMock: vi.fn(),
   validateDirectoryStructureMock: vi.fn(),
+  platformMock: vi.fn((): Platform => 'windows'),
+}))
+
+vi.mock('@tauri-apps/plugin-os', () => ({
+  platform: platformMock,
 }))
 
 vi.mock('@tauri-apps/plugin-log', () => ({
@@ -125,6 +133,7 @@ describe('templateManager', () => {
     useStorageSettingsStoreMock.mockReturnValue({
       templateSavePath: '/templates',
     })
+    platformMock.mockReturnValue('windows')
   })
 
   afterEach(() => {
@@ -190,6 +199,22 @@ describe('templateManager', () => {
       status: 'created',
     })
     expect(resourceStoreMock.finishProgress).toHaveBeenCalledWith('template-1')
+  })
+
+  it('importTemplate 安装失败时会永久清理目标目录', async () => {
+    validateDirectoryStructureMock.mockResolvedValue(true)
+    readTextFileMock.mockResolvedValue(JSON.stringify({
+      name: 'Modern Template',
+    }))
+    dbTemplatesAddMock.mockResolvedValue('template-1')
+    dbTemplatesDeleteMock.mockResolvedValue(undefined)
+    copyDirectoryWithProgressMock.mockRejectedValue(new Error('disk full'))
+    existsMock.mockResolvedValueOnce(false).mockResolvedValueOnce(true)
+
+    await expect(templateManager.importTemplate(AbsPath.from('/source/template'))).rejects.toThrow('disk full')
+
+    expect(dbTemplatesDeleteMock).toHaveBeenCalledWith('template-1')
+    expect(deleteFileMock).toHaveBeenCalledWith('/templates/Modern Template', true)
   })
 
   it('managed import 预检只读并在发布后直接注册最终目录', async () => {
@@ -593,7 +618,7 @@ describe('templateManager', () => {
       },
     })
 
-    expect(deleteFileMock).toHaveBeenCalledWith('/templates/Modern Template', true)
+    expect(deleteFileMock).toHaveBeenCalledWith('/templates/Modern Template', false)
     expect(dbTemplatesDeleteMock).toHaveBeenCalledWith('template-created')
   })
 
@@ -741,6 +766,25 @@ describe('templateManager', () => {
         name: 'Modern Template',
       },
     })).resolves.toBeUndefined()
+
+    expect(deleteFileMock).toHaveBeenCalledWith('/templates/Modern Template', false)
+    expect(dbTemplatesDeleteMock).toHaveBeenCalledWith('template-created')
+  })
+
+  it('deleteTemplate 在 Android 上永久删除模板目录', async () => {
+    platformMock.mockReturnValue('android')
+
+    await templateManager.deleteTemplate({
+      id: 'template-created',
+      path: AbsPath.from('/templates/Modern Template'),
+      pathLookupKey: '/templates/modern template',
+      createdAt: 0,
+      status: 'created',
+      availability: 'available',
+      metadata: {
+        name: 'Modern Template',
+      },
+    })
 
     expect(deleteFileMock).toHaveBeenCalledWith('/templates/Modern Template', true)
     expect(dbTemplatesDeleteMock).toHaveBeenCalledWith('template-created')

--- a/src/services/engine-manager.ts
+++ b/src/services/engine-manager.ts
@@ -8,6 +8,7 @@ import { Engine, Game } from '~/database/model'
 import { isWebgalEditorRuntimeCompatible, normalizeWebgalRuntimeVersion } from '~/domain/engine/runtime-capabilities'
 import { AbsPath, RelPath } from '~/domain/path'
 import { engineIconPath } from '~/services/platform/app-paths'
+import { isDesktopRuntime } from '~/services/platform/runtime'
 import {
   classifyAvailability,
   createWarning,
@@ -653,7 +654,7 @@ async function uninstallEngine(engine: Engine): Promise<void> {
   logger.info(`[引擎卸载] ${engine.name}@${engine.version ?? '未知'}: ${engine.path}`)
   if (engine.availability === 'available') {
     try {
-      await fsCmds.deleteFile(engine.path, true)
+      await fsCmds.deleteFile(engine.path, !isDesktopRuntime())
     } catch (error) {
       logger.warn(`[引擎卸载] 删除托管目录失败，继续清理数据库记录: ${engine.path} - ${error}`)
     }

--- a/src/services/template-manager.ts
+++ b/src/services/template-manager.ts
@@ -6,6 +6,7 @@ import { projectConfigCmds } from '~/commands/project-config'
 import { db } from '~/database/db'
 import { AbsPath } from '~/domain/path'
 import { templateManifestPath } from '~/services/platform/app-paths'
+import { isDesktopRuntime } from '~/services/platform/runtime'
 import { normalizeImportPath, ResourceAvailability } from '~/services/resource-health'
 import { caseFoldedEquals, toLookupPathKey } from '~/services/resource-path/lookup'
 import {
@@ -336,7 +337,7 @@ async function deleteTemplate(template: Template): Promise<void> {
 
   if (template.availability === 'available') {
     try {
-      await fsCmds.deleteFile(template.path, true)
+      await fsCmds.deleteFile(template.path, !isDesktopRuntime())
     } catch (error) {
       logger.warn(`[模板删除] 删除模板目录失败，继续清理数据库记录: ${template.path} - ${error}`)
     }


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [x] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [x] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

修复模板和引擎主动卸载时始终永久删除托管目录的问题：

- 桌面端卸载模板或引擎时，将目录移动到系统回收站。
- Android 卸载模板或引擎时，继续永久删除目录。
- 引擎组卸载沿用相同的平台删除策略。
- 导入失败、安装回滚和残留清理仍使用永久删除。
- 删除目录失败时，仍会清理对应的数据库记录。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

桌面端已有文件和游戏删除的回收站策略，但模板和引擎卸载仍固定使用永久删除，导致用户无法恢复误删的托管资源。本次统一主动卸载行为的平台策略，同时保留失败清理路径的永久删除语义。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->

已覆盖桌面端与 Android 的模板、引擎单个卸载和引擎组卸载测试，以及导入失败清理测试。

### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
