### PR TITLE
🐛 修复自动发现资源导入失败仅显示计数

### DIFF
--- a/src/components/home/WelcomeSection.vue
+++ b/src/components/home/WelcomeSection.vue
@@ -1,10 +1,9 @@
 <script setup lang="ts">
 import { FolderOpen, Plus } from '@lucide/vue'
 
-import { MIN_WEBGAL_EDITOR_RUNTIME_VERSION } from '~/domain/engine/runtime-capabilities'
 import { resolveHomeResourceImportNotification } from '~/features/home/shared/home-resource-import'
 import {
-  managedImportErrorMessages,
+  createHomeResourceImportMessages,
   reportHomeResourceImportNotification,
 } from '~/features/home/shared/useHomeResourceImportActions'
 import { requestImportDependencyResolution } from '~/features/modals/import-dependency-resolution/request-import-dependency-resolution'
@@ -15,8 +14,6 @@ import { useManagedImportStore } from '~/stores/managed-import'
 import { useModalStore } from '~/stores/modal'
 import { useResourceStore } from '~/stores/resource'
 import { useWorkspaceStore } from '~/stores/workspace'
-
-import type { HomeResourceImportMessages } from '~/features/home/shared/useHomeResourceImportActions'
 
 const workspaceStore = useWorkspaceStore()
 const managedImportStore = useManagedImportStore()
