### PR TITLE
✨ 支持 Opus 格式音频文件

### DIFF
--- a/integration/support/mock-tauri.ts
+++ b/integration/support/mock-tauri.ts
@@ -383,7 +383,7 @@ export async function installMockTauri(page: Page, options: InstallMockTauriOpti
       }
 
       function isBinaryPath(path: string) {
-        return /\.(png|jpe?g|gif|webp|ico|bmp|mp3|wav|ogg|m4a|mp4|webm|mov|ttf|otf|woff2?)$/i.test(path)
+        return /\.(png|jpe?g|gif|webp|ico|bmp|mp3|wav|ogg|m4a|opus|mp4|webm|mov|ttf|otf|woff2?)$/i.test(path)
       }
 
       function isGameContentPath(relPath: string) {

--- a/src/components/editor/TextEditor.spec.ts
+++ b/src/components/editor/TextEditor.spec.ts
@@ -363,14 +363,14 @@ describe('TextEditor', () => {
 
   it('会将场景运行时能力传入诊断器', async () => {
     const { state } = createHarness()
-    state.runtimeCapabilities = { multilineStatements: false }
+    state.runtimeCapabilities = { multilineStatements: false, opusVocalShorthand: false }
 
     renderTextEditor(state)
     await nextTick()
 
     expect(updateEditorDiagnosticsMock).toHaveBeenCalledWith(
       { id: 'model-1' },
-      { multilineStatements: false },
+      { multilineStatements: false, opusVocalShorthand: false },
     )
   })
 
@@ -714,14 +714,14 @@ describe('TextEditor', () => {
     await result.rerender({
       state: {
         ...state,
-        runtimeCapabilities: { multilineStatements: false },
+        runtimeCapabilities: { multilineStatements: false, opusVocalShorthand: false },
       },
     })
     await nextTick()
 
     expect(updateEditorDiagnosticsMock).toHaveBeenCalledWith(
       model,
-      { multilineStatements: false },
+      { multilineStatements: false, opusVocalShorthand: false },
     )
   })
 

--- a/src/components/modals/game-config/GameConfigFieldsSection.spec.ts
+++ b/src/components/modals/game-config/GameConfigFieldsSection.spec.ts
@@ -163,7 +163,7 @@ describe('GameConfigFieldsSection', () => {
     const result = renderSection()
 
     await expect.element(page.getByLabelText('modals.gameConfig.fields.titleBgm.label')).toHaveAttribute('data-root-path', '/games/demo/game/bgm')
-    await expect.element(page.getByLabelText('modals.gameConfig.fields.titleBgm.label')).toHaveAttribute('data-extensions', '.mp3|.ogg|.wav')
+    await expect.element(page.getByLabelText('modals.gameConfig.fields.titleBgm.label')).toHaveAttribute('data-extensions', '.mp3|.ogg|.wav|.opus')
     await expect.element(page.getByLabelText('modals.gameConfig.fields.titleBgm.label')).toHaveAttribute('data-popover-title', 'modals.gameConfig.fields.titleBgm.pickerTitle')
 
     await result.unmount()

--- a/src/domain/engine/__tests__/runtime-capabilities.test.ts
+++ b/src/domain/engine/__tests__/runtime-capabilities.test.ts
@@ -15,15 +15,18 @@ describe('Engine runtime capabilities', () => {
     expect(normalizeWebgalRuntimeVersion(undefined)).toBeUndefined()
   })
 
-  it('从引擎版本派生多行语句能力', () => {
+  it('从引擎版本派生运行时能力', () => {
     expect(resolveEngineRuntimeCapabilities('4.6.2')).toEqual({
       multilineStatements: false,
+      opusVocalShorthand: false,
     })
     expect(resolveEngineRuntimeCapabilities('4.6.3')).toEqual({
       multilineStatements: true,
+      opusVocalShorthand: true,
     })
     expect(resolveEngineRuntimeCapabilities('4.10.0')).toEqual({
       multilineStatements: true,
+      opusVocalShorthand: true,
     })
   })
 
@@ -35,5 +38,7 @@ describe('Engine runtime capabilities', () => {
   it('无效或早于稳定阈值的预发布版本不会启用运行时能力', () => {
     expect(supportsEngineRuntimeCapability('4.6.3-beta.1', 'multilineStatements')).toBe(false)
     expect(supportsEngineRuntimeCapability(undefined, 'multilineStatements')).toBe(false)
+    expect(supportsEngineRuntimeCapability('4.6.3-beta.1', 'opusVocalShorthand')).toBe(false)
+    expect(supportsEngineRuntimeCapability(undefined, 'opusVocalShorthand')).toBe(false)
   })
 })

--- a/src/domain/engine/runtime-capabilities.ts
+++ b/src/domain/engine/runtime-capabilities.ts
@@ -2,6 +2,7 @@ import { compareVersions, validateStrict } from 'compare-versions'
 
 export interface EngineRuntimeCapabilities {
   multilineStatements: boolean
+  opusVocalShorthand: boolean
 }
 
 type EngineRuntimeCapability = keyof EngineRuntimeCapabilities
@@ -10,14 +11,17 @@ export const MIN_WEBGAL_EDITOR_RUNTIME_VERSION = '4.6.2'
 
 const CAPABILITY_MINIMUM_VERSIONS: Record<EngineRuntimeCapability, string> = {
   multilineStatements: '4.6.3',
+  opusVocalShorthand: '4.6.3',
 }
 
 export const LEGACY_ENGINE_RUNTIME_CAPABILITIES: EngineRuntimeCapabilities = {
   multilineStatements: false,
+  opusVocalShorthand: false,
 }
 
 export const LATEST_ENGINE_RUNTIME_CAPABILITIES: EngineRuntimeCapabilities = {
   multilineStatements: true,
+  opusVocalShorthand: true,
 }
 
 export function normalizeWebgalRuntimeVersion(version: string | undefined): string | undefined {
@@ -52,5 +56,6 @@ export function resolveEngineRuntimeCapabilities(
 ): EngineRuntimeCapabilities {
   return {
     multilineStatements: supportsEngineRuntimeCapability(version, 'multilineStatements'),
+    opusVocalShorthand: supportsEngineRuntimeCapability(version, 'opusVocalShorthand'),
   }
 }

--- a/src/features/editor/command-registry/__tests__/common-params.test.ts
+++ b/src/features/editor/command-registry/__tests__/common-params.test.ts
@@ -22,7 +22,7 @@ import { resolveI18n } from '~/features/editor/command-registry/schema'
 
 describe('命令注册表通用参数', () => {
   it('背景与立绘扩展名集合覆盖预期资源类型', () => {
-    expect(AUDIO_EXTENSIONS).toEqual(expect.arrayContaining(['.mp3', '.ogg', '.wav']))
+    expect(AUDIO_EXTENSIONS).toEqual(expect.arrayContaining(['.mp3', '.ogg', '.wav', '.opus']))
     expect(IMAGE_EXTENSIONS).toEqual(expect.arrayContaining(['.png', '.jpg', '.jpeg', '.gif', '.webp']))
     expect(VIDEO_EXTENSIONS).toEqual(expect.arrayContaining(['.mp4', '.webm', '.mkv']))
     expect(BACKGROUND_EXTENSIONS).toEqual(expect.arrayContaining(['.png', '.mp4', '.skel']))

--- a/src/features/editor/command-registry/__tests__/diagnostics.test.ts
+++ b/src/features/editor/command-registry/__tests__/diagnostics.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import { commandType } from 'webgal-parser/src/interface/sceneInterface'
 
+import { LATEST_ENGINE_RUNTIME_CAPABILITIES, LEGACY_ENGINE_RUNTIME_CAPABILITIES } from '~/domain/engine/runtime-capabilities'
 import { parseSentence } from '~/domain/script/parser'
 
-import { querySentenceResourceReferences } from '../diagnostics'
+import { findUnsupportedEngineOpusVocalReferences, querySentenceResourceReferences } from '../diagnostics'
 
 describe('querySentenceResourceReferences', () => {
   it('从注册表字段读取内容资源引用', () => {
@@ -42,5 +43,32 @@ describe('querySentenceResourceReferences', () => {
         source: { kind: 'choice', index: 1 },
       },
     ])
+  })
+})
+
+describe('findUnsupportedEngineOpusVocalReferences', () => {
+  it('仅诊断旧引擎的 say Opus 语音参数', () => {
+    expect(findUnsupportedEngineOpusVocalReferences(
+      parseSentence('say:hello -voice.opus;')!,
+      LEGACY_ENGINE_RUNTIME_CAPABILITIES,
+    )).toEqual([{
+      source: { kind: 'argument', key: 'vocal' },
+      value: 'voice.opus',
+    }])
+
+    expect(findUnsupportedEngineOpusVocalReferences(
+      parseSentence('say:hello -vocal=voice.opus;')!,
+      LEGACY_ENGINE_RUNTIME_CAPABILITIES,
+    )).toHaveLength(1)
+
+    expect(findUnsupportedEngineOpusVocalReferences(
+      parseSentence('bgm:theme.opus;')!,
+      LEGACY_ENGINE_RUNTIME_CAPABILITIES,
+    )).toEqual([])
+
+    expect(findUnsupportedEngineOpusVocalReferences(
+      parseSentence('say:hello -voice.opus;')!,
+      LATEST_ENGINE_RUNTIME_CAPABILITIES,
+    )).toEqual([])
   })
 })

--- a/src/features/editor/command-registry/__tests__/monaco-completion-adapter.browser.test.ts
+++ b/src/features/editor/command-registry/__tests__/monaco-completion-adapter.browser.test.ts
@@ -199,7 +199,7 @@ describe('WebGAL Monaco 补全', () => {
       listByAssetType: () => [{ key: { relativePath: 'chapter/next.txt' } }],
     })
     useResourceStoreMock.mockReturnValue({
-      currentEngineRuntimeCapabilities: { multilineStatements: true },
+      currentEngineRuntimeCapabilities: { multilineStatements: true, opusVocalShorthand: true },
     })
     useWorkspaceStoreMock.mockReturnValue({ currentGame: { path: '/game' } })
   })

--- a/src/features/editor/command-registry/__tests__/monaco-diagnostics-adapter.browser.test.ts
+++ b/src/features/editor/command-registry/__tests__/monaco-diagnostics-adapter.browser.test.ts
@@ -256,4 +256,22 @@ describe('updateEditorDiagnostics', () => {
       }),
     ])
   })
+
+  it('为旧引擎的 say Opus 语音引用定位黄色 marker', () => {
+    useResourceIndex.mockReturnValue({
+      status: { value: 'ready' },
+      hasAssetKey: vi.fn(() => true),
+    })
+
+    const model = createModel('say:voice.opus -voice.opus;')
+    updateEditorDiagnostics(model, LEGACY_ENGINE_RUNTIME_CAPABILITIES)
+
+    expect(readMarkers(model)).toEqual([expect.objectContaining({
+      startLineNumber: 1,
+      startColumn: 17,
+      endColumn: 27,
+      severity: monaco.MarkerSeverity.Warning,
+      message: 'edit.diagnostics.unsupportedOpusVocal:',
+    })])
+  })
 })

--- a/src/features/editor/command-registry/common-params.ts
+++ b/src/features/editor/command-registry/common-params.ts
@@ -4,7 +4,7 @@ import type { AutocompleteTextField, ChoiceField, NumberField, ResourceReference
 
 // ─── WebGAL 支持的文件扩展名 ───
 
-export const AUDIO_EXTENSIONS = ['.mp3', '.ogg', '.wav']
+export const AUDIO_EXTENSIONS = ['.mp3', '.ogg', '.wav', '.opus']
 export const IMAGE_EXTENSIONS = ['.png', '.jpg', '.jpeg', '.gif', '.webp']
 export const VIDEO_EXTENSIONS = ['.mp4', '.webm', '.mkv']
 export const BACKGROUND_EXTENSIONS = [...IMAGE_EXTENSIONS, ...VIDEO_EXTENSIONS, '.skel']

--- a/src/features/editor/command-registry/diagnostics.ts
+++ b/src/features/editor/command-registry/diagnostics.ts
@@ -9,12 +9,18 @@ import { deriveArgFieldsFromEditorFields, readEditorFields, readFieldResourceRef
 
 import type { ISentence } from 'webgal-parser/src/interface/sceneInterface'
 import type { EngineModelCapabilities, EngineModelType } from '~/domain/engine/model-capabilities'
+import type { EngineRuntimeCapabilities } from '~/domain/engine/runtime-capabilities'
 import type { AssetKey } from '~/services/resource-index/keys'
 import type { ResourceReferenceQuery, ResourceReferenceSource } from '~/services/resource-index/reference-query'
 
 export interface UnsupportedEngineModelReference {
   modelType: EngineModelType
   source: { kind: 'content' }
+  value: string
+}
+
+export interface UnsupportedEngineOpusVocalReference {
+  source: { kind: 'argument', key: 'vocal' }
   value: string
 }
 
@@ -76,6 +82,26 @@ export function findUnsupportedEngineModelReferences(
     modelType,
     source: { kind: 'content' },
     value,
+  }]
+}
+
+export function findUnsupportedEngineOpusVocalReferences(
+  sentence: ISentence,
+  capabilities: Pick<EngineRuntimeCapabilities, 'opusVocalShorthand'>,
+): UnsupportedEngineOpusVocalReference[] {
+  if (sentence.command !== commandType.say || capabilities.opusVocalShorthand) {
+    return []
+  }
+
+  // 解析器会把显式 vocal 参数和文件简写归一化为同一字段；Craft 保存时统一输出简写。
+  const vocal = sentence.args.find(arg => arg.key === 'vocal')
+  if (typeof vocal?.value !== 'string' || !vocal.value.toLowerCase().endsWith('.opus')) {
+    return []
+  }
+
+  return [{
+    source: { kind: 'argument', key: 'vocal' },
+    value: vocal.value,
   }]
 }
 

--- a/src/features/editor/diagnostics/__tests__/scene-diagnostics.test.ts
+++ b/src/features/editor/diagnostics/__tests__/scene-diagnostics.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
+import { LATEST_ENGINE_RUNTIME_CAPABILITIES, LEGACY_ENGINE_RUNTIME_CAPABILITIES } from '~/domain/engine/runtime-capabilities'
 import { parseSentence } from '~/domain/script/parser'
 
 import { diagnoseEditorDocument } from '../document-diagnostics'
@@ -139,6 +140,29 @@ describe('diagnoseScene', () => {
       parseSentence('changeFigure:live2d/hero.json;'),
       parseSentence('changeFigure:spine/hero.skel;'),
     ])).toEqual([])
+  })
+
+  it('为旧引擎的 say Opus 语音引用生成警告', () => {
+    const sentences = [
+      parseSentence('say:hello -voice.opus;'),
+      parseSentence('say:world -vocal=voice.ogg;'),
+      parseSentence('bgm:theme.opus;'),
+    ]
+
+    expect(diagnoseScene(sentences, {
+      runtimeCapabilities: LEGACY_ENGINE_RUNTIME_CAPABILITIES,
+    })).toEqual([{
+      code: 'unsupported-opus-vocal',
+      field: { kind: 'argument', key: 'vocal' },
+      severity: 'warning',
+      source: 'engine',
+      statementIndex: 0,
+      value: 'voice.opus',
+    }])
+
+    expect(diagnoseScene(sentences, {
+      runtimeCapabilities: LATEST_ENGINE_RUNTIME_CAPABILITIES,
+    })).toEqual([])
   })
 })
 

