### PR TITLE
✨ 在模板切换弹窗中支持重置当前模板

### DIFF
--- a/src/components/modals/SwitchTemplateModal.spec.ts
+++ b/src/components/modals/SwitchTemplateModal.spec.ts
@@ -57,13 +57,7 @@ function translate(key: string): string {
       return '重置当前模板'
     }
     case 'modals.switchTemplate.reset.description': {
-      return '确定要重置当前模板吗？'
-    }
-    case 'modals.switchTemplate.reset.warning': {
-      return '此操作会清空当前项目 game/template/ 下的所有覆盖内容，包括新增、修改和删除的文件，并恢复为当前模板的初始状态。'
-    }
-    case 'modals.switchTemplate.reset.unsavedWarning': {
-      return '当前打开但尚未保存的模板文件也会被关闭，未保存内容将丢失。'
+      return '此操作会清空当前项目 game/template/ 下的所有覆盖内容，包括新增、修改、未保存和删除的文件，并恢复为当前模板的初始状态。'
     }
     case 'modals.switchTemplate.dirtyWarning': {
       return '当前模板已被修改，切换将清除所有修改。'
@@ -204,9 +198,8 @@ describe('SwitchTemplateModal', () => {
     await page.getByRole('button', { name: '重置模板' }).click()
 
     await expect.element(page.getByRole('heading', { name: '重置当前模板' })).toBeInTheDocument()
-    await expect.element(page.getByText('game/template/')).toBeInTheDocument()
     await expect.element(
-      page.getByText('当前打开但尚未保存的模板文件也会被关闭，未保存内容将丢失。', { exact: true }),
+      page.getByText('此操作会清空当前项目 game/template/ 下的所有覆盖内容，包括新增、修改、未保存和删除的文件，并恢复为当前模板的初始状态。', { exact: true }),
     ).toBeInTheDocument()
     expect(resetTemplateMock).not.toHaveBeenCalled()
   })

--- a/src/components/modals/SwitchTemplateModal.spec.ts
+++ b/src/components/modals/SwitchTemplateModal.spec.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { page } from 'vitest/browser'
+import { defineComponent, h } from 'vue'
 
 import {
   createBrowserClickStub,
@@ -114,8 +115,21 @@ vi.mock('vue-i18n', async importOriginal => ({
   }),
 }))
 