@@ -32,21 +29,7 @@ watchOnce(() => resourceStore.games, (games) => {
 const modalStore = useModalStore()
 const { t } = useI18n()
 
-const gameImportMessages: HomeResourceImportMessages = {
-  ...managedImportErrorMessages,
-  alreadyRegistered: t => t('home.games.importAlreadyExists'),
-  engineEditorIncompatible: t => t('home.games.importEngineEditorIncompatible'),
-  engineNotFound: t => t('home.games.importEngineNotFound'),
-  engineUnavailable: t => t('home.games.importEngineUnavailable'),
-  engineVersionInvalid: t => t('home.games.importEngineVersionInvalid'),
-  engineVersionTooOld: t => t('home.games.importEngineVersionTooOld', { version: MIN_WEBGAL_EDITOR_RUNTIME_VERSION }),
-  gameConfigCorrupted: t => t('home.games.importConfigCorrupted'),
-  gameSchemaTooNew: t => t('home.games.importSchemaVersionTooNew'),
-  invalidFolder: t => t('home.games.importInvalidFolder'),
-  multipleFolders: t => t('home.games.importMultipleFolders'),
-  selectFolderTitle: t => t('common.dialogs.selectGameFolder'),
-  unknownError: t => t('home.games.importUnknownError'),
-}
+const gameImportMessages = createHomeResourceImportMessages('games', t)
 
 const gameImportWorkflow = createGameImportWorkflow({
   android: isAndroidRuntime(),

--- a/src/features/home/__tests__/useDiscoverResources.test.ts
+++ b/src/features/home/__tests__/useDiscoverResources.test.ts
@@ -5,12 +5,14 @@ import { toLookupPathKey } from '~/services/resource-path/lookup'
 
 const {
   classifyEngineMock,
+  engineImportMock,
   gameIdentityKeyOfMock,
   engineIdentityKeyOfMock,
   existsMock,
   getEnginePreviewAssetsMock,
   getGameSnapshotMock,
   getTemplateMetadataMock,
+  gameImportMock,
   loggerErrorMock,
   modalOpenMock,
   toastErrorMock,
@@ -28,6 +30,7 @@ const {
   validateTemplateMock,
 } = vi.hoisted(() => ({
   classifyEngineMock: vi.fn(),
+  engineImportMock: vi.fn(),
   gameIdentityKeyOfMock: vi.fn((resource: { path: AbsPath }) => toLookupPathKey(resource.path)),
   engineIdentityKeyOfMock: vi.fn((resource: { path: AbsPath, engineId?: string, version?: string }) =>
     resource.engineId && resource.version
@@ -38,6 +41,7 @@ const {
   getEnginePreviewAssetsMock: vi.fn(),
   getGameSnapshotMock: vi.fn(),
   getTemplateMetadataMock: vi.fn(),
+  gameImportMock: vi.fn(),
   loggerErrorMock: vi.fn(),
   modalOpenMock: vi.fn(),
   toastErrorMock: vi.fn(),
@@ -95,7 +99,7 @@ vi.mock('~/services/engine-manager', () => ({
     classifyEngine: classifyEngineMock,
     getEnginePreviewAssets: getEnginePreviewAssetsMock,
     identityKeyOf: engineIdentityKeyOfMock,
-    importEngine: vi.fn(),
+    importEngine: engineImportMock,
     validateEngine: validateEngineMock,
   },
 }))
@@ -104,7 +108,7 @@ vi.mock('~/services/game-manager', () => ({
   gameManager: {
     getGameSnapshot: getGameSnapshotMock,
     identityKeyOf: gameIdentityKeyOfMock,
-    importGame: vi.fn(),
+    importGame: gameImportMock,
     resolvePreviewSite: vi.fn(),
     validateGame: vi.fn(),
   },
@@ -139,12 +143,14 @@ describe('useDiscoverResources', () => {
     vi.resetModules()
 
     classifyEngineMock.mockReset()
+    engineImportMock.mockReset()
     gameIdentityKeyOfMock.mockClear()
     engineIdentityKeyOfMock.mockClear()
     existsMock.mockReset()
     getEnginePreviewAssetsMock.mockReset()
     getGameSnapshotMock.mockReset()
     getTemplateMetadataMock.mockReset()
+    gameImportMock.mockReset()
     loggerErrorMock.mockReset()
     modalOpenMock.mockReset()
     toastErrorMock.mockReset()
@@ -239,6 +245,45 @@ describe('useDiscoverResources', () => {
     }))
     expect(classifyEngineMock).toHaveBeenCalledWith('/engines/WebGAL/4.5.0')
     expect(classifyEngineMock).toHaveBeenCalledWith('/engines/WebGAL/legacy')
+  })
+
+  it('发现引擎单项导入失败时显示具体错误', async () => {
+    const { AppError } = await import('~/types/errors')
+    readDirMock.mockImplementation(async (path: string) => {
+      switch (path) {
+        case '/engines': {
+          return [{ isDirectory: true, name: 'WebGAL' }]
+        }
+        case '/engines/WebGAL': {
+          return [{ isDirectory: true, name: 'legacy' }]
+        }
+        default: {
+          return []
+        }
+      }
+    })
+    validateEngineMock.mockResolvedValue(true)
+    classifyEngineMock.mockResolvedValue({
+      status: 'ok',
+      manifest: {
+        id: 'webgal',
+        name: 'WebGAL',
+        version: 'legacy',
+      },
+    })
+    engineImportMock.mockRejectedValue(new AppError('INVALID_MANIFEST', 'legacy engine', {
+      details: { reason: 'LEGACY_ENGINE' },
+    }))
+
+    const { useDiscoverResources } = await import('../useDiscoverResources')
+    const discoverResources = useDiscoverResources()
+
+    await discoverResources.checkResourcesForActiveTab()
+
+    const modalProps = modalOpenMock.mock.calls[0]?.[1] as { onImport?: (paths: AbsPath[]) => Promise<void> } | undefined
+    await modalProps?.onImport?.([AbsPath.from('/engines/WebGAL/legacy')])
+
+    expect(toastErrorMock).toHaveBeenCalledWith('home.engines.importUnsupportedLegacyEngine (1/1)')
   })
 
   it('会把 Windows 风格扫描目录归一化后再发现模板', async () => {
@@ -356,6 +401,35 @@ describe('useDiscoverResources', () => {
     }))
     expect(getTemplateMetadataMock).toHaveBeenCalledWith('/templates/modern')
     expect(getTemplateMetadataMock).toHaveBeenCalledWith('/templates/broken')
+  })
+
+  it('发现模板单项导入失败时显示具体错误', async () => {
+    const { AppError } = await import('~/types/errors')
+    resolveHomeTabDefinitionMock.mockReturnValue({ discoveryType: 'templates' })
+    useWorkspaceStoreMock.mockReturnValue({ activeTab: 'templates' })
+    readDirMock.mockImplementation(async (path: string) => {
+      switch (path) {
+        case '/templates': {
+          return [{ isDirectory: true, name: 'duplicate' }]
+        }
+        default: {
+          return []
+        }
+      }
+    })
+    validateTemplateMock.mockResolvedValue(true)
+    getTemplateMetadataMock.mockResolvedValue({ name: 'Duplicate Template' })
+    templateImportMock.mockRejectedValue(new AppError('DUPLICATE_RESOURCE', 'duplicate template'))
+
+    const { useDiscoverResources } = await import('../useDiscoverResources')
+    const discoverResources = useDiscoverResources()
+
+    await discoverResources.checkResourcesForActiveTab()
+
+    const modalProps = modalOpenMock.mock.calls[0]?.[1] as { onImport?: (paths: AbsPath[]) => Promise<void> } | undefined
+    await modalProps?.onImport?.([AbsPath.from('/templates/duplicate')])
+
+    expect(toastErrorMock).toHaveBeenCalledWith('home.templates.importDuplicate (1/1)')
   })
 
   it('已导入同名模板时不会再次展示不同路径的重复模板', async () => {
@@ -557,6 +631,45 @@ describe('useDiscoverResources', () => {
     expect(gameIdentityKeyOfMock).toHaveBeenCalled()
   })
 
+  it('发现游戏单项导入失败时显示具体错误', async () => {
+    const { AppError } = await import('~/types/errors')
+    const { gameManager } = await import('~/services/game-manager')
+    vi.mocked(gameManager.validateGame).mockResolvedValue(true)
+    vi.mocked(gameManager.resolvePreviewSite).mockResolvedValue({
+      projectPath: AbsPath.from('/games/broken-config'),
+    })
+    gameImportMock.mockRejectedValue(new AppError('INVALID_CONFIG', 'broken config', {
+      details: { reason: 'PARSE_FAILED' },
+    }))
+    resolveHomeTabDefinitionMock.mockReturnValue({ discoveryType: 'games' })
+    useWorkspaceStoreMock.mockReturnValue({ activeTab: 'games' })
+    useStorageSettingsStoreMock.mockReturnValue({
+      engineSavePath: '/engines',
+      gameSavePath: '/games',
+      templateSavePath: '/templates',
+    })
+    readDirMock.mockImplementation(async (path: string) => {
+      switch (path) {
+        case '/games': {
+          return [{ isDirectory: true, name: 'broken-config' }]
+        }
+        default: {
+          return []
+        }
+      }
+    })
+
+    const { useDiscoverResources } = await import('../useDiscoverResources')
+    const discoverResources = useDiscoverResources()
+
+    await discoverResources.checkResourcesForActiveTab()
+
+    const modalProps = modalOpenMock.mock.calls[0]?.[1] as { onImport?: (paths: AbsPath[]) => Promise<void> } | undefined
+    await modalProps?.onImport?.([AbsPath.from('/games/broken-config')])
+
+    expect(toastErrorMock).toHaveBeenCalledWith('home.games.importConfigCorrupted (1/1)')
+  })
+
   it('批量导入发现的游戏时会提供组合依赖解析回调', async () => {
     const { gameManager } = await import('~/services/game-manager')
     vi.mocked(gameManager.validateGame).mockResolvedValue(true)
@@ -677,6 +790,50 @@ describe('useDiscoverResources', () => {
     expect(toastErrorMock).not.toHaveBeenCalled()
     expect(toastInfoMock).not.toHaveBeenCalled()
     expect(toastSuccessMock).not.toHaveBeenCalled()
+  })
+
+  it('发现资源批量导入包含多种错误时在同一条通知中列出具体原因', async () => {
+    const { AppError } = await import('~/types/errors')
+    resolveHomeTabDefinitionMock.mockReturnValue({ discoveryType: 'templates' })
+    useWorkspaceStoreMock.mockReturnValue({ activeTab: 'templates' })
+    readDirMock.mockImplementation(async (path: string) => {
+      switch (path) {
+        case '/templates': {
+          return [
+            { isDirectory: true, name: 'invalid' },
+            { isDirectory: true, name: 'duplicate' },
+          ]
+        }
+        default: {
+          return []
+        }
+      }
+    })
+    validateTemplateMock.mockResolvedValue(true)
+    getTemplateMetadataMock.mockImplementation(async (path: AbsPath) => ({
+      name: AbsPath.basename(path),
+    }))
+    templateImportMock.mockImplementation(async (path: AbsPath) => {
+      if (path.endsWith('/invalid')) {
+        throw new AppError('INVALID_STRUCTURE', 'invalid template')
+      }
+      throw new AppError('DUPLICATE_RESOURCE', 'duplicate template')
+    })
+
+    const { useDiscoverResources } = await import('../useDiscoverResources')
+    const discoverResources = useDiscoverResources()
+
+    await discoverResources.checkResourcesForActiveTab()
+
+    const modalProps = modalOpenMock.mock.calls[0]?.[1] as { onImport?: (paths: AbsPath[]) => Promise<void> } | undefined
+    await modalProps?.onImport?.([
+      AbsPath.from('/templates/invalid'),
+      AbsPath.from('/templates/duplicate'),
+    ])
+
+    expect(toastErrorMock).toHaveBeenCalledWith('home.templates.importFailed (2/2)', {
+      description: 'home.templates.importInvalidFolder; home.templates.importDuplicate',
+    })
   })
 
   it('批量导入失败日志只统计样例之外的剩余失败数', async () => {

--- a/src/features/home/engines-tab/useEnginesTabController.ts
+++ b/src/features/home/engines-tab/useEnginesTabController.ts
@@ -1,9 +1,8 @@
 import { openPath } from '@tauri-apps/plugin-opener'
 
 import { db } from '~/database/db'
-import { MIN_WEBGAL_EDITOR_RUNTIME_VERSION } from '~/domain/engine/runtime-capabilities'
 import { AbsPath } from '~/domain/path'
-import { managedImportErrorMessages, useHomeResourceImportActions } from '~/features/home/shared/useHomeResourceImportActions'
+import { createHomeResourceImportMessages, useHomeResourceImportActions } from '~/features/home/shared/useHomeResourceImportActions'
 import { createEngineImportWorkflow } from '~/features/resource-import/resource-import-workflows'
 import { engineManager } from '~/services/engine-manager'
 import { resourceReconcile } from '~/services/resource-reconcile'
@@ -27,20 +26,7 @@ export function useEnginesTabController(options: UseEnginesTabControllerOptions)
     activeProgress: options.activeProgress,
     importResource: path => engineManager.importEngine(path),
     selectResource: importWorkflow.importFromPicker,
-    messages: {
-      ...managedImportErrorMessages,
-      alreadyRegistered: t => t('home.engines.importAlreadyExists'),
-      engineEditorIncompatible: t => t('home.engines.importEditorIncompatible'),
-      engineVersionInvalid: t => t('home.engines.importVersionInvalid'),
-      engineVersionTooOld: t => t('home.engines.importVersionTooOld', { version: MIN_WEBGAL_EDITOR_RUNTIME_VERSION }),
-      engineSchemaTooNew: t => t('home.engines.importSchemaTooNew'),
-      invalidFolder: t => t('home.engines.importInvalidFolder'),
-      multipleFolders: t => t('home.engines.importMultipleFolders'),
-      selectFolderTitle: t => t('common.dialogs.selectEngineFolder'),
-      targetConflict: t => t('home.engines.importTargetConflict'),
-      unsupportedLegacyEngine: t => t('home.engines.importUnsupportedLegacyEngine'),
-      unknownError: t => t('home.engines.importUnknownError'),
-    },
+    messages: createHomeResourceImportMessages('engines', options.t),
     t: options.t,
   })
 

--- a/src/features/home/games-tab/useGamesTabController.ts
+++ b/src/features/home/games-tab/useGamesTabController.ts
@@ -1,5 +1,4 @@
-import { MIN_WEBGAL_EDITOR_RUNTIME_VERSION } from '~/domain/engine/runtime-capabilities'
-import { managedImportErrorMessages, useHomeResourceImportActions } from '~/features/home/shared/useHomeResourceImportActions'
+import { createHomeResourceImportMessages, useHomeResourceImportActions } from '~/features/home/shared/useHomeResourceImportActions'
 import { requestGameRuntimeRebind, resolveRuntimeRebindIssue } from '~/features/modals/import-dependency-resolution/request-game-runtime-rebind'
 import { requestImportDependencyResolution } from '~/features/modals/import-dependency-resolution/request-import-dependency-resolution'
 import { createGameImportWorkflow } from '~/features/resource-import/resource-import-workflows'
@@ -40,21 +39,7 @@ export function useGamesTabController(options: UseGamesTabControllerOptions) {
     activeProgress: options.activeProgress,
     importResource: path => gameManager.importGame(path, { resolveDependencies }),
     selectResource: importWorkflow.importFromPicker,
-    messages: {
-      ...managedImportErrorMessages,
-      alreadyRegistered: t => t('home.games.importAlreadyExists'),
-      engineEditorIncompatible: t => t('home.games.importEngineEditorIncompatible'),
-      engineNotFound: t => t('home.games.importEngineNotFound'),
-      engineUnavailable: t => t('home.games.importEngineUnavailable'),
-      engineVersionInvalid: t => t('home.games.importEngineVersionInvalid'),
-      engineVersionTooOld: t => t('home.games.importEngineVersionTooOld', { version: MIN_WEBGAL_EDITOR_RUNTIME_VERSION }),
-      gameConfigCorrupted: t => t('home.games.importConfigCorrupted'),
-      gameSchemaTooNew: t => t('home.games.importSchemaVersionTooNew'),
-      invalidFolder: t => t('home.games.importInvalidFolder'),
-      multipleFolders: t => t('home.games.importMultipleFolders'),
-      selectFolderTitle: t => t('common.dialogs.selectGameFolder'),
-      unknownError: t => t('home.games.importUnknownError'),
-    },
+    messages: createHomeResourceImportMessages('games', options.t),
     t: options.t,
   })
 

--- a/src/features/home/shared/__tests__/home-resource-import.test.ts
+++ b/src/features/home/shared/__tests__/home-resource-import.test.ts
@@ -79,6 +79,13 @@ describe('首页共享导入纯逻辑', () => {
       kind: 'game-config-corrupted',
       level: 'error',
     })
+
+    expect(resolveHomeResourceImportNotification(new AppError('INVALID_CONFIG', 'broken', {
+      details: { reason: 'PARSE_FAILED' },
+    }))).toEqual({
+      kind: 'game-config-corrupted',
+      level: 'error',
+    })
   })
 
   it('schema 版本过新错误会映射为专用通知', () => {

--- a/src/features/home/shared/__tests__/useHomeResourceImportActions.test.ts
+++ b/src/features/home/shared/__tests__/useHomeResourceImportActions.test.ts
@@ -37,6 +37,7 @@ function createActions() {
     importResource: importResourceMock,
     selectResource: selectResourceMock,
     messages: {
+      importFailed: t => t('home.engines.importFailed'),
       invalidFolder: t => t('home.engines.importInvalidFolder'),
       multipleFolders: t => t('home.engines.importMultipleFolders'),
       selectFolderTitle: t => t('common.dialogs.selectEngineFolder'),

--- a/src/features/home/shared/home-resource-import.ts
+++ b/src/features/home/shared/home-resource-import.ts
@@ -82,6 +82,10 @@ function resolveErrorNotificationKind(error: unknown): HomeResourceImportNotific
     return 'unknown-error'
   }
 
+  if (error.code === 'INVALID_CONFIG') {
+    return 'game-config-corrupted'
+  }
+
   // 优先按 details.reason 匹配（更具体的错误分类）
   switch (error.details?.reason) {
     case 'PARSE_FAILED': { return 'invalid-folder' }

--- a/src/features/home/shared/useHomeResourceImportActions.ts
+++ b/src/features/home/shared/useHomeResourceImportActions.ts
@@ -1,5 +1,6 @@
 import { openPath } from '@tauri-apps/plugin-opener'
 
+import { MIN_WEBGAL_EDITOR_RUNTIME_VERSION } from '~/domain/engine/runtime-capabilities'
 import { AbsPath } from '~/domain/path'
 import { resolveI18nLike } from '~/utils/i18n-like'
 
@@ -14,6 +15,7 @@ import type { HomeResourceImportNotification, HomeResourceImportOutcome } from '
 import type { I18nLike, I18nT } from '~/utils/i18n-like'
 
 export interface HomeResourceImportMessages {
+  importFailed: I18nLike
   invalidFolder: I18nLike
   unknownError: I18nLike
   multipleFolders: I18nLike
@@ -39,6 +41,8 @@ export interface HomeResourceImportMessages {
   importBusy?: I18nLike
 }
 
+export type HomeResourceType = 'games' | 'engines' | 'templates'
+
 export const managedImportErrorMessages = {
   providerDenied: t => t('home.managedImport.error.providerDenied'),
   copyFailed: t => t('home.managedImport.error.copyFailed'),
@@ -48,6 +52,60 @@ export const managedImportErrorMessages = {
   rollbackFailed: t => t('home.managedImport.error.rollbackFailed'),
   importBusy: t => t('home.managedImport.error.busy'),
 } satisfies Partial<HomeResourceImportMessages>
+
+export function createHomeResourceImportMessages(type: HomeResourceType, t: I18nT): HomeResourceImportMessages {
+  switch (type) {
+    case 'games': {
+      return {
+        ...managedImportErrorMessages,
+        alreadyRegistered: t => t('home.games.importAlreadyExists'),
+        engineEditorIncompatible: t => t('home.games.importEngineEditorIncompatible'),
+        engineNotFound: t => t('home.games.importEngineNotFound'),
+        engineUnavailable: t => t('home.games.importEngineUnavailable'),
+        engineVersionInvalid: t => t('home.games.importEngineVersionInvalid'),
+        engineVersionTooOld: t => t('home.games.importEngineVersionTooOld', { version: MIN_WEBGAL_EDITOR_RUNTIME_VERSION }),
+        gameConfigCorrupted: t => t('home.games.importConfigCorrupted'),
+        gameSchemaTooNew: t => t('home.games.importSchemaVersionTooNew'),
+        invalidFolder: t => t('home.games.importInvalidFolder'),
+        importFailed: t => t('home.games.importFailed'),
+        multipleFolders: t => t('home.games.importMultipleFolders'),
+        selectFolderTitle: t('common.dialogs.selectGameFolder'),
+        unknownError: t => t('home.games.importUnknownError'),
+      }
+    }
+    case 'engines': {
+      return {
+        ...managedImportErrorMessages,
+        alreadyRegistered: t => t('home.engines.importAlreadyExists'),
+        engineEditorIncompatible: t => t('home.engines.importEditorIncompatible'),
+        engineSchemaTooNew: t => t('home.engines.importSchemaTooNew'),
+        engineVersionInvalid: t => t('home.engines.importVersionInvalid'),
+        engineVersionTooOld: t => t('home.engines.importVersionTooOld', { version: MIN_WEBGAL_EDITOR_RUNTIME_VERSION }),
+        invalidFolder: t => t('home.engines.importInvalidFolder'),
+        importFailed: t => t('home.engines.importFailed'),
+        multipleFolders: t => t('home.engines.importMultipleFolders'),
+        selectFolderTitle: t('common.dialogs.selectEngineFolder'),
+        targetConflict: t => t('home.engines.importTargetConflict'),
+        unsupportedLegacyEngine: t => t('home.engines.importUnsupportedLegacyEngine'),
+        unknownError: t => t('home.engines.importUnknownError'),
+      }
+    }
+    case 'templates': {
+      return {
+        ...managedImportErrorMessages,
+        duplicateResource: t => t('home.templates.importDuplicate'),
+        invalidFolder: t => t('home.templates.importInvalidFolder'),
+        importFailed: t => t('home.templates.importFailed'),
+        multipleFolders: t => t('home.templates.importMultipleFolders'),
+        selectFolderTitle: t('common.dialogs.selectTemplateFolder'),
+        unknownError: t => t('home.templates.importUnknownError'),
+      }
+    }
+    default: {
+      throw new Error(`未知的资源类型: ${type satisfies never}`)
+    }
+  }
+}
 
 interface UseHomeResourceImportActionsOptions {
   activeProgress: ReadonlyMap<string, number>

--- a/src/features/home/templates-tab/useTemplatesTabController.ts
+++ b/src/features/home/templates-tab/useTemplatesTabController.ts
@@ -1,4 +1,4 @@
-import { managedImportErrorMessages, useHomeResourceImportActions } from '~/features/home/shared/useHomeResourceImportActions'
+import { createHomeResourceImportMessages, useHomeResourceImportActions } from '~/features/home/shared/useHomeResourceImportActions'
 import { createTemplateImportWorkflow } from '~/features/resource-import/resource-import-workflows'
 import { resourceReconcile } from '~/services/resource-reconcile'
 import { templateManager } from '~/services/template-manager'
@@ -28,14 +28,7 @@ export function useTemplatesTabController(options: UseTemplatesTabControllerOpti
     activeProgress: options.activeProgress,
     importResource: path => templateManager.importTemplate(path),
     selectResource: importWorkflow.importFromPicker,
-    messages: {
-      ...managedImportErrorMessages,
-      duplicateResource: t => t('home.templates.importDuplicate'),
-      invalidFolder: t => t('home.templates.importInvalidFolder'),
-      multipleFolders: t => t('home.templates.importMultipleFolders'),
-      selectFolderTitle: t => t('common.dialogs.selectTemplateFolder'),
-      unknownError: t => t('home.templates.importUnknownError'),
-    },
+    messages: createHomeResourceImportMessages('templates', options.t),
     t: options.t,
   })
 

--- a/src/features/home/useDiscoverResources.ts
+++ b/src/features/home/useDiscoverResources.ts
@@ -3,6 +3,10 @@ import { exists, readDir } from '@tauri-apps/plugin-fs'
 import { AbsPath } from '~/domain/path'
 import { resolveHomeTabDefinition } from '~/features/home/home-tabs'
 import { resolveHomeResourceImportNotification } from '~/features/home/shared/home-resource-import'
+import {
+  createHomeResourceImportMessages,
+  resolveImportNotificationMessage,
+} from '~/features/home/shared/useHomeResourceImportActions'
 import { requestImportDependencyResolution } from '~/features/modals/import-dependency-resolution/request-import-dependency-resolution'
 import { engineManager } from '~/services/engine-manager'
 import { gameManager } from '~/services/game-manager'
@@ -11,10 +15,12 @@ import { useModalStore } from '~/stores/modal'
 import { useResourceStore } from '~/stores/resource'
 import { useStorageSettingsStore } from '~/stores/storage-settings'
 import { useWorkspaceStore } from '~/stores/workspace'
+import { resolveI18nLike } from '~/utils/i18n-like'
 
 import type { DiscoveredResource } from './discovered-resource'
 import type { Engine, Game, Template } from '~/database/model'
 import type { HomeResourceImportOutcome } from '~/features/home/shared/home-resource-import'
+import type { HomeResourceImportMessages, HomeResourceType } from '~/features/home/shared/useHomeResourceImportActions'
 import type { StaticSiteConfig } from '~/types/server'
 
 export type { DiscoveredResource } from './discovered-resource'
@@ -245,7 +251,7 @@ function filterAlreadyImported(
   return discovered.filter(resource => !existingKeys.has(getDiscoveredResourceKey(type, resource)))
 }
 
-type ResourceType = 'games' | 'engines' | 'templates'
+type ResourceType = HomeResourceType
 
 function discoverByType(type: ResourceType): Promise<DiscoveredResource[]> {
   switch (type) {
@@ -256,36 +262,8 @@ function discoverByType(type: ResourceType): Promise<DiscoveredResource[]> {
   }
 }
 
-interface ImportMessages {
-  alreadyRegistered?: string
-  error: string
-}
-
 function isHomeResourceImportOutcome(value: unknown): value is HomeResourceImportOutcome {
   return typeof value === 'object' && value !== null && 'alreadyRegistered' in value
-}
-
-function resolveImportMessages(type: ResourceType, t: (key: string) => string): ImportMessages {
-  switch (type) {
-    case 'games': {
-      return {
-        alreadyRegistered: t('home.games.importAlreadyExists'),
-        error: t('home.games.importUnknownError'),
-      }
-    }
-    case 'engines': {
-      return {
-        alreadyRegistered: t('home.engines.importAlreadyExists'),
-        error: t('home.engines.importUnknownError'),
-      }
-    }
-    case 'templates': {
-      return {
-        error: t('home.templates.importUnknownError'),
-      }
-    }
-    default: { throw new Error(`未知的资源类型: ${type satisfies never}`) }
-  }
 }
 
 function resolveImportFn(type: ResourceType): (path: AbsPath) => Promise<unknown> {
@@ -340,7 +318,7 @@ export function useDiscoverResources() {
   async function handleImport(
     paths: AbsPath[],
     importFn: (path: AbsPath) => Promise<unknown>,
-    messages: ImportMessages,
+    messages: HomeResourceImportMessages,
   ) {
     const results = await Promise.all(
       paths.map(async (path) => {
@@ -368,6 +346,18 @@ export function useDiscoverResources() {
 
     const alreadyRegisteredCount = notifications.filter(result => result.kind === 'already-registered').length
     const failCount = notifications.filter(result => result.level === 'error').length
+    const failureDetails = new Map<string, number>()
+
+    for (const { notification } of results) {
+      if (notification.level !== 'error') {
+        continue
+      }
+
+      const message = resolveImportNotificationMessage(notification, messages, t)
+      if (message) {
+        failureDetails.set(message, (failureDetails.get(message) ?? 0) + 1)
+      }
+    }
 
     if (failedImports.length > 0) {
       const samplePaths = failedImports
@@ -382,11 +372,29 @@ export function useDiscoverResources() {
       )
     }
 
-    if (alreadyRegisteredCount > 0 && messages.alreadyRegistered) {
-      toast.info(`${messages.alreadyRegistered} (${alreadyRegisteredCount}/${paths.length})`)
+    if (alreadyRegisteredCount > 0) {
+      const message = resolveImportNotificationMessage(
+        { kind: 'already-registered', level: 'info' },
+        messages,
+        t,
+      )
+      if (message) {
+        toast.info(`${message} (${alreadyRegisteredCount}/${paths.length})`)
+      }
     }
     if (failCount > 0) {
-      toast.error(`${messages.error} (${failCount}/${paths.length})`)
+      const details = [...failureDetails.entries()]
+        .map(([message, count]) => count > 1 ? `${message} (${count})` : message)
+        .join('; ')
+      const [singleFailureMessage] = failureDetails.keys()
+
+      if (failureDetails.size === 1 && singleFailureMessage) {
+        toast.error(`${singleFailureMessage} (${failCount}/${paths.length})`)
+      } else {
+        toast.error(`${resolveI18nLike(messages.importFailed, t)} (${failCount}/${paths.length})`, {
+          description: details,
+        })
+      }
     }
   }
 
@@ -406,7 +414,7 @@ export function useDiscoverResources() {
       return
     }
 
-    const messages = resolveImportMessages(type, t)
+    const messages = createHomeResourceImportMessages(type, t)
     const importFn = resolveImportFn(type)
 
     modalStore.open('DiscoveredResourcesModal', {

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -176,6 +176,7 @@ home:
     importEngineVersionInvalid: The engine bound to this project does not provide valid version information. Choose another engine.
     importEngineVersionTooOld: The engine bound to this project is too old. Choose an engine for WebGAL {version} or later.
     importAlreadyExists: This project already exists
+    importFailed: Import failed
     importInvalidFolder: This does not look like a game project folder. Please check its contents.
     importSchemaVersionTooNew: This project was created by a newer version of the app. Please upgrade and try again.
     importUnknownError: An unknown error occurred while importing the game
@@ -191,6 +192,7 @@ home:
     dropEngineFolder: Drag and drop game engine folder here
     engineIcon: "{name} engine icon"
     importAlreadyExists: This engine already exists
+    importFailed: Import failed
     importInvalidFolder: This does not look like an engine folder. Please check its contents.
     importing: Importing engine...
     importSchemaTooNew: This engine is too new for the current app. Please upgrade the app and try again.
@@ -213,6 +215,7 @@ home:
     deleteTemplate: Delete Template
     dropTemplateFolder: Drag and drop template folder here
     importInvalidFolder: This is not a valid template folder
+    importFailed: Import failed
     importDuplicate: A template with the same name already exists
     importUnknownError: An unknown error occurred while importing the template
     importMultipleFolders: Only one template folder can be imported at a time

--- a/src/locales/ja.yml
+++ b/src/locales/ja.yml
@@ -176,6 +176,7 @@ home:
     importEngineVersionInvalid: このプロジェクトに紐付いたエンジンには有効なバージョン情報がありません。別のエンジンを選択してください
     importEngineVersionTooOld: このプロジェクトに紐付いたエンジンは古すぎます。WebGAL {version} 以降に対応したエンジンを選択してください
     importAlreadyExists: このプロジェクトは既に存在します
+    importFailed: インポートに失敗しました
     importInvalidFolder: ゲームプロジェクトフォルダのようには見えません。中身を確認してください。
     importSchemaVersionTooNew: このプロジェクトはより新しいバージョンのアプリで作成されています。アプリをアップグレードしてから再度お試しください。
     importUnknownError: ゲームのインポート中に不明なエラーが発生しました
@@ -191,6 +192,7 @@ home:
     dropEngineFolder: ゲームエンジンフォルダをここにドラッグ＆ドロップ
     engineIcon: "{name} エンジンアイコン"
     importAlreadyExists: このエンジンは既に存在します
+    importFailed: インポートに失敗しました
     importInvalidFolder: エンジンフォルダのようには見えません。中身を確認してください。
     importing: エンジンをインポート中...
     importSchemaTooNew: このエンジンは現在のアプリには新しすぎます。アプリをアップグレードしてから再度お試しください。
@@ -213,6 +215,7 @@ home:
     deleteTemplate: テンプレートを削除
     dropTemplateFolder: テンプレートフォルダをここにドラッグ＆ドロップ
     importInvalidFolder: これは有効なテンプレートフォルダではありません
+    importFailed: インポートに失敗しました
     importDuplicate: 同じ名前のテンプレートが既に存在します
     importUnknownError: テンプレートのインポート中に不明なエラーが発生しました
     importMultipleFolders: 一度にインポートできるテンプレートフォルダは1つだけです

--- a/src/locales/zh-Hans.yml
+++ b/src/locales/zh-Hans.yml
@@ -176,6 +176,7 @@ home:
     importEngineVersionInvalid: 该项目绑定的引擎缺少有效的版本信息，请重新选择其他引擎
     importEngineVersionTooOld: 该项目绑定的引擎版本过旧，请重新选择 WebGAL {version} 及以上版本的引擎
     importAlreadyExists: 该项目已存在
+    importFailed: 导入失败
     importInvalidFolder: 这不像是游戏项目文件夹，请确认目录结构
     importSchemaVersionTooNew: 该项目由更新版本的应用创建，请升级应用后再尝试打开
     importUnknownError: 导入游戏时发生未知错误
@@ -191,6 +192,7 @@ home:
     dropEngineFolder: 将游戏引擎文件夹拖放到此处
     engineIcon: "{name} 引擎图标"
     importAlreadyExists: 该引擎已存在
+    importFailed: 导入失败
     importInvalidFolder: 这不像是引擎文件夹，请确认目录结构
     importing: 引擎导入中……
     importSchemaTooNew: 该引擎版本过新，请升级应用后再尝试导入
@@ -213,6 +215,7 @@ home:
     deleteTemplate: 删除模板
     dropTemplateFolder: 将模板文件夹拖放到此处
     importInvalidFolder: 这不是一个有效的模板文件夹
+    importFailed: 导入失败
     importDuplicate: 已存在同名模板
     importUnknownError: 导入模板时发生未知错误
     importMultipleFolders: 一次只能导入一个模板文件夹

--- a/src/locales/zh-Hant.yml
+++ b/src/locales/zh-Hant.yml
@@ -176,6 +176,7 @@ home:
     importEngineVersionInvalid: 該專案綁定的引擎缺少有效的版本資訊，請重新選擇其他引擎
     importEngineVersionTooOld: 該專案綁定的引擎版本過舊，請重新選擇 WebGAL {version} 及以上版本的引擎
     importAlreadyExists: 該專案已存在
+    importFailed: 匯入失敗
     importInvalidFolder: 這不像是遊戲專案資料夾，請確認目錄結構
     importSchemaVersionTooNew: 該專案由更新版本的應用建立，請升級應用後再嘗試開啟
     importUnknownError: 匯入遊戲時發生未知錯誤
@@ -191,6 +192,7 @@ home:
     dropEngineFolder: 將遊戲引擎資料夾拖放到此處
     engineIcon: "{name} 引擎圖示"
     importAlreadyExists: 該引擎已存在
+    importFailed: 匯入失敗
     importInvalidFolder: 這不像是引擎資料夾，請確認目錄結構
     importing: 引擎匯入中……
     importSchemaTooNew: 該引擎版本過新，請升級應用後再嘗試匯入
@@ -213,6 +215,7 @@ home:
     deleteTemplate: 刪除模板
     dropTemplateFolder: 將模板資料夾拖放到此處
     importInvalidFolder: 這不是一個有效的模板資料夾
+    importFailed: 匯入失敗
     importDuplicate: 已存在同名模板
     importUnknownError: 匯入模板時發生未知錯誤
     importMultipleFolders: 一次只能匯入一個模板資料夾


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [x] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [x] 代码重构
- [x] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

修复首页自动发现资源批量导入失败时只显示“导入失败（计数）”、不显示具体原因的问题。

- 单一失败直接显示对应的本地化错误文案和失败计数。
- 多种失败合并到一条通知中，列出各类失败原因及数量。
- 复用游戏、引擎、模板现有的导入错误消息映射。
- 修复游戏 `INVALID_CONFIG` 错误的具体分类。
- 保持取消操作静默，原始异常继续写入日志。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

自动发现入口原先只按通知级别统计失败数量，丢失了结构化错误类型，导致用户无法判断导入失败的具体原因。该改动将已有错误分类映射复用于批量导入反馈，提升问题定位能力。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
