### PR TITLE
✨ 保护场景入口文件并完善预览状态

### DIFF
--- a/src/components/editor/FileTree.vue
+++ b/src/components/editor/FileTree.vue
@@ -39,6 +39,7 @@ interface Props {
   sortOrder?: FileViewerSortOrder
   enableDragTransfer?: boolean
   rootPath?: string
+  isPathOperationDisabled?: (path: string) => boolean
 }
 
 const {
@@ -60,6 +61,7 @@ const {
   sortOrder = 'asc',
   enableDragTransfer = false,
   rootPath,
+  isPathOperationDisabled,
 } = defineProps<Props>()
 const inputRef: Readonly<ShallowRef<unknown>> = useTemplateRef('inputRef')
 const creatingInputRef: Readonly<ShallowRef<unknown>> = useTemplateRef('creatingInputRef')
@@ -132,6 +134,7 @@ const {
   sortBy: () => sortBy,
   sortOrder: () => sortOrder,
   treeName: () => treeName,
+  isPathOperationDisabled: path => isPathOperationDisabled?.(path) ?? false,
 })
 const fileTreeViewportRef = computed(() => getViewportElement())
 
@@ -628,6 +631,15 @@ function getFileTreeDragSourceProps(item: FlattenedItem<T>) {
     : {} as FileTreeDragSourceHandlers
 }
 