+const AlertDialogStub = defineComponent({
+  name: 'StubAlertDialog',
+  props: {
+    open: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  setup(props, { slots }) {
+    return () => props.open ? h('div', slots.default?.()) : undefined
+  },
+})
+
 const globalStubs = {
-  AlertDialog: createBrowserContainerStub('StubAlertDialog'),
+  AlertDialog: AlertDialogStub,
   AlertDialogAction: createBrowserClickStub('StubAlertDialogAction'),
   AlertDialogCancel: createBrowserClickStub('StubAlertDialogCancel'),
   AlertDialogContent: createBrowserContainerStub('StubAlertDialogContent'),
@@ -195,6 +209,7 @@ describe('SwitchTemplateModal', () => {
     renderSwitchTemplateModal()
 
     await expect.element(page.getByRole('button', { name: '重置模板' })).toBeEnabled()
+    await expect.element(page.getByRole('button', { name: '确认重置' })).not.toBeInTheDocument()
     await page.getByRole('button', { name: '重置模板' }).click()
 
     await expect.element(page.getByRole('heading', { name: '重置当前模板' })).toBeInTheDocument()

--- a/src/components/modals/SwitchTemplateModal.spec.ts
+++ b/src/components/modals/SwitchTemplateModal.spec.ts
@@ -1,0 +1,251 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { page } from 'vitest/browser'
+
+import {
+  createBrowserClickStub,
+  createBrowserContainerStub,
+  renderInBrowser,
+} from '~/__tests__/browser-render'
+import { createTestEngine, createTestGame } from '~/__tests__/factories'
+import { AbsPath } from '~/domain/path'
+
+import SwitchTemplateModal from './SwitchTemplateModal.vue'
+
+const {
+  dbEngineGetMock,
+  handleErrorMock,
+  isTemplateDirtyMock,
+  readProjectConfigMock,
+  resetTemplateMock,
+  refreshCurrentGameSnapshotMock,
+  switchTemplateMock,
+  updateOpenMock,
+  useWorkspaceStoreMock,
+} = vi.hoisted(() => ({
+  dbEngineGetMock: vi.fn(),
+  handleErrorMock: vi.fn(),
+  isTemplateDirtyMock: vi.fn(),
+  readProjectConfigMock: vi.fn(),
+  resetTemplateMock: vi.fn(),
+  refreshCurrentGameSnapshotMock: vi.fn(),
+  switchTemplateMock: vi.fn(),
+  updateOpenMock: vi.fn(),
+  useWorkspaceStoreMock: vi.fn(),
+}))
+
+function translate(key: string): string {
+  switch (key) {
+    case 'common.cancel': {
+      return '取消'
+    }
+    case 'common.save': {
+      return '保存'
+    }
+    case 'modals.switchTemplate.title': {
+      return '切换模板'
+    }
+    case 'modals.switchTemplate.selectTemplate': {
+      return '选择要切换的游戏模板'
+    }
+    case 'modals.switchTemplate.templateLabel': {
+      return '游戏模板'
+    }
+    case 'modals.switchTemplate.reset.label': {
+      return '重置模板'
+    }
+    case 'modals.switchTemplate.reset.title': {
+      return '重置当前模板'
+    }
+    case 'modals.switchTemplate.reset.description': {
+      return '确定要重置当前模板吗？'
+    }
+    case 'modals.switchTemplate.reset.warning': {
+      return '此操作会清空当前项目 game/template/ 下的所有覆盖内容，包括新增、修改和删除的文件，并恢复为当前模板的初始状态。'
+    }
+    case 'modals.switchTemplate.reset.unsavedWarning': {
+      return '当前打开但尚未保存的模板文件也会被关闭，未保存内容将丢失。'
+    }
+    case 'modals.switchTemplate.dirtyWarning': {
+      return '当前模板已被修改，切换将清除所有修改。'
+    }
+    case 'modals.switchTemplate.dirtyUnsavedWarning': {
+      return '当前打开但尚未保存的模板文件也会被关闭，未保存内容将丢失。确定要继续吗？'
+    }
+    case 'modals.switchTemplate.reset.confirm': {
+      return '确认重置'
+    }
+    case 'modals.switchTemplate.reset.error': {
+      return '模板重置失败'
+    }
+    default: {
+      return key
+    }
+  }
+}
+
+vi.mock('~/commands/project-config', () => ({
+  projectConfigCmds: {
+    readProjectConfig: readProjectConfigMock,
+  },
+}))
+
+vi.mock('~/database/db', () => ({
+  db: {
+    engines: {
+      get: dbEngineGetMock,
+    },
+  },
+}))
+
+vi.mock('~/services/template-switch', () => ({
+  templateSwitch: {
+    isTemplateDirty: isTemplateDirtyMock,
+    resetTemplate: resetTemplateMock,
+    switchTemplate: switchTemplateMock,
+  },
+}))
+
+vi.mock('~/stores/workspace', () => ({
+  useWorkspaceStore: useWorkspaceStoreMock,
+}))
+
+vi.mock('~/utils/error-handler', () => ({
+  handleError: handleErrorMock,
+}))
+
+vi.mock('vue-i18n', async importOriginal => ({
+  ...(await importOriginal<typeof import('vue-i18n')>()),
+  useI18n: () => ({
+    t: translate,
+  }),
+}))
+
+const globalStubs = {
+  AlertDialog: createBrowserContainerStub('StubAlertDialog'),
+  AlertDialogAction: createBrowserClickStub('StubAlertDialogAction'),
+  AlertDialogCancel: createBrowserClickStub('StubAlertDialogCancel'),
+  AlertDialogContent: createBrowserContainerStub('StubAlertDialogContent'),
+  AlertDialogDescription: createBrowserContainerStub('StubAlertDialogDescription'),
+  AlertDialogFooter: createBrowserContainerStub('StubAlertDialogFooter'),
+  AlertDialogHeader: createBrowserContainerStub('StubAlertDialogHeader'),
+  AlertDialogTitle: createBrowserContainerStub('StubAlertDialogTitle', 'h2'),
+  Button: createBrowserClickStub('StubButton'),
+  Dialog: createBrowserContainerStub('StubDialog'),
+  DialogClose: createBrowserContainerStub('StubDialogClose'),
+  DialogContent: createBrowserContainerStub('StubDialogContent'),
+  DialogDescription: createBrowserContainerStub('StubDialogDescription'),
+  DialogFooter: createBrowserContainerStub('StubDialogFooter'),
+  DialogHeader: createBrowserContainerStub('StubDialogHeader'),
+  DialogTitle: createBrowserContainerStub('StubDialogTitle', 'h2'),
+  Label: createBrowserContainerStub('StubLabel', 'label'),
+  TemplateSelector: createBrowserContainerStub('StubTemplateSelector'),
+}
+
+function renderSwitchTemplateModal() {
+  const game = createTestGame({
+    id: 'game-1',
+    engineId: 'engine-current',
+    path: AbsPath.from('/games/demo'),
+  })
+
+  renderInBrowser(SwitchTemplateModal, {
+    props: {
+      game,
+      'open': true,
+      'onUpdate:open': updateOpenMock,
+    },
+    global: {
+      mocks: {
+        $t: translate,
+      },
+      stubs: globalStubs,
+    },
+  })
+
+  return game
+}
+
+describe('SwitchTemplateModal', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+
+    const currentGame = createTestGame({
+      id: 'game-1',
+      engineId: 'engine-current',
+      path: AbsPath.from('/games/demo'),
+    })
+    const currentEngine = createTestEngine({
+      id: 'engine-current',
+      engineId: 'open-webgal.webgal',
+      name: 'WebGAL',
+      version: '4.5.0',
+    })
+
+    dbEngineGetMock.mockResolvedValue(currentEngine)
+    handleErrorMock.mockReset()
+    isTemplateDirtyMock.mockResolvedValue(true)
+    readProjectConfigMock.mockResolvedValue({
+      version: 1,
+      engine: { id: 'open-webgal.webgal', version: '4.5.0' },
+    })
+    refreshCurrentGameSnapshotMock.mockResolvedValue(undefined)
+    resetTemplateMock.mockResolvedValue(undefined)
+    switchTemplateMock.mockResolvedValue(undefined)
+    useWorkspaceStoreMock.mockReturnValue({
+      currentGame,
+      refreshCurrentGameSnapshot: refreshCurrentGameSnapshotMock,
+    })
+  })
+
+  it('点击重置入口时先展示影响范围确认，不会立即清理模板', async () => {
+    renderSwitchTemplateModal()
+
+    await expect.element(page.getByRole('button', { name: '重置模板' })).toBeEnabled()
+    await page.getByRole('button', { name: '重置模板' }).click()
+
+    await expect.element(page.getByRole('heading', { name: '重置当前模板' })).toBeInTheDocument()
+    await expect.element(page.getByText('game/template/')).toBeInTheDocument()
+    await expect.element(
+      page.getByText('当前打开但尚未保存的模板文件也会被关闭，未保存内容将丢失。', { exact: true }),
+    ).toBeInTheDocument()
+    expect(resetTemplateMock).not.toHaveBeenCalled()
+  })
+
+  it('模板没有覆盖内容时隐藏重置入口', async () => {
+    isTemplateDirtyMock.mockResolvedValue(false)
+
+    renderSwitchTemplateModal()
+
+    await expect.element(page.getByRole('button', { name: '重置模板' })).not.toBeInTheDocument()
+  })
+
+  it('确认重置后清理当前模板并隐藏入口', async () => {
+    const game = renderSwitchTemplateModal()
+
+    await expect.element(page.getByRole('button', { name: '重置模板' })).toBeEnabled()
+    await page.getByRole('button', { name: '重置模板' }).click()
+    await page.getByRole('button', { name: '确认重置' }).click()
+
+    await vi.waitFor(() => {
+      expect(resetTemplateMock).toHaveBeenCalledWith(game.path)
+    })
+    await expect.element(page.getByRole('button', { name: '重置模板' })).not.toBeInTheDocument()
+  })
+
+  it('重置失败时通过错误处理器反馈失败原因', async () => {
+    resetTemplateMock.mockRejectedValueOnce(new Error('reset failed'))
+
+    renderSwitchTemplateModal()
+
+    await expect.element(page.getByRole('button', { name: '重置模板' })).toBeEnabled()
+    await page.getByRole('button', { name: '重置模板' }).click()
+    await page.getByRole('button', { name: '确认重置' }).click()
+
+    await vi.waitFor(() => {
+      expect(handleErrorMock).toHaveBeenCalledWith(
+        expect.any(Error),
+        { context: '模板重置失败' },
+      )
+    })
+  })
+})

--- a/src/components/modals/SwitchTemplateModal.vue
+++ b/src/components/modals/SwitchTemplateModal.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { TriangleAlert } from '@lucide/vue'
+import { RotateCcw, TriangleAlert } from '@lucide/vue'
 
 import { projectConfigCmds } from '~/commands/project-config'
 import { db } from '~/database/db'
@@ -21,19 +21,24 @@ const props = defineProps<{
 const workspaceStore = useWorkspaceStore()
 
 let isSwitching = $ref(false)
+let isResetting = $ref(false)
 let isDirty = $ref(false)
 let showDirtyConfirm = $ref(false)
+let showResetConfirm = $ref(false)
 let isEngineAvailable = $ref(true)
 let selectedBinding = $ref<TemplateBinding | undefined>(undefined)
 
 watch(() => open.value, async (isOpen) => {
   if (!isOpen) {
     showDirtyConfirm = false
+    showResetConfirm = false
     return
   }
 
   isSwitching = false
+  isResetting = false
   showDirtyConfirm = false
+  showResetConfirm = false
 
   // Initial binding mirrors the project's current state so the dialog reflects reality.
   try {
@@ -50,7 +55,7 @@ watch(() => open.value, async (isOpen) => {
     isEngineAvailable = true
   }
 
-  isDirty = isEngineAvailable ? await templateSwitch.isTemplateDirty(props.game.path) : false
+  isDirty = await templateSwitch.isTemplateDirty(props.game.path)
 }, { immediate: true })
 
 async function performSwitch(skipDirtyCheck: boolean) {
@@ -72,7 +77,7 @@ async function performSwitch(skipDirtyCheck: boolean) {
 }
 
 async function handleConfirm() {
-  if (isSwitching) {
+  if (isSwitching || isResetting) {
     return
   }
 
@@ -88,11 +93,36 @@ async function handleDirtyConfirm() {
   showDirtyConfirm = false
   await performSwitch(true)
 }
+
+function handleResetRequest() {
+  if (isSwitching || isResetting || !isDirty) {
+    return
+  }
+
+  showResetConfirm = true
+}
+
+async function handleResetConfirm() {
+  showResetConfirm = false
+  if (isSwitching || isResetting || !isDirty) {
+    return
+  }
+
+  isResetting = true
+  try {
+    await templateSwitch.resetTemplate(props.game.path)
+    isDirty = false
+  } catch (error) {
+    handleError(error, { context: t('modals.switchTemplate.reset.error') })
+  } finally {
+    isResetting = false
+  }
+}
 </script>
 
 <template>
   <Dialog ::open="open">
-    <DialogContent class="sm:max-w-[425px]">
+    <DialogContent class="sm:max-w-[450px]" :hide-close="isSwitching || isResetting">
       <DialogHeader>
         <DialogTitle>
           {{ $t('modals.switchTemplate.title') }}
@@ -124,15 +154,27 @@ async function handleDirtyConfirm() {
         </div>
       </div>
 
-      <DialogFooter>
-        <DialogClose as-child>
-          <Button variant="outline">
-            {{ $t('common.cancel') }}
-          </Button>
-        </DialogClose>
-        <Button :disabled="isSwitching || !isEngineAvailable" @click="handleConfirm">
-          {{ $t('common.save') }}
+      <DialogFooter class="gap-3 sm:justify-between">
+        <Button
+          v-if="isDirty"
+          variant="ghost"
+          class="text-destructive hover:text-destructive hover:bg-destructive/10"
+          :disabled="isSwitching || isResetting"
+          @click="handleResetRequest"
+        >
+          <RotateCcw class="size-4" aria-hidden="true" />
+          {{ $t('modals.switchTemplate.reset.label') }}
         </Button>
+        <div class="flex gap-2">
+          <DialogClose as-child>
+            <Button variant="outline" :disabled="isSwitching || isResetting">
+              {{ $t('common.cancel') }}
+            </Button>
+          </DialogClose>
+          <Button :disabled="isSwitching || isResetting || !isEngineAvailable" @click="handleConfirm">
+            {{ $t('common.save') }}
+          </Button>
+        </div>
       </DialogFooter>
     </DialogContent>
   </Dialog>
@@ -165,6 +207,39 @@ async function handleDirtyConfirm() {
           @click="handleDirtyConfirm"
         >
           {{ $t('modals.switchTemplate.dirtyConfirm.confirm') }}
+        </AlertDialogAction>
+      </AlertDialogFooter>
+    </AlertDialogContent>
+  </AlertDialog>
+
+  <AlertDialog ::open="showResetConfirm">
+    <AlertDialogContent>
+      <div class="flex flex-col gap-2 sm:flex-row sm:gap-4 max-sm:items-center">
+        <div
+          class="text-destructive rounded-lg bg-destructive/10 flex shrink-0 size-9 items-center justify-center"
+          aria-hidden="true"
+        >
+          <TriangleAlert class="size-5" aria-hidden="true" />
+        </div>
+        <AlertDialogHeader>
+          <AlertDialogTitle>
+            {{ $t('modals.switchTemplate.reset.title') }}
+          </AlertDialogTitle>
+          <AlertDialogDescription>
+            {{ $t('modals.switchTemplate.reset.description') }}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+      </div>
+      <AlertDialogFooter>
+        <AlertDialogCancel>
+          {{ $t('common.cancel') }}
+        </AlertDialogCancel>
+        <AlertDialogAction
+          variant="destructive"
+          :disabled="isResetting"
+          @click="handleResetConfirm"
+        >
+          {{ $t('modals.switchTemplate.reset.confirm') }}
         </AlertDialogAction>
       </AlertDialogFooter>
     </AlertDialogContent>

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -350,6 +350,12 @@ modals:
     dirtyConfirm:
       title: Switching will discard modifications
       confirm: Confirm switch
+    reset:
+      label: Reset Template
+      title: Are you sure you want to reset the current template?
+      description: This will clear all overrides under the project's game/template/ directory, including added, modified, unsaved, and deleted files, and restore the initial state of the selected template.
+      confirm: Confirm Reset
+      error: Template reset failed
     error: Template switch failed
     engineUnavailable: The bound engine is unavailable. Restore or reinstall it before switching templates.
   deleteEngineGroup:

--- a/src/locales/ja.yml
+++ b/src/locales/ja.yml
@@ -350,6 +350,12 @@ modals:
     dirtyConfirm:
       title: 切り替えると変更が失われます
       confirm: 切り替えを確認
+    reset:
+      label: テンプレートをリセット
+      title: 現在のテンプレートをリセットしてもよろしいですか？
+      description: この操作では、プロジェクトの game/template/ 以下にある追加・変更・未保存・削除されたファイルを含むすべての上書き内容を消去し、選択中のテンプレートを初期状態に戻します。
+      confirm: リセットを確認
+      error: テンプレートのリセットに失敗しました
     error: テンプレートの切り替えに失敗しました
     engineUnavailable: 紐付けられたエンジンが現在利用できません。エンジンを復旧または再インストールしてからテンプレートを切り替えてください。
   deleteEngineGroup:

--- a/src/locales/zh-Hans.yml
+++ b/src/locales/zh-Hans.yml
@@ -350,6 +350,12 @@ modals:
     dirtyConfirm:
       title: 切换模板将丢失修改
       confirm: 确认切换
+    reset:
+      label: 重置模板
+      title: 确定要重置当前模板吗？
+      description: 此操作会清空当前项目 game/template/ 下的所有覆盖内容，包括新增、修改、未保存和删除的文件，并恢复为当前模板的初始状态。
+      confirm: 确认重置
+      error: 模板重置失败
     error: 模板切换失败
     engineUnavailable: 绑定的引擎当前不可用，请先恢复或重新安装引擎再切换模板。
   deleteEngineGroup:

--- a/src/locales/zh-Hant.yml
+++ b/src/locales/zh-Hant.yml
@@ -350,6 +350,12 @@ modals:
     dirtyConfirm:
       title: 切換模板將遺失修改
       confirm: 確認切換
+    reset:
+      label: 重設模板
+      title: 確定要重設目前模板嗎？
+      description: 此操作會清空目前專案 game/template/ 下的所有覆蓋內容，包括新增、修改、未儲存和刪除的檔案，並恢復為目前模板的初始狀態。
+      confirm: 確認重設
+      error: 模板重設失敗
     error: 模板切換失敗
     engineUnavailable: 綁定的引擎目前不可用，請先恢復或重新安裝引擎再切換模板。
   deleteEngineGroup:
@@ -745,7 +751,7 @@ edit:
     unsupportedCallSceneArgument: 「呼叫場景」命令向子場景傳遞參數需要 WebGAL 4.6.3 或更新版本。
     unsupportedLocalVariable: 「局部變數」參數需要 WebGAL 4.6.3 或更新版本。
     unsupportedSpine: 目前引擎不支援 Spine 模型。
-    reservedCallSceneArgument: '「{argument}」為保留參數，不能用於 callScene。'
+    reservedCallSceneArgument: "「{argument}」為保留參數，不能用於 callScene。"
   errors:
     fileSyncFailed: 檔案同步失敗，請稍後重試
     previewUnavailable: 預覽地址不存在，請先啟動預覽

--- a/src/services/__tests__/template-switch.test.ts
+++ b/src/services/__tests__/template-switch.test.ts
@@ -5,6 +5,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { AbsPath } from '~/domain/path'
 import { templateSwitch } from '~/services/template-switch'
 
+vi.mock('@tauri-apps/plugin-log', () => ({
+  info: vi.fn(),
+  warn: vi.fn(),
+}))
+
 const {
   cleanTemplateUpperMock,
   closeTabMock,
@@ -141,5 +146,30 @@ describe('templateSwitch.resetTemplate', () => {
     expect(cleanTemplateUpperMock).not.toHaveBeenCalled()
     expect(refreshTemplateOverlayMock).not.toHaveBeenCalled()
     expect(debugCommanderMock.refetchTemplates).not.toHaveBeenCalled()
+  })
+
+  it('刷新模板 overlay 失败时不会报告重置成功', async () => {
+    refreshTemplateOverlayMock.mockRejectedValueOnce(new Error('overlay failed'))
+
+    await expect(templateSwitch.resetTemplate(AbsPath.from('/games/demo'))).rejects.toThrow('overlay failed')
+
+    expect(cleanTemplateUpperMock).toHaveBeenCalledWith('/games/demo')
+    expect(debugCommanderMock.refetchTemplates).not.toHaveBeenCalled()
+  })
+
+  it('预览状态重置时不阻止模板重置', async () => {
+    debugCommanderMock.refetchTemplates.mockRejectedValueOnce(new Error('preview state reset'))
+
+    await expect(templateSwitch.resetTemplate(AbsPath.from('/games/demo'))).resolves.toBeUndefined()
+
+    expect(cleanTemplateUpperMock).toHaveBeenCalledWith('/games/demo')
+  })
+
+  it('其他预览刷新失败会向调用方传播', async () => {
+    debugCommanderMock.refetchTemplates.mockRejectedValueOnce(new Error('preview failed'))
+
+    await expect(templateSwitch.resetTemplate(AbsPath.from('/games/demo'))).rejects.toThrow('preview failed')
+
+    expect(cleanTemplateUpperMock).toHaveBeenCalledWith('/games/demo')
   })
 })

--- a/src/services/__tests__/template-switch.test.ts
+++ b/src/services/__tests__/template-switch.test.ts
@@ -6,19 +6,23 @@ import { AbsPath } from '~/domain/path'
 import { templateSwitch } from '~/services/template-switch'
 
 const {
+  cleanTemplateUpperMock,
   closeTabMock,
-  collectDocumentPathsUnderMock,
   debugCommanderMock,
   findTabIndexMock,
   refreshTemplateOverlayMock,
+  tabsStoreMock,
 } = vi.hoisted(() => ({
+  cleanTemplateUpperMock: vi.fn(),
   closeTabMock: vi.fn(),
-  collectDocumentPathsUnderMock: vi.fn(),
   debugCommanderMock: {
     refetchTemplates: vi.fn(),
   },
   findTabIndexMock: vi.fn(),
   refreshTemplateOverlayMock: vi.fn(),
+  tabsStoreMock: {
+    tabs: [] as { path: string }[],
+  },
 }))
 
 vi.mock('~/services/debug-commander', () => ({
@@ -27,7 +31,7 @@ vi.mock('~/services/debug-commander', () => ({
 
 vi.mock('~/stores/editor', () => ({
   useEditorStore: () => ({
-    collectDocumentPathsUnder: collectDocumentPathsUnderMock,
+    hasUnsavedDocumentsUnder: vi.fn(),
   }),
 }))
 
@@ -39,24 +43,32 @@ vi.mock('~/stores/file', () => ({
 
 vi.mock('~/stores/tabs', () => ({
   useTabsStore: () => ({
+    tabs: tabsStoreMock.tabs,
     closeTab: closeTabMock,
     findTabIndex: findTabIndexMock,
   }),
 }))
 
-describe('templateSwitch.notifyTemplateChanged', () => {
-  beforeEach(() => {
-    closeTabMock.mockReset()
-    collectDocumentPathsUnderMock.mockReset()
-    debugCommanderMock.refetchTemplates.mockReset()
-    findTabIndexMock.mockReset()
-    refreshTemplateOverlayMock.mockReset()
+vi.mock('~/commands/vfs', () => ({
+  vfsCmds: {
+    cleanTemplateUpper: cleanTemplateUpperMock,
+  },
+}))
 
-    collectDocumentPathsUnderMock.mockReturnValue([])
-    refreshTemplateOverlayMock.mockResolvedValue(undefined)
-    debugCommanderMock.refetchTemplates.mockResolvedValue(undefined)
+beforeEach(() => {
+  vi.resetAllMocks()
+
+  tabsStoreMock.tabs = []
+  findTabIndexMock.mockImplementation(path => tabsStoreMock.tabs.findIndex(tab => tab.path === path))
+  closeTabMock.mockImplementation((index: number) => {
+    tabsStoreMock.tabs.splice(index, 1)
   })
+  cleanTemplateUpperMock.mockResolvedValue(undefined)
+  refreshTemplateOverlayMock.mockResolvedValue(undefined)
+  debugCommanderMock.refetchTemplates.mockResolvedValue(undefined)
+})
 
+describe('templateSwitch.notifyTemplateChanged', () => {
   it('默认通知预览重新加载模板', async () => {
     await templateSwitch.notifyTemplateChanged(AbsPath.from('/games/demo'))
 
@@ -76,6 +88,44 @@ describe('templateSwitch.notifyTemplateChanged', () => {
       nextEnginePath: undefined,
       nextTemplatePath: undefined,
     })
+    expect(debugCommanderMock.refetchTemplates).not.toHaveBeenCalled()
+  })
+})
+
+describe('templateSwitch.resetTemplate', () => {
+  it('关闭模板标签、清理覆盖层后刷新文件缓存和预览', async () => {
+    const gamePath = AbsPath.from('/games/demo')
+    tabsStoreMock.tabs = [
+      { path: '/games/demo/game/template/custom.txt' },
+      { path: '/games/demo/game/scene/start.txt' },
+      { path: '/games/demo/game/template/styles.css' },
+      { path: '/games/demo/game/template-old/kept.txt' },
+    ]
+
+    await templateSwitch.resetTemplate(gamePath)
+
+    expect(closeTabMock).toHaveBeenNthCalledWith(1, 0)
+    expect(closeTabMock).toHaveBeenNthCalledWith(2, 1)
+    expect(tabsStoreMock.tabs).toEqual([
+      { path: '/games/demo/game/scene/start.txt' },
+      { path: '/games/demo/game/template-old/kept.txt' },
+    ])
+    expect(cleanTemplateUpperMock).toHaveBeenCalledWith('/games/demo')
+    expect(refreshTemplateOverlayMock).toHaveBeenCalledWith('/games/demo', {
+      nextEnginePath: undefined,
+      nextTemplatePath: undefined,
+    })
+    expect(debugCommanderMock.refetchTemplates).toHaveBeenCalledTimes(1)
+    expect(cleanTemplateUpperMock.mock.invocationCallOrder[0]).toBeGreaterThan(closeTabMock.mock.invocationCallOrder[1])
+    expect(refreshTemplateOverlayMock.mock.invocationCallOrder[0]).toBeGreaterThan(cleanTemplateUpperMock.mock.invocationCallOrder[0])
+  })
+
+  it('清理失败时不会刷新模板消费者', async () => {
+    cleanTemplateUpperMock.mockRejectedValueOnce(new Error('clean failed'))
+
+    await expect(templateSwitch.resetTemplate(AbsPath.from('/games/demo'))).rejects.toThrow('clean failed')
+
+    expect(refreshTemplateOverlayMock).not.toHaveBeenCalled()
     expect(debugCommanderMock.refetchTemplates).not.toHaveBeenCalled()
   })
 })

--- a/src/services/__tests__/template-switch.test.ts
+++ b/src/services/__tests__/template-switch.test.ts
@@ -128,4 +128,18 @@ describe('templateSwitch.resetTemplate', () => {
     expect(refreshTemplateOverlayMock).not.toHaveBeenCalled()
     expect(debugCommanderMock.refetchTemplates).not.toHaveBeenCalled()
   })
+
+  it('关闭模板标签失败时不会清理覆盖层', async () => {
+    const gamePath = AbsPath.from('/games/demo')
+    tabsStoreMock.tabs = [{ path: '/games/demo/game/template/custom.txt' }]
+    closeTabMock.mockImplementationOnce(() => {
+      throw new Error('close failed')
+    })
+
+    await expect(templateSwitch.resetTemplate(gamePath)).rejects.toThrow('close failed')
+
+    expect(cleanTemplateUpperMock).not.toHaveBeenCalled()
+    expect(refreshTemplateOverlayMock).not.toHaveBeenCalled()
+    expect(debugCommanderMock.refetchTemplates).not.toHaveBeenCalled()
+  })
 })

--- a/src/services/template-switch.ts
+++ b/src/services/template-switch.ts
@@ -43,21 +43,17 @@ async function isTemplateDirty(gamePath: AbsPath): Promise<boolean> {
 }
 
 async function closeOpenedTemplateDocuments(gamePath: AbsPath): Promise<void> {
-  try {
-    const templateRoot = templateUpperPath(gamePath)
-    const tabsStore = useTabsStore()
-    const openedPaths = tabsStore.tabs
-      .filter(tab => isPathWithinDirectory(tab.path, templateRoot))
-      .map(tab => tab.path)
+  const templateRoot = templateUpperPath(gamePath)
+  const tabsStore = useTabsStore()
+  const openedPaths = tabsStore.tabs
+    .filter(tab => isPathWithinDirectory(tab.path, templateRoot))
+    .map(tab => tab.path)
 
-    for (const path of openedPaths) {
-      const index = tabsStore.findTabIndex(path)
-      if (index !== -1) {
-        tabsStore.closeTab(index)
-      }
+  for (const path of openedPaths) {
+    const index = tabsStore.findTabIndex(path)
+    if (index !== -1) {
+      tabsStore.closeTab(index)
     }
-  } catch (error) {
-    logger.warn(`[模板切换] 关闭模板文档失败: ${error}`)
   }
 }
 

--- a/src/services/template-switch.ts
+++ b/src/services/template-switch.ts
@@ -19,6 +19,15 @@ function templateUpperPath(gamePath: AbsPath): AbsPath {
   return AbsPath.join(gamePath, RelPath.from('game/template'))
 }
 
+function isPathWithinDirectory(path: AbsPath, directory: AbsPath): boolean {
+  try {
+    AbsPath.relativize(path, directory)
+    return true
+  } catch {
+    return false
+  }
+}
+
 async function isTemplateDirty(gamePath: AbsPath): Promise<boolean> {
   if (await vfsCmds.isTemplateDirty(gamePath)) {
     return true
@@ -36,11 +45,13 @@ async function isTemplateDirty(gamePath: AbsPath): Promise<boolean> {
 async function closeOpenedTemplateDocuments(gamePath: AbsPath): Promise<void> {
   try {
     const templateRoot = templateUpperPath(gamePath)
-    const editorStore = useEditorStore()
     const tabsStore = useTabsStore()
-    const openedPaths = editorStore.collectDocumentPathsUnder(templateRoot)
+    const openedPaths = tabsStore.tabs
+      .filter(tab => isPathWithinDirectory(tab.path, templateRoot))
+      .map(tab => tab.path)
+
     for (const path of openedPaths) {
-      const index = tabsStore.findTabIndex(AbsPath.from(path))
+      const index = tabsStore.findTabIndex(path)
       if (index !== -1) {
         tabsStore.closeTab(index)
       }
@@ -56,24 +67,10 @@ interface NotifyTemplateChangedOptions {
   skipPreviewTemplateReload?: boolean
 }
 
-/**
- * 切换收尾通用清理：
- * - 关闭仍打开的模板文档（联动 editor session 清理与未保存状态丢弃）
- * - 失效 file store 中模板子树缓存并刷新 enginePath / templatePath
- * - 按调用场景通知运行中的预览拉取新模板
- *
- * @param options.nextEnginePath 引擎切换路径下的新引擎路径。必须由调用方显式
- *   传入，因为此时 `workspaceStore.currentGame.engineId` 仍是切换前的快照。
- * @param options.nextTemplatePath 模板切换后的解析路径。`null` 表示回到
- *   "跟随当前引擎默认"（缺省 binding）。
- * @param options.skipPreviewTemplateReload 引擎切换已重载预览 iframe 时跳过独立的模板重载请求。
- */
-async function notifyTemplateChanged(
+async function refreshTemplateOverlayAndPreview(
   gamePath: AbsPath,
-  options: NotifyTemplateChangedOptions = {},
+  options: NotifyTemplateChangedOptions,
 ): Promise<void> {
-  await closeOpenedTemplateDocuments(gamePath)
-
   // 失效 file store 中模板子树缓存并刷新 enginePath / templatePath，
   // 同时由 store 内部 emit `directory:modified` 通知订阅者重读。
   // 引擎/模板切换不会改动磁盘文件本身（只是 lower 路径变了），
@@ -95,6 +92,36 @@ async function notifyTemplateChanged(
       logger.warn(`[模板切换] 通知预览刷新模板失败: ${error}`)
     }
   }
+}
+
+/**
+ * 切换收尾通用清理：
+ * - 关闭仍打开的模板文档（联动 editor session 清理与未保存状态丢弃）
+ * - 失效 file store 中模板子树缓存并刷新 enginePath / templatePath
+ * - 按调用场景通知运行中的预览拉取新模板
+ *
+ * @param options.nextEnginePath 引擎切换路径下的新引擎路径。必须由调用方显式
+ *   传入，因为此时 `workspaceStore.currentGame.engineId` 仍是切换前的快照。
+ * @param options.nextTemplatePath 模板切换后的解析路径。`null` 表示回到
+ *   "跟随当前引擎默认"（缺省 binding）。
+ * @param options.skipPreviewTemplateReload 引擎切换已重载预览 iframe 时跳过独立的模板重载请求。
+ */
+async function notifyTemplateChanged(
+  gamePath: AbsPath,
+  options: NotifyTemplateChangedOptions = {},
+): Promise<void> {
+  await closeOpenedTemplateDocuments(gamePath)
+  await refreshTemplateOverlayAndPreview(gamePath, options)
+}
+
+/**
+ * 重置项目当前模板的所有覆盖内容，恢复到当前模板的初始状态。
+ * 清理前关闭模板文档，避免打开的文档继续指向已移除的 upper 路径。
+ */
+async function resetTemplate(gamePath: AbsPath): Promise<void> {
+  await closeOpenedTemplateDocuments(gamePath)
+  await vfsCmds.cleanTemplateUpper(gamePath)
+  await refreshTemplateOverlayAndPreview(gamePath, {})
 }
 
 /** 站点未注册时为非致命情形（项目尚未打开预览），吞掉错误并 warn */
@@ -209,6 +236,7 @@ export const templateSwitch = {
   resolveTemplatePath,
   evaluateTemplateStrategy,
   isTemplateDirty,
+  resetTemplate,
   switchTemplate,
   notifyTemplateChanged,
 }

--- a/src/services/template-switch.ts
+++ b/src/services/template-switch.ts
@@ -5,6 +5,7 @@ import { db } from '~/database/db'
 import { AbsPath, RelPath } from '~/domain/path'
 import { debugCommander } from '~/services/debug-commander'
 import { engineManager, isEngineUsable } from '~/services/engine-manager'
+import { isPreviewStateResetError } from '~/services/preview-protocol-client'
 import { useEditorStore } from '~/stores/editor'
 import { useFileStore } from '~/stores/file'
 import { useTabsStore } from '~/stores/tabs'
@@ -71,21 +72,20 @@ async function refreshTemplateOverlayAndPreview(
   // 同时由 store 内部 emit `directory:modified` 通知订阅者重读。
   // 引擎/模板切换不会改动磁盘文件本身（只是 lower 路径变了），
   // OS watcher 不会触发；必须主动失效，否则 listDir 仍会用旧 lower 配置返回。
-  try {
-    await useFileStore().refreshTemplateOverlay(gamePath, {
-      nextEnginePath: options.nextEnginePath,
-      nextTemplatePath: options.nextTemplatePath,
-    })
-  } catch (error) {
-    logger.warn(`[模板切换] 失效模板 overlay 缓存失败: ${error}`)
-  }
+  await useFileStore().refreshTemplateOverlay(gamePath, {
+    nextEnginePath: options.nextEnginePath,
+    nextTemplatePath: options.nextTemplatePath,
+  })
 
   if (!options.skipPreviewTemplateReload) {
     try {
       await debugCommander.refetchTemplates()
     } catch (error) {
-      // 无运行中的预览或站点未连接时忽略
-      logger.warn(`[模板切换] 通知预览刷新模板失败: ${error}`)
+      if (isPreviewStateResetError(error)) {
+        logger.warn(`[模板切换] 通知预览刷新模板失败: ${error}`)
+        return
+      }
+      throw error
     }
   }
 }


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [ ] 错误修复
- [x] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [x] 代码重构
- [x] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

- 在模板切换弹窗中增加“重置模板”入口，仅在当前模板存在覆盖内容或未保存编辑时显示。
- 重置前通过二次确认明确说明会清空 `game/template/` 下的覆盖内容，并关闭所有已打开的模板文件；未保存内容会被丢弃。
- 清理完成后刷新文件树缓存和运行中的预览，避免界面继续展示旧模板内容。
- 同步更新英文、日文、简体中文和繁体中文文案，并补充组件与服务行为测试。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

模板覆盖内容分散在新增、修改和删除记录中，缺少一个明确且集中恢复当前模板初始状态的操作入口。重置前关闭相关标签页可以同时丢弃未保存编辑，避免标签页继续引用已经清理的覆盖路径。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
