### PR TITLE
🐛 修复编辑页入口校验期间误显示缺失遮罩

### DIFF
--- a/src/components/editor/PreviewPanel.spec.ts
+++ b/src/components/editor/PreviewPanel.spec.ts
@@ -156,7 +156,7 @@ let previewSessionStoreState: {
 }
 
 let sceneEntryStatusState: {
-  status: ReturnType<typeof ref<'valid' | 'missing'>>
+  status: ReturnType<typeof ref<'checking' | 'valid' | 'missing'>>
 }
 
 const transformOverlayReferenceBox: ReferenceBox = {
@@ -437,6 +437,23 @@ describe('PreviewPanel', () => {
 
     await expect.element(page.getByTitle('preview-title::Demo Game')).toBeVisible()
     expect(previewSessionStoreState.reloadVersion).toBeGreaterThan(0)
+  })
+
+  it('入口校验期间不显示缺失遮罩，校验通过后挂载预览', async () => {
+    sceneEntryStatusState.status.value = 'checking'
+
+    renderInBrowser(PreviewPanel, {
+      global: {
+        plugins: [createPreviewPanelLiteI18n()],
+        stubs: globalStubs,
+      },
+    })
+
+    expect(document.querySelector('[data-testid="preview-missing-entry-overlay"]')).toBeNull()
+    expect(document.querySelector('iframe')).toBeNull()
+
+    sceneEntryStatusState.status.value = 'valid'
+    await expect.element(page.getByTitle('preview-title::Demo Game')).toBeVisible()
   })
 
   it('收到同源 iframe 转发的空格按键消息时会让 iframe 上的拖拽交给外层视口平移', async () => {

--- a/src/components/editor/PreviewPanel.spec.ts
+++ b/src/components/editor/PreviewPanel.spec.ts
@@ -454,6 +454,7 @@ describe('PreviewPanel', () => {
 
     sceneEntryStatusState.status.value = 'valid'
     await expect.element(page.getByTitle('preview-title::Demo Game')).toBeVisible()
+    expect(previewSessionStoreState.reloadVersion).toBeGreaterThan(0)
   })
 
   it('收到同源 iframe 转发的空格按键消息时会让 iframe 上的拖拽交给外层视口平移', async () => {

--- a/src/components/editor/PreviewPanel.vue
+++ b/src/components/editor/PreviewPanel.vue
@@ -55,6 +55,7 @@ const transformOverlayDisplayTransform = $computed(() => transformOverlayBridge?
 const previewUrl = $computed(() => previewSessionStore.currentGameServeUrl ?? '')
 const hasPreviewUrl = $computed(() => !!previewSessionStore.currentGameServeUrl)
 const hasValidEntryPoint = $computed(() => sceneEntryStatus.status.value === 'valid')
+const hasMissingEntryPoint = $computed(() => sceneEntryStatus.status.value === 'missing')
 const canPreview = $computed(() => hasPreviewUrl && hasValidEntryPoint)
 
 const { t } = useI18n()
@@ -486,12 +487,12 @@ watch(
 watch(
   () => sceneEntryStatus.status.value,
   (status, previousStatus) => {
-    if (status === 'missing') {
+    if (status !== 'valid') {
       updateEmbeddedPreviewSlot(undefined)
       return
     }
 
-    if (status === 'valid' && previousStatus === 'missing' && hasPreviewUrl) {
+    if (previousStatus !== 'valid' && hasPreviewUrl) {
       previewSessionStore.refresh()
     }
   },
@@ -630,7 +631,7 @@ onBeforeUnmount(() => {
           @preview:display-transform="previewTransformOverlayDisplayTransform"
         />
         <div
-          v-if="!hasValidEntryPoint"
+          v-if="hasMissingEntryPoint"
           data-testid="preview-missing-entry-overlay"
           role="alert"
           class="p-6 text-center bg-muted flex flex-col gap-1 items-center inset-0 justify-center absolute z-10"

--- a/src/domain/scene/entry-point.ts
+++ b/src/domain/scene/entry-point.ts
@@ -2,7 +2,7 @@ import { AbsPath } from '~/domain/path'
 
 export const SCENE_ENTRY_FILE_NAME = 'start.txt'
 
-export type SceneEntryStatus = 'valid' | 'missing'
+export type SceneEntryStatus = 'checking' | 'valid' | 'missing'
 
 function sceneEntryPath(sceneRoot: AbsPath): AbsPath {
   return AbsPath.append(sceneRoot, SCENE_ENTRY_FILE_NAME)

--- a/src/features/editor/scene-entry/useSceneEntryStatus.ts
+++ b/src/features/editor/scene-entry/useSceneEntryStatus.ts
@@ -25,16 +25,18 @@ export const useSceneEntryStatus = createGlobalState(() => {
     const gamePath = workspaceStore.currentGame?.path
     return gamePath ? gameSceneDir(AbsPath.from(gamePath)) : undefined
   })
-  const status = ref<SceneEntryStatus>('missing')
+  const status = ref<SceneEntryStatus>('checking')
   let refreshToken = 0
 
   async function refresh(): Promise<void> {
     const currentRoot = sceneRoot.value
     const token = ++refreshToken
     if (!currentRoot) {
-      status.value = 'missing'
+      status.value = 'checking'
       return
     }
+
+    status.value = 'checking'
 
     try {
       await fileStore.initialized

--- a/src/features/editor/scene-entry/useSceneEntryStatus.ts
+++ b/src/features/editor/scene-entry/useSceneEntryStatus.ts
@@ -53,7 +53,7 @@ export const useSceneEntryStatus = createGlobalState(() => {
         return
       }
       logger.warn(`[SceneEntry] 检查入口文件失败: ${error}`)
-      status.value = 'missing'
+      status.value = 'checking'
     }
   }
 


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [x] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [x] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

编辑页启动时，入口文件状态在异步检查完成前会经历未知阶段。此前该阶段被错误标记为 `missing`，导致即使 `start.txt` 存在，也会短暂显示缺失入口遮罩。

本次将入口状态扩展为 `checking`、`valid`、`missing`：

- 入口检查期间保持 `checking`
- 仅在确认缺少 `start.txt` 时显示错误遮罩
- 校验通过后正常挂载预览并刷新预览会话
- 当前游戏尚未恢复时不再误报入口缺失

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

修复进入编辑页时缺失入口遮罩闪现的问题，避免将异步初始化状态误判为实际文件缺失。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->

已添加浏览器回归测试，覆盖入口校验期间不显示缺失遮罩、校验通过后挂载预览的场景。

### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