+function isOperationDisabledForPath(path: string): boolean {
+  return isPathOperationDisabled?.(path) ?? false
+}
+
+function isOperationDisabledForSelection(path: string): boolean {
+  return isOperationDisabledForPath(path)
+    || selectedFileTreePaths.some(selectedPath => isOperationDisabledForPath(selectedPath))
+}
+
 function getFileTreeItemBind(item: FlattenedItem<T>) {
   const dragSourceProps = getFileTreeDragSourceProps(item)
 
@@ -718,7 +730,7 @@ function handleShortcutRename() {
   }
 
   const fileItem = toShortcutTargetFileItem()
-  if (!fileItem) {
+  if (!fileItem || isOperationDisabledForSelection(fileItem.path)) {
     return
   }
 
@@ -731,7 +743,7 @@ function handleShortcutDelete() {
   }
 
   const fileItem = toShortcutTargetFileItem()
-  if (!fileItem) {
+  if (!fileItem || isOperationDisabledForSelection(fileItem.path)) {
     return
   }
 
@@ -844,9 +856,11 @@ tryOnUnmounted(() => {
             <FileTreeContextMenu
               v-else
               :item="renderItem.fileItem"
+              :selected-items="getFileTreeSelectedItems(renderItem.fileItem)"
               :on-rename="handleContextMenuRename"
               :on-create-file="handleContextMenuCreateFile"
               :on-create-folder="handleContextMenuCreateFolder"
+              :operation-disabled="isOperationDisabledForSelection(renderItem.fileItem.path)"
               :disabled="!enableContextMenu"
             >
               <TreeItem
@@ -920,7 +934,7 @@ tryOnUnmounted(() => {
                           </div>
                           <span
                             v-if="resolveItemBadgeText(renderItem.item.value)"
-                            class="text-[10px] text-muted-foreground leading-none px-1.5 py-0.5 rounded bg-muted shrink-0"
+                            class="text-[10px] text-muted-foreground leading-none px-1.5 py-0.75 rounded bg-muted shrink-0"
                           >
                             {{ resolveItemBadgeText(renderItem.item.value) }}
                           </span>

--- a/src/components/editor/FileTreeContextMenu.vue
+++ b/src/components/editor/FileTreeContextMenu.vue
@@ -8,21 +8,25 @@ interface FileItem {
 
 interface Props {
   item: FileItem
+  selectedItems?: FileItem[]
   onRename?: (item: FileItem) => void
   onCreateFile?: (item: FileItem) => void
   onCreateFolder?: (item: FileItem) => void
   clipboardKey?: string
   disabled?: boolean
+  operationDisabled?: boolean
   isRoot?: boolean
 }
 
 const {
   item,
+  selectedItems,
   onRename,
   onCreateFile,
   onCreateFolder,
   clipboardKey = 'default',
   disabled = false,
+  operationDisabled = false,
   isRoot = false,
 } = defineProps<Props>()
 </script>
@@ -37,9 +41,11 @@ const {
         :clipboard-key="clipboardKey"
         :is-root="isRoot"
         :item="item"
+        :selected-items="selectedItems"
         :on-create-file="onCreateFile"
         :on-create-folder="onCreateFolder"
         :on-rename="onRename"
+        :operation-disabled="operationDisabled"
       />
     </ContextMenuContent>
   </ContextMenu>

--- a/src/components/editor/FileTreeContextMenuContent.spec.ts
+++ b/src/components/editor/FileTreeContextMenuContent.spec.ts
@@ -155,4 +155,24 @@ describe('FileTreeContextMenuContent', () => {
     const openFolderItem = page.getByText('edit.fileTree.revealInExplorer')
     await expect.element(openFolderItem).toBeDisabled()
   })
+
+  it('受保护入口文件会保留但禁用剪切、重命名和删除', async () => {
+    renderInBrowser(FileTreeContextMenuContent, {
+      props: {
+        item: {
+          name: 'start.txt',
+          path: '/games/demo/game/scene/start.txt',
+        },
+        onRename: vi.fn(),
+        operationDisabled: true,
+      },
+      global: {
+        stubs: globalStubs,
+      },
+    })
+
+    await expect.element(page.getByText('edit.fileTree.cut')).toBeDisabled()
+    await expect.element(page.getByText('edit.fileTree.rename')).toBeDisabled()
+    await expect.element(page.getByText('common.delete')).toBeDisabled()
+  })
 })

--- a/src/components/editor/FileTreeContextMenuContent.vue
+++ b/src/components/editor/FileTreeContextMenuContent.vue
@@ -36,22 +36,26 @@ interface FileItem {
 
 interface Props {
   item: FileItem
+  selectedItems?: FileItem[]
   onRename?: (item: FileItem) => void
   onCreateFile?: (item: FileItem) => void
   onCreateFolder?: (item: FileItem) => void
   clipboardKey?: string
   isRoot?: boolean
   revealInExplorerDisabled?: boolean
+  operationDisabled?: boolean
 }
 
 const {
   item,
+  selectedItems = [],
   onRename,
   onCreateFile,
   onCreateFolder,
   clipboardKey = 'default',
   isRoot = false,
   revealInExplorerDisabled = false,
+  operationDisabled = false,
 } = defineProps<Props>()
 
 const { clipboard, operationType, canPaste, setClipboard, clearClipboard } = $(useFileClipboard(clipboardKey))
@@ -81,20 +85,20 @@ function handleCreateFolder(): void {
   onCreateFolder?.(item)
 }
 
+function updateClipboard(isCut: boolean): void {
+  setClipboard((selectedItems.length > 0 ? selectedItems : [item]).map(selectedItem => ({
+    path: selectedItem.path,
+    isCut,
+    isDir: selectedItem.isDir ?? false,
+  })))
+}
+
 function handleCopy(): void {
-  setClipboard({
-    path: item.path,
-    isCut: false,
-    isDir: item.isDir ?? false,
-  })
+  updateClipboard(false)
 }
 
 function handleCut(): void {
-  setClipboard({
-    path: item.path,
-    isCut: true,
-    isDir: item.isDir ?? false,
-  })
+  updateClipboard(true)
 }
 
 async function handlePaste(): Promise<void> {
@@ -206,7 +210,7 @@ const menuItems = $computed(() => {
   if (!isRoot) {
     items.push(
       { icon: Copy, label: t('edit.fileTree.copy'), onClick: handleCopy },
-      { icon: Scissors, label: t('edit.fileTree.cut'), onClick: handleCut },
+      { icon: Scissors, label: t('edit.fileTree.cut'), onClick: handleCut, disabled: operationDisabled },
     )
   }
 
@@ -223,7 +227,7 @@ const menuItems = $computed(() => {
     pushSeparator(items)
 
     if (onRename) {
-      items.push({ icon: Pencil, label: t('edit.fileTree.rename'), onClick: handleRename })
+      items.push({ icon: Pencil, label: t('edit.fileTree.rename'), onClick: handleRename, disabled: operationDisabled })
     }
 
     if (sceneLogicalPath) {
@@ -234,6 +238,7 @@ const menuItems = $computed(() => {
       icon: Trash2,
       label: t('common.delete'),
       onClick: handleDelete,
+      disabled: operationDisabled,
       class: 'text-destructive focus:text-destructive-foreground focus:bg-destructive',
     })
   }

--- a/src/components/editor/PreviewPanel.spec.ts
+++ b/src/components/editor/PreviewPanel.spec.ts
@@ -30,6 +30,7 @@ const {
   usePreviewRuntimeStoreMock,
   usePreviewSessionStoreMock,
   usePreviewSyncStoreMock,
+  useSceneEntryStatusMock,
   useWorkspaceStoreMock,
 } = vi.hoisted(() => ({
   copyMock: vi.fn(),
@@ -47,6 +48,7 @@ const {
   usePreviewRuntimeStoreMock: vi.fn(),
   usePreviewSessionStoreMock: vi.fn(),
   usePreviewSyncStoreMock: vi.fn(),
+  useSceneEntryStatusMock: vi.fn(),
   useWorkspaceStoreMock: vi.fn(),
 }))
 
@@ -93,6 +95,10 @@ vi.mock('~/stores/preview-session', () => ({
 
 vi.mock('~/stores/preview-sync', () => ({
   usePreviewSyncStore: usePreviewSyncStoreMock,
+}))
+
+vi.mock('~/features/editor/scene-entry/useSceneEntryStatus', () => ({
+  useSceneEntryStatus: useSceneEntryStatusMock,
 }))
 
 vi.mock('~/commands/game', async () => {
@@ -147,6 +153,10 @@ let previewSessionStoreState: {
   currentGameServeUrl: string
   reloadVersion: number
   refresh: () => void
+}
+
+let sceneEntryStatusState: {
+  status: ReturnType<typeof ref<'valid' | 'missing'>>
 }
 
 const transformOverlayReferenceBox: ReferenceBox = {
@@ -322,6 +332,7 @@ describe('PreviewPanel', () => {
     usePreviewRuntimeStoreMock.mockReset()
     usePreviewSessionStoreMock.mockReset()
     usePreviewSyncStoreMock.mockReset()
+    useSceneEntryStatusMock.mockReset()
     useWorkspaceStoreMock.mockReset()
 
     workspaceStoreState = reactive({
@@ -343,6 +354,10 @@ describe('PreviewPanel', () => {
       },
     })
     usePreviewSessionStoreMock.mockReturnValue(previewSessionStoreState)
+    sceneEntryStatusState = {
+      status: ref('valid'),
+    }
+    useSceneEntryStatusMock.mockReturnValue(sceneEntryStatusState)
     useClipboardMock.mockReturnValue({
       copied: ref(true),
       copy: copyMock,
@@ -395,6 +410,33 @@ describe('PreviewPanel', () => {
     expect(getGameConfigMock).toHaveBeenCalledWith('/games/demo')
     expect(resetEmbeddedPreviewStateMock).toHaveBeenCalledTimes(1)
     expect(setEmbeddedPreviewLaunchIdMock).toHaveBeenCalledWith(expect.any(String))
+  })
+
+  it('缺少规范入口时只显示错误遮罩，入口恢复后重新挂载预览', async () => {
+    sceneEntryStatusState.status.value = 'missing'
+
+    renderInBrowser(PreviewPanel, {
+      global: {
+        plugins: [createPreviewPanelLiteI18n()],
+        stubs: globalStubs,
+      },
+    })
+
+    await expect.element(page.getByTestId('preview-missing-entry-overlay')).toHaveRole('alert')
+    expect(document.querySelector('iframe')).toBeNull()
+    await expect.element(page.getByTestId('preview-bottom-toolbar')).toBeVisible()
+    await expect.element(page.getByRole('button', { name: 'edit.previewPanel.zoomOut' })).toBeDisabled()
+    await expect.element(page.getByRole('button', { name: 'edit.previewPanel.zoomIn' })).toBeDisabled()
+    await expect.element(page.getByRole('button', { name: 'edit.previewPanel.fitToView' })).toBeDisabled()
+    await expect.element(page.getByRole('button', { name: 'edit.previewPanel.refreshPreview' })).toBeDisabled()
+    await expect.element(page.getByRole('button', { name: 'edit.previewPanel.copyUrl' })).toBeDisabled()
+    await expect.element(page.getByRole('button', { name: 'edit.previewPanel.openInBrowser' })).toBeDisabled()
+
+    sceneEntryStatusState.status.value = 'valid'
+    await nextTick()
+
+    await expect.element(page.getByTitle('preview-title::Demo Game')).toBeVisible()
+    expect(previewSessionStoreState.reloadVersion).toBeGreaterThan(0)
   })
 
   it('收到同源 iframe 转发的空格按键消息时会让 iframe 上的拖拽交给外层视口平移', async () => {

--- a/src/components/editor/PreviewPanel.vue
+++ b/src/components/editor/PreviewPanel.vue
@@ -19,6 +19,7 @@ import {
   resolvePreviewPanelStageSize,
 } from '~/features/editor/preview/preview-panel'
 import { resolvePreviewReadySyncTarget } from '~/features/editor/preview/preview-ready-sync-target'
+import { useSceneEntryStatus } from '~/features/editor/scene-entry/useSceneEntryStatus'
 import { useShortcutContext } from '~/features/editor/shortcut/useShortcutContext'
 import { TRANSFORM_OVERLAY_BRIDGE_KEY } from '~/features/editor/transform-overlay/context'
 import { debugCommander } from '~/services/debug-commander'
@@ -42,6 +43,7 @@ const previewRuntimeStore = usePreviewRuntimeStore()
 const previewSessionStore = usePreviewSessionStore()
 const previewSyncStore = usePreviewSyncStore()
 const workspaceStore = useWorkspaceStore()
+const sceneEntryStatus = useSceneEntryStatus()
 const iframeRef = useTemplateRef<HTMLIFrameElement>('iframeRef')
 const previewWorkspaceRef = useTemplateRef<HTMLElement>('previewWorkspace')
 const viewportRef = useTemplateRef<HTMLElement>('viewportRef')
@@ -52,6 +54,8 @@ const transformOverlayDisplayTransform = $computed(() => transformOverlayBridge?
 
 const previewUrl = $computed(() => previewSessionStore.currentGameServeUrl ?? '')
 const hasPreviewUrl = $computed(() => !!previewSessionStore.currentGameServeUrl)
+const hasValidEntryPoint = $computed(() => sceneEntryStatus.status.value === 'valid')
+const canPreview = $computed(() => hasPreviewUrl && hasValidEntryPoint)
 
 const { t } = useI18n()
 const { copy } = useClipboard({ source: $$(previewUrl) })
@@ -155,6 +159,22 @@ function handlePreviewWorkspacePointerDown(event: PointerEvent): void {
   }
 }
 
+function handlePreviewViewportWheel(event: WheelEvent): void {
+  if (!canPreview) {
+    return
+  }
+
+  previewViewport.handleWheel(event)
+}
+
+function handlePreviewViewportPointerDown(event: PointerEvent): void {
+  if (!canPreview) {
+    return
+  }
+
+  previewViewport.handlePointerDown(event)
+}
+
 function applyStageSize(nextStageSize: PreviewPanelStageSize) {
   aspectRatio = nextStageSize.aspectRatio
   stageWidth = nextStageSize.stageWidth
@@ -248,12 +268,12 @@ function updateEmbeddedPreviewSlot(nextEmbeddedLaunchId?: string): void {
 }
 
 function refreshEmbeddedPreviewSlot(): void {
-  const nextEmbeddedLaunchId = hasPreviewUrl ? createEmbeddedPreviewLaunchId() : undefined
+  const nextEmbeddedLaunchId = canPreview ? createEmbeddedPreviewLaunchId() : undefined
   updateEmbeddedPreviewSlot(nextEmbeddedLaunchId)
 }
 
 async function copyUrl(): Promise<void> {
-  if (!hasPreviewUrl) {
+  if (!canPreview) {
     return
   }
 
@@ -269,7 +289,7 @@ function refreshIframe(): void {
 }
 
 async function openPreviewInBrowser(): Promise<void> {
-  if (!hasPreviewUrl) {
+  if (!canPreview) {
     return
   }
 
@@ -464,6 +484,20 @@ watch(
 )
 
 watch(
+  () => sceneEntryStatus.status.value,
+  (status, previousStatus) => {
+    if (status === 'missing') {
+      updateEmbeddedPreviewSlot(undefined)
+      return
+    }
+
+    if (status === 'valid' && previousStatus === 'missing' && hasPreviewUrl) {
+      previewSessionStore.refresh()
+    }
+  },
+)
+
+watch(
   [() => previewSyncStore.isPreviewReady, () => embeddedLaunchId],
   ([isPreviewReady, currentEmbeddedLaunchId]) => {
     if (!isPreviewReady || !currentEmbeddedLaunchId || consumedReadyLaunchId === currentEmbeddedLaunchId) {
@@ -520,7 +554,7 @@ onBeforeUnmount(() => {
         <div class="text-muted-foreground flex flex-shrink-0 gap-1">
           <Tooltip>
             <TooltipTrigger as-child>
-              <Button variant="ghost" size="icon" class="size-6" @click="copyUrl">
+              <Button variant="ghost" size="icon" class="size-6" :disabled="!canPreview" @click="copyUrl">
                 <Copy class="size-4" />
                 <span class="sr-only">{{ $t('edit.previewPanel.copyUrl') }}</span>
               </Button>
@@ -531,7 +565,7 @@ onBeforeUnmount(() => {
           </Tooltip>
           <Tooltip>
             <TooltipTrigger as-child>
-              <Button variant="ghost" size="icon" class="size-6" @click="previewSessionStore.refresh()">
+              <Button variant="ghost" size="icon" class="size-6" :disabled="!canPreview" @click="previewSessionStore.refresh()">
                 <RotateCw class="size-4" />
                 <span class="sr-only">{{ $t('edit.previewPanel.refreshPreview') }}</span>
               </Button>
@@ -542,7 +576,7 @@ onBeforeUnmount(() => {
           </Tooltip>
           <Tooltip>
             <TooltipTrigger as-child>
-              <Button variant="ghost" size="icon" class="size-6" @click="openPreviewInBrowser">
+              <Button variant="ghost" size="icon" class="size-6" :disabled="!canPreview" @click="openPreviewInBrowser">
                 <ExternalLink class="size-4" />
                 <span class="sr-only">{{ $t('edit.previewPanel.openInBrowser') }}</span>
               </Button>
@@ -566,11 +600,11 @@ onBeforeUnmount(() => {
         data-testid="preview-viewport"
         class="bg-muted flex-1 min-h-0 relative overflow-hidden"
         :class="previewViewportClass"
-        @wheel="previewViewport.handleWheel"
-        @pointerdown="previewViewport.handlePointerDown"
+        @wheel="handlePreviewViewportWheel"
+        @pointerdown="handlePreviewViewportPointerDown"
       >
         <div
-          v-if="hasPreviewUrl"
+          v-if="canPreview"
           data-testid="preview-canvas"
           class="bg-background shadow-sm origin-top-left left-0 top-0 absolute"
           :style="previewCanvasStyle"
@@ -585,7 +619,7 @@ onBeforeUnmount(() => {
           />
         </div>
         <TransformOverlay
-          v-if="hasPreviewUrl && transformOverlayEnabled"
+          v-if="canPreview && transformOverlayEnabled"
           :box="transformOverlayReferenceBox"
           :canvas-height="stageHeight"
           :canvas-placement="previewViewport.canvasPlacement.value"
@@ -595,6 +629,19 @@ onBeforeUnmount(() => {
           @commit:display-transform="commitTransformOverlayDisplayTransform"
           @preview:display-transform="previewTransformOverlayDisplayTransform"
         />
+        <div
+          v-if="!hasValidEntryPoint"
+          data-testid="preview-missing-entry-overlay"
+          role="alert"
+          class="p-6 text-center bg-muted flex flex-col gap-1 items-center inset-0 justify-center absolute z-10"
+        >
+          <p class="font-medium">
+            {{ $t('edit.previewPanel.missingEntryTitle') }}
+          </p>
+          <p class="text-sm text-muted-foreground max-w-80">
+            {{ $t('edit.previewPanel.missingEntryDescription') }}
+          </p>
+        </div>
         <div
           v-if="isPreviewInteractionOverlayVisible"
           data-testid="preview-interaction-overlay"
@@ -616,6 +663,7 @@ onBeforeUnmount(() => {
           {{ resolutionLabel }}
         </output>
         <ViewportControls
+          :disabled="!canPreview"
           :zoom-ratio="previewViewport.zoomRatio.value"
           @zoom-in="previewViewport.zoomIn"
           @zoom-out="previewViewport.zoomOut"

--- a/src/components/editor/ScenePanel.vue
+++ b/src/components/editor/ScenePanel.vue
@@ -3,6 +3,7 @@ import { CopyMinus, FilePlus, FolderPlus, Layers, RotateCw } from '@lucide/vue'
 
 import { useFileSystemEvents } from '~/composables/useFileSystemEvents'
 import { AbsPath } from '~/domain/path'
+import { isSceneEntryPath } from '~/domain/scene/entry-point'
 import {
   findScenePanelNodeByPath,
   loadScenePanelTreeNodes,
@@ -72,6 +73,10 @@ function getSceneItemDiagnosticSeverity(item: ScenePanelTreeNode): DiagnosticSev
     return
   }
   return diagnosticsStore.getHighestSeverity(AbsPath.from(item.path))
+}
+
+function isProtectedSceneEntry(path: string): boolean {
+  return !!scenePath.value && isSceneEntryPath(AbsPath.from(path), AbsPath.from(scenePath.value))
 }
 
 function handleDoubleClick(item: FlattenedItem<ScenePanelTreeNode>) {
@@ -229,6 +234,7 @@ onScopeDispose(() => {
       ::selected-item="selectedItem"
       :items="items"
       :item-severity="getSceneItemDiagnosticSeverity"
+      :item-badge-text="(item) => isProtectedSceneEntry(item.path) ? $t('edit.fileTree.entryPointBadge') : undefined"
       :get-key="(item) => item.path"
       open-created-file-in-tab
       :enable-tooltip="false"
@@ -237,6 +243,7 @@ onScopeDispose(() => {
       tree-name="scene"
       enable-drag-transfer
       :root-path="scenePath"
+      :is-path-operation-disabled="isProtectedSceneEntry"
       :default-file-name-parts="{ stem: '', extension: '.txt' }"
       @click="handleClick"
       @dblclick="handleDoubleClick"

--- a/src/components/editor/ViewportControls.vue
+++ b/src/components/editor/ViewportControls.vue
@@ -2,6 +2,7 @@
 import { Maximize, Minus, Plus } from '@lucide/vue'
 
 interface Props {
+  disabled?: boolean
   zoomRatio: number
 }
 
@@ -11,7 +12,9 @@ interface Emits {
   zoomOut: []
 }
 
-const props = defineProps<Props>()
+const props = withDefaults(defineProps<Props>(), {
+  disabled: false,
+})
 const emit = defineEmits<Emits>()
 
 const zoomPercent = $computed(() => `${Math.round(props.zoomRatio * 100)}%`)
@@ -30,6 +33,7 @@ const buttonClass = 'size-6 text-muted-foreground hover:text-foreground'
             variant="ghost"
             size="icon"
             :class="buttonClass"
+            :disabled="props.disabled"
             @click="emit('zoomOut')"
           >
             <Minus class="size-3.5" />
@@ -54,6 +58,7 @@ const buttonClass = 'size-6 text-muted-foreground hover:text-foreground'
             variant="ghost"
             size="icon"
             :class="buttonClass"
+            :disabled="props.disabled"
             @click="emit('zoomIn')"
           >
             <Plus class="size-3.5" />
@@ -73,6 +78,7 @@ const buttonClass = 'size-6 text-muted-foreground hover:text-foreground'
             variant="ghost"
             size="icon"
             :class="[buttonClass, 'ml-0.5']"
+            :disabled="props.disabled"
             @click="emit('fitToView')"
           >
             <Maximize class="size-3.5" />

--- a/src/domain/scene/__tests__/entry-point.test.ts
+++ b/src/domain/scene/__tests__/entry-point.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+
+import { AbsPath } from '~/domain/path'
+
+import {
+  isSceneEntryPath,
+  resolveSceneEntryStatus,
+} from '../entry-point'
+
+const sceneRoot = AbsPath.from('/games/demo/game/scene')
+
+describe('scene entry point', () => {
+  it('只保护场景根目录下 start.txt 的大小写变体', () => {
+    expect(isSceneEntryPath(AbsPath.from('/games/demo/game/scene/start.txt'), sceneRoot)).toBe(true)
+    expect(isSceneEntryPath(AbsPath.from('/GAMES/DEMO/GAME/SCENE/Start.TXT'), sceneRoot)).toBe(true)
+    expect(isSceneEntryPath(AbsPath.from('/games/demo/game/scene/chapter/start.txt'), sceneRoot)).toBe(false)
+  })
+
+  it('只接受规范拼写作为可用入口', () => {
+    expect(resolveSceneEntryStatus(['Start.txt'])).toBe('missing')
+    expect(resolveSceneEntryStatus(['start.txt'])).toBe('valid')
+  })
+})

--- a/src/domain/scene/entry-point.ts
+++ b/src/domain/scene/entry-point.ts
@@ -1,0 +1,22 @@
+import { AbsPath } from '~/domain/path'
+
+export const SCENE_ENTRY_FILE_NAME = 'start.txt'
+
+export type SceneEntryStatus = 'valid' | 'missing'
+
+function sceneEntryPath(sceneRoot: AbsPath): AbsPath {
+  return AbsPath.append(sceneRoot, SCENE_ENTRY_FILE_NAME)
+}
+
+/**
+ * 入口文件身份不区分大小写，但只匹配当前场景根目录的直接子项，避免误伤嵌套场景。
+ */
+export function isSceneEntryPath(path: AbsPath, sceneRoot: AbsPath): boolean {
+  return path.toLowerCase() === sceneEntryPath(sceneRoot).toLowerCase()
+}
+
+export function resolveSceneEntryStatus(
+  fileNames: readonly string[],
+): SceneEntryStatus {
+  return fileNames.includes(SCENE_ENTRY_FILE_NAME) ? 'valid' : 'missing'
+}

--- a/src/features/editor/effect-editor/__tests__/useEffectEditorProvider-queue.test.ts
+++ b/src/features/editor/effect-editor/__tests__/useEffectEditorProvider-queue.test.ts
@@ -312,6 +312,22 @@ describe('useEffectEditorProvider', () => {
     expect(debugCommanderMock.setEffect).not.toHaveBeenCalled()
   })
 
+  it('预览未启动时会跳过运行时请求但仍允许应用脚本变更', async () => {
+    useEditSettingsStore().autoApplyEffectEditorChanges = false
+    previewSyncStoreMock.isPreviewReady = false
+    const applyMock = vi.fn()
+    const provider = createProvider()
+
+    await provider.open(createOpenTarget({ onApply: applyMock }))
+    provider.updateDraft({ transform: { blur: 12 } })
+
+    await expect(provider.apply()).resolves.toBe(true)
+    expect(applyMock).toHaveBeenCalledWith(expect.objectContaining({
+      transform: { blur: 12 },
+    }))
+    expect(debugCommanderMock.setEffect).not.toHaveBeenCalled()
+  })
+
   it('未产生 visual preview 时关闭效果编辑器不会重复恢复场景预览', async () => {
     useEditSettingsStore().autoApplyEffectEditorChanges = false
     const provider = createEffectEditorProvider()

--- a/src/features/editor/effect-editor/useEffectEditorProvider.ts
+++ b/src/features/editor/effect-editor/useEffectEditorProvider.ts
@@ -491,6 +491,10 @@ export function createEffectEditorProvider(options: CreateEffectEditorProviderOp
       // 面板关闭时跳过运行时请求，但不阻止脚本层提交效果编辑器草稿。
       return true
     }
+    if (!previewSyncStore.isPreviewReady) {
+      // 预览未启动或暂不可用时，仍允许脚本层提交效果编辑器草稿。
+      return true
+    }
     if (isPreviewTerminalUnsynced()) {
       return false
     }

--- a/src/features/editor/file-tree/__tests__/useFileTreeController.test.ts
+++ b/src/features/editor/file-tree/__tests__/useFileTreeController.test.ts
@@ -158,6 +158,7 @@ function createFixture(options: {
     stem: string
   }
   openCreatedFileInTab?: boolean
+  isPathOperationDisabled?: (path: string) => boolean
   savedExpanded?: string[]
   savedScrollPosition?: {
     left: number
@@ -217,6 +218,7 @@ function createFixture(options: {
     sortBy: () => 'name',
     sortOrder: () => 'asc',
     treeName: () => 'scene',
+    isPathOperationDisabled: options.isPathOperationDisabled,
   }))
 
   if (!controller) {
@@ -478,6 +480,27 @@ describe('useFileTreeController', () => {
       value: '',
     })
 
+    scope.stop()
+  })
+
+  it('受保护路径不会进入重命名流程或调用路径操作服务', async () => {
+    const { controller, items, scope } = createFixture({
+      isPathOperationDisabled: path => path.toLowerCase() === '/project/scene/start.txt',
+    })
+    const startItem = createFlattenedItem({
+      name: 'Start.TXT',
+      path: '/project/scene/Start.TXT',
+    }, {
+      hasChildren: false,
+      level: 1,
+    })
+
+    controller.itemMap.set(startItem.value.path, startItem)
+    controller.handleContextMenuRename({ path: startItem.value.path })
+
+    expect(controller.renameState.value.itemKey).toBeUndefined()
+    expect(pathOperation.perform).not.toHaveBeenCalled()
+    expect(items).toHaveLength(1)
     scope.stop()
   })
 

--- a/src/features/editor/file-tree/useFileTreeController.ts
+++ b/src/features/editor/file-tree/useFileTreeController.ts
@@ -6,6 +6,7 @@ import {
   findFileTreeItemByPath,
   getFileTreeNameSelectionEnd,
   getFileTreeParentPath,
+  getFileTreeTransferPayloadItems,
   hasFileTreeDuplicateName,
   insertCreatingFileTreeItem,
   resolveDroppableFileTreeTransferItems,
@@ -68,6 +69,7 @@ interface UseFileTreeControllerOptions<T extends object> {
   sortBy: () => FileViewerSortBy
   sortOrder: () => FileViewerSortOrder
   treeName: () => string | undefined
+  isPathOperationDisabled?: (path: string) => boolean
 }
 
 function scheduleFrame(callback: FrameRequestCallback): void {
@@ -120,6 +122,7 @@ export function useFileTreeController<T extends object>(options: UseFileTreeCont
   const { t } = useI18n()
   const confirmPathOperationRewrite = createPathOperationRewriteConfirm(t)
   const pathOperationFeedback = usePathOperationFeedback()
+  const isPathOperationDisabled = (path: string): boolean => options.isPathOperationDisabled?.(path) ?? false
 
   function asRecord(item: T): Record<string, unknown> {
     return item as Record<string, unknown>
@@ -244,7 +247,12 @@ export function useFileTreeController<T extends object>(options: UseFileTreeCont
   }
 
   function startRenaming(item: FlattenedItem<T>): void {
-    if (renameState.value.isStarting || renameState.value.isInProgress || createState.value.isInProgress) {
+    if (
+      isPathOperationDisabled(getItemPath(item.value))
+      || renameState.value.isStarting
+      || renameState.value.isInProgress
+      || createState.value.isInProgress
+    ) {
       return
     }
 
@@ -274,6 +282,10 @@ export function useFileTreeController<T extends object>(options: UseFileTreeCont
       || renameState.value.isStarting
       || renameState.value.isInProgress
     ) {
+      return
+    }
+
+    if (isPathOperationDisabled(getItemPath(item.value))) {
       return
     }
 
@@ -620,6 +632,10 @@ export function useFileTreeController<T extends object>(options: UseFileTreeCont
   const itemMap = new Map<string, FlattenedItem<T>>()
 
   function handleContextMenuRename(fileItem: { path: string }): void {
+    if (isPathOperationDisabled(fileItem.path)) {
+      return
+    }
+
     const flattenedItem = itemMap.get(fileItem.path)
     if (flattenedItem) {
       startRenaming(flattenedItem)
@@ -639,6 +655,13 @@ export function useFileTreeController<T extends object>(options: UseFileTreeCont
     targetDirectoryPath: string,
     operation: DragTransferOperation = 'move',
   ): boolean {
+    if (
+      operation === 'move'
+      && getFileTreeTransferPayloadItems(payload).some(item => isPathOperationDisabled(item.path))
+    ) {
+      return false
+    }
+
     return canDropFileTreeTransferPayloadToDirectory(
       payload,
       targetDirectoryPath,
@@ -656,7 +679,7 @@ export function useFileTreeController<T extends object>(options: UseFileTreeCont
 
   async function moveFileSystemItems(payload: FileSystemDragPayload, targetDirectoryPath: string): Promise<void> {
     const items = resolveDroppableFileTreeTransferItems(payload, targetDirectoryPath)
-    if (!items) {
+    if (!items || items.some(item => isPathOperationDisabled(item.path))) {
       return
     }
 

--- a/src/features/editor/scene-entry/useSceneEntryStatus.ts
+++ b/src/features/editor/scene-entry/useSceneEntryStatus.ts
@@ -1,0 +1,94 @@
+import { createGlobalState } from '@vueuse/core'
+
+import { useFileSystemEvents } from '~/composables/useFileSystemEvents'
+import { AbsPath } from '~/domain/path'
+import { resolveSceneEntryStatus } from '~/domain/scene/entry-point'
+import { gameSceneDir } from '~/services/platform/app-paths'
+import { toLookupPathKey } from '~/services/resource-path/lookup'
+import { useFileStore } from '~/stores/file'
+import { useWorkspaceStore } from '~/stores/workspace'
+
+import type { SceneEntryStatus } from '~/domain/scene/entry-point'
+
+function isPathWithin(path: AbsPath, root: AbsPath): boolean {
+  const pathKey = toLookupPathKey(path)
+  const rootKey = toLookupPathKey(root)
+  return pathKey === rootKey || pathKey.startsWith(`${rootKey}/`)
+}
+
+export const useSceneEntryStatus = createGlobalState(() => {
+  const fileStore = useFileStore()
+  const workspaceStore = useWorkspaceStore()
+  const fileSystemEvents = useFileSystemEvents()
+
+  const sceneRoot = computed(() => {
+    const gamePath = workspaceStore.currentGame?.path
+    return gamePath ? gameSceneDir(AbsPath.from(gamePath)) : undefined
+  })
+  const status = ref<SceneEntryStatus>('missing')
+  let refreshToken = 0
+
+  async function refresh(): Promise<void> {
+    const currentRoot = sceneRoot.value
+    const token = ++refreshToken
+    if (!currentRoot) {
+      status.value = 'missing'
+      return
+    }
+
+    try {
+      await fileStore.initialized
+      const entries = await fileStore.getFolderContents(currentRoot)
+      if (token !== refreshToken || sceneRoot.value !== currentRoot) {
+        return
+      }
+
+      status.value = resolveSceneEntryStatus(
+        entries.filter(entry => !entry.isDir).map(entry => entry.name),
+      )
+    } catch (error) {
+      if (token !== refreshToken) {
+        return
+      }
+      logger.warn(`[SceneEntry] 检查入口文件失败: ${error}`)
+      status.value = 'missing'
+    }
+  }
+
+  watch(sceneRoot, () => {
+    void refresh()
+  }, { immediate: true })
+
+  const eventTypes = [
+    'file:created',
+    'file:removed',
+    'file:renamed',
+    'directory:created',
+    'directory:removed',
+    'directory:renamed',
+  ] as const
+
+  const stops = eventTypes.map(type => fileSystemEvents.on(type, (event) => {
+    const root = sceneRoot.value
+    if (!root) {
+      return
+    }
+
+    const paths = 'oldPath' in event
+      ? [event.oldPath, event.newPath]
+      : [event.path]
+    if (paths.some(path => isPathWithin(path, root))) {
+      void refresh()
+    }
+  }))
+
+  tryOnScopeDispose(() => {
+    for (const stop of stops) {
+      stop()
+    }
+  })
+
+  return {
+    status: readonly(status),
+  }
+})

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -737,6 +737,7 @@ edit:
       moveConfirm: Move anyway
     errors:
       blockedPlan: Path operation is blocked
+      protectedEntryPoint: The scene entry file start.txt cannot be moved, renamed, or deleted.
       duplicateTarget: Target path already exists or matches the source path.
       inFlightConflict: Another path operation is already in progress on this path. Please try again later.
       crossRootMove: Only reference rewrites within the same resource root are supported.
@@ -796,6 +797,7 @@ edit:
     pastePartialFailed: Partial paste failed ({failed}/{total})
     viewHistory: View Version History
     dragPreviewCount: "{count} file(s)"
+    entryPointBadge: Entry point
   previewPanel:
     copyUrl: Copy URL
     refreshPreview: Refresh Preview
@@ -807,6 +809,8 @@ edit:
     fitToView: Fit to View
     zoomLevel: Zoom Level
     resolution: Preview Resolution
+    missingEntryTitle: Missing entry file
+    missingEntryDescription: The scene root does not contain start.txt, so preview cannot start.
     transformOverlay:
       move: Move target
       rotate: Rotate target

--- a/src/locales/ja.yml
+++ b/src/locales/ja.yml
@@ -737,6 +737,7 @@ edit:
       moveConfirm: そのまま移動
     errors:
       blockedPlan: パス操作はブロックされました
+      protectedEntryPoint: シーンのエントリーファイル start.txt は移動、名前変更、削除できません。
       duplicateTarget: その移動先は既に存在するか、移動元と同じです。
       inFlightConflict: このパスでは別のパス操作が進行中です。しばらくしてから再試行してください。
       crossRootMove: 同じリソースルート内の参照更新のみ対応しています。
@@ -796,6 +797,7 @@ edit:
     pastePartialFailed: 一部の貼り付けに失敗しました ({failed}/{total})
     viewHistory: 履歴を表示
     dragPreviewCount: "{count} 個のファイル"
+    entryPointBadge: エントリーポイント
   previewPanel:
     copyUrl: URLをコピー
     refreshPreview: プレビューを更新
@@ -807,6 +809,8 @@ edit:
     fitToView: 表示に合わせる
     zoomLevel: ズーム率
     resolution: プレビュー解像度
+    missingEntryTitle: エントリーファイルがありません
+    missingEntryDescription: シーンルートに start.txt がないため、プレビューを起動できません。
     transformOverlay:
       move: 対象を移動
       rotate: 対象を回転

--- a/src/locales/zh-Hans.yml
+++ b/src/locales/zh-Hans.yml
@@ -737,6 +737,7 @@ edit:
       moveConfirm: 仍然移动
     errors:
       blockedPlan: 路径操作被阻断
+      protectedEntryPoint: 场景入口文件 start.txt 不能移动、重命名或删除。
       duplicateTarget: 目标路径已存在或与源路径相同。
       inFlightConflict: 该路径上已有进行中的操作，请稍后再试。
       crossRootMove: 当前仅支持同一资源根目录内的引用重写。
@@ -796,6 +797,7 @@ edit:
     pastePartialFailed: 部分粘贴失败 ({failed}/{total})
     viewHistory: 查看历史版本
     dragPreviewCount: "{count} 个文件"
+    entryPointBadge: 入口
   previewPanel:
     copyUrl: 复制地址
     refreshPreview: 刷新预览
@@ -807,6 +809,8 @@ edit:
     fitToView: 适应视图
     zoomLevel: 缩放比例
     resolution: 预览分辨率
+    missingEntryTitle: 缺少入口文件
+    missingEntryDescription: 场景根目录中未找到 start.txt，无法启动预览。
     transformOverlay:
       move: 移动目标
       rotate: 旋转目标

--- a/src/locales/zh-Hant.yml
+++ b/src/locales/zh-Hant.yml
@@ -737,6 +737,7 @@ edit:
       moveConfirm: 仍然移動
     errors:
       blockedPlan: 路徑操作被阻擋
+      protectedEntryPoint: 場景入口檔案 start.txt 不能移動、重新命名或刪除。
       duplicateTarget: 目標路徑已存在或與來源路徑相同。
       inFlightConflict: 此路徑上已有進行中的操作，請稍後再試。
       crossRootMove: 目前僅支援同一資源根目錄內的引用重寫。
@@ -796,6 +797,7 @@ edit:
     pastePartialFailed: 部分貼上失敗 ({failed}/{total})
     viewHistory: 檢視歷史版本
     dragPreviewCount: "{count} 個檔案"
+    entryPointBadge: 入口
   previewPanel:
     copyUrl: 複製網址
     refreshPreview: 重新整理預覽
@@ -807,6 +809,8 @@ edit:
     fitToView: 適應視圖
     zoomLevel: 縮放比例
     resolution: 預覽解析度
+    missingEntryTitle: 缺少入口檔案
+    missingEntryDescription: 場景根目錄中找不到 start.txt，無法啟動預覽。
     transformOverlay:
       move: 移動目標
       rotate: 旋轉目標

--- a/src/services/__tests__/game-fs.test.ts
+++ b/src/services/__tests__/game-fs.test.ts
@@ -285,6 +285,21 @@ describe('gameFs', () => {
     expect(touchCurrentGameLastModifiedMock).not.toHaveBeenCalled()
   })
 
+  it('底层删除边界也拒绝场景入口文件的大小写变体', async () => {
+    await expect(gameFs.deleteFile(AbsPath.from('/project/game/scene/Start.TXT'), true))
+      .rejects.toMatchObject({ code: 'PATH_OPERATION' })
+    await expect(gameFs.renameFile(AbsPath.from('/project/game/scene/start.txt'), 'intro.txt'))
+      .rejects.toMatchObject({ code: 'PATH_OPERATION' })
+    await expect(gameFs.moveFile(
+      AbsPath.from('/project/game/scene/START.TXT'),
+      AbsPath.from('/project/game/scene/chapter'),
+    )).rejects.toMatchObject({ code: 'PATH_OPERATION' })
+
+    expect(deleteFileMock).not.toHaveBeenCalled()
+    expect(fsRenameFileMock).not.toHaveBeenCalled()
+    expect(fsMoveFileMock).not.toHaveBeenCalled()
+  })
+
   it('VFS 项目中的普通路径 rename 或 move 仍走 native adapter', async () => {
     useFileStoreMock.mockReturnValue({
       copyEntry: copyEntryMock,

--- a/src/services/__tests__/path-operation.test.ts
+++ b/src/services/__tests__/path-operation.test.ts
@@ -163,6 +163,22 @@ describe('pathOperation', () => {
     existsMock.mockResolvedValue(false)
   })
 
+  it('会在任何文件变更前拒绝移动大小写变体的场景入口文件', async () => {
+    const deps = createDeps()
+    const service = createPathOperationService(deps)
+
+    await expect(service.perform({
+      kind: 'move',
+      sourcePath: AbsPath.from('/PROJECT/game/scene/Start.TXT'),
+      target: { type: 'directory', directory: AbsPath.from('/project/game/scene/chapter') },
+    })).rejects.toMatchObject({
+      code: 'blocked-plan',
+      blockedReasons: [expect.objectContaining({ kind: 'protected-entry-point' })],
+    })
+    expect(deps.gameFs.moveFile).not.toHaveBeenCalled()
+    expect(deps.fileStore.applyPathMutation).not.toHaveBeenCalled()
+  })
+
   it('无引用 rename 会执行 FS、副作用提交、事件广播和单次游戏刷新', async () => {
     const deps = createDeps()
     const service = createPathOperationService(deps)
@@ -660,7 +676,7 @@ describe('pathOperation', () => {
     const deps = createDeps({
       fileStore: {
         getItemByPath: vi.fn((path: AbsPath) =>
-          path === AbsPath.from('/project/game/scene/start.txt') ? { isDir: false } : undefined,
+          path === AbsPath.from('/project/game/scene/chapter.txt') ? { isDir: false } : undefined,
         ),
       },
       history: {
@@ -671,7 +687,7 @@ describe('pathOperation', () => {
 
     const plan = await service.plan({
       kind: 'rename',
-      sourcePath: AbsPath.from('/project/game/scene/start.txt'),
+      sourcePath: AbsPath.from('/project/game/scene/chapter.txt'),
       target: { type: 'name', name: 'intro.txt' },
     })
 
@@ -681,7 +697,7 @@ describe('pathOperation', () => {
 
     expect(deps.history.migrateSceneHistory).toHaveBeenCalledWith({
       projectPath: '/project',
-      oldLogicalPath: 'game/scene/start.txt',
+      oldLogicalPath: 'game/scene/chapter.txt',
       newLogicalPath: 'game/scene/intro.txt',
     })
   })
@@ -694,7 +710,7 @@ describe('pathOperation', () => {
     const deps = createDeps({
       fileStore: {
         getItemByPath: vi.fn((path: AbsPath) =>
-          path === AbsPath.from('/project/game/scene/start.txt') ? { isDir: false } : undefined,
+          path === AbsPath.from('/project/game/scene/chapter.txt') ? { isDir: false } : undefined,
         ),
       },
       gameManager: {
@@ -708,7 +724,7 @@ describe('pathOperation', () => {
 
     const plan = await service.plan({
       kind: 'rename',
-      sourcePath: AbsPath.from('/project/game/scene/start.txt'),
+      sourcePath: AbsPath.from('/project/game/scene/chapter.txt'),
       target: { type: 'name', name: 'intro.txt' },
     })
 
@@ -716,23 +732,23 @@ describe('pathOperation', () => {
 
     expect(migrateSceneHistory).toHaveBeenNthCalledWith(1, {
       projectPath: '/project',
-      oldLogicalPath: 'game/scene/start.txt',
+      oldLogicalPath: 'game/scene/chapter.txt',
       newLogicalPath: 'game/scene/intro.txt',
     })
     expect(migrateSceneHistory).toHaveBeenNthCalledWith(2, {
       projectPath: '/project',
       oldLogicalPath: 'game/scene/intro.txt',
-      newLogicalPath: 'game/scene/start.txt',
+      newLogicalPath: 'game/scene/chapter.txt',
     })
     expect(deps.fileStore.applyPathMutation).toHaveBeenNthCalledWith(
       1,
-      '/project/game/scene/start.txt',
+      '/project/game/scene/chapter.txt',
       '/project/game/scene/intro.txt',
     )
     expect(deps.fileStore.applyPathMutation).toHaveBeenNthCalledWith(
       2,
       '/project/game/scene/intro.txt',
-      '/project/game/scene/start.txt',
+      '/project/game/scene/chapter.txt',
     )
     expect(refreshRegisteredGameSnapshot).toHaveBeenCalledTimes(1)
   })
@@ -1244,15 +1260,15 @@ describe('pathOperation', () => {
 
   it.each([
     {
-      firstSourcePath: '/project/game/scene/chapter/start.txt',
+      firstSourcePath: '/project/game/scene/chapter/branch.txt',
       firstTargetDirectory: '/project/game/scene',
-      secondSourcePath: '/project/game/scene/start.txt',
+      secondSourcePath: '/project/game/scene/chapter.txt',
       secondTargetDirectory: '/project/game/scene/chapter',
     },
     {
-      firstSourcePath: '/project/game/scene/start.txt',
+      firstSourcePath: '/project/game/scene/chapter.txt',
       firstTargetDirectory: '/project/game/scene/chapter',
-      secondSourcePath: '/project/game/scene/chapter/start.txt',
+      secondSourcePath: '/project/game/scene/chapter/branch.txt',
       secondTargetDirectory: '/project/game/scene',
     },
   ])('连续反向 move 不会被上一轮 watcher pending 阻断', async ({

--- a/src/services/game-fs.ts
+++ b/src/services/game-fs.ts
@@ -3,12 +3,14 @@ import { mkdir, readFile, writeFile as writeBinaryFile, writeTextFile } from '@t
 import { fsCmds } from '~/commands/fs'
 import { vfsCmds } from '~/commands/vfs'
 import { AbsPath, RelPath } from '~/domain/path'
+import { isSceneEntryPath } from '~/domain/scene/entry-point'
 import {
   commitPendingFileWrite,
   registerPendingFileWrite,
   rollbackPendingFileWrite,
 } from '~/services/file-write-echo-registry'
 import { gameManager } from '~/services/game-manager'
+import { gameSceneDir } from '~/services/platform/app-paths'
 import { useFileStore } from '~/stores/file'
 import { useRuntimeTaskStore } from '~/stores/runtime-task'
 import { useWorkspaceStore } from '~/stores/workspace'
@@ -116,6 +118,15 @@ function markPathChanged(path: AbsPath, options: { includeChildren?: boolean } =
   }
 
   gameManager.touchCurrentGameLastModified()
+}
+
+function assertMutableSceneEntry(path: AbsPath): void {
+  const gamePath = useWorkspaceStore().currentGame?.path
+  if (gamePath && isSceneEntryPath(path, gameSceneDir(gamePath))) {
+    throw new AppError('PATH_OPERATION', '场景入口文件受保护，不能移动、重命名或删除', {
+      details: { path },
+    })
+  }
 }
 
 function usesTemplateOverlayPath(path: AbsPath): boolean {
@@ -246,6 +257,7 @@ async function moveTemplateOverlayPath(
 }
 
 async function renameFile(oldPath: AbsPath, newName: string): Promise<PathMutationResult> {
+  assertMutableSceneEntry(oldPath)
   if (usesTemplateOverlayPath(oldPath)) {
     return renameTemplateOverlayPath(oldPath, newName)
   }
@@ -254,6 +266,7 @@ async function renameFile(oldPath: AbsPath, newName: string): Promise<PathMutati
 }
 
 async function deleteFile(path: AbsPath, permanent?: boolean): Promise<void> {
+  assertMutableSceneEntry(path)
   const fileStore = useFileStore()
   if (fileStore.isVfs && await fileStore.deleteEntry(path)) {
     markPathChanged(path, { includeChildren: true })
@@ -334,6 +347,7 @@ async function copyFile(sourcePath: AbsPath, targetPath: AbsPath): Promise<AbsPa
 }
 
 async function moveFile(sourcePath: AbsPath, targetPath: AbsPath, targetName?: string): Promise<PathMutationResult> {
+  assertMutableSceneEntry(sourcePath)
   if (usesTemplateOverlayPath(sourcePath) || usesTemplateOverlayPath(targetPath)) {
     return moveTemplateOverlayPath(sourcePath, targetPath, targetName)
   }

--- a/src/services/path-operation-feedback.ts
+++ b/src/services/path-operation-feedback.ts
@@ -14,6 +14,7 @@ export interface PathOperationBlockReasonMessage {
     | 'unsupported-reference'
     | 'duplicate-target'
     | 'in-flight-conflict'
+    | 'protected-entry-point'
   i18nMessage: I18nLike
 }
 

--- a/src/services/path-operation.ts
+++ b/src/services/path-operation.ts
@@ -5,6 +5,7 @@ import { gameCmds } from '~/commands/game'
 import { useFileSystemEvents } from '~/composables/useFileSystemEvents'
 import { decodeTextFile, encodeTextFile } from '~/domain/document/file-codec'
 import { AbsPath, RelPath } from '~/domain/path'
+import { isSceneEntryPath } from '~/domain/scene/entry-point'
 import { parseChooseContent, stringifyChooseContent } from '~/domain/script/content'
 import { parseSceneOrEmpty } from '~/domain/script/parser'
 import { serializeSentence } from '~/domain/script/serialize'
@@ -12,7 +13,7 @@ import { backupManager } from '~/services/backup-manager'
 import { gameFs } from '~/services/game-fs'
 import { gameManager } from '~/services/game-manager'
 import { pathOperationRegistry } from '~/services/path-operation-registry'
-import { gameAssetDir, gameRootDir } from '~/services/platform/app-paths'
+import { gameAssetDir, gameRootDir, gameSceneDir } from '~/services/platform/app-paths'
 import { useResourceIndex } from '~/services/resource-index/service'
 import { useEditorStore } from '~/stores/editor'
 import { useFileStore } from '~/stores/file'
@@ -63,6 +64,7 @@ export interface PathOperationBlockReason {
     | 'unsupported-reference'
     | 'duplicate-target'
     | 'in-flight-conflict'
+    | 'protected-entry-point'
   i18nMessage: PathOperationBlockReasonMessage['i18nMessage']
   filePath?: AbsPath
 }
@@ -1127,6 +1129,14 @@ export function createPathOperationService(deps: PathOperationDeps) {
     const targetPath = await resolveTargetPath(deps, input)
     const blockedReasons: PathOperationBlockReason[] = []
     const gamePath = deps.getGamePath()
+
+    if (gamePath && isSceneEntryPath(input.sourcePath, gameSceneDir(gamePath))) {
+      blockedReasons.push({
+        kind: 'protected-entry-point',
+        i18nMessage: t => t('edit.pathOperation.errors.protectedEntryPoint'),
+        filePath: input.sourcePath,
+      })
+    }
 
     if (
       AbsPath.equals(input.sourcePath, targetPath)


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [ ] 错误修复
- [x] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [x] 测试用例
- [ ] 性能优化
- [x] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

- 将当前游戏 `game/scene/start.txt` 识别为受保护的场景入口文件。规范文件名及大小写变体均不能被移动、重命名或删除，保护规则覆盖右键菜单、快捷键、拖放、批量操作及底层路径操作服务。
- 在场景文件树中为入口文件显示本地化徽标；受保护操作保持可见但处于禁用状态，复制、打开和编辑等安全操作不受影响。
- 由编辑器 feature 统一维护入口状态并响应文件系统事件。缺少规范 `start.txt` 时，预览画布显示可访问的错误遮罩，不挂载预览 iframe，并禁用依赖有效预览的控件；入口恢复后自动重新加载预览。
- 预览未启动或暂不可用时，效果编辑器仍可编辑并应用脚本变更，仅跳过运行时效果同步。
- 为英文、日文、简体中文和繁体中文补充入口保护及预览错误文案。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

WebGAL 引擎依赖 `start.txt` 作为游戏启动入口。文件树中的移动、重命名、删除和批量操作如果能够修改该文件，会使工程无法按约定启动。导入工程或外部文件变更也可能造成规范入口缺失，因此需要在预览区域持续显示明确状态，同时保留场景树和编辑器的正常工作流。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->

- 不会自动创建、重命名或写入缺失的入口文件。
- 场景根目录之外的同名文件不受入口保护规则影响。

### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
