### PR TITLE
✨ 在编辑器标签中为同名文件追加路径提示

### DIFF
--- a/src/components/editor/EditorTabButton.vue
+++ b/src/components/editor/EditorTabButton.vue
@@ -39,7 +39,6 @@ const attrs = useAttrs()
       props.sorting ? 'cursor-grabbing' : 'cursor-default',
     ]"
     :style="props.itemStyle"
-    :title="props.tab.path"
     un-before="h-0.5 w-full absolute top-0 inset-x-0 content-empty z-20"
     v-bind="attrs"
   >

--- a/src/components/editor/EditorTabButton.vue
+++ b/src/components/editor/EditorTabButton.vue
@@ -12,6 +12,7 @@ interface Props {
   closeInteractive?: boolean
   diagnosticSeverity?: DiagnosticSeverity
   itemStyle?: StyleValue
+  pathHint?: string
   sorting?: boolean
   tab: Tab
   tintClass: string
@@ -38,6 +39,7 @@ const attrs = useAttrs()
       props.sorting ? 'cursor-grabbing' : 'cursor-default',
     ]"
     :style="props.itemStyle"
+    :title="props.tab.path"
     un-before="h-0.5 w-full absolute top-0 inset-x-0 content-empty z-20"
     v-bind="attrs"
   >
@@ -53,6 +55,7 @@ const attrs = useAttrs()
         :active="props.active"
         :close-interactive="props.closeInteractive"
         :diagnostic-severity="props.diagnosticSeverity"
+        :path-hint="props.pathHint"
         @close="emit('close')"
       />
     </span>

--- a/src/components/editor/EditorTabContent.vue
+++ b/src/components/editor/EditorTabContent.vue
@@ -30,7 +30,6 @@ function handleCloseClick() {
 
   emit('close')
 }
-
 </script>
 
 <template>

--- a/src/components/editor/EditorTabContent.vue
+++ b/src/components/editor/EditorTabContent.vue
@@ -30,6 +30,10 @@ function handleCloseClick() {
 
   emit('close')
 }
+
+function getPathHintLabel(pathHint: string): string {
+  return pathHint === '/' ? './' : `.../${pathHint}`
+}
 </script>
 
 <template>