--- a/src/features/editor/diagnostics/__tests__/useEditorDiagnostics.test.ts
+++ b/src/features/editor/diagnostics/__tests__/useEditorDiagnostics.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { effectScope, nextTick, reactive, shallowRef } from 'vue'
 
+import { LATEST_ENGINE_RUNTIME_CAPABILITIES, LEGACY_ENGINE_RUNTIME_CAPABILITIES } from '~/domain/engine/runtime-capabilities'
 import { AbsPath } from '~/domain/path'
 import { buildStatements } from '~/domain/script/sentence'
 
@@ -187,6 +188,48 @@ describe('useEditorDiagnostics', () => {
 
     expect(diagnosticsStore.publish).toHaveBeenLastCalledWith(path, [])
     expect(diagnosticsStore.invalidateSource).not.toHaveBeenCalledWith('resource')
+    scope.stop()
+  })
+
+  it('当前引擎运行时能力变化后重新发布 Opus 兼容性诊断', async () => {
+    const path = AbsPath.from('/game/scene/start.txt')
+    const diagnosticsStore = {
+      invalidateSource: vi.fn(),
+      publish: vi.fn(),
+    }
+    const resourceStore = reactive({
+      currentEngineCapabilities: undefined,
+      currentEngineRuntimeCapabilities: LEGACY_ENGINE_RUNTIME_CAPABILITIES,
+    })
+
+    useEditorDiagnosticsStoreMock.mockReturnValue(diagnosticsStore)
+    useEditorStoreMock.mockReturnValue({
+      getTextProjectionState: vi.fn(() => undefined),
+      getVisualProjectionState: vi.fn(() => reactive({
+        kind: 'scene' as const,
+        statements: buildStatements('say:hello -voice.opus;'),
+      })),
+      peekSceneRevision: vi.fn(() => 'revision-1'),
+    })
+    useResourceIndexMock.mockReturnValue({
+      hasAssetKey: vi.fn(() => true),
+      revision: shallowRef(0),
+      status: shallowRef('ready'),
+    })
+    useResourceStoreMock.mockReturnValue(resourceStore)
+    useTabsStoreMock.mockReturnValue(reactive({ tabs: [{ path }] }))
+
+    const scope = effectScope()
+    scope.run(useEditorDiagnostics)
+
+    expect(diagnosticsStore.publish).toHaveBeenLastCalledWith(path, [
+      expect.objectContaining({ code: 'unsupported-opus-vocal' }),
+    ])
+
+    resourceStore.currentEngineRuntimeCapabilities = LATEST_ENGINE_RUNTIME_CAPABILITIES
+    await nextTick()
+
+    expect(diagnosticsStore.publish).toHaveBeenLastCalledWith(path, [])
     scope.stop()
   })
 })

