### PR TITLE
🐛 修复 Live2D 能力检测逻辑

### DIFF
--- a/src/services/__tests__/engine-manager.test.ts
+++ b/src/services/__tests__/engine-manager.test.ts
@@ -323,7 +323,11 @@ describe('engineManager', () => {
     enginesUpdateMock.mockResolvedValue(undefined)
     deleteFileMock.mockResolvedValue(undefined)
     copyDirectoryWithProgressMock.mockRejectedValue(new Error('disk full'))
-    existsMock.mockResolvedValueOnce(false).mockResolvedValueOnce(true)
+    existsMock
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true)
 
     await expect(engineManager.importEngine(AbsPath.from('/downloads/webgal'))).rejects.toThrow('disk full')
 
@@ -687,6 +691,88 @@ describe('engineManager', () => {
     })
   })
 
+  it('引擎 manifest 显式声明支持 Live2D 时跳过运行时文件检查', async () => {
+    readEngineManifestMock.mockResolvedValue({
+      status: 'ok',
+      manifest: {
+        schemaVersion: '1.0.0',
+        id: 'open-webgal.webgal',
+        name: 'WebGAL',
+        version: '4.5.0',
+        engineType: 'official',
+        webgalVersion: '4.5.0',
+        live2dSupport: true,
+      },
+    })
+    validateDirectoryStructureMock.mockResolvedValue(true)
+    existsMock.mockImplementation(async (path: string) => {
+      if (path === '/source' || path === '/source/icons/favicon.ico') {
+        return true
+      }
+      throw new Error(`unexpected Live2D file check: ${path}`)
+    })
+
+    await expect(engineManager.inspectEngine(AbsPath.from('/source'))).resolves.toMatchObject({
+      availability: 'available',
+      payload: { metadata: { live2dSupport: true } },
+    })
+  })
+
+  it.each([false, undefined] as const)('manifest live2dSupport 为 %s 时根据两个运行时文件判断可用性', async (declaredSupport) => {
+    const manifest = {
+      schemaVersion: '1.0.0',
+      id: 'open-webgal.webgal',
+      name: 'WebGAL',
+      version: '4.5.0',
+      engineType: 'official',
+      webgalVersion: '4.5.0',
+      ...(declaredSupport === undefined ? {} : { live2dSupport: declaredSupport }),
+    }
+    readEngineManifestMock.mockResolvedValue({
+      status: 'ok',
+      manifest,
+    })
+    validateDirectoryStructureMock.mockResolvedValue(true)
+    existsMock.mockImplementation(async (path: string) => path !== '/source/lib/live2dcubismcore.min.js')
+
+    await expect(engineManager.inspectEngine(AbsPath.from('/source'))).resolves.toMatchObject({
+      availability: 'available',
+      payload: { metadata: { live2dSupport: false } },
+    })
+    expect(existsMock).toHaveBeenCalledWith('/source/lib/live2d.min.js')
+    expect(existsMock).toHaveBeenCalledWith('/source/lib/live2dcubismcore.min.js')
+  })
+
+  it('批量重检会同步用户直接修改后的 Live2D 文件状态', async () => {
+    const engine = createTestEngine({
+      id: 'engine-1',
+      path: AbsPath.from('/engines/WebGAL/4.5.0'),
+      metadata: { live2dSupport: true },
+      status: 'created',
+    })
+    enginesToArrayMock.mockResolvedValue([engine])
+    existsMock.mockImplementation(async (path: string) => path === '/engines/WebGAL/4.5.0')
+    validateDirectoryStructureMock.mockResolvedValue(true)
+    readEngineManifestMock.mockResolvedValue({
+      status: 'ok',
+      manifest: {
+        schemaVersion: '1.0.0',
+        id: 'open-webgal.webgal',
+        name: 'WebGAL',
+        version: '4.5.0',
+        engineType: 'official',
+        webgalVersion: '4.5.0',
+        live2dSupport: false,
+      },
+    })
+
+    await engineManager.validateAllEngines()
+
+    expect(enginesUpdateMock).toHaveBeenCalledWith('engine-1', expect.objectContaining({
+      metadata: { ...engine.metadata, live2dSupport: false },
+    }))
+  })
+
   it('inspectEngine 检查 manifest 中自定义 icon 路径', async () => {
     readEngineManifestMock.mockResolvedValue({
       status: 'ok',
@@ -748,6 +834,7 @@ describe('engineManager', () => {
       createTestEngine({
         id: 'engine-1',
         path: AbsPath.from('/engines/WebGAL/4.5.0'),
+        metadata: { live2dSupport: true },
         previewAssets: {
           icon: { path: '/engines/WebGAL/4.5.0/icons/favicon.ico' },
         },
@@ -778,6 +865,7 @@ describe('engineManager', () => {
       createTestEngine({
         id: 'engine-1',
         path: AbsPath.from('/engines/WebGAL/4.6.2'),
+        metadata: { live2dSupport: true },
         previewAssets: {
           icon: { path: '/engines/.import-staging/session/icons/favicon.ico' },
         },

--- a/src/services/engine-manager.ts
+++ b/src/services/engine-manager.ts
@@ -60,6 +60,11 @@ interface DeleteEngineCheckResult {
   reason?: 'ENGINE_HAS_ASSOCIATED_GAMES'
 }
 
+const LIVE2D_RUNTIME_FILES = [
+  RelPath.from('lib/live2d.min.js'),
+  RelPath.from('lib/live2dcubismcore.min.js'),
+]
+
 export type EngineEditorCompatibilityIssue =
   | 'unavailable'
   | 'versionInvalid'
@@ -78,7 +83,23 @@ function sanitizeEnginePathSegment(value: string, fieldName: '引擎名称' | '�
   return sanitized
 }
 
-function buildEngineMetadata(manifest: EngineManifest): EngineMetadata {
+async function resolveLive2dSupport(
+  enginePath: AbsPath,
+  declaredSupport: boolean | undefined,
+): Promise<boolean> {
+  if (declaredSupport === true) {
+    return true
+  }
+
+  const runtimeFilesExist = await Promise.all(
+    LIVE2D_RUNTIME_FILES.map(file => exists(AbsPath.join(enginePath, file))),
+  )
+  return runtimeFilesExist.every(Boolean)
+}
+
+async function buildEngineMetadata(enginePath: AbsPath, manifest: EngineManifest): Promise<EngineMetadata> {
+  const live2dSupport = await resolveLive2dSupport(enginePath, manifest.live2dSupport)
+
   return {
     type: manifest.engineType as EngineMetadata['type'],
     webgalVersion: manifest.webgalVersion,
@@ -88,7 +109,7 @@ function buildEngineMetadata(manifest: EngineManifest): EngineMetadata {
     license: manifest.license,
     icon: manifest.icon ?? 'icons/favicon.ico',
     urls: manifest.urls,
-    live2dSupport: manifest.live2dSupport,
+    live2dSupport,
     spineSupport: manifest.spineSupport,
   }
 }
@@ -109,7 +130,7 @@ async function classifyEngine(enginePath: AbsPath): Promise<EngineManifestResult
 }
 
 async function buildEngineSnapshot(enginePath: AbsPath, manifest: EngineManifest): Promise<EngineSnapshot> {
-  const metadata = buildEngineMetadata(manifest)
+  const metadata = await buildEngineMetadata(enginePath, manifest)
 
   return {
     engineId: manifest.id,
@@ -294,12 +315,18 @@ async function validateEngineRecordForBatch(engine: Engine): Promise<ResourceVal
       structureValid,
       semanticsValid: classification?.status === 'ok',
     })
-    const patch: Partial<Pick<Engine, 'availability' | 'previewAssets'>> = {}
+    const patch: Partial<Pick<Engine, 'availability' | 'metadata' | 'previewAssets'>> = {}
     if (engine.availability !== nextAvailability) {
       patch.availability = nextAvailability
     }
     if (classification?.status === 'ok') {
-      const metadata = buildEngineMetadata(classification.manifest)
+      const metadata = await buildEngineMetadata(engine.path, classification.manifest)
+      if (engine.metadata.live2dSupport !== metadata.live2dSupport) {
+        patch.metadata = {
+          ...engine.metadata,
+          live2dSupport: metadata.live2dSupport,
+        }
+      }
       const expectedIconPath = await resolveEngineIconPreviewPath(engine.path, metadata)
       if (engine.previewAssets.icon.path !== expectedIconPath) {
         patch.previewAssets = withEnginePreviewCacheVersion({


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [x] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [x] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

修复 Live2D 能力检测仅依赖引擎描述文件的问题。

- `live2dSupport` 显式为 `true` 时，直接判定引擎支持 Live2D。
- `live2dSupport` 为 `false` 或不存在时，检查以下运行时文件：
  - `lib/live2d.min.js`
  - `lib/live2dcubismcore.min.js`
- 两个文件均存在时判定支持 Live2D。
- 引擎导入、能力快照生成和批量重检统一使用新的判断逻辑。
- 批量重检会同步用户直接修改引擎运行时文件后的能力状态。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

用户可能直接修改已安装的引擎目录，导致描述文件中的能力声明与实际运行时文件不一致。Live2D 的实际启用依赖两个运行时文件，因此在未显式声明支持时需要根据文件状态进行检测。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->

显式声明 `live2dSupport: true` 时按声明优先，即使运行时文件缺失也不会执行文件检查。

### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
