### PR TITLE
🐛 优化引擎切换时的预览刷新与日志信息

### DIFF
--- a/src/services/__tests__/engine-switch.test.ts
+++ b/src/services/__tests__/engine-switch.test.ts
@@ -14,6 +14,7 @@ const {
   dbEngineGetMock,
   dbGameUpdateMock,
   evaluateTemplateStrategyMock,
+  loggerInfoMock,
   notifyTemplateChangedMock,
   readProjectConfigMock,
   refreshIfCurrentGameMock,
@@ -28,6 +29,7 @@ const {
   dbEngineGetMock: vi.fn(),
   dbGameUpdateMock: vi.fn(),
   evaluateTemplateStrategyMock: vi.fn(),
+  loggerInfoMock: vi.fn(),
   notifyTemplateChangedMock: vi.fn(),
   readProjectConfigMock: vi.fn(),
   refreshIfCurrentGameMock: vi.fn(),
@@ -42,7 +44,7 @@ const {
 vi.mock('@tauri-apps/plugin-log', () => ({
   debug: vi.fn(),
   error: vi.fn(),
-  info: vi.fn(),
+  info: loggerInfoMock,
   warn: vi.fn(),
   attachConsole: vi.fn(),
 }))
@@ -106,6 +108,7 @@ describe('engineSwitch.switchEngine', () => {
     dbEngineGetMock.mockReset()
     dbGameUpdateMock.mockReset()
     evaluateTemplateStrategyMock.mockReset()
+    loggerInfoMock.mockReset()
     notifyTemplateChangedMock.mockReset()
     readProjectConfigMock.mockReset()
     refreshIfCurrentGameMock.mockReset()
@@ -191,6 +194,9 @@ describe('engineSwitch.switchEngine', () => {
     expect(updateSiteEngineMock).toHaveBeenCalledWith('/games/demo', '/engines/new')
     expect(updateSiteTemplateMock).toHaveBeenCalledWith('/games/demo', '/engines/new/game/template')
     expect(refreshRegisteredGameSnapshotMock).toHaveBeenCalledWith('/games/demo', { invalidate: 'all' })
+    expect(loggerInfoMock).toHaveBeenCalledWith(
+      '[引擎切换] /games/demo: 开始切换到引擎 Default Engine@4.6.0',
+    )
     expect(notifyTemplateChangedMock).toHaveBeenCalledWith('/games/demo', {
       nextEnginePath: '/engines/new',
       nextTemplatePath: '/engines/new/game/template',

--- a/src/services/__tests__/engine-switch.test.ts
+++ b/src/services/__tests__/engine-switch.test.ts
@@ -191,6 +191,11 @@ describe('engineSwitch.switchEngine', () => {
     expect(updateSiteEngineMock).toHaveBeenCalledWith('/games/demo', '/engines/new')
     expect(updateSiteTemplateMock).toHaveBeenCalledWith('/games/demo', '/engines/new/game/template')
     expect(refreshRegisteredGameSnapshotMock).toHaveBeenCalledWith('/games/demo', { invalidate: 'all' })
+    expect(notifyTemplateChangedMock).toHaveBeenCalledWith('/games/demo', {
+      nextEnginePath: '/engines/new',
+      nextTemplatePath: '/engines/new/game/template',
+      skipPreviewTemplateReload: true,
+    })
     expect(cleanTemplateUpperMock).not.toHaveBeenCalled()
     expect(refreshIfCurrentGameMock).not.toHaveBeenCalled()
     expect(syncIfCurrentGameMock).toHaveBeenCalledWith({

--- a/src/services/__tests__/template-switch.test.ts
+++ b/src/services/__tests__/template-switch.test.ts
@@ -1,0 +1,81 @@
+import '~/__tests__/setup'
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { AbsPath } from '~/domain/path'
+import { templateSwitch } from '~/services/template-switch'
+
+const {
+  closeTabMock,
+  collectDocumentPathsUnderMock,
+  debugCommanderMock,
+  findTabIndexMock,
+  refreshTemplateOverlayMock,
+} = vi.hoisted(() => ({
+  closeTabMock: vi.fn(),
+  collectDocumentPathsUnderMock: vi.fn(),
+  debugCommanderMock: {
+    refetchTemplates: vi.fn(),
+  },
+  findTabIndexMock: vi.fn(),
+  refreshTemplateOverlayMock: vi.fn(),
+}))
+
+vi.mock('~/services/debug-commander', () => ({
+  debugCommander: debugCommanderMock,
+}))
+
+vi.mock('~/stores/editor', () => ({
+  useEditorStore: () => ({
+    collectDocumentPathsUnder: collectDocumentPathsUnderMock,
+  }),
+}))
+
+vi.mock('~/stores/file', () => ({
+  useFileStore: () => ({
+    refreshTemplateOverlay: refreshTemplateOverlayMock,
+  }),
+}))
+
+vi.mock('~/stores/tabs', () => ({
+  useTabsStore: () => ({
+    closeTab: closeTabMock,
+    findTabIndex: findTabIndexMock,
+  }),
+}))
+
+describe('templateSwitch.notifyTemplateChanged', () => {
+  beforeEach(() => {
+    closeTabMock.mockReset()
+    collectDocumentPathsUnderMock.mockReset()
+    debugCommanderMock.refetchTemplates.mockReset()
+    findTabIndexMock.mockReset()
+    refreshTemplateOverlayMock.mockReset()
+
+    collectDocumentPathsUnderMock.mockReturnValue([])
+    refreshTemplateOverlayMock.mockResolvedValue(undefined)
+    debugCommanderMock.refetchTemplates.mockResolvedValue(undefined)
+  })
+
+  it('默认通知预览重新加载模板', async () => {
+    await templateSwitch.notifyTemplateChanged(AbsPath.from('/games/demo'))
+
+    expect(refreshTemplateOverlayMock).toHaveBeenCalledWith('/games/demo', {
+      nextEnginePath: undefined,
+      nextTemplatePath: undefined,
+    })
+    expect(debugCommanderMock.refetchTemplates).toHaveBeenCalledTimes(1)
+  })
+
+  it('引擎切换时跳过独立的模板重载请求', async () => {
+    await templateSwitch.notifyTemplateChanged(AbsPath.from('/games/demo'), {
+      skipPreviewTemplateReload: true,
+    })
+
+    expect(refreshTemplateOverlayMock).toHaveBeenCalledWith('/games/demo', {
+      nextEnginePath: undefined,
+      nextTemplatePath: undefined,
+    })
+    expect(debugCommanderMock.refetchTemplates).not.toHaveBeenCalled()
+  })
+})

--- a/src/services/engine-switch.ts
+++ b/src/services/engine-switch.ts
@@ -138,7 +138,8 @@ async function switchEngine(
     // 让首页卡片与编辑器头部都能拉到新引擎图标，避免浏览器命中旧缓存
     await runFinalizer(() => gameManager.refreshRegisteredGameSnapshot(game.path, { invalidate: 'all' }), '刷新游戏快照失败')
 
-    // 收尾：关闭打开的模板文档、刷新文件树、通知预览拉取新模板
+    // 收尾：关闭打开的模板文档、刷新文件树。后续重载预览 iframe 会重新加载模板，
+    // 因此不再额外发送模板重载请求。
     // 显式传入 newEngine.path 与 newTemplatePath：此时 workspaceStore.currentGame
     // 仍是切换前快照，file store 单靠它反查会拿到旧引擎/模板路径，
     // 导致首次切换不刷新模板内容。
@@ -147,6 +148,7 @@ async function switchEngine(
       nextEnginePath: newEngine.path,
       // eslint-disable-next-line unicorn/no-null
       nextTemplatePath: newTemplatePath ?? null,
+      skipPreviewTemplateReload: true,
     }), '通知模板变更失败')
 
     // 引擎换的是 runtime 本身（webgal.js、index.html、内置资源等），

--- a/src/services/engine-switch.ts
+++ b/src/services/engine-switch.ts
@@ -86,7 +86,7 @@ async function switchEngine(
     })
   }
 
-  logger.info(`[引擎切换] ${game.path}: 开始切换到引擎 ${newEngine.name}`)
+  logger.info(`[引擎切换] ${game.path}: 开始切换到引擎 ${newEngine.name}@${newEngine.version ?? '未知'}`)
 
   // 仅在模板脏状态时才需要用户决策
   const templateDecision = strategy === 'dirty' ? options.templateDecision : undefined

--- a/src/services/template-switch.ts
+++ b/src/services/template-switch.ts
@@ -50,20 +50,27 @@ async function closeOpenedTemplateDocuments(gamePath: AbsPath): Promise<void> {
   }
 }
 
+interface NotifyTemplateChangedOptions {
+  nextEnginePath?: AbsPath
+  nextTemplatePath?: AbsPath | null
+  skipPreviewTemplateReload?: boolean
+}
+
 /**
  * 切换收尾通用清理：
  * - 关闭仍打开的模板文档（联动 editor session 清理与未保存状态丢弃）
  * - 失效 file store 中模板子树缓存并刷新 enginePath / templatePath
- * - broadcast REFETCH_TEMPLATE_FILES 让运行中的预览拉取新模板
+ * - 按调用场景通知运行中的预览拉取新模板
  *
  * @param options.nextEnginePath 引擎切换路径下的新引擎路径。必须由调用方显式
  *   传入，因为此时 `workspaceStore.currentGame.engineId` 仍是切换前的快照。
  * @param options.nextTemplatePath 模板切换后的解析路径。`null` 表示回到
  *   "跟随当前引擎默认"（缺省 binding）。
+ * @param options.skipPreviewTemplateReload 引擎切换已重载预览 iframe 时跳过独立的模板重载请求。
  */
 async function notifyTemplateChanged(
   gamePath: AbsPath,
-  options: { nextEnginePath?: AbsPath, nextTemplatePath?: AbsPath | null } = {},
+  options: NotifyTemplateChangedOptions = {},
 ): Promise<void> {
   await closeOpenedTemplateDocuments(gamePath)
 
@@ -80,11 +87,13 @@ async function notifyTemplateChanged(
     logger.warn(`[模板切换] 失效模板 overlay 缓存失败: ${error}`)
   }
 
-  try {
-    await debugCommander.refetchTemplates()
-  } catch (error) {
-    // 无运行中的预览或站点未连接时忽略
-    logger.warn(`[模板切换] 通知预览刷新模板失败: ${error}`)
+  if (!options.skipPreviewTemplateReload) {
+    try {
+      await debugCommander.refetchTemplates()
+    } catch (error) {
+      // 无运行中的预览或站点未连接时忽略
+      logger.warn(`[模板切换] 通知预览刷新模板失败: ${error}`)
+    }
   }
 }
 


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [x] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [x] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

- 引擎切换继续刷新模板 overlay 和预览 iframe，但跳过冗余的 `preview.command.reload-templates` 请求。
- 普通模板切换仍按原流程通知预览重新加载模板。
- 引擎切换开始日志改为输出 `引擎名@版本`；缺失版本时显示 `未知`。
- 增加服务层测试，覆盖模板刷新默认路径、引擎切换跳过路径和带版本日志。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

引擎切换本身会重载预览 iframe，iframe 重载会重新加载模板，因此额外发送模板重载请求没有必要。移除该请求可以减少预览协议通信和状态抖动；日志补充版本后，可以区分同一引擎的不同已安装版本，便于定位切换问题。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