--- a/src/features/editor/diagnostics/document-diagnostics.ts
+++ b/src/features/editor/diagnostics/document-diagnostics.ts
@@ -3,6 +3,7 @@ import { diagnoseScene } from '~/features/editor/diagnostics/scene-diagnostics'
 
 import type { EditorDiagnostic } from './types'
 import type { EngineModelCapabilities } from '~/domain/engine/model-capabilities'
+import type { EngineRuntimeCapabilities } from '~/domain/engine/runtime-capabilities'
 import type { StatementEntry } from '~/domain/script/sentence'
 import type { AssetKey } from '~/services/resource-index/keys'
 
@@ -19,6 +20,7 @@ interface EditorDiagnosticVisualProjection {
 interface DiagnoseEditorDocumentOptions {
   engineCapabilities?: EngineModelCapabilities
   hasAssetKey?: (key: AssetKey) => boolean
+  runtimeCapabilities?: Pick<EngineRuntimeCapabilities, 'opusVocalShorthand'>
   textProjection?: EditorDiagnosticTextProjection
   visualProjection?: EditorDiagnosticVisualProjection
 }

--- a/src/features/editor/diagnostics/presentation.ts
+++ b/src/features/editor/diagnostics/presentation.ts
@@ -53,6 +53,9 @@ export function getEditorDiagnosticMessage(
     case 'unsupported-spine': {
       return t('edit.diagnostics.unsupportedSpine')
     }
+    case 'unsupported-opus-vocal': {
+      return t('edit.diagnostics.unsupportedOpusVocal')
+    }
     default: {
       const exhaustiveCheck: never = diagnostic
       return exhaustiveCheck

--- a/src/features/editor/diagnostics/scene-diagnostics.ts
+++ b/src/features/editor/diagnostics/scene-diagnostics.ts
@@ -2,16 +2,19 @@ import { diagnoseDuplicateSceneLabels, diagnoseMissingSceneLabels } from '~/doma
 import {
   findMissingSentenceResourceReferences,
   findUnsupportedEngineModelReferences,
+  findUnsupportedEngineOpusVocalReferences,
 } from '~/features/editor/command-registry/diagnostics'
 
 import type { SceneEditorDiagnostic } from './types'
 import type { ISentence } from 'webgal-parser/src/interface/sceneInterface'
 import type { EngineModelCapabilities } from '~/domain/engine/model-capabilities'
+import type { EngineRuntimeCapabilities } from '~/domain/engine/runtime-capabilities'
 import type { AssetKey } from '~/services/resource-index/keys'
 
 interface DiagnoseSceneOptions {
   engineCapabilities?: EngineModelCapabilities
   hasAssetKey?: (key: AssetKey) => boolean
+  runtimeCapabilities?: Pick<EngineRuntimeCapabilities, 'opusVocalShorthand'>
 }
 
 export function diagnoseScene(
@@ -60,21 +63,36 @@ export function diagnoseScene(
     }
   }
 
-  if (options.engineCapabilities) {
+  if (options.engineCapabilities || options.runtimeCapabilities) {
     for (const [statementIndex, sentence] of sentences.entries()) {
       if (!sentence) {
         continue
       }
 
-      for (const reference of findUnsupportedEngineModelReferences(sentence, options.engineCapabilities)) {
-        diagnostics.push({
-          code: reference.modelType === 'live2d' ? 'unsupported-live2d' : 'unsupported-spine',
-          field: reference.source,
-          severity: 'warning',
-          source: 'engine',
-          statementIndex,
-          value: reference.value,
-        })
+      if (options.engineCapabilities) {
+        for (const reference of findUnsupportedEngineModelReferences(sentence, options.engineCapabilities)) {
+          diagnostics.push({
+            code: reference.modelType === 'live2d' ? 'unsupported-live2d' : 'unsupported-spine',
+            field: reference.source,
+            severity: 'warning',
+            source: 'engine',
+            statementIndex,
+            value: reference.value,
+          })
+        }
+      }
+
+      if (options.runtimeCapabilities) {
+        for (const reference of findUnsupportedEngineOpusVocalReferences(sentence, options.runtimeCapabilities)) {
+          diagnostics.push({
+            code: 'unsupported-opus-vocal',
+            field: reference.source,
+            severity: 'warning',
+            source: 'engine',
+            statementIndex,
+            value: reference.value,
+          })
+        }
       }
     }
   }

--- a/src/features/editor/diagnostics/types.ts
+++ b/src/features/editor/diagnostics/types.ts
@@ -54,6 +54,14 @@ export interface UnsupportedSpineEditorDiagnostic extends SceneEditorDiagnosticB
   value: string
 }
 
+export interface UnsupportedOpusVocalEditorDiagnostic extends SceneEditorDiagnosticBase {
+  code: 'unsupported-opus-vocal'
+  field: { kind: 'argument', key: 'vocal' }
+  severity: 'warning'
+  source: 'engine'
+  value: string
+}
+
 export interface InvalidAnimationDocumentDiagnostic extends EditorDiagnosticBase {
   code: 'invalid-animation-json'
   severity: 'error'
@@ -66,6 +74,7 @@ export type SceneEditorDiagnostic =
   | MissingResourceEditorDiagnostic
   | UnsupportedLive2dEditorDiagnostic
   | UnsupportedSpineEditorDiagnostic
+  | UnsupportedOpusVocalEditorDiagnostic
 
 export type EditorFieldDiagnostic =
   | Omit<DuplicateLabelEditorDiagnostic, 'statementIndex'>
@@ -73,6 +82,7 @@ export type EditorFieldDiagnostic =
   | Omit<MissingResourceEditorDiagnostic, 'statementIndex'>
   | Omit<UnsupportedLive2dEditorDiagnostic, 'statementIndex'>
   | Omit<UnsupportedSpineEditorDiagnostic, 'statementIndex'>
+  | Omit<UnsupportedOpusVocalEditorDiagnostic, 'statementIndex'>
 
 export type EditorDiagnostic =
   | SceneEditorDiagnostic

--- a/src/features/editor/diagnostics/useEditorDiagnostics.ts
+++ b/src/features/editor/diagnostics/useEditorDiagnostics.ts
@@ -29,6 +29,7 @@ export function useEditorDiagnostics(): void {
         hasAssetKey: canCheckResources
           ? key => resourceIndex.hasAssetKey(key)
           : undefined,
+        runtimeCapabilities: resourceStore.currentEngineRuntimeCapabilities,
         textProjection,
         visualProjection,
       }))
@@ -54,7 +55,10 @@ export function useEditorDiagnostics(): void {
     publishOpenDocumentDiagnostics()
   })
 
-  watch(() => resourceStore.currentEngineCapabilities, () => {
+  watch(() => [
+    resourceStore.currentEngineCapabilities,
+    resourceStore.currentEngineRuntimeCapabilities,
+  ], () => {
     publishOpenDocumentDiagnostics()
   })
 }

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -698,6 +698,7 @@ edit:
     missingLabel: 'Label "{label}" is not defined in this scene.'
     unsupportedLive2d: The current engine does not support Live2D models.
     unsupportedMultilineStatements: The current engine does not support multiline statements.
+    unsupportedOpusVocal: The current engine does not support Opus vocal shorthand in say statements. Upgrade to WebGAL 4.6.3 or later.
     unsupportedSpine: The current engine does not support Spine models.
   errors:
     fileSyncFailed: Failed to sync the file. Please try again shortly.

--- a/src/locales/ja.yml
+++ b/src/locales/ja.yml
@@ -698,6 +698,7 @@ edit:
     missingLabel: "ラベル「{label}」は現在のシーンで定義されていません。"
     unsupportedLive2d: 現在のエンジンは Live2D モデルをサポートしていません。
     unsupportedMultilineStatements: 現在のエンジンは複数行のステートメントをサポートしていません。
+    unsupportedOpusVocal: 現在のエンジンは say の Opus 音声省略形式をサポートしていません。WebGAL 4.6.3 以降にアップグレードしてください。
     unsupportedSpine: 現在のエンジンは Spine モデルをサポートしていません。
   errors:
     fileSyncFailed: ファイルの同期に失敗しました。しばらくしてからもう一度お試しください。

--- a/src/locales/zh-Hans.yml
+++ b/src/locales/zh-Hans.yml
@@ -698,6 +698,7 @@ edit:
     missingLabel: "标签“{label}”未在当前场景中定义。"
     unsupportedLive2d: 当前引擎不支持 Live2D 模型。
     unsupportedMultilineStatements: 当前引擎不支持多行语句。
+    unsupportedOpusVocal: 当前引擎不支持 say 的 Opus 语音简写，请升级到 WebGAL 4.6.3 或更高版本。
     unsupportedSpine: 当前引擎不支持 Spine 模型。
   errors:
     fileSyncFailed: 文件同步失败，请稍后重试

--- a/src/locales/zh-Hant.yml
+++ b/src/locales/zh-Hant.yml
@@ -698,6 +698,7 @@ edit:
     missingLabel: "標籤「{label}」未在目前場景中定義。"
     unsupportedLive2d: 目前引擎不支援 Live2D 模型。
     unsupportedMultilineStatements: 目前引擎不支援多行陳述式。
+    unsupportedOpusVocal: 目前引擎不支援 say 的 Opus 語音簡寫，請升級至 WebGAL 4.6.3 或更新版本。
     unsupportedSpine: 目前引擎不支援 Spine 模型。
   errors:
     fileSyncFailed: 檔案同步失敗，請稍後重試

--- a/src/plugins/editor/diagnostics.ts
+++ b/src/plugins/editor/diagnostics.ts
@@ -9,13 +9,14 @@ import { useResourceIndex } from '~/services/resource-index/service'
 import { useResourceStore } from '~/stores/resource'
 import { useWorkspaceStore } from '~/stores/workspace'
 
-import type { StatementSourceRange, StatementSyntaxCapabilities } from '~/domain/script/sentence'
+import type { EngineRuntimeCapabilities } from '~/domain/engine/runtime-capabilities'
+import type { StatementSourceRange } from '~/domain/script/sentence'
 import type { ResourceReferenceQuery } from '~/services/resource-index/reference-query'
 
 const OWNER = 'webgal-editor-diagnostics'
 export function updateEditorDiagnostics(
   model: monaco.editor.ITextModel,
-  runtimeCapabilities?: StatementSyntaxCapabilities,
+  runtimeCapabilities?: EngineRuntimeCapabilities,
 ): void {
   if (model.getLanguageId() !== 'webgalscript') {
     monaco.editor.setModelMarkers(model, OWNER, [])
@@ -37,6 +38,7 @@ export function updateEditorDiagnostics(
     hasAssetKey: canCheckResources
       ? key => resourceIndex.hasAssetKey(key)
       : undefined,
+    runtimeCapabilities,
   })
 
   for (const diagnostic of diagnostics) {
@@ -65,7 +67,7 @@ export function updateEditorDiagnostics(
       continue
     }
 
-    if (diagnostic.code === 'unsupported-live2d' || diagnostic.code === 'unsupported-spine') {
+    if (['unsupported-live2d', 'unsupported-spine', 'unsupported-opus-vocal'].includes(diagnostic.code)) {
       markers.push({
         ...locateReference(lines, range, sentence, {
           source: diagnostic.field,
@@ -149,6 +151,22 @@ function locateReference(
         line,
         start: findReferenceStart(text, reference.value, valueStart, valueStart + (match[1]?.length ?? 0)),
       }, reference.value.length)
+    }
+
+    if (reference.source.key === 'vocal') {
+      const shorthandPattern = new RegExp(String.raw`(?:^|\s)-${escapeRegExp(reference.value)}(?=\s|;|$)`)
+      for (let line = range.startLine; line <= range.endLine; line++) {
+        const text = lines[line] ?? ''
+        const match = shorthandPattern.exec(text)
+        if (match?.index === undefined) {
+          continue
+        }
+
+        return createMarkerRange({
+          line,
+          start: match.index + match[0].lastIndexOf(reference.value),
+        }, reference.value.length)
+      }
     }
   }
 

--- a/src/stores/__tests__/editor.test.ts
+++ b/src/stores/__tests__/editor.test.ts
@@ -85,7 +85,7 @@ const workspaceStoreMock = reactive({
 })
 
 const resourceStoreMock = reactive({
-  currentEngineRuntimeCapabilities: { multilineStatements: false },
+  currentEngineRuntimeCapabilities: { multilineStatements: false, opusVocalShorthand: false },
 })
 
 vi.mock('@tauri-apps/plugin-fs', () => ({
@@ -333,7 +333,7 @@ describe('编辑器文本与文档流程', () => {
     preferenceStoreMock.editorMode = 'text'
     workspaceStoreMock.currentGame = { id: 'game-1', path: '/game' }
     workspaceStoreMock.cwd = '/game'
-    resourceStoreMock.currentEngineRuntimeCapabilities = { multilineStatements: false }
+    resourceStoreMock.currentEngineRuntimeCapabilities = { multilineStatements: false, opusVocalShorthand: false }
     previewSessionStoreMock.currentGameServeUrl = 'http://127.0.0.1:8899'
   })
 
@@ -792,10 +792,10 @@ describe('编辑器文本与文档流程', () => {
     expect(editorStore.redoDocument(path).applied).toBe(true)
     expect(textProjection.textContent).toBe(editedContent)
 
-    resourceStoreMock.currentEngineRuntimeCapabilities = { multilineStatements: false }
+    resourceStoreMock.currentEngineRuntimeCapabilities = { multilineStatements: false, opusVocalShorthand: false }
     await flushEditorWatchers()
 
-    expect(textProjection.runtimeCapabilities).toEqual({ multilineStatements: false })
+    expect(textProjection.runtimeCapabilities).toEqual({ multilineStatements: false, opusVocalShorthand: false })
     expect(visualProjection.statements.map(statement => statement.rawText)).toEqual([
       'changeFigure:hero.png',
       '  -id=hero;',

--- a/src/stores/__tests__/resource.test.ts
+++ b/src/stores/__tests__/resource.test.ts
@@ -196,10 +196,10 @@ describe('useResourceStore', () => {
     workspaceStoreState.currentGame = createTestGame({ engineId: 'webgal-462' })
 
     const store = useResourceStore()
-    expect(store.currentEngineRuntimeCapabilities).toEqual({ multilineStatements: false })
+    expect(store.currentEngineRuntimeCapabilities).toEqual({ multilineStatements: false, opusVocalShorthand: false })
 
     workspaceStoreState.currentGame = createTestGame({ engineId: 'webgal-463' })
-    expect(store.currentEngineRuntimeCapabilities).toEqual({ multilineStatements: true })
+    expect(store.currentEngineRuntimeCapabilities).toEqual({ multilineStatements: true, opusVocalShorthand: true })
   })
 
   it('会把独立模板和引擎内置模板整理为模板族展示模型', () => {


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [ ] 错误修复
- [x] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [x] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

- 将 `.opus` 纳入音频资源扩展名，支持资源选择、资源预览、语句音频预览和编辑器补全。
- 根据当前引擎运行时能力判断 Opus 语音简写是否可用。
- 当旧引擎遇到 `-voice.opus` 简写时，在场景诊断和 Monaco 编辑器中给出定位明确的警告。
- 同步英文、日文、简体中文和繁体中文的诊断文本。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

WebGAL 4.6.3 支持通过语句简写引用 Opus 语音文件。应用此前未将 Opus 视为音频资源，导致选择、预览和补全能力不完整；而旧版引擎无法解析该简写，编辑器需要在保持现有语句保存行为的前提下提前提示用户。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
