### PR TITLE
✨ 在资源管理器中显示资源引用计数

### DIFF
--- a/src/components/editor/AssetView.spec.ts
+++ b/src/components/editor/AssetView.spec.ts
@@ -822,6 +822,55 @@ describe('AssetView', () => {
     expect(getReferencesTo).not.toHaveBeenCalled()
   })
 
+  it('不会为 animationTable.json 显示引用计数', async () => {
+    const resolveByAbsolutePath = vi.fn(() => ({
+      key: {
+        assetType: 'animation',
+        relativePath: 'fade.json',
+        root: 'asset',
+      },
+    }))
+    const getReferencesTo = vi.fn(() => [])
+    useResourceIndexMock.mockReturnValue({
+      getReferencesTo,
+      resolveByAbsolutePath,
+      revision: resourceIndexRevision,
+      status: resourceIndexStatus,
+    })
+    getFolderContentsMock.mockResolvedValue([
+      createAssetFileSystemItem({
+        isDir: false,
+        mimeType: 'application/json',
+        modifiedAt: 2,
+        name: 'animationTable.json',
+        path: '/games/demo/game/animation/animationTable.json',
+        source: 'upper',
+      }),
+      createAssetFileSystemItem({
+        isDir: false,
+        mimeType: 'application/json',
+        modifiedAt: 3,
+        name: 'fade.json',
+        path: '/games/demo/game/animation/fade.json',
+        source: 'upper',
+      }),
+    ])
+
+    renderInBrowser(createHarness('animation'), {
+      global: {
+        stubs: {
+          ...commonGlobalStubs,
+          FileViewer: createReferenceCountFileViewerStub(),
+        },
+      },
+    })
+
+    await expect.element(page.getByTestId('reference-count-animationTable.json')).toHaveTextContent('unavailable')
+    await expect.element(page.getByTestId('reference-count-fade.json')).toHaveTextContent('0')
+    expect(resolveByAbsolutePath).toHaveBeenCalledWith('/games/demo/game/animation/fade.json')
+    expect(resolveByAbsolutePath).not.toHaveBeenCalledWith('/games/demo/game/animation/animationTable.json')
+  })
+
   it('FileViewer 上抛中键点击时会以普通标签打开资源', async () => {
     const openTab = vi.fn()
     useTabsStoreMock.mockReturnValue({

--- a/src/components/editor/AssetView.spec.ts
+++ b/src/components/editor/AssetView.spec.ts
@@ -501,6 +501,7 @@ function createAssetFileSystemItem(options: {
   name: string
   path: string
   mimeType?: string
+  source?: FileSystemItem['source']
   size?: number
 }) {
   return {
@@ -509,6 +510,7 @@ function createAssetFileSystemItem(options: {
     name: options.name,
     path: options.path,
     size: options.size ?? 0,
+    source: options.source,
     ...(options.isDir
       ? { isDir: true }
       : { isDir: false, mimeType: options.mimeType }),
@@ -784,6 +786,40 @@ describe('AssetView', () => {
     })
 
     await expect.element(page.getByTestId('reference-count-hero.png')).toHaveTextContent('unavailable')
+  })
+
+  it('模板层文件不会显示引用计数', async () => {
+    const resolveByAbsolutePath = vi.fn()
+    const getReferencesTo = vi.fn()
+    useResourceIndexMock.mockReturnValue({
+      getReferencesTo,
+      resolveByAbsolutePath,
+      revision: resourceIndexRevision,
+      status: resourceIndexStatus,
+    })
+    getFolderContentsMock.mockResolvedValue([
+      createAssetFileSystemItem({
+        isDir: false,
+        mimeType: 'text/css',
+        modifiedAt: 2,
+        name: 'base.scss',
+        path: '/games/demo/game/template/base.scss',
+        source: 'templateLower',
+      }),
+    ])
+
+    renderInBrowser(createHarness('template'), {
+      global: {
+        stubs: {
+          ...commonGlobalStubs,
+          FileViewer: createReferenceCountFileViewerStub(),
+        },
+      },
+    })
+
+    await expect.element(page.getByTestId('reference-count-base.scss')).toHaveTextContent('unavailable')
+    expect(resolveByAbsolutePath).not.toHaveBeenCalled()
+    expect(getReferencesTo).not.toHaveBeenCalled()
   })
 
   it('FileViewer 上抛中键点击时会以普通标签打开资源', async () => {

--- a/src/components/editor/AssetView.spec.ts
+++ b/src/components/editor/AssetView.spec.ts
@@ -29,6 +29,7 @@ const {
   useFileStoreMock,
   usePreferenceStoreMock,
   usePreviewSessionStoreMock,
+  useResourceIndexMock,
   useTabsStoreMock,
   useWorkspaceStoreMock,
 } = vi.hoisted(() => ({
@@ -45,6 +46,7 @@ const {
   useFileStoreMock: vi.fn(),
   usePreferenceStoreMock: vi.fn(),
   usePreviewSessionStoreMock: vi.fn(),
+  useResourceIndexMock: vi.fn(),
   useTabsStoreMock: vi.fn(),
   useWorkspaceStoreMock: vi.fn(),
 }))
@@ -178,6 +180,10 @@ vi.mock('~/stores/preference', () => ({
 
 vi.mock('~/stores/preview-session', () => ({
   usePreviewSessionStore: usePreviewSessionStoreMock,
+}))
+
+vi.mock('~/services/resource-index/service', () => ({
+  useResourceIndex: useResourceIndexMock,
 }))
 
 vi.mock('~/stores/tabs', () => ({
@@ -370,6 +376,25 @@ function createLoadingStateFileViewerStub() {
         h('output', { 'data-testid': 'file-viewer-loading' }, String(props.isLoading)),
         h('output', { 'data-testid': 'file-viewer-item-count' }, String(props.items.length)),
       ])
+    },
+  })
+}
+
+function createReferenceCountFileViewerStub() {
+  return defineComponent({
+    name: 'StubReferenceCountFileViewer',
+    props: {
+      items: {
+        type: Array as PropType<FileViewerItem[]>,
+        required: true,
+      },
+    },
+    setup(props) {
+      return () => h('div', (props.items ?? []).map(item => h(
+        'output',
+        { 'data-testid': `reference-count-${item.name}` },
+        String(item.referenceCount ?? 'unavailable'),
+      )))
     },
   })
 }
@@ -579,6 +604,8 @@ const commonGlobalStubs = {
 let previewSessionStoreState: {
   currentGameServeUrl: string | undefined
 }
+let resourceIndexRevision = ref(0)
+let resourceIndexStatus = ref<'idle' | 'building' | 'ready' | 'degraded'>('ready')
 
 function setPreviewUnavailable() {
   previewSessionStoreState.currentGameServeUrl = undefined
@@ -599,6 +626,7 @@ describe('AssetView', () => {
     useFileStoreMock.mockReset()
     usePreferenceStoreMock.mockReset()
     usePreviewSessionStoreMock.mockReset()
+    useResourceIndexMock.mockReset()
     useTabsStoreMock.mockReset()
     useWorkspaceStoreMock.mockReset()
 
@@ -632,6 +660,14 @@ describe('AssetView', () => {
       currentGameServeUrl: 'http://127.0.0.1:8899/game/demo/',
     })
     usePreviewSessionStoreMock.mockReturnValue(previewSessionStoreState)
+    resourceIndexRevision = ref(0)
+    resourceIndexStatus = ref('ready')
+    useResourceIndexMock.mockReturnValue({
+      getReferencesTo: vi.fn(() => []),
+      resolveByAbsolutePath: vi.fn(() => undefined),
+      revision: resourceIndexRevision,
+      status: resourceIndexStatus,
+    })
     useWorkspaceStoreMock.mockReturnValue(reactive({
       currentGame: {
         path: '/games/demo',
@@ -669,6 +705,85 @@ describe('AssetView', () => {
 
     await expect.element(page.getByTestId('preview-context')).toHaveAttribute('data-preview-cwd', '/games/demo')
     await expect.element(page.getByTestId('preview-context')).toHaveAttribute('data-preview-base-url', 'http://127.0.0.1:8899/game/demo/')
+  })
+
+  it('会显示零引用和多个引用，并在资源索引修订后刷新计数', async () => {
+    let heroReferenceCount = 2
+    const resolveByAbsolutePath = vi.fn((path: string) => ({
+      key: {
+        assetType: 'background',
+        relativePath: path.endsWith('/hero.png') ? 'hero.png' : 'unused.png',
+        root: 'asset',
+      },
+    }))
+    const getReferencesTo = vi.fn((key: { relativePath: string }) =>
+      Array.from({ length: key.relativePath === 'hero.png' ? heroReferenceCount : 0 }),
+    )
+    useResourceIndexMock.mockReturnValue({
+      getReferencesTo,
+      resolveByAbsolutePath,
+      revision: resourceIndexRevision,
+      status: resourceIndexStatus,
+    })
+    getFolderContentsMock.mockResolvedValue([
+      createAssetFileSystemItem({
+        isDir: false,
+        mimeType: 'image/png',
+        modifiedAt: 2,
+        name: 'hero.png',
+        path: '/games/demo/game/background/hero.png',
+      }),
+      createAssetFileSystemItem({
+        isDir: false,
+        mimeType: 'image/png',
+        modifiedAt: 3,
+        name: 'unused.png',
+        path: '/games/demo/game/background/unused.png',
+      }),
+    ])
+
+    renderInBrowser(createHarness('background'), {
+      global: {
+        stubs: {
+          ...commonGlobalStubs,
+          FileViewer: createReferenceCountFileViewerStub(),
+        },
+      },
+    })
+
+    await expect.element(page.getByTestId('reference-count-hero.png')).toHaveTextContent('2')
+    await expect.element(page.getByTestId('reference-count-unused.png')).toHaveTextContent('0')
+    expect(resolveByAbsolutePath).toHaveBeenCalledWith('/games/demo/game/background/hero.png')
+    expect(getReferencesTo).toHaveBeenCalled()
+
+    heroReferenceCount = 0
+    resourceIndexRevision.value += 1
+
+    await expect.element(page.getByTestId('reference-count-hero.png')).toHaveTextContent('0')
+  })
+
+  it('资源索引未就绪时不会把暂态状态显示为零引用', async () => {
+    resourceIndexStatus.value = 'building'
+    getFolderContentsMock.mockResolvedValue([
+      createAssetFileSystemItem({
+        isDir: false,
+        mimeType: 'image/png',
+        modifiedAt: 2,
+        name: 'hero.png',
+        path: '/games/demo/game/background/hero.png',
+      }),
+    ])
+
+    renderInBrowser(createHarness('background'), {
+      global: {
+        stubs: {
+          ...commonGlobalStubs,
+          FileViewer: createReferenceCountFileViewerStub(),
+        },
+      },
+    })
+
+    await expect.element(page.getByTestId('reference-count-hero.png')).toHaveTextContent('unavailable')
   })
 
   it('FileViewer 上抛中键点击时会以普通标签打开资源', async () => {

--- a/src/components/editor/AssetView.vue
+++ b/src/components/editor/AssetView.vue
@@ -18,6 +18,7 @@ import {
 import { gameFs } from '~/services/game-fs'
 import { pathOperation } from '~/services/path-operation'
 import { createPathOperationRewriteConfirm } from '~/services/path-operation-confirm'
+import { useResourceIndex } from '~/services/resource-index/service'
 import { FileSystemItem, useFileStore } from '~/stores/file'
 import { usePreferenceStore } from '~/stores/preference'
 import { usePreviewSessionStore } from '~/stores/preview-session'
@@ -62,6 +63,7 @@ const tabsStore = useTabsStore()
 const fileStore = useFileStore()
 const fileSystemEvents = useFileSystemEvents()
 const previewSessionStore = usePreviewSessionStore()
+const resourceIndex = useResourceIndex()
 const workspaceStore = useWorkspaceStore()
 const { t } = useI18n()
 const confirmPathOperationRewrite = createPathOperationRewriteConfirm(t)
@@ -180,6 +182,25 @@ const {
 })
 
 const items = $computed(() => itemsRef.value)
+
+function resolveReferenceCount(item: FileViewerItem): number | undefined {
+  if (item.isDir || resourceIndex.status.value !== 'ready') {
+    return
+  }
+
+  const entry = resourceIndex.resolveByAbsolutePath(AbsPath.from(item.path))
+  return entry ? resourceIndex.getReferencesTo(entry.key).length : 0
+}
+
+const itemsWithReferenceCounts = $computed(() => {
+  // 引用记录的增量更新保持 ready 状态不变，显式订阅 revision 才能刷新当前视图。
+  void resourceIndex.revision.value
+  return items.map(item => ({
+    ...item,
+    referenceCount: resolveReferenceCount(item),
+  }))
+})
+
 const isLoading = $computed(() => isLoadingRef.value)
 const errorMsg = $computed(() => errorMsgRef.value)
 const isRootDirectoryMissing = $computed(() => isRootDirectoryMissingRef.value)
@@ -187,10 +208,10 @@ const isRootDirectoryMissing = $computed(() => isRootDirectoryMissingRef.value)
 const filteredItems = $computed(() => {
   const keyword = searchQuery.trim().toLocaleLowerCase()
   if (!keyword) {
-    return items
+    return itemsWithReferenceCounts
   }
 
-  return items.filter(item => item.name.toLocaleLowerCase().includes(keyword))
+  return itemsWithReferenceCounts.filter(item => item.name.toLocaleLowerCase().includes(keyword))
 })
 const canCreateFileInCurrentDirectory = $computed(() => canCreateAssetFile(assetType))
 

--- a/src/components/editor/AssetView.vue
+++ b/src/components/editor/AssetView.vue
@@ -184,7 +184,7 @@ const {
 const items = $computed(() => itemsRef.value)
 
 function resolveReferenceCount(item: FileViewerItem): number | undefined {
-  if (item.isDir || resourceIndex.status.value !== 'ready') {
+  if (item.isDir || item.source === 'templateLower' || resourceIndex.status.value !== 'ready') {
     return
   }
 

--- a/src/components/editor/AssetView.vue
+++ b/src/components/editor/AssetView.vue
@@ -15,6 +15,7 @@ import {
   resolveDroppableFileTreeTransferItems,
   resolveFileTreeDefaultFileDraft,
 } from '~/features/editor/file-tree/file-tree'
+import { isAnimationTablePath } from '~/services/animation-table-sync'
 import { gameFs } from '~/services/game-fs'
 import { pathOperation } from '~/services/path-operation'
 import { createPathOperationRewriteConfirm } from '~/services/path-operation-confirm'
@@ -185,6 +186,11 @@ const items = $computed(() => itemsRef.value)
 
 function resolveReferenceCount(item: FileViewerItem): number | undefined {
   if (item.isDir || item.source === 'templateLower' || resourceIndex.status.value !== 'ready') {
+    return
+  }
+
+  const gamePath = workspaceStore.currentGame?.path
+  if (gamePath && isAnimationTablePath(gamePath, AbsPath.from(item.path))) {
     return
   }
 

--- a/src/components/file-viewer/FileViewer.spec.ts
+++ b/src/components/file-viewer/FileViewer.spec.ts
@@ -631,6 +631,9 @@ describe('FileViewer', () => {
     const referenceCounts = page.getByTestId('file-viewer-reference-count')
     await expect.element(referenceCounts.nth(0)).toHaveTextContent('0')
     await expect.element(referenceCounts.nth(1)).toHaveTextContent('3')
+    const referenceIcons = page.getByTestId('file-viewer-reference-icon')
+    await expect.element(referenceIcons.nth(0)).toBeVisible()
+    await expect.element(referenceIcons.nth(1)).toBeVisible()
   })
 
   it('列表模式会显示独立引用数列，并在窄窗口保持可见', async () => {
@@ -653,6 +656,7 @@ describe('FileViewer', () => {
     const referenceCounts = page.getByTestId('file-viewer-reference-count')
     await expect.element(referenceCounts.nth(0)).toHaveTextContent('0')
     await expect.element(referenceCounts.nth(1)).toHaveTextContent('3')
+    await expect.element(page.getByTestId('file-viewer-reference-icon')).not.toBeInTheDocument()
     await expect.element(page.getByRole('columnheader', { name: 'common.fileMeta.size' })).not.toBeInTheDocument()
   })
 

--- a/src/components/file-viewer/FileViewer.spec.ts
+++ b/src/components/file-viewer/FileViewer.spec.ts
@@ -265,6 +265,13 @@ function createItem(index: number): FileViewerItem {
   }
 }
 
+function createReferenceCountItem(index: number, referenceCount: number): FileViewerItem {
+  return {
+    ...createItem(index),
+    referenceCount,
+  }
+}
+
 function createImageItem(index: number): FileViewerItem {
   return {
     ...createItem(index),
@@ -603,6 +610,50 @@ describe('FileViewer', () => {
 
     expect(resolveAssetUrlMock).not.toHaveBeenCalled()
     await expect.element(page.getByAltText('file-1.txt')).not.toBeInTheDocument()
+  })
+
+  it('网格模式会显示包含零引用的资源引用计数角标', async () => {
+    viewportWidthMock.value = 780
+
+    renderInBrowser(FileViewer, {
+      props: {
+        items: [
+          createReferenceCountItem(1, 0),
+          createReferenceCountItem(2, 3),
+        ],
+        viewMode: 'grid',
+      },
+      global: {
+        stubs: globalStubs,
+      },
+    })
+
+    const referenceCounts = page.getByTestId('file-viewer-reference-count')
+    await expect.element(referenceCounts.nth(0)).toHaveTextContent('0')
+    await expect.element(referenceCounts.nth(1)).toHaveTextContent('3')
+  })
+
+  it('列表模式会显示独立引用数列，并在窄窗口保持可见', async () => {
+    viewportWidthMock.value = 520
+
+    renderInBrowser(FileViewer, {
+      props: {
+        items: [
+          createReferenceCountItem(1, 0),
+          createReferenceCountItem(2, 3),
+        ],
+        viewMode: 'list',
+      },
+      global: {
+        stubs: globalStubs,
+      },
+    })
+
+    await expect.element(page.getByRole('columnheader', { name: 'common.fileMeta.referenceCount' })).toBeVisible()
+    const referenceCounts = page.getByTestId('file-viewer-reference-count')
+    await expect.element(referenceCounts.nth(0)).toHaveTextContent('0')
+    await expect.element(referenceCounts.nth(1)).toHaveTextContent('3')
+    await expect.element(page.getByRole('columnheader', { name: 'common.fileMeta.size' })).not.toBeInTheDocument()
   })
 
   it('提供预览上下文后会在 FileViewer 内部生成缩略图地址', async () => {

--- a/src/components/file-viewer/FileViewer.vue
+++ b/src/components/file-viewer/FileViewer.vue
@@ -147,6 +147,10 @@ const shouldShowState = computed(() =>
   isLoading || !!errorMsg || isEmptyState.value,
 )
 
+const showListReferenceCount = computed(() =>
+  sortedItems.value.some(item => item.referenceCount !== undefined),
+)
+
 function resolveBuiltInPreviewUrl(item: FileViewerItem, previewSize: FileViewerPreviewSize): string | undefined {
   if (item.isDir || !item.mimeType?.startsWith('image/')) {
     return undefined
@@ -471,6 +475,7 @@ defineExpose(fileViewerExpose)
       :show-list-size="layout.showListSize.value"
       :show-list-modified-at="layout.showListModifiedAt.value"
       :show-list-created-at="layout.showListCreatedAt.value"
+      :show-list-reference-count="showListReferenceCount"
       :sort-by="sortBy"
       :sort-order="sortOrder"
       :sortable-headers="sortableHeaders"
@@ -523,6 +528,7 @@ defineExpose(fileViewerExpose)
           :show-list-size="layout.showListSize.value"
           :show-list-modified-at="layout.showListModifiedAt.value"
           :show-list-created-at="layout.showListCreatedAt.value"
+          :show-list-reference-count="showListReferenceCount"
           :get-grid-row-items="virtualizer.getGridRowItems"
           :get-list-item="virtualizer.getListItem"
           :get-drag-source-props="getDragSourceProps"

--- a/src/components/file-viewer/FileViewerBody.vue
+++ b/src/components/file-viewer/FileViewerBody.vue
@@ -51,6 +51,7 @@ interface FileViewerBodyProps {
   showListSize: boolean
   showListModifiedAt: boolean
   showListCreatedAt: boolean
+  showListReferenceCount: boolean
   getGridRowItems: (rowIndex: number) => FileViewerItem[]
   getListItem: (index: number) => FileViewerItem
   resolvePreviewUrl?: (item: FileViewerItem, previewSize: FileViewerPreviewSize) => string | undefined
@@ -73,6 +74,7 @@ const {
   showListSize,
   showListModifiedAt,
   showListCreatedAt,
+  showListReferenceCount,
   getGridRowItems,
   getListItem,
   resolvePreviewUrl,
@@ -551,41 +553,53 @@ onUnmounted(() => {
             @click="handleItemClick(displayItem.item)"
             @auxclick="(event: MouseEvent) => handleItemAuxClick(event, displayItem.item)"
           >
-            <FileViewerImageHoverCard
-              :close-delay="resolveHoverCardCloseDelay(displayItem.item.path)"
-              :item="displayItem.item"
-              :open="openHoverPreviewPath === displayItem.item.path"
-              :preview-size="HOVER_PREVIEW_SIZE"
-              :resolve-preview-url="resolvePreviewUrl"
-              side="top"
-              @update:open="handleHoverCardOpenChange(displayItem.item.path, $event)"
+            <div
+              class="flex shrink-0 items-center justify-center relative"
+              :style="{ width: `${gridPreviewSize}px`, height: `${gridPreviewSize}px` }"
             >
-              <div
-                class="flex shrink-0 items-center justify-center"
-                :style="{ width: `${gridPreviewSize}px`, height: `${gridPreviewSize}px` }"
-                @pointerenter="scheduleHoverPreviewWarmup(displayItem.item)"
-                @pointerleave="clearPendingHoverPreviewWarmup(displayItem.item.path)"
+              <FileViewerImageHoverCard
+                :close-delay="resolveHoverCardCloseDelay(displayItem.item.path)"
+                :item="displayItem.item"
+                :open="openHoverPreviewPath === displayItem.item.path"
+                :preview-size="HOVER_PREVIEW_SIZE"
+                :resolve-preview-url="resolvePreviewUrl"
+                side="top"
+                @update:open="handleHoverCardOpenChange(displayItem.item.path, $event)"
               >
-                <img
-                  v-if="displayItem.previewUrl"
-                  :alt="displayItem.item.name"
-                  :src="displayItem.previewUrl"
-                  class="h-full w-full object-contain"
-                  decoding="async"
-                  draggable="false"
-                  loading="lazy"
-                  @error="handleImageError(displayItem.item.path, displayItem.previewUrl)"
+                <div
+                  class="flex h-full w-full items-center justify-center"
+                  @pointerenter="scheduleHoverPreviewWarmup(displayItem.item)"
+                  @pointerleave="clearPendingHoverPreviewWarmup(displayItem.item.path)"
                 >
-                <slot v-else name="icon" :icon-size="gridIconSize" :item="displayItem.item">
-                  <component
-                    :is="getDefaultIconComponent(displayItem.item)"
-                    class="shrink-0"
-                    :stroke-width="1.25"
-                    :style="{ width: `${gridIconSize}px`, height: `${gridIconSize}px` }"
-                  />
-                </slot>
-              </div>
-            </FileViewerImageHoverCard>
+                  <img
+                    v-if="displayItem.previewUrl"
+                    :alt="displayItem.item.name"
+                    :src="displayItem.previewUrl"
+                    class="h-full w-full object-contain"
+                    decoding="async"
+                    draggable="false"
+                    loading="lazy"
+                    @error="handleImageError(displayItem.item.path, displayItem.previewUrl)"
+                  >
+                  <slot v-else name="icon" :icon-size="gridIconSize" :item="displayItem.item">
+                    <component
+                      :is="getDefaultIconComponent(displayItem.item)"
+                      class="shrink-0"
+                      :stroke-width="1.25"
+                      :style="{ width: `${gridIconSize}px`, height: `${gridIconSize}px` }"
+                    />
+                  </slot>
+                </div>
+              </FileViewerImageHoverCard>
+              <span
+                v-if="displayItem.item.referenceCount !== undefined"
+                data-testid="file-viewer-reference-count"
+                class="text-[10px] text-foreground leading-none font-medium px-1 border rounded-sm bg-background/90 inline-flex h-4 min-w-4 [font-variant-numeric:tabular-nums] items-center justify-center absolute -right-1 -top-1"
+                :aria-label="$t('common.fileMeta.referenceCountValue', { count: displayItem.item.referenceCount })"
+              >
+                {{ displayItem.item.referenceCount }}
+              </span>
+            </div>
             <div
               data-file-viewer-name="true"
               class="text-xs text-center break-all line-clamp-2"
@@ -672,6 +686,17 @@ onUnmounted(() => {
               </div>
             </div>
             <div class="text-[11px] text-muted-foreground ml-2 flex shrink-0 gap-3 [font-variant-numeric:tabular-nums] items-center" role="note">
+              <div v-if="showListReferenceCount" class="text-center w-20" :aria-label="$t('common.fileMeta.referenceCount')">
+                <template v-if="displayItem.item.referenceCount !== undefined">
+                  <span data-testid="file-viewer-reference-count">
+                    {{ displayItem.item.referenceCount }}
+                  </span>
+                </template>
+                <template v-else>
+                  <span aria-hidden="true">--</span>
+                  <span class="sr-only">{{ $t('common.fileMeta.unavailableA11y') }}</span>
+                </template>
+              </div>
               <div v-if="showListSize" class="text-right w-20" :aria-label="$t('common.fileMeta.size')">
                 <template v-if="displayItem.item.isDir">
                   <span aria-hidden="true">--</span>

--- a/src/components/file-viewer/FileViewerBody.vue
+++ b/src/components/file-viewer/FileViewerBody.vue
@@ -594,13 +594,13 @@ onUnmounted(() => {
               <span
                 v-if="displayItem.item.referenceCount !== undefined"
                 data-testid="file-viewer-reference-count"
-                class="text-[10px] text-foreground leading-none font-medium px-1 border rounded-sm bg-background/90 inline-flex gap-0.5 h-4 min-w-4 [font-variant-numeric:tabular-nums] items-center justify-center absolute -right-1 -top-1"
+                class="text-[10px] text-secondary-foreground leading-none font-medium px-1 rounded-sm bg-secondary inline-flex gap-0.5 h-4 min-w-4 [font-variant-numeric:tabular-nums] items-center justify-center absolute -right-1 -top-1"
                 :aria-label="$t('common.fileMeta.referenceCountValue', { count: displayItem.item.referenceCount })"
               >
                 <Link2
                   data-testid="file-viewer-reference-icon"
                   aria-hidden="true"
-                  class="text-muted-foreground shrink-0 size-2.5"
+                  class="text-secondary-foreground/70 shrink-0 size-2.5"
                   :stroke-width="1.75"
                 />
                 {{ displayItem.item.referenceCount }}

--- a/src/components/file-viewer/FileViewerBody.vue
+++ b/src/components/file-viewer/FileViewerBody.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { File, FileImage, FileJson2, FileMusic, FileVideo, Folder } from '@lucide/vue'
+import { File, FileImage, FileJson2, FileMusic, FileVideo, Folder, Link2 } from '@lucide/vue'
 
 import { loadFileViewerImageDimensions } from '~/components/file-viewer/fileViewerImageDimensions'
 import { useDragSession } from '~/composables/useDragSession'
@@ -594,9 +594,15 @@ onUnmounted(() => {
               <span
                 v-if="displayItem.item.referenceCount !== undefined"
                 data-testid="file-viewer-reference-count"
-                class="text-[10px] text-foreground leading-none font-medium px-1 border rounded-sm bg-background/90 inline-flex h-4 min-w-4 [font-variant-numeric:tabular-nums] items-center justify-center absolute -right-1 -top-1"
+                class="text-[10px] text-foreground leading-none font-medium px-1 border rounded-sm bg-background/90 inline-flex gap-0.5 h-4 min-w-4 [font-variant-numeric:tabular-nums] items-center justify-center absolute -right-1 -top-1"
                 :aria-label="$t('common.fileMeta.referenceCountValue', { count: displayItem.item.referenceCount })"
               >
+                <Link2
+                  data-testid="file-viewer-reference-icon"
+                  aria-hidden="true"
+                  class="text-muted-foreground shrink-0 size-2.5"
+                  :stroke-width="1.75"
+                />
                 {{ displayItem.item.referenceCount }}
               </span>
             </div>

--- a/src/components/file-viewer/FileViewerHeader.vue
+++ b/src/components/file-viewer/FileViewerHeader.vue
@@ -8,6 +8,7 @@ interface FileViewerHeaderProps {
   showListSize: boolean
   showListModifiedAt: boolean
   showListCreatedAt: boolean
+  showListReferenceCount: boolean
   sortBy: FileViewerSortBy
   sortOrder: FileViewerSortOrder
   sortableHeaders: boolean
@@ -18,6 +19,7 @@ const {
   showListSize,
   showListModifiedAt,
   showListCreatedAt,
+  showListReferenceCount,
   sortBy,
   sortOrder,
   sortableHeaders,
@@ -82,6 +84,9 @@ function getHeaderInteractionClass(): string {
       </div>
     </div>
     <div class="text-[11px] ml-2 flex shrink-0 gap-3 items-center">
+      <div v-if="showListReferenceCount" class="text-center w-20" role="columnheader">
+        <span class="text-muted-foreground truncate">{{ $t('common.fileMeta.referenceCount') }}</span>
+      </div>
       <div v-if="showListSize" class="contents" role="columnheader" :aria-sort="getHeaderAriaSort('size')">
         <button
           type="button"

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -38,6 +38,8 @@ common:
     size: File size
     modifiedAt: Modified time
     createdAt: Created time
+    referenceCount: References
+    referenceCountValue: "{count} references"
     unavailableA11y: Unavailable
 
 filePicker:

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -39,7 +39,7 @@ common:
     modifiedAt: Modified time
     createdAt: Created time
     referenceCount: References
-    referenceCountValue: "{count} references"
+    referenceCountValue: "Reference count: {count}"
     unavailableA11y: Unavailable
 
 filePicker:

--- a/src/locales/ja.yml
+++ b/src/locales/ja.yml
@@ -38,6 +38,8 @@ common:
     size: ファイルサイズ
     modifiedAt: 更新日時
     createdAt: 作成日時
+    referenceCount: 参照数
+    referenceCountValue: "{count} 件の参照"
     unavailableA11y: 利用不可
 
 filePicker:

--- a/src/locales/zh-Hans.yml
+++ b/src/locales/zh-Hans.yml
@@ -38,6 +38,8 @@ common:
     size: 文件大小
     modifiedAt: 修改时间
     createdAt: 创建时间
+    referenceCount: 引用数
+    referenceCountValue: "{count} 处引用"
     unavailableA11y: 不可用
 
 filePicker:

--- a/src/locales/zh-Hant.yml
+++ b/src/locales/zh-Hant.yml
@@ -38,6 +38,8 @@ common:
     size: 檔案大小
     modifiedAt: 修改時間
     createdAt: 建立時間
+    referenceCount: 引用數
+    referenceCountValue: "{count} 處引用"
     unavailableA11y: 不可用
 
 filePicker:

--- a/src/services/__tests__/animation-table-sync.test.ts
+++ b/src/services/__tests__/animation-table-sync.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { AbsPath, normalizePosix } from '~/domain/path'
-import { isAnimationTableRelatedPath, syncAnimationTable } from '~/services/animation-table-sync'
+import { isAnimationTablePath, isAnimationTableRelatedPath, syncAnimationTable } from '~/services/animation-table-sync'
 
 import type { DirEntry } from '@tauri-apps/plugin-fs'
 
@@ -129,6 +129,14 @@ describe('animationTableSync', () => {
   })
 
   it('只把 animation 目录内非索引路径视为相关路径', () => {
+    expect(isAnimationTablePath(
+      AbsPath.from('/project'),
+      AbsPath.from('/project/game/animation/animationTable.json'),
+    )).toBe(true)
+    expect(isAnimationTablePath(
+      AbsPath.from('/project'),
+      AbsPath.from('/project/game/animation/fade.json'),
+    )).toBe(false)
     expect(isAnimationTableRelatedPath(
       AbsPath.from('/project'),
       AbsPath.from('/project/game/animation/aaa/bbb.json'),

--- a/src/services/animation-table-sync.ts
+++ b/src/services/animation-table-sync.ts
@@ -10,6 +10,11 @@ function getAnimationRootPath(gamePath: AbsPath): AbsPath {
   return AbsPath.join(gamePath, RelPath.from('game/animation'))
 }
 
+export function isAnimationTablePath(gamePath: AbsPath, path: AbsPath): boolean {
+  const animationRootPath = getAnimationRootPath(gamePath)
+  return path.toLowerCase() === `${animationRootPath}/${ANIMATION_TABLE_FILE_NAME}`.toLowerCase()
+}
+
 function toAnimationTableEntry(animationRootPath: AbsPath, path: AbsPath): RelPath | undefined {
   if (!path.startsWith(`${animationRootPath}/`)) {
     return
@@ -68,7 +73,7 @@ export function isAnimationTableRelatedPath(gamePath: AbsPath, path: AbsPath): b
     return false
   }
 
-  return path.toLowerCase() !== `${animationRootPath}/${ANIMATION_TABLE_FILE_NAME}`.toLowerCase()
+  return !isAnimationTablePath(gamePath, path)
 }
 
 export async function syncAnimationTable(gamePath: AbsPath): Promise<void> {

--- a/src/types/file-viewer.ts
+++ b/src/types/file-viewer.ts
@@ -9,6 +9,7 @@ export interface FileViewerItem {
   isDir: boolean
   mimeType?: string
   isSupported?: boolean
+  referenceCount?: number
   size?: number
   modifiedAt?: number
   createdAt?: number


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [ ] 错误修复
- [x] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [x] 测试用例
- [ ] 性能优化
- [x] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

- 为资源管理器资源项补充引用计数，计数来自现有资源索引，仅统计项目内可解析内容对当前资源的有效引用；未被引用的资源显示为 `0`。
- 网格模式在缩略图右上角显示带 `Link2` 图标的引用计数角标，使用低饱和色区分引用信息；列表模式增加独立的“引用数”列并保持纯数字显示。
- 资源索引完成初始化后展示计数，并订阅索引 revision，使引用新增、删除、修改以及资源重命名或移动后的刷新结果能够同步到资源管理器。
- 目录、索引未就绪、缺失资源、解析失败和无效引用不会被错误计入，也不会阻塞资源管理器加载。
- 同步中、英、日、繁中四份界面文本，并补充资源视图与文件查看器测试，覆盖零引用、多个引用、无效引用和引用变更刷新。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

资源管理器缺少资源使用范围的可见信息，用户在清理或移动资源前难以判断其影响。展示准确且能随资源索引刷新及时更新的引用计数，可以帮助用户快速识别未使用资源并评估操作风险，同时在缩略图和列表视图中保持一致的统计口径。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