@@ -50,7 +54,7 @@ function handleCloseClick() {
       class="text-[11.7px] text-muted-foreground/70 font-light max-w-28 min-w-0 truncate"
       data-editor-tab-path-hint
     >
-      ...\{{ props.pathHint }}
+      {{ getPathHintLabel(props.pathHint) }}
     </span>
     <Button
       variant="ghost"

--- a/src/components/editor/EditorTabContent.vue
+++ b/src/components/editor/EditorTabContent.vue
@@ -10,6 +10,7 @@ interface Props {
   active: boolean
   closeInteractive?: boolean
   diagnosticSeverity?: DiagnosticSeverity
+  pathHint?: string
   tab: Tab
 }
 
@@ -33,9 +34,9 @@ function handleCloseClick() {
 
 <template>
   <div class="flex gap-1.5 items-center">
-    <FileText class="size-4" />
+    <FileText class="shrink-0 size-4" />
     <span
-      class="text-sm font-light"
+      class="text-sm font-light shrink-0"
       :class="[
         { 'italic': props.tab.isPreview },
         getDiagnosticSeverityTextClass(props.diagnosticSeverity),
@@ -43,6 +44,13 @@ function handleCloseClick() {
       :data-diagnostic-severity="props.diagnosticSeverity"
     >
       {{ props.tab.name }}
+    </span>
+    <span
+      v-if="props.pathHint"
+      class="text-xs text-muted-foreground/70 max-w-28 min-w-0 truncate"
+      data-editor-tab-path-hint
+    >
+      ({{ props.pathHint }})
     </span>
     <Button
       variant="ghost"

--- a/src/components/editor/EditorTabContent.vue
+++ b/src/components/editor/EditorTabContent.vue
@@ -36,7 +36,7 @@ function handleCloseClick() {
   <div class="flex gap-1.5 items-center">
     <FileText class="shrink-0 size-4" />
     <span
-      class="text-sm font-light shrink-0"
+      class="text-13px font-light shrink-0"
       :class="[
         { 'italic': props.tab.isPreview },
         getDiagnosticSeverityTextClass(props.diagnosticSeverity),
@@ -47,10 +47,10 @@ function handleCloseClick() {
     </span>
     <span
       v-if="props.pathHint"
-      class="text-xs text-muted-foreground/70 max-w-28 min-w-0 truncate"
+      class="text-[11.7px] text-muted-foreground/70 font-light max-w-28 min-w-0 truncate"
       data-editor-tab-path-hint
     >
-      ({{ props.pathHint }})
+      ...\{{ props.pathHint }}
     </span>
     <Button
       variant="ghost"

--- a/src/components/editor/EditorTabContent.vue
+++ b/src/components/editor/EditorTabContent.vue
@@ -31,9 +31,6 @@ function handleCloseClick() {
   emit('close')
 }
 
-function getPathHintLabel(pathHint: string): string {
-  return pathHint === '/' ? './' : `.../${pathHint}`
-}
 </script>
 
 <template>
@@ -54,7 +51,7 @@ function getPathHintLabel(pathHint: string): string {
       class="text-[11.7px] text-muted-foreground/70 font-light max-w-28 min-w-0 truncate"
       data-editor-tab-path-hint
     >
-      {{ getPathHintLabel(props.pathHint) }}
+      {{ props.pathHint }}
     </span>
     <Button
       variant="ghost"

--- a/src/components/editor/EditorTabs.spec.ts
+++ b/src/components/editor/EditorTabs.spec.ts
@@ -266,11 +266,36 @@ describe('EditorTabs', () => {
     const assetsPathHint = assetsTab?.querySelector('[data-editor-tab-path-hint]')
 
     expect(scenesTab?.querySelector('.text-13px')).toBeTruthy()
-    expect(scenesPathHint).toHaveTextContent(String.raw`...\scenes`)
+    expect(scenesPathHint).toHaveTextContent('.../scenes')
     expect(scenesPathHint).toHaveClass('text-[11.7px]')
-    expect(assetsPathHint).toHaveTextContent(String.raw`...\assets`)
+    expect(assetsPathHint).toHaveTextContent('.../assets')
     expect(assetsPathHint).toHaveClass('text-[11.7px]')
     expect(otherTab?.querySelector('[data-editor-tab-path-hint]')).toBeNull()
+  })
+
+  it('根目录文档使用归一化的当前目录提示', () => {
+    useTabsStoreMock.mockReturnValue(createTabsStore([
+      {
+        activeAt: 1,
+        isPreview: false,
+        name: 'test.txt',
+        path: AbsPath.from('/test.txt'),
+      },
+      {
+        activeAt: 2,
+        isPreview: false,
+        name: 'test.txt',
+        path: AbsPath.from('/x/test.txt'),
+      },
+    ]))
+
+    renderInBrowser(EditorTabs, { global: {} })
+
+    const rootTab = document.querySelector<HTMLElement>('[data-testid="editor-tab-/test.txt"]')
+    const nestedTab = document.querySelector<HTMLElement>('[data-testid="editor-tab-/x/test.txt"]')
+
+    expect(rootTab?.querySelector('[data-editor-tab-path-hint]')).toHaveTextContent('./')
+    expect(nestedTab?.querySelector('[data-editor-tab-path-hint]')).toHaveTextContent('.../x')
   })
 
   it('双击预览标签会将其固定为普通标签', async () => {

--- a/src/components/editor/EditorTabs.spec.ts
+++ b/src/components/editor/EditorTabs.spec.ts
@@ -281,7 +281,6 @@ describe('EditorTabs', () => {
     const assetsPathHint = assetsTab?.querySelector('[data-editor-tab-path-hint]')
 
     expect(scenesTab?.querySelector('.text-13px')).toBeTruthy()
-    expect(scenesTab).toHaveAttribute('title', '/project/game/scene/scene.txt')
     expect(scenesPathHint).toHaveTextContent('scene')
     expect(scenesPathHint).toHaveClass('text-[11.7px]')
     expect(assetsPathHint).toHaveTextContent('background')

--- a/src/components/editor/EditorTabs.spec.ts
+++ b/src/components/editor/EditorTabs.spec.ts
@@ -281,6 +281,7 @@ describe('EditorTabs', () => {
     const assetsPathHint = assetsTab?.querySelector('[data-editor-tab-path-hint]')
 
     expect(scenesTab?.querySelector('.text-13px')).toBeTruthy()
+    expect(scenesTab).toHaveAttribute('title', '/project/game/scene/scene.txt')
     expect(scenesPathHint).toHaveTextContent('scene')
     expect(scenesPathHint).toHaveClass('text-[11.7px]')
     expect(assetsPathHint).toHaveTextContent('background')

--- a/src/components/editor/EditorTabs.spec.ts
+++ b/src/components/editor/EditorTabs.spec.ts
@@ -262,8 +262,14 @@ describe('EditorTabs', () => {
     const assetsTab = document.querySelector<HTMLElement>('[data-testid="editor-tab-/project/assets/scene.txt"]')
     const otherTab = document.querySelector<HTMLElement>('[data-testid="editor-tab-/project/other.txt"]')
 
-    expect(scenesTab?.querySelector('[data-editor-tab-path-hint]')).toHaveTextContent('(scenes)')
-    expect(assetsTab?.querySelector('[data-editor-tab-path-hint]')).toHaveTextContent('(assets)')
+    const scenesPathHint = scenesTab?.querySelector('[data-editor-tab-path-hint]')
+    const assetsPathHint = assetsTab?.querySelector('[data-editor-tab-path-hint]')
+
+    expect(scenesTab?.querySelector('.text-13px')).toBeTruthy()
+    expect(scenesPathHint).toHaveTextContent(String.raw`...\scenes`)
+    expect(scenesPathHint).toHaveClass('text-[11.7px]')
+    expect(assetsPathHint).toHaveTextContent(String.raw`...\assets`)
+    expect(assetsPathHint).toHaveClass('text-[11.7px]')
     expect(otherTab?.querySelector('[data-editor-tab-path-hint]')).toBeNull()
   })
 

--- a/src/components/editor/EditorTabs.spec.ts
+++ b/src/components/editor/EditorTabs.spec.ts
@@ -67,6 +67,7 @@ const {
   useEditorDiagnosticsStoreMock,
   useModalStoreMock,
   useTabsStoreMock,
+  useWorkspaceStoreMock,
 } = vi.hoisted(() => ({
   modalOpenMock: vi.fn(),
   saveFileMock: vi.fn(),
@@ -74,6 +75,7 @@ const {
   useEditorDiagnosticsStoreMock: vi.fn(),
   useModalStoreMock: vi.fn(),
   useTabsStoreMock: vi.fn(),
+  useWorkspaceStoreMock: vi.fn(),
 }))
 
 vi.mock('~/stores/editor', () => ({
@@ -91,6 +93,16 @@ vi.mock('~/stores/modal', () => ({
 vi.mock('~/stores/tabs', () => ({
   useTabsStore: useTabsStoreMock,
 }))
+
+vi.mock('~/stores/workspace', () => ({
+  useWorkspaceStore: useWorkspaceStoreMock,
+}))
+
+function createWorkspaceStore(gamePath?: string) {
+  return reactive({
+    currentGame: gamePath ? { path: AbsPath.from(gamePath) } : undefined,
+  })
+}
 
 function createTabsStore(tabs: Tab[], activeTabIndex: number = 0) {
   const store = reactive({
@@ -147,6 +159,7 @@ describe('EditorTabs', () => {
     useEditorDiagnosticsStoreMock.mockReset()
     useModalStoreMock.mockReset()
     useTabsStoreMock.mockReset()
+    useWorkspaceStoreMock.mockReset()
 
     useEditorStoreMock.mockReturnValue({
       saveFile: saveFileMock,
@@ -157,6 +170,7 @@ describe('EditorTabs', () => {
     useModalStoreMock.mockReturnValue({
       open: modalOpenMock,
     })
+    useWorkspaceStoreMock.mockReturnValue(createWorkspaceStore())
   })
 
   it('按文档最高问题等级只给标签名称着色', async () => {
@@ -235,67 +249,69 @@ describe('EditorTabs', () => {
   })
 
   it('同名标签会显示足以区分文件的父目录提示', () => {
+    useWorkspaceStoreMock.mockReturnValue(createWorkspaceStore('/project'))
     useTabsStoreMock.mockReturnValue(createTabsStore([
       {
         activeAt: 1,
         isPreview: false,
         name: 'scene.txt',
-        path: AbsPath.from('/project/scenes/scene.txt'),
+        path: AbsPath.from('/project/game/scene/scene.txt'),
       },
       {
         activeAt: 2,
         isPreview: false,
         name: 'scene.txt',
-        path: AbsPath.from('/project/assets/scene.txt'),
+        path: AbsPath.from('/project/game/background/scene.txt'),
       },
       {
         activeAt: 3,
         isPreview: false,
         name: 'other.txt',
-        path: AbsPath.from('/project/other.txt'),
+        path: AbsPath.from('/project/game/other.txt'),
       },
     ]))
 
     renderInBrowser(EditorTabs, { global: {} })
 
-    const scenesTab = document.querySelector<HTMLElement>('[data-testid="editor-tab-/project/scenes/scene.txt"]')
-    const assetsTab = document.querySelector<HTMLElement>('[data-testid="editor-tab-/project/assets/scene.txt"]')
-    const otherTab = document.querySelector<HTMLElement>('[data-testid="editor-tab-/project/other.txt"]')
+    const scenesTab = document.querySelector<HTMLElement>('[data-testid="editor-tab-/project/game/scene/scene.txt"]')
+    const assetsTab = document.querySelector<HTMLElement>('[data-testid="editor-tab-/project/game/background/scene.txt"]')
+    const otherTab = document.querySelector<HTMLElement>('[data-testid="editor-tab-/project/game/other.txt"]')
 
     const scenesPathHint = scenesTab?.querySelector('[data-editor-tab-path-hint]')
     const assetsPathHint = assetsTab?.querySelector('[data-editor-tab-path-hint]')
 
     expect(scenesTab?.querySelector('.text-13px')).toBeTruthy()
-    expect(scenesPathHint).toHaveTextContent('.../scenes')
+    expect(scenesPathHint).toHaveTextContent('scene')
     expect(scenesPathHint).toHaveClass('text-[11.7px]')
-    expect(assetsPathHint).toHaveTextContent('.../assets')
+    expect(assetsPathHint).toHaveTextContent('background')
     expect(assetsPathHint).toHaveClass('text-[11.7px]')
     expect(otherTab?.querySelector('[data-editor-tab-path-hint]')).toBeNull()
   })
 
-  it('根目录文档使用归一化的当前目录提示', () => {
+  it('同一资源根内的标签使用相对于资源根的路径提示', () => {
+    useWorkspaceStoreMock.mockReturnValue(createWorkspaceStore('/project'))
     useTabsStoreMock.mockReturnValue(createTabsStore([
       {
         activeAt: 1,
         isPreview: false,
-        name: 'test.txt',
-        path: AbsPath.from('/test.txt'),
+        name: 'scene.txt',
+        path: AbsPath.from('/project/game/scene/scene.txt'),
       },
       {
         activeAt: 2,
         isPreview: false,
-        name: 'test.txt',
-        path: AbsPath.from('/x/test.txt'),
+        name: 'scene.txt',
+        path: AbsPath.from('/project/game/scene/chapter-a/scene.txt'),
       },
     ]))
 
     renderInBrowser(EditorTabs, { global: {} })
 
-    const rootTab = document.querySelector<HTMLElement>('[data-testid="editor-tab-/test.txt"]')
-    const nestedTab = document.querySelector<HTMLElement>('[data-testid="editor-tab-/x/test.txt"]')
+    const rootTab = document.querySelector<HTMLElement>('[data-testid="editor-tab-/project/game/scene/scene.txt"]')
+    const nestedTab = document.querySelector<HTMLElement>('[data-testid="editor-tab-/project/game/scene/chapter-a/scene.txt"]')
 
     expect(rootTab?.querySelector('[data-editor-tab-path-hint]')).toHaveTextContent('./')
-    expect(nestedTab?.querySelector('[data-editor-tab-path-hint]')).toHaveTextContent('.../x')
+    expect(nestedTab?.querySelector('[data-editor-tab-path-hint]')).toHaveTextContent('chapter-a')
   })
 
   it('双击预览标签会将其固定为普通标签', async () => {

--- a/src/components/editor/EditorTabs.spec.ts
+++ b/src/components/editor/EditorTabs.spec.ts
@@ -234,6 +234,39 @@ describe('EditorTabs', () => {
     }))
   })
 
+  it('同名标签会显示足以区分文件的父目录提示', () => {
+    useTabsStoreMock.mockReturnValue(createTabsStore([
+      {
+        activeAt: 1,
+        isPreview: false,
+        name: 'scene.txt',
+        path: AbsPath.from('/project/scenes/scene.txt'),
+      },
+      {
+        activeAt: 2,
+        isPreview: false,
+        name: 'scene.txt',
+        path: AbsPath.from('/project/assets/scene.txt'),
+      },
+      {
+        activeAt: 3,
+        isPreview: false,
+        name: 'other.txt',
+        path: AbsPath.from('/project/other.txt'),
+      },
+    ]))
+
+    renderInBrowser(EditorTabs, { global: {} })
+
+    const scenesTab = document.querySelector<HTMLElement>('[data-testid="editor-tab-/project/scenes/scene.txt"]')
+    const assetsTab = document.querySelector<HTMLElement>('[data-testid="editor-tab-/project/assets/scene.txt"]')
+    const otherTab = document.querySelector<HTMLElement>('[data-testid="editor-tab-/project/other.txt"]')
+
+    expect(scenesTab?.querySelector('[data-editor-tab-path-hint]')).toHaveTextContent('(scenes)')
+    expect(assetsTab?.querySelector('[data-editor-tab-path-hint]')).toHaveTextContent('(assets)')
+    expect(otherTab?.querySelector('[data-editor-tab-path-hint]')).toBeNull()
+  })
+
   it('双击预览标签会将其固定为普通标签', async () => {
     const tabsStore = createTabsStore([
       {

--- a/src/components/editor/EditorTabs.vue
+++ b/src/components/editor/EditorTabs.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { useDragSort } from '~/composables/useDragSort'
+import { getEditorTabPathHints } from '~/features/editor/editor-tabs/editor-tab-path-hints'
 import { getCloseTabDecision, shouldFixPreviewTab } from '~/features/editor/editor-tabs/editor-tabs'
 import { useEditorStore } from '~/stores/editor'
 import { useEditorDiagnosticsStore } from '~/stores/editor-diagnostics'
@@ -18,6 +19,7 @@ const editorStore = useEditorStore()
 const modalStore = useModalStore()
 const tabs = toRef(tabsStore, 'tabs')
 const activeTabPath = $computed(() => tabsStore.activeTab?.path)
+const pathHints = $computed(() => getEditorTabPathHints(tabs.value))
 
 const scrollAreaRef = $(useTemplateRef('scrollAreaRef'))
 const scrollViewportRef = shallowRef<HTMLElement>()
@@ -46,6 +48,10 @@ function updateScrollViewportRef() {
 
 function isActiveTab(tab: Tab): boolean {
   return activeTabPath === tab.path
+}
+
+function getTabPathHint(tab: Tab): string | undefined {
+  return pathHints.get(tab.path)
 }
 
 function getTabTintClass(tab: Tab, isDragOverlay = false): string {
@@ -143,6 +149,7 @@ onMounted(() => {
         :diagnostic-severity="diagnosticsStore.getHighestSeverity(tab.path)"
         :sorting="tabSort.isSorting.value"
         :tab="tab"
+        :path-hint="getTabPathHint(tab)"
         :tint-class="getTabTintClass(tab)"
         :item-style="tabSort.getItemStyle(index)"
         :data-active="isActiveTab(tab)"
@@ -170,6 +177,7 @@ onMounted(() => {
       :close-interactive="false"
       :sorting="tabSort.isSorting.value"
       :tab="tabSort.overlayState.value.item"
+      :path-hint="getTabPathHint(tabSort.overlayState.value.item)"
       :tint-class="getTabTintClass(tabSort.overlayState.value.item, true)"
     />
   </DragOverlay>

--- a/src/components/editor/EditorTabs.vue
+++ b/src/components/editor/EditorTabs.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
 import { useDragSort } from '~/composables/useDragSort'
-import { getEditorTabPathHints } from '~/features/editor/editor-tabs/editor-tab-path-hints'
+import { getEditorTabPathHints, getEditorTabResourceRootPath } from '~/features/editor/editor-tabs/editor-tab-path-hints'
 import { getCloseTabDecision, shouldFixPreviewTab } from '~/features/editor/editor-tabs/editor-tabs'
 import { useEditorStore } from '~/stores/editor'
 import { useEditorDiagnosticsStore } from '~/stores/editor-diagnostics'
 import { useModalStore } from '~/stores/modal'
 import { useTabsStore } from '~/stores/tabs'
+import { useWorkspaceStore } from '~/stores/workspace'
 import { handleWheelToHorizontalScroll } from '~/utils/wheel'
 
 import type { ScrollArea } from '~/components/ui/scroll-area'
@@ -17,9 +18,14 @@ const tabsStore = useTabsStore()
 const diagnosticsStore = useEditorDiagnosticsStore()
 const editorStore = useEditorStore()
 const modalStore = useModalStore()
+const workspaceStore = useWorkspaceStore()
 const tabs = toRef(tabsStore, 'tabs')
 const activeTabPath = $computed(() => tabsStore.activeTab?.path)
-const pathHints = $computed(() => getEditorTabPathHints(tabs.value))
+const pathHints = $computed(() => getEditorTabPathHints(tabs.value.map(tab => ({
+  name: tab.name,
+  path: tab.path,
+  resourceRootPath: getEditorTabResourceRootPath(tab.path, workspaceStore.currentGame?.path),
+}))))
 
 const scrollAreaRef = $(useTemplateRef('scrollAreaRef'))
 const scrollViewportRef = shallowRef<HTMLElement>()

--- a/src/features/editor/editor-tabs/__tests__/editor-tab-path-hints.test.ts
+++ b/src/features/editor/editor-tabs/__tests__/editor-tab-path-hints.test.ts
@@ -2,12 +2,13 @@ import { describe, expect, it } from 'vitest'
 
 import { AbsPath } from '~/domain/path'
 
-import { getEditorTabPathHints } from '../editor-tab-path-hints'
+import { getEditorTabPathHints, getEditorTabResourceRootPath } from '../editor-tab-path-hints'
 
-function createTab(name: string, path: string) {
+function createTab(name: string, path: string, resourceRootPath?: string) {
   return {
     name,
     path: AbsPath.from(path),
+    resourceRootPath: resourceRootPath ? AbsPath.from(resourceRootPath) : undefined,
   }
 }
 
@@ -30,8 +31,8 @@ describe('getEditorTabPathHints', () => {
       createTab('scene.txt', secondPath),
     ])
 
-    expect(hints.get(firstPath)).toBe('scenes')
-    expect(hints.get(secondPath)).toBe('assets')
+    expect(hints.get(firstPath)).toBe('.../scenes')
+    expect(hints.get(secondPath)).toBe('.../assets')
   })
 
   it('父路径互为后缀时会继续追加上级目录直到产生差异', () => {
@@ -43,8 +44,8 @@ describe('getEditorTabPathHints', () => {
       createTab('scene.txt', secondPath),
     ])
 
-    expect(hints.get(firstPath)).toBe('game/route-a')
-    expect(hints.get(secondPath)).toBe('deep/route-a')
+    expect(hints.get(firstPath)).toBe('.../game/route-a')
+    expect(hints.get(secondPath)).toBe('.../deep/route-a')
   })
 
   it('最近父目录也相同时会保留共享目录之后的最短路径', () => {
@@ -56,8 +57,8 @@ describe('getEditorTabPathHints', () => {
       createTab('scene.txt', secondPath),
     ])
 
-    expect(hints.get(firstPath)).toBe('route-a/shared')
-    expect(hints.get(secondPath)).toBe('route-b/shared')
+    expect(hints.get(firstPath)).toBe('.../route-a/shared')
+    expect(hints.get(secondPath)).toBe('.../route-b/shared')
   })
 
   it('根目录文件会使用根标识参与路径区分', () => {
@@ -69,7 +70,53 @@ describe('getEditorTabPathHints', () => {
       createTab('scene.txt', nestedPath),
     ])
 
-    expect(hints.get(rootPath)).toBe('/')
-    expect(hints.get(nestedPath)).toBe('game')
+    expect(hints.get(rootPath)).toBe('./')
+    expect(hints.get(nestedPath)).toBe('.../game')
+  })
+
+  it('同一资源根内使用相对资源根的最短路径提示', () => {
+    const resourceRootPath = '/project/game/scene'
+    const rootPath = AbsPath.from(`${resourceRootPath}/scene.txt`)
+    const nestedPath = AbsPath.from(`${resourceRootPath}/chapter-a/scene.txt`)
+
+    const hints = getEditorTabPathHints([
+      createTab('scene.txt', rootPath, resourceRootPath),
+      createTab('scene.txt', nestedPath, resourceRootPath),
+    ])
+
+    expect(hints.get(rootPath)).toBe('./')
+    expect(hints.get(nestedPath)).toBe('chapter-a')
+  })
+
+  it('跨资源根时保留资源类型目录名', () => {
+    const scenePath = AbsPath.from('/project/game/scene/chapter-a/scene.txt')
+    const backgroundPath = AbsPath.from('/project/game/background/chapter-a/scene.txt')
+
+    const hints = getEditorTabPathHints([
+      createTab('scene.txt', scenePath, '/project/game/scene'),
+      createTab('scene.txt', backgroundPath, '/project/game/background'),
+    ])
+
+    expect(hints.get(scenePath)).toBe('scene/chapter-a')
+    expect(hints.get(backgroundPath)).toBe('background/chapter-a')
+  })
+})
+
+describe('getEditorTabResourceRootPath', () => {
+  const gamePath = AbsPath.from('/project')
+
+  it('将场景文件归入 game/scene 根目录', () => {
+    expect(getEditorTabResourceRootPath(AbsPath.from('/project/game/scene/chapter-a/start.txt'), gamePath))
+      .toBe('/project/game/scene')
+  })
+
+  it('将资产文件归入对应的 game 资源类型根目录', () => {
+    expect(getEditorTabResourceRootPath(AbsPath.from('/project/game/background/chapter-a/start.png'), gamePath))
+      .toBe('/project/game/background')
+  })
+
+  it('路径不属于当前项目时不设置资源根目录', () => {
+    expect(getEditorTabResourceRootPath(AbsPath.from('/other-project/game/scene/start.txt'), gamePath))
+      .toBeUndefined()
   })
 })

--- a/src/features/editor/editor-tabs/__tests__/editor-tab-path-hints.test.ts
+++ b/src/features/editor/editor-tabs/__tests__/editor-tab-path-hints.test.ts
@@ -74,6 +74,19 @@ describe('getEditorTabPathHints', () => {
     expect(hints.get(nestedPath)).toBe('.../game')
   })
 
+  it('根目录路径提示只保留一个根分隔符', () => {
+    const firstPath = AbsPath.from('/game/scene.txt')
+    const secondPath = AbsPath.from('/other/game/scene.txt')
+
+    const hints = getEditorTabPathHints([
+      createTab('scene.txt', firstPath),
+      createTab('scene.txt', secondPath),
+    ])
+
+    expect(hints.get(firstPath)).toBe('/game')
+    expect(hints.get(secondPath)).toBe('.../other/game')
+  })
+
   it('同一资源根内使用相对资源根的最短路径提示', () => {
     const resourceRootPath = '/project/game/scene'
     const rootPath = AbsPath.from(`${resourceRootPath}/scene.txt`)

--- a/src/features/editor/editor-tabs/__tests__/editor-tab-path-hints.test.ts
+++ b/src/features/editor/editor-tabs/__tests__/editor-tab-path-hints.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+
+import { AbsPath } from '~/domain/path'
+
+import { getEditorTabPathHints } from '../editor-tab-path-hints'
+
+function createTab(name: string, path: string) {
+  return {
+    name,
+    path: AbsPath.from(path),
+  }
+}
+
+describe('getEditorTabPathHints', () => {
+  it('没有同名标签页时不添加路径提示', () => {
+    const tabs = [
+      createTab('scene.txt', '/game/scenes/scene.txt'),
+      createTab('config.json', '/game/config.json'),
+    ]
+
+    expect(getEditorTabPathHints(tabs).size).toBe(0)
+  })
+
+  it('只显示足以区分同名标签页的最近父目录', () => {
+    const firstPath = AbsPath.from('/game/scenes/scene.txt')
+    const secondPath = AbsPath.from('/game/assets/scene.txt')
+
+    const hints = getEditorTabPathHints([
+      createTab('scene.txt', firstPath),
+      createTab('scene.txt', secondPath),
+    ])
+
+    expect(hints.get(firstPath)).toBe('scenes')
+    expect(hints.get(secondPath)).toBe('assets')
+  })
+
+  it('父路径互为后缀时会继续追加上级目录直到产生差异', () => {
+    const firstPath = AbsPath.from('/game/route-a/scene.txt')
+    const secondPath = AbsPath.from('/game/deep/route-a/scene.txt')
+
+    const hints = getEditorTabPathHints([
+      createTab('scene.txt', firstPath),
+      createTab('scene.txt', secondPath),
+    ])
+
+    expect(hints.get(firstPath)).toBe('game/route-a')
+    expect(hints.get(secondPath)).toBe('deep/route-a')
+  })
+
+  it('最近父目录也相同时会保留共享目录之后的最短路径', () => {
+    const firstPath = AbsPath.from('/game/route-a/shared/scene.txt')
+    const secondPath = AbsPath.from('/game/route-b/shared/scene.txt')
+
+    const hints = getEditorTabPathHints([
+      createTab('scene.txt', firstPath),
+      createTab('scene.txt', secondPath),
+    ])
+
+    expect(hints.get(firstPath)).toBe('route-a/shared')
+    expect(hints.get(secondPath)).toBe('route-b/shared')
+  })
+
+  it('根目录文件会使用根标识参与路径区分', () => {
+    const rootPath = AbsPath.from('/scene.txt')
+    const nestedPath = AbsPath.from('/game/scene.txt')
+
+    const hints = getEditorTabPathHints([
+      createTab('scene.txt', rootPath),
+      createTab('scene.txt', nestedPath),
+    ])
+
+    expect(hints.get(rootPath)).toBe('/')
+    expect(hints.get(nestedPath)).toBe('game')
+  })
+})

--- a/src/features/editor/editor-tabs/__tests__/editor-tab-path-hints.test.ts
+++ b/src/features/editor/editor-tabs/__tests__/editor-tab-path-hints.test.ts
@@ -97,8 +97,8 @@ describe('getEditorTabPathHints', () => {
       createTab('scene.txt', backgroundPath, '/project/game/background'),
     ])
 
-    expect(hints.get(scenePath)).toBe('scene/chapter-a')
-    expect(hints.get(backgroundPath)).toBe('background/chapter-a')
+    expect(hints.get(scenePath)).toBe('scene')
+    expect(hints.get(backgroundPath)).toBe('background')
   })
 })
 

--- a/src/features/editor/editor-tabs/editor-tab-path-hints.ts
+++ b/src/features/editor/editor-tabs/editor-tab-path-hints.ts
@@ -1,0 +1,73 @@
+import { AbsPath } from '~/domain/path'
+
+export interface EditorTabPathIdentity {
+  name: string
+  path: AbsPath
+}
+
+type PathSegments = readonly string[]
+
+/**
+ * 为同名标签页计算足以区分它们的父路径后缀。
+ *
+ * 只展示从文件所在目录向上数的最短唯一路径，避免把完整绝对路径带进标签页。
+ */
+export function getEditorTabPathHints(
+  tabs: readonly EditorTabPathIdentity[],
+): ReadonlyMap<AbsPath, string> {
+  const tabsByName = new Map<string, EditorTabPathIdentity[]>()
+
+  for (const tab of tabs) {
+    const sameNameTabs = tabsByName.get(tab.name)
+    if (sameNameTabs) {
+      sameNameTabs.push(tab)
+    } else {
+      tabsByName.set(tab.name, [tab])
+    }
+  }
+
+  const pathHints = new Map<AbsPath, string>()
+  for (const sameNameTabs of tabsByName.values()) {
+    if (sameNameTabs.length < 2) {
+      continue
+    }
+
+    const parentPaths = sameNameTabs.map(tab => getParentPathSegments(tab.path))
+    const depth = findMinimumUniqueSuffixDepth(parentPaths)
+
+    for (const [index, tab] of sameNameTabs.entries()) {
+      const parentPath = parentPaths[index]
+      if (parentPath) {
+        pathHints.set(tab.path, getPathSuffix(parentPath, depth))
+      }
+    }
+  }
+
+  return pathHints
+}
+
+function getParentPathSegments(path: AbsPath): PathSegments {
+  const segments = path.split('/').filter(Boolean)
+  if (path.startsWith('/')) {
+    segments.unshift('/')
+  }
+  segments.pop()
+  return segments
+}
+
+function findMinimumUniqueSuffixDepth(paths: readonly PathSegments[]): number {
+  const maximumDepth = Math.max(...paths.map(path => path.length), 1)
+
+  for (let depth = 1; depth <= maximumDepth; depth++) {
+    const suffixes = paths.map(path => getPathSuffix(path, depth))
+    if (new Set(suffixes).size === suffixes.length) {
+      return depth
+    }
+  }
+
+  return maximumDepth
+}
+
+function getPathSuffix(path: PathSegments, depth: number): string {
+  return path.slice(-depth).join('/')
+}

--- a/src/features/editor/editor-tabs/editor-tab-path-hints.ts
+++ b/src/features/editor/editor-tabs/editor-tab-path-hints.ts
@@ -87,10 +87,8 @@ function getDisplayParentPathSegments(
   }
 
   if (tab.resourceRootPath) {
-    const relativeParentPath = getRelativeParentPathSegments(tab.path, tab.resourceRootPath)
-    if (relativeParentPath) {
-      return [AbsPath.basename(tab.resourceRootPath), ...relativeParentPath]
-    }
+    // 不同资源根的根名已经足够区分标签，不再带入根内子目录。
+    return [AbsPath.basename(tab.resourceRootPath)]
   }
 
   return getAbsoluteParentPathSegments(tab.path)

--- a/src/features/editor/editor-tabs/editor-tab-path-hints.ts
+++ b/src/features/editor/editor-tabs/editor-tab-path-hints.ts
@@ -106,7 +106,7 @@ function getRelativeParentPathSegments(path: AbsPath, rootPath: AbsPath): PathSe
 function getAbsoluteParentPathSegments(path: AbsPath): PathSegments {
   const segments = path.split('/').filter(Boolean)
   if (path.startsWith('/')) {
-    segments.unshift('/')
+    segments.unshift('')
   }
   segments.pop()
   return segments

--- a/src/features/editor/editor-tabs/editor-tab-path-hints.ts
+++ b/src/features/editor/editor-tabs/editor-tab-path-hints.ts
@@ -1,8 +1,10 @@
 import { AbsPath } from '~/domain/path'
+import { gameRootDir } from '~/services/platform/app-paths'
 
 export interface EditorTabPathIdentity {
   name: string
   path: AbsPath
+  resourceRootPath?: AbsPath
 }
 
 type PathSegments = readonly string[]
@@ -32,21 +34,78 @@ export function getEditorTabPathHints(
       continue
     }
 
-    const parentPaths = sameNameTabs.map(tab => getParentPathSegments(tab.path))
+    const sharedResourceRootPath = getSharedResourceRootPath(sameNameTabs)
+    const parentPaths = sameNameTabs.map(tab => getDisplayParentPathSegments(tab, sharedResourceRootPath))
     const depth = findMinimumUniqueSuffixDepth(parentPaths)
 
     for (const [index, tab] of sameNameTabs.entries()) {
       const parentPath = parentPaths[index]
-      if (parentPath) {
-        pathHints.set(tab.path, getPathSuffix(parentPath, depth))
-      }
+      pathHints.set(tab.path, createPathHint(parentPath, depth))
     }
   }
 
   return pathHints
 }
 
-function getParentPathSegments(path: AbsPath): PathSegments {
+/**
+ * 根据游戏工程路径识别文档所属的资源根目录。
+ *
+ * 场景和资产都位于 game 目录的一级子目录下，标签提示只在该资源根内展示相对路径。
+ */
+export function getEditorTabResourceRootPath(path: AbsPath, gamePath?: AbsPath): AbsPath | undefined {
+  if (!gamePath) {
+    return
+  }
+
+  const gameRootPath = gameRootDir(gamePath)
+  let relativePath: string
+  try {
+    relativePath = AbsPath.relativize(path, gameRootPath)
+  } catch {
+    return
+  }
+
+  const segments = relativePath.split('/').filter(Boolean)
+  return segments.length > 1 ? AbsPath.append(gameRootPath, segments[0]!) : gameRootPath
+}
+
+function getSharedResourceRootPath(tabs: readonly EditorTabPathIdentity[]): AbsPath | undefined {
+  const resourceRootPath = tabs[0]?.resourceRootPath
+  if (!resourceRootPath || tabs.some(tab => tab.resourceRootPath !== resourceRootPath)) {
+    return
+  }
+
+  return resourceRootPath
+}
+
+function getDisplayParentPathSegments(
+  tab: EditorTabPathIdentity,
+  sharedResourceRootPath?: AbsPath,
+): PathSegments {
+  if (sharedResourceRootPath) {
+    return getRelativeParentPathSegments(tab.path, sharedResourceRootPath) ?? getAbsoluteParentPathSegments(tab.path)
+  }
+
+  if (tab.resourceRootPath) {
+    const relativeParentPath = getRelativeParentPathSegments(tab.path, tab.resourceRootPath)
+    if (relativeParentPath) {
+      return [AbsPath.basename(tab.resourceRootPath), ...relativeParentPath]
+    }
+  }
+
+  return getAbsoluteParentPathSegments(tab.path)
+}
+
+function getRelativeParentPathSegments(path: AbsPath, rootPath: AbsPath): PathSegments | undefined {
+  try {
+    const relativePath = AbsPath.relativize(AbsPath.parent(path), rootPath)
+    return relativePath.split('/').filter(Boolean)
+  } catch {
+    return
+  }
+}
+
+function getAbsoluteParentPathSegments(path: AbsPath): PathSegments {
   const segments = path.split('/').filter(Boolean)
   if (path.startsWith('/')) {
     segments.unshift('/')
@@ -70,4 +129,13 @@ function findMinimumUniqueSuffixDepth(paths: readonly PathSegments[]): number {
 
 function getPathSuffix(path: PathSegments, depth: number): string {
   return path.slice(-depth).join('/')
+}
+
+function createPathHint(path: PathSegments, depth: number): string {
+  const suffix = getPathSuffix(path, depth)
+  if (!suffix || suffix === '/') {
+    return './'
+  }
+
+  return depth < path.length ? `.../${suffix}` : suffix
 }


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [ ] 错误修复
- [x] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [x] 测试用例
- [ ] 性能优化
- [x] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

- 当多个打开的文件同名时，在编辑器标签标题后显示足以区分文件的最短父路径提示；唯一文件不增加额外路径文本。
- 场景文件以 `game/scene` 为资源根，其他资源以对应的 `game/{assetType}` 为资源根；同一资源根内使用相对资源根的路径，跨资源根时保留资源类型目录名。
- 路径提示直接使用项目统一归一化后的 `/` 表示；只有确实省略了父级路径时才显示 `.../`，资源根目录下的文件显示 `./`。
- 调整标签名称与路径提示的字号、收缩和截断行为，并让拖拽浮层保持相同的路径提示。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

编辑器允许同时打开多个同名文件，只有文件名时难以判断当前标签对应的文件。需要在不挤压文件名、不引入 Windows 路径分隔符分裂的前提下提供足够的上下文，同时遵循项目资源目录边界，让场景和各类资产的提示从各自资源根开始计算。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
