### PR TITLE
✨ 支持从外部拖拽导入场景和资源

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -44,6 +44,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ambient-authority"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9d4ee0d472d1cd2e28c97dfa124b3d8d992e10eb0a035f33f5d12e3a177ba3b"
+
+[[package]]
 name = "android_log-sys"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -583,6 +589,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "cap-primitives"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdadbd7c002d3a484b35243669abdae85a0ebaded5a61117169dc3400f9a7ff0"
+dependencies = [
+ "ambient-authority",
+ "fs-set-times",
+ "io-extras",
+ "io-lifetimes 3.0.1",
+ "ipnet",
+ "maybe-owned",
+ "rustix",
+ "rustix-linux-procfs",
+ "windows-sys 0.61.2",
+ "winx",
+]
+
+[[package]]
+name = "cap-std"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7281235d6e96d3544ca18bba9049be92f4190f8d923e3caef1b5f66cfa752608"
+dependencies = [
+ "cap-primitives",
+ "io-extras",
+ "io-lifetimes 3.0.1",
+ "rustix",
+]
+
+[[package]]
 name = "cargo-platform"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1010,7 +1046,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1212,7 +1248,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1358,6 +1394,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs-set-times"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
+dependencies = [
+ "io-lifetimes 2.0.4",
+ "rustix",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1973,7 +2020,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.56.0",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -2189,6 +2236,28 @@ checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "io-extras"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20fd6de4ccfcc187e38bc21cfa543cb5a302cb86a8b114eb7f0bf0dc9f8ac00f"
+dependencies = [
+ "io-lifetimes 3.0.1",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
+
+[[package]]
+name = "io-lifetimes"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0fb0570afe1fed943c5c3d4102d5358592d8625fda6a0007fdbe65a92fba96"
 
 [[package]]
 name = "ipnet"
@@ -2520,6 +2589,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
+name = "maybe-owned"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
+
+[[package]]
 name = "memchr"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2606,7 +2681,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3407,7 +3482,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3729,7 +3804,17 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustix-linux-procfs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fc84bf7e9aa16c4f2c758f27412dc9841341e16aa682d9c7ac308fe3ee12056"
+dependencies = [
+ "once_cell",
+ "rustix",
 ]
 
 [[package]]
@@ -3787,7 +3872,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4230,7 +4315,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4948,7 +5033,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5364,7 +5449,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5409,7 +5494,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5764,6 +5849,7 @@ name = "webgal-craft"
 version = "0.0.0"
 dependencies = [
  "axum",
+ "cap-std",
  "chrono",
  "futures-util",
  "image",
@@ -5911,7 +5997,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6405,6 +6491,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
 dependencies = [
  "cfg-if",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "winx"
+version = "0.36.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
+dependencies = [
+ "bitflags 2.13.0",
  "windows-sys 0.59.0",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -24,6 +24,7 @@ tauri-plugin-prevent-default = { version = "5.0", features = ["platform-windows"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 log = "0.4"
+cap-std = "4.0.2"
 axum = { version = "0.8", features = ["ws"] }
 tokio = { version = "1.52", features = ["rt", "sync", "fs", "net", "io-util"] }
 tower = "0.5"

--- a/src-tauri/src/commands/external_import.rs
+++ b/src-tauri/src/commands/external_import.rs
@@ -1,0 +1,440 @@
+use std::{
+    fs::{self, OpenOptions},
+    io::{self, ErrorKind},
+    path::{Component, Path},
+};
+
+use super::{AppError, AppResult};
+use crate::vfs::VfsError;
+
+fn is_link_or_reparse_point(metadata: &fs::Metadata) -> bool {
+    if metadata.file_type().is_symlink() {
+        return true;
+    }
+
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::MetadataExt;
+
+        const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x400;
+        metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0
+    }
+
+    #[cfg(not(windows))]
+    {
+        false
+    }
+}
+
+fn path_denied() -> AppError {
+    VfsError::PathDenied.into()
+}
+
+fn validate_import_name(name: &str) -> AppResult<()> {
+    let mut components = Path::new(name).components();
+    match (components.next(), components.next()) {
+        (Some(Component::Normal(_)), None) => Ok(()),
+        _ => Err(path_denied()),
+    }
+}
+
+fn import_name_parts(base_name: &str, is_directory: bool) -> (&str, &str) {
+    let last_dot = base_name.rfind('.');
+    let has_extension = !is_directory && last_dot.is_some_and(|index| index > 0);
+    if has_extension {
+        base_name.split_at(last_dot.expect("extension index should exist"))
+    } else {
+        (base_name, "")
+    }
+}
+
+fn numbered_import_name(base_name: &str, is_directory: bool, counter: usize) -> String {
+    let (stem, extension) = import_name_parts(base_name, is_directory);
+    format!("{stem} ({counter}){extension}")
+}
+
+fn next_conflict_counter(
+    source_name: &str,
+    is_directory: bool,
+    preferred_name: &str,
+) -> AppResult<usize> {
+    if preferred_name == source_name {
+        return Ok(1);
+    }
+
+    let (stem, extension) = import_name_parts(source_name, is_directory);
+    let prefix = format!("{stem} (");
+    let suffix = format!("){extension}");
+    let counter = preferred_name
+        .strip_prefix(&prefix)
+        .and_then(|value| value.strip_suffix(&suffix))
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|counter| *counter > 0)
+        .ok_or_else(path_denied)?;
+
+    if numbered_import_name(source_name, is_directory, counter) != preferred_name {
+        return Err(path_denied());
+    }
+
+    counter.checked_add(1).ok_or_else(path_denied)
+}
+
+fn validate_created_destination(destination: &Path, project_root: &Path) -> AppResult<()> {
+    let canonical_destination = destination.canonicalize()?;
+    if canonical_destination != destination || !canonical_destination.starts_with(project_root) {
+        return Err(path_denied());
+    }
+
+    Ok(())
+}
+
+fn copy_directory(source: &Path, destination: &Path) -> AppResult<()> {
+    for entry in fs::read_dir(source)? {
+        let entry = entry?;
+        let source_path = entry.path();
+        let destination_path = destination.join(entry.file_name());
+        let metadata = fs::symlink_metadata(&source_path)?;
+
+        if is_link_or_reparse_point(&metadata) {
+            return Err(path_denied());
+        }
+
+        if metadata.is_dir() {
+            fs::create_dir(&destination_path)?;
+            copy_directory(&source_path, &destination_path)?;
+        } else if metadata.is_file() {
+            let mut source_file = fs::File::open(&source_path)?;
+            let mut destination_file = OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&destination_path)?;
+            io::copy(&mut source_file, &mut destination_file)?;
+        } else {
+            return Err(path_denied());
+        }
+    }
+
+    Ok(())
+}
+
+fn rollback_destination(
+    destination: &Path,
+    is_directory: bool,
+    import_error: AppError,
+) -> AppError {
+    let cleanup_result = if is_directory {
+        fs::remove_dir_all(destination)
+    } else {
+        fs::remove_file(destination)
+    };
+
+    match cleanup_result {
+        Ok(()) => import_error,
+        Err(cleanup_error) => AppError::Server(format!(
+            "外部导入失败且无法清理目标 {}：导入错误: {import_error}；清理错误: {cleanup_error}",
+            destination.display(),
+        )),
+    }
+}
+
+fn import_external_entry_impl(
+    source: &Path,
+    target_directory: &Path,
+    preferred_name: &str,
+    project_root: &Path,
+) -> AppResult<String> {
+    validate_import_name(preferred_name)?;
+
+    let source_metadata = fs::symlink_metadata(source)?;
+    if is_link_or_reparse_point(&source_metadata)
+        || (!source_metadata.is_file() && !source_metadata.is_dir())
+    {
+        return Err(path_denied());
+    }
+
+    let canonical_source = source.canonicalize()?;
+    let canonical_project_root = project_root.canonicalize()?;
+    let canonical_target_directory = target_directory.canonicalize()?;
+    if !canonical_project_root.is_dir()
+        || !canonical_target_directory.is_dir()
+        || !canonical_target_directory.starts_with(&canonical_project_root)
+    {
+        return Err(path_denied());
+    }
+
+    let is_directory = source_metadata.is_dir();
+    if is_directory && canonical_target_directory.starts_with(&canonical_source) {
+        return Err(path_denied());
+    }
+
+    let source_name = source
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(path_denied)?;
+    let mut candidate_name = preferred_name.to_owned();
+    let mut counter = next_conflict_counter(source_name, is_directory, preferred_name)?;
+
+    loop {
+        let destination = canonical_target_directory.join(&candidate_name);
+
+        if is_directory {
+            match fs::create_dir(&destination) {
+                Ok(()) => {
+                    let copy_result =
+                        validate_created_destination(&destination, &canonical_project_root)
+                            .and_then(|()| copy_directory(&canonical_source, &destination));
+
+                    if let Err(error) = copy_result {
+                        return Err(rollback_destination(&destination, true, error));
+                    }
+                    return Ok(candidate_name);
+                }
+                Err(error) if error.kind() == ErrorKind::AlreadyExists => {}
+                Err(error) => return Err(error.into()),
+            }
+        } else {
+            match OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&destination)
+            {
+                Ok(mut destination_file) => {
+                    let copy_result =
+                        validate_created_destination(&destination, &canonical_project_root)
+                            .and_then(|()| {
+                                let mut source_file = fs::File::open(&canonical_source)?;
+                                io::copy(&mut source_file, &mut destination_file)?;
+                                Ok(())
+                            });
+                    drop(destination_file);
+
+                    if let Err(error) = copy_result {
+                        return Err(rollback_destination(&destination, false, error));
+                    }
+                    return Ok(candidate_name);
+                }
+                Err(error) if error.kind() == ErrorKind::AlreadyExists => {}
+                Err(error) => return Err(error.into()),
+            }
+        }
+
+        candidate_name = numbered_import_name(source_name, is_directory, counter);
+        counter = counter.checked_add(1).ok_or_else(path_denied)?;
+    }
+}
+
+#[tauri::command]
+pub async fn import_external_entry(
+    source: String,
+    target_directory: String,
+    preferred_name: String,
+    project_root: String,
+) -> AppResult<String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        import_external_entry_impl(
+            Path::new(&source),
+            Path::new(&target_directory),
+            &preferred_name,
+            Path::new(&project_root),
+        )
+    })
+    .await
+    .map_err(|error| AppError::Server(format!("外部导入任务执行失败: {error}")))?
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(windows)]
+    use std::process::Command;
+    use std::{
+        fs,
+        path::Path,
+        sync::{Arc, Barrier},
+        thread,
+    };
+
+    use tempfile::tempdir;
+
+    use super::{import_external_entry_impl, AppError};
+
+    #[cfg(unix)]
+    fn create_dir_link(target: &Path, link: &Path) {
+        std::os::unix::fs::symlink(target, link).expect("directory symlink should be created");
+    }
+
+    #[cfg(windows)]
+    fn create_dir_link(target: &Path, link: &Path) {
+        let command = format!(
+            "$link = '{}'; $target = '{}'; New-Item -ItemType Junction -Path $link -Target $target | Out-Null",
+            link.display(),
+            target.display(),
+        );
+        let status = Command::new("powershell")
+            .args(["-NoProfile", "-Command", &command])
+            .status()
+            .expect("junction command should run");
+
+        assert!(status.success(), "directory junction should be created");
+    }
+
+    #[test]
+    fn import_external_entry_copies_files_and_resolves_concurrent_name_conflicts() {
+        let fixture = tempdir().expect("fixture should be created");
+        let project = fixture.path().join("project");
+        let target = project.join("game/background");
+        let first_source = fixture.path().join("first/hero.png");
+        let second_source = fixture.path().join("second/hero.png");
+        fs::create_dir_all(&target).expect("target should be created");
+        fs::create_dir_all(first_source.parent().expect("source should have parent"))
+            .expect("first source parent should be created");
+        fs::create_dir_all(second_source.parent().expect("source should have parent"))
+            .expect("second source parent should be created");
+        fs::write(&first_source, "first").expect("first source should be written");
+        fs::write(&second_source, "second").expect("second source should be written");
+
+        let barrier = Arc::new(Barrier::new(2));
+        let handles = [first_source, second_source].map(|source| {
+            let barrier = Arc::clone(&barrier);
+            let project = project.clone();
+            let target = target.clone();
+            thread::spawn(move || {
+                barrier.wait();
+                import_external_entry_impl(&source, &target, "hero.png", &project)
+                    .expect("concurrent import should succeed")
+            })
+        });
+        let mut imported_names = handles
+            .into_iter()
+            .map(|handle| handle.join().expect("import thread should finish"))
+            .collect::<Vec<_>>();
+        imported_names.sort();
+
+        assert_eq!(imported_names, ["hero (1).png", "hero.png"]);
+        let mut imported_contents = imported_names
+            .iter()
+            .map(|name| fs::read_to_string(target.join(name)).expect("import should be readable"))
+            .collect::<Vec<_>>();
+        imported_contents.sort();
+        assert_eq!(imported_contents, ["first", "second"]);
+    }
+
+    #[test]
+    fn import_external_entry_copies_directory_tree() {
+        let fixture = tempdir().expect("fixture should be created");
+        let project = fixture.path().join("project");
+        let target = project.join("game/scene");
+        let source = fixture.path().join("chapter");
+        fs::create_dir_all(&target).expect("target should be created");
+        fs::create_dir_all(source.join("nested")).expect("source tree should be created");
+        fs::write(source.join("start.txt"), "start").expect("source file should be written");
+        fs::write(source.join("nested/next.txt"), "next")
+            .expect("nested source file should be written");
+
+        let imported_name = import_external_entry_impl(&source, &target, "chapter", &project)
+            .expect("directory import should succeed");
+
+        assert_eq!(imported_name, "chapter");
+        assert_eq!(
+            fs::read_to_string(target.join("chapter/start.txt"))
+                .expect("imported file should be readable"),
+            "start"
+        );
+        assert_eq!(
+            fs::read_to_string(target.join("chapter/nested/next.txt"))
+                .expect("nested imported file should be readable"),
+            "next"
+        );
+    }
+
+    #[test]
+    fn import_external_entry_continues_numbering_after_preferred_name_conflict() {
+        let fixture = tempdir().expect("fixture should be created");
+        let project = fixture.path().join("project");
+        let target = project.join("game/background");
+        let source = fixture.path().join("hero.png");
+        fs::create_dir_all(&target).expect("target should be created");
+        fs::write(&source, "new").expect("source should be written");
+        fs::write(target.join("hero (2).png"), "existing")
+            .expect("preferred target conflict should be written");
+
+        let imported_name = import_external_entry_impl(&source, &target, "hero (2).png", &project)
+            .expect("import should continue after preferred conflict number");
+
+        assert_eq!(imported_name, "hero (3).png");
+        assert_eq!(
+            fs::read_to_string(target.join("hero (2).png"))
+                .expect("existing target should remain readable"),
+            "existing"
+        );
+        assert_eq!(
+            fs::read_to_string(target.join("hero (3).png"))
+                .expect("imported target should be readable"),
+            "new"
+        );
+    }
+
+    #[test]
+    fn import_external_entry_rejects_target_link_outside_project() {
+        let fixture = tempdir().expect("fixture should be created");
+        let project = fixture.path().join("project");
+        let outside = fixture.path().join("outside");
+        let linked_target = project.join("linked-target");
+        let source = fixture.path().join("hero.png");
+        fs::create_dir_all(&project).expect("project should be created");
+        fs::create_dir_all(&outside).expect("outside target should be created");
+        fs::write(&source, "hero").expect("source should be written");
+        create_dir_link(&outside, &linked_target);
+
+        let error = import_external_entry_impl(&source, &linked_target, "hero.png", &project)
+            .expect_err("linked target outside project should be rejected");
+
+        assert!(matches!(error, AppError::Vfs(_)));
+        assert!(
+            fs::read_dir(&outside)
+                .expect("outside target should be readable")
+                .next()
+                .is_none(),
+            "outside target must remain untouched"
+        );
+    }
+
+    #[test]
+    fn import_external_entry_rejects_directory_import_into_its_subtree() {
+        let fixture = tempdir().expect("fixture should be created");
+        let project = fixture.path().join("project");
+        let target = project.join("game/scene");
+        fs::create_dir_all(&target).expect("project subtree should be created");
+        fs::write(project.join("game/config.txt"), "config")
+            .expect("source content should be written");
+
+        let error = import_external_entry_impl(&project, &target, "project", &project)
+            .expect_err("directory import into its subtree should be rejected");
+
+        assert!(matches!(error, AppError::Vfs(_)));
+        assert!(!target.join("project").exists());
+    }
+
+    #[test]
+    fn import_external_entry_rejects_source_links_and_rolls_back_directory() {
+        let fixture = tempdir().expect("fixture should be created");
+        let project = fixture.path().join("project");
+        let target = project.join("game/background");
+        let source = fixture.path().join("assets");
+        let outside = fixture.path().join("outside");
+        fs::create_dir_all(&target).expect("target should be created");
+        fs::create_dir_all(&source).expect("source should be created");
+        fs::create_dir_all(&outside).expect("outside directory should be created");
+        fs::write(source.join("asset.txt"), "asset").expect("source file should be written");
+        fs::write(outside.join("secret.txt"), "secret").expect("outside file should be written");
+        create_dir_link(&outside, &source.join("linked"));
+
+        let error = import_external_entry_impl(&source, &target, "assets", &project)
+            .expect_err("source links should be rejected");
+
+        assert!(matches!(error, AppError::Vfs(_)));
+        assert!(
+            !target.join("assets").exists(),
+            "failed directory import must be removed completely"
+        );
+    }
+}

--- a/src-tauri/src/commands/external_import.rs
+++ b/src-tauri/src/commands/external_import.rs
@@ -1,5 +1,11 @@
+#[cfg(windows)]
+use cap_std::fs::MetadataExt as CapMetadataExt;
+use cap_std::{
+    ambient_authority,
+    fs::{Dir, File, Metadata, OpenOptions},
+};
 use std::{
-    fs::{self, OpenOptions},
+    fs,
     io::{self, ErrorKind},
     path::{Component, Path},
 };
@@ -16,6 +22,23 @@ fn is_link_or_reparse_point(metadata: &fs::Metadata) -> bool {
     {
         use std::os::windows::fs::MetadataExt;
 
+        const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x400;
+        metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0
+    }
+
+    #[cfg(not(windows))]
+    {
+        false
+    }
+}
+
+fn is_cap_link_or_reparse_point(metadata: &Metadata) -> bool {
+    if metadata.is_symlink() {
+        return true;
+    }
+
+    #[cfg(windows)]
+    {
         const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x400;
         metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0
     }
@@ -79,35 +102,25 @@ fn next_conflict_counter(
     counter.checked_add(1).ok_or_else(path_denied)
 }
 
-fn validate_created_destination(destination: &Path, project_root: &Path) -> AppResult<()> {
-    let canonical_destination = destination.canonicalize()?;
-    if canonical_destination != destination || !canonical_destination.starts_with(project_root) {
-        return Err(path_denied());
-    }
-
-    Ok(())
-}
-
-fn copy_directory(source: &Path, destination: &Path) -> AppResult<()> {
-    for entry in fs::read_dir(source)? {
+fn copy_directory(source: &Dir, destination: &Dir) -> AppResult<()> {
+    for entry in source.entries()? {
         let entry = entry?;
-        let source_path = entry.path();
-        let destination_path = destination.join(entry.file_name());
-        let metadata = fs::symlink_metadata(&source_path)?;
+        let file_name = entry.file_name();
+        let metadata = source.symlink_metadata(&file_name)?;
 
-        if is_link_or_reparse_point(&metadata) {
+        if is_cap_link_or_reparse_point(&metadata) {
             return Err(path_denied());
         }
 
         if metadata.is_dir() {
-            fs::create_dir(&destination_path)?;
-            copy_directory(&source_path, &destination_path)?;
+            let source_child = entry.open_dir()?;
+            destination.create_dir(&file_name)?;
+            let destination_child = destination.open_dir(&file_name)?;
+            copy_directory(&source_child, &destination_child)?;
         } else if metadata.is_file() {
-            let mut source_file = fs::File::open(&source_path)?;
-            let mut destination_file = OpenOptions::new()
-                .write(true)
-                .create_new(true)
-                .open(&destination_path)?;
+            let mut source_file = entry.open()?;
+            let mut destination_file = destination
+                .open_with(&file_name, OpenOptions::new().write(true).create_new(true))?;
             io::copy(&mut source_file, &mut destination_file)?;
         } else {
             return Err(path_denied());
@@ -117,23 +130,112 @@ fn copy_directory(source: &Path, destination: &Path) -> AppResult<()> {
     Ok(())
 }
 
-fn rollback_destination(
+fn rollback_result(
     destination: &Path,
-    is_directory: bool,
     import_error: AppError,
+    cleanup_result: io::Result<()>,
 ) -> AppError {
-    let cleanup_result = if is_directory {
-        fs::remove_dir_all(destination)
-    } else {
-        fs::remove_file(destination)
-    };
-
     match cleanup_result {
         Ok(()) => import_error,
         Err(cleanup_error) => AppError::Server(format!(
             "外部导入失败且无法清理目标 {}：导入错误: {import_error}；清理错误: {cleanup_error}",
             destination.display(),
         )),
+    }
+}
+
+fn open_project_target_directory(project_root: &Path, target_directory: &Path) -> AppResult<Dir> {
+    let project_directory = Dir::open_ambient_dir(project_root, ambient_authority())?;
+    let relative_target = target_directory
+        .strip_prefix(project_root)
+        .map_err(|_| path_denied())?;
+    let relative_target = if relative_target.as_os_str().is_empty() {
+        Path::new(".")
+    } else {
+        relative_target
+    };
+
+    Ok(project_directory.open_dir(relative_target)?)
+}
+
+fn import_directory(
+    source: &Dir,
+    target_directory: &Dir,
+    target_path: &Path,
+    source_name: &str,
+    preferred_name: &str,
+) -> AppResult<String> {
+    let mut candidate_name = preferred_name.to_owned();
+    let mut counter = next_conflict_counter(source_name, true, preferred_name)?;
+
+    loop {
+        let candidate_path = target_path.join(&candidate_name);
+        match target_directory.create_dir(&candidate_name) {
+            Ok(()) => {
+                let destination = match target_directory.open_dir(&candidate_name) {
+                    Ok(destination) => destination,
+                    Err(error) => {
+                        let import_error: AppError = error.into();
+                        return Err(rollback_result(
+                            &candidate_path,
+                            import_error,
+                            target_directory.remove_dir(&candidate_name),
+                        ));
+                    }
+                };
+                if let Err(error) = copy_directory(source, &destination) {
+                    return Err(rollback_result(
+                        &candidate_path,
+                        error,
+                        destination.remove_open_dir_all(),
+                    ));
+                }
+                return Ok(candidate_name);
+            }
+            Err(error) if error.kind() == ErrorKind::AlreadyExists => {}
+            Err(error) => return Err(error.into()),
+        }
+
+        candidate_name = numbered_import_name(source_name, true, counter);
+        counter = counter.checked_add(1).ok_or_else(path_denied)?;
+    }
+}
+
+fn import_file(
+    source: &mut File,
+    target_directory: &Dir,
+    target_path: &Path,
+    source_name: &str,
+    preferred_name: &str,
+) -> AppResult<String> {
+    let mut candidate_name = preferred_name.to_owned();
+    let mut counter = next_conflict_counter(source_name, false, preferred_name)?;
+
+    loop {
+        let candidate_path = target_path.join(&candidate_name);
+        match target_directory.open_with(
+            &candidate_name,
+            OpenOptions::new().write(true).create_new(true),
+        ) {
+            Ok(mut destination_file) => {
+                let copy_result = io::copy(source, &mut destination_file).map(|_| ());
+                drop(destination_file);
+                if let Err(error) = copy_result {
+                    let import_error: AppError = error.into();
+                    return Err(rollback_result(
+                        &candidate_path,
+                        import_error,
+                        target_directory.remove_file(&candidate_name),
+                    ));
+                }
+                return Ok(candidate_name);
+            }
+            Err(error) if error.kind() == ErrorKind::AlreadyExists => {}
+            Err(error) => return Err(error.into()),
+        }
+
+        candidate_name = numbered_import_name(source_name, false, counter);
+        counter = counter.checked_add(1).ok_or_else(path_denied)?;
     }
 }
 
@@ -171,55 +273,30 @@ fn import_external_entry_impl(
         .file_name()
         .and_then(|name| name.to_str())
         .ok_or_else(path_denied)?;
-    let mut candidate_name = preferred_name.to_owned();
-    let mut counter = next_conflict_counter(source_name, is_directory, preferred_name)?;
+    let target_directory_handle =
+        open_project_target_directory(&canonical_project_root, &canonical_target_directory)?;
 
-    loop {
-        let destination = canonical_target_directory.join(&candidate_name);
-
-        if is_directory {
-            match fs::create_dir(&destination) {
-                Ok(()) => {
-                    let copy_result =
-                        validate_created_destination(&destination, &canonical_project_root)
-                            .and_then(|()| copy_directory(&canonical_source, &destination));
-
-                    if let Err(error) = copy_result {
-                        return Err(rollback_destination(&destination, true, error));
-                    }
-                    return Ok(candidate_name);
-                }
-                Err(error) if error.kind() == ErrorKind::AlreadyExists => {}
-                Err(error) => return Err(error.into()),
-            }
-        } else {
-            match OpenOptions::new()
-                .write(true)
-                .create_new(true)
-                .open(&destination)
-            {
-                Ok(mut destination_file) => {
-                    let copy_result =
-                        validate_created_destination(&destination, &canonical_project_root)
-                            .and_then(|()| {
-                                let mut source_file = fs::File::open(&canonical_source)?;
-                                io::copy(&mut source_file, &mut destination_file)?;
-                                Ok(())
-                            });
-                    drop(destination_file);
-
-                    if let Err(error) = copy_result {
-                        return Err(rollback_destination(&destination, false, error));
-                    }
-                    return Ok(candidate_name);
-                }
-                Err(error) if error.kind() == ErrorKind::AlreadyExists => {}
-                Err(error) => return Err(error.into()),
-            }
-        }
-
-        candidate_name = numbered_import_name(source_name, is_directory, counter);
-        counter = counter.checked_add(1).ok_or_else(path_denied)?;
+    if is_directory {
+        let source_directory = Dir::open_ambient_dir(&canonical_source, ambient_authority())?;
+        import_directory(
+            &source_directory,
+            &target_directory_handle,
+            &canonical_target_directory,
+            source_name,
+            preferred_name,
+        )
+    } else {
+        let source_parent = canonical_source.parent().ok_or_else(path_denied)?;
+        let source_file_name = canonical_source.file_name().ok_or_else(path_denied)?;
+        let source_directory = Dir::open_ambient_dir(source_parent, ambient_authority())?;
+        let mut source_file = source_directory.open(source_file_name)?;
+        import_file(
+            &mut source_file,
+            &target_directory_handle,
+            &canonical_target_directory,
+            source_name,
+            preferred_name,
+        )
     }
 }
 

--- a/src-tauri/src/commands/external_import.rs
+++ b/src-tauri/src/commands/external_import.rs
@@ -1,5 +1,3 @@
-#[cfg(windows)]
-use cap_std::fs::MetadataExt as CapMetadataExt;
 use cap_std::{
     ambient_authority,
     fs::{Dir, File, Metadata, OpenOptions},
@@ -32,21 +30,8 @@ fn is_link_or_reparse_point(metadata: &fs::Metadata) -> bool {
     }
 }
 
-fn is_cap_link_or_reparse_point(metadata: &Metadata) -> bool {
-    if metadata.is_symlink() {
-        return true;
-    }
-
-    #[cfg(windows)]
-    {
-        const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x400;
-        metadata.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0
-    }
-
-    #[cfg(not(windows))]
-    {
-        false
-    }
+fn is_cap_symlink(metadata: &Metadata) -> bool {
+    metadata.is_symlink()
 }
 
 fn path_denied() -> AppError {
@@ -108,7 +93,7 @@ fn copy_directory(source: &Dir, destination: &Dir) -> AppResult<()> {
         let file_name = entry.file_name();
         let metadata = source.symlink_metadata(&file_name)?;
 
-        if is_cap_link_or_reparse_point(&metadata) {
+        if is_cap_symlink(&metadata) {
             return Err(path_denied());
         }
 

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -3,6 +3,7 @@ pub mod backup;
 pub mod engine;
 pub mod error;
 pub mod export;
+pub mod external_import;
 pub mod fs;
 pub mod game;
 pub mod project_config;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -125,6 +125,7 @@ pub fn run() {
             commands::fs::copy_directory_with_progress,
             commands::fs::validate_directory_structure,
             commands::fs::delete_file,
+            commands::external_import::import_external_entry,
             commands::fs::rename_file,
             commands::fs::is_binary_file,
             commands::fs::get_image_dimensions,

--- a/src/commands/fs.ts
+++ b/src/commands/fs.ts
@@ -157,6 +157,20 @@ async function copyFile(sourcePath: AbsPath, targetPath: AbsPath): Promise<AbsPa
   return destPath
 }
 
+async function importExternalEntry(
+  sourcePath: AbsPath,
+  targetDirectory: AbsPath,
+  preferredName: string,
+  projectRoot: AbsPath,
+): Promise<string> {
+  return safeInvoke<string>('import_external_entry', {
+    source: sourcePath,
+    targetDirectory,
+    preferredName,
+    projectRoot,
+  })
+}
+
 async function moveFile(sourcePath: AbsPath, targetPath: AbsPath, targetName?: string): Promise<AbsPath> {
   const { destPath } = await getDestinationPath(sourcePath, targetPath, targetName)
   await rename(sourcePath, destPath)
@@ -182,6 +196,7 @@ export const fsCmds = {
   deleteFile,
   renameFile,
   copyFile,
+  importExternalEntry,
   moveFile,
   isBinaryFile,
   getImageDimensions,

--- a/src/components/editor/AssetView.spec.ts
+++ b/src/components/editor/AssetView.spec.ts
@@ -19,6 +19,7 @@ const {
   copyFileMock,
   createFileMock,
   createFolderMock,
+  externalDropTargetPath,
   existsMock,
   fileSystemEventHandlers,
   fileSystemEventsOnMock,
@@ -36,6 +37,7 @@ const {
   copyFileMock: vi.fn(),
   createFileMock: vi.fn(),
   createFolderMock: vi.fn(),
+  externalDropTargetPath: { value: undefined as string | undefined },
   existsMock: vi.fn(),
   fileSystemEventHandlers: new Map<string, ((event: Record<string, unknown>) => void)[]>(),
   fileSystemEventsOnMock: vi.fn(),
@@ -156,6 +158,12 @@ vi.mock('~/composables/useFileSystemEvents', () => ({
   }),
 }))
 
+vi.mock('~/features/editor/external-file-import/useExternalFileDropImport', () => ({
+  useExternalFileDropImport: () => ({
+    targetDirectory: externalDropTargetPath,
+  }),
+}))
+
 vi.mock('~/services/game-fs', () => ({
   gameFs: {
     copyFile: copyFileMock,
@@ -210,6 +218,10 @@ function createPreviewFileViewerStub() {
         type: String,
         required: false,
       },
+      externalDropTargetPath: {
+        type: String,
+        required: false,
+      },
     },
     setup(props, { expose }) {
       expose({
@@ -222,6 +234,7 @@ function createPreviewFileViewerStub() {
         'data-testid': 'preview-context',
         'data-preview-base-url': props.previewBaseUrl ?? '',
         'data-preview-cwd': props.previewCwd ?? '',
+        'data-external-drop-target-path': props.externalDropTargetPath ?? '',
       })
     },
   })
@@ -616,6 +629,7 @@ function setPreviewUnavailable() {
 describe('AssetView', () => {
   beforeEach(() => {
     fileSystemEventHandlers.clear()
+    externalDropTargetPath.value = undefined
     fileSystemEventsOnMock.mockReset()
     copyFileMock.mockReset()
     createFileMock.mockReset()
@@ -707,6 +721,22 @@ describe('AssetView', () => {
 
     await expect.element(page.getByTestId('preview-context')).toHaveAttribute('data-preview-cwd', '/games/demo')
     await expect.element(page.getByTestId('preview-context')).toHaveAttribute('data-preview-base-url', 'http://127.0.0.1:8899/game/demo/')
+  })
+
+  it('会把外部拖拽目标传给资源浏览器', async () => {
+    externalDropTargetPath.value = '/games/demo/game/background/shared'
+
+    renderInBrowser(createHarness(), {
+      global: {
+        stubs: {
+          ...commonGlobalStubs,
+          FileViewer: createPreviewFileViewerStub(),
+        },
+      },
+    })
+
+    await expect.element(page.getByTestId('preview-context'))
+      .toHaveAttribute('data-external-drop-target-path', '/games/demo/game/background/shared')
   })
 
   it('会显示零引用和多个引用，并在资源索引修订后刷新计数', async () => {

--- a/src/components/editor/AssetView.vue
+++ b/src/components/editor/AssetView.vue
@@ -8,6 +8,7 @@ import { PopoverAnchor } from '~/components/ui/popover'
 import { useFileSystemEvents } from '~/composables/useFileSystemEvents'
 import { usePathOperationFeedback } from '~/composables/usePathOperationFeedback'
 import { AbsPath, RelPath } from '~/domain/path'
+import { useExternalFileDropImport } from '~/features/editor/external-file-import/useExternalFileDropImport'
 import {
   canDropFileTreeTransferItemsToDirectory,
   getFileTreeNameSelectionEnd,
@@ -71,6 +72,7 @@ const confirmPathOperationRewrite = createPathOperationRewriteConfirm(t)
 const pathOperationFeedback = usePathOperationFeedback()
 
 const fileViewerRef = useTemplateRef<InstanceType<typeof FileViewer>>('fileViewerRef')
+const externalDropZoneRef = useTemplateRef<HTMLElement>('externalDropZoneRef')
 const renameInputRef = useTemplateRef('renameInputRef')
 
 let scrollTop = 0
@@ -237,6 +239,11 @@ const currentDirectoryContextMenuItem = $computed(() => {
     path: directoryPath,
     source: fileStore.getItemByPath(AbsPath.from(directoryPath))?.source,
   }
+})
+
+const externalFileImport = useExternalFileDropImport({
+  dropZone: externalDropZoneRef,
+  rootDirectory: () => currentDirectoryPath || undefined,
 })
 
 function canDropFileTransferItems(
@@ -780,13 +787,14 @@ for (const eventType of FILE_SYSTEM_REFRESH_EVENT_TYPES) {
 </script>
 
 <template>
-  <div class="h-full">
+  <div ref="externalDropZoneRef" class="h-full">
     <FileViewer
       ref="fileViewerRef"
       :error-msg="errorMsg"
       :can-drop-file-transfer="canDropFileTransfer"
       :drop-target-directory="currentDirectoryContextMenuItem"
       enable-drag-transfer
+      :external-drop-target-path="externalFileImport.targetDirectory.value"
       :highlighted-item-path="renameTargetItem?.path"
       :is-loading="isLoading"
       :items="filteredItems"

--- a/src/components/editor/FileTree.spec.ts
+++ b/src/components/editor/FileTree.spec.ts
@@ -540,6 +540,72 @@ describe('FileTree', () => {
     await expect.element(page.getByRole('status', { name: 'common.loading' })).toBeInTheDocument()
   })
 
+  it('外部文件拖拽到目录子层级时会高亮目标目录及其子树', () => {
+    renderFileTree({
+      externalDropTargetPath: '/project/chapter',
+      getKey: (item: Record<string, unknown>) => String(item.path),
+      items: [
+        {
+          name: 'chapter',
+          path: '/project/chapter',
+          children: [
+            {
+              name: 'opening.txt',
+              path: '/project/chapter/opening.txt',
+            },
+          ],
+        },
+        {
+          name: 'scene.txt',
+          path: '/project/scene.txt',
+        },
+      ],
+      rootPath: '/project',
+    })
+
+    const directory = document.querySelector<HTMLElement>('[data-file-tree-path="/project/chapter"]')
+    const child = document.querySelector<HTMLElement>('[data-file-tree-path="/project/chapter/opening.txt"]')
+    const sibling = document.querySelector<HTMLElement>('[data-file-tree-path="/project/scene.txt"]')
+
+    expect(directory).toHaveClass('bg-accent', 'outline', 'outline-primary/50')
+    expect(child).toHaveAttribute('data-file-tree-drop-target-path', '/project/chapter')
+    expect(child).toHaveClass('bg-accent/60')
+    expect(sibling).not.toHaveClass('bg-accent/60')
+    expect(sibling).not.toHaveClass('outline')
+  })
+
+  it('外部文件拖拽到根目录时会高亮整棵树', () => {
+    renderFileTree({
+      externalDropTargetPath: '/project',
+      getKey: (item: Record<string, unknown>) => String(item.path),
+      items: [
+        {
+          name: 'chapter',
+          path: '/project/chapter',
+          children: [
+            {
+              name: 'opening.txt',
+              path: '/project/chapter/opening.txt',
+            },
+          ],
+        },
+        {
+          name: 'scene.txt',
+          path: '/project/scene.txt',
+        },
+      ],
+      rootPath: '/project',
+    })
+
+    const treeItems = document.querySelectorAll<HTMLElement>('[data-file-tree-path]')
+
+    expect(treeItems).toHaveLength(3)
+    for (const treeItem of treeItems) {
+      expect(treeItem).toHaveClass('bg-accent/60')
+    }
+    expect(document.querySelector('[data-file-tree-root-surface]')).toHaveClass('bg-accent/35')
+  })
+
   it('点击文件项会发出 click 事件', async () => {
     const onClick = vi.fn()
 

--- a/src/components/editor/FileTree.vue
+++ b/src/components/editor/FileTree.vue
@@ -38,6 +38,7 @@ interface Props {
   sortBy?: FileViewerSortBy
   sortOrder?: FileViewerSortOrder
   enableDragTransfer?: boolean
+  externalDropTargetPath?: AbsPath
   rootPath?: string
   isPathOperationDisabled?: (path: string) => boolean
 }
@@ -60,6 +61,7 @@ const {
   sortBy = 'name',
   sortOrder = 'asc',
   enableDragTransfer = false,
+  externalDropTargetPath,
   rootPath,
   isPathOperationDisabled,
 } = defineProps<Props>()
@@ -209,6 +211,7 @@ const fileDragSource = useDragSource<FileSystemDragPayload>({
 })
 
 const effectiveRootPath = $computed(() => rootPath ?? getRootPath())
+const highlightedDropTargetPath = $computed(() => activeDropTargetPath ?? externalDropTargetPath)
 
 const activeFileTreePayload = $computed(() => {
   const state = dragSession.state.value
@@ -661,10 +664,10 @@ function getFileTreeItemBind(item: FlattenedItem<T>) {
 
 function isFileTreeDropRangeActive(renderItem: FileTreeFileRenderItem): boolean {
   return Boolean(
-    activeDropTargetPath !== undefined
+    highlightedDropTargetPath !== undefined
     && (
-      activeDropTargetPath === renderItem.fileItem.path
-      || renderItem.ancestorDirectoryPaths.includes(activeDropTargetPath)
+      highlightedDropTargetPath === renderItem.fileItem.path
+      || renderItem.ancestorDirectoryPaths.includes(highlightedDropTargetPath)
     ),
   )
 }
@@ -674,13 +677,13 @@ function getFileTreeDropTargetClass(renderItem: FileTreeFileRenderItem): string 
     return ''
   }
 
-  return activeDropTargetPath === renderItem.fileItem.path
+  return highlightedDropTargetPath === renderItem.fileItem.path
     ? 'bg-accent outline outline-1 outline-primary/50'
     : 'bg-accent/60'
 }
 
 const isRootDropTargetActive = $computed(() =>
-  activeDropTargetPath !== undefined && activeDropTargetPath === effectiveRootPath,
+  highlightedDropTargetPath === effectiveRootPath,
 )
 
 function isItemDimmed(item: T): boolean {
@@ -811,6 +814,7 @@ tryOnUnmounted(() => {
       <TooltipProvider :skip-delay-duration="0" :ignore-non-keyboard-focus="true">
         <div
           :ref="setFileTreeContainerElement"
+          data-file-tree-root-surface="true"
           :class="[
             'relative shrink-0',
             isRootDropTargetActive ? 'bg-accent/35' : '',
@@ -870,6 +874,7 @@ tryOnUnmounted(() => {
                 :level="renderItem.item.level"
                 :has-children="renderItem.item.hasChildren"
                 :data-file-tree-path="renderItem.fileItem.path"
+                :data-file-tree-drop-target-path="renderItem.dropTarget.path"
                 :data-file-tree-is-dir="renderItem.fileItem.isDir ? 'true' : 'false'"
                 :data-file-tree-name="renderItem.fileItem.name"
                 :data-file-tree-selected="isFileTreePathSelected(renderItem.fileItem.path) ? 'true' : undefined"
@@ -965,6 +970,7 @@ tryOnUnmounted(() => {
       >
         <div
           :ref="setRootDropAreaElement"
+          data-file-tree-root-surface="true"
           :class="[
             'flex-1 min-h-[26px]',
             isRootDropTargetActive ? 'bg-accent/60' : '',

--- a/src/components/editor/ScenePanel.spec.ts
+++ b/src/components/editor/ScenePanel.spec.ts
@@ -7,6 +7,7 @@ const {
   fileSystemEventHandlers,
   fileSystemEventsOnMock,
   gameSceneDirMock,
+  externalDropTargetPath,
   scrollIntoViewMock,
   useFileStoreMock,
   useEditorDiagnosticsStoreMock,
@@ -16,6 +17,7 @@ const {
   fileSystemEventHandlers: new Map<string, (event: unknown) => void>(),
   fileSystemEventsOnMock: vi.fn(),
   gameSceneDirMock: vi.fn(),
+  externalDropTargetPath: { value: undefined as string | undefined },
   scrollIntoViewMock: vi.fn(),
   useFileStoreMock: vi.fn(),
   useEditorDiagnosticsStoreMock: vi.fn(),
@@ -66,6 +68,12 @@ vi.mock('~/stores/workspace', () => ({
 vi.mock('~/composables/useFileSystemEvents', () => ({
   useFileSystemEvents: () => ({
     on: fileSystemEventsOnMock,
+  }),
+}))
+
+vi.mock('~/features/editor/external-file-import/useExternalFileDropImport', () => ({
+  useExternalFileDropImport: () => ({
+    targetDirectory: externalDropTargetPath,
   }),
 }))
 
@@ -146,6 +154,10 @@ const globalStubs = {
         type: Object,
         default: undefined,
       },
+      externalDropTargetPath: {
+        type: String,
+        default: undefined,
+      },
     },
     emits: ['auxclick', 'click', 'dblclick', 'update:selectedItem'],
     setup(props, { emit, expose }) {
@@ -214,7 +226,13 @@ const globalStubs = {
       return () => h('div', {
         'ref': setViewportElement,
         'data-testid': 'scene-panel-viewport',
-      }, renderItems(props.items as TreeNode[]))
+      }, [
+        h('output', {
+          'data-testid': 'scene-panel-external-drop-target',
+          'data-path': props.externalDropTargetPath ?? '',
+        }),
+        ...renderItems(props.items as TreeNode[]),
+      ])
     },
   }),
 }
@@ -265,6 +283,7 @@ describe('ScenePanel', () => {
   beforeEach(() => {
     vi.resetAllMocks()
     fileSystemEventHandlers.clear()
+    externalDropTargetPath.value = undefined
 
     fileSystemEventsOnMock.mockImplementation((eventType: string, handler: (event: unknown) => void) => {
       fileSystemEventHandlers.set(eventType, handler)
@@ -308,6 +327,27 @@ describe('ScenePanel', () => {
     const fileStore = useFileStoreMock.mock.results[0]?.value as ReturnType<typeof createFileStore>
     expect(fileStore.getFolderContents).toHaveBeenCalledWith('/games/demo/game/scene')
     expect(fileStore.getFolderContents).toHaveBeenCalledWith('/games/demo/game/scene/chapter-1')
+  })
+
+  it('会把外部拖拽目标传给文件树', async () => {
+    externalDropTargetPath.value = '/games/demo/game/scene/chapter-1'
+
+    renderInBrowser(ScenePanel, {
+      browser: {
+        i18nMode: 'localized',
+        messages: {
+          'zh-Hans': {
+            edit: {},
+          },
+        },
+      },
+      global: {
+        stubs: globalStubs,
+      },
+    })
+
+    await expect.element(page.getByTestId('scene-panel-external-drop-target'))
+      .toHaveAttribute('data-path', '/games/demo/game/scene/chapter-1')
   })
 
   it('只给诊断索引中存在问题的已分析场景文件着色', async () => {

--- a/src/components/editor/ScenePanel.vue
+++ b/src/components/editor/ScenePanel.vue
@@ -4,6 +4,7 @@ import { CopyMinus, FilePlus, FolderPlus, Layers, RotateCw } from '@lucide/vue'
 import { useFileSystemEvents } from '~/composables/useFileSystemEvents'
 import { AbsPath } from '~/domain/path'
 import { isSceneEntryPath } from '~/domain/scene/entry-point'
+import { useExternalFileDropImport } from '~/features/editor/external-file-import/useExternalFileDropImport'
 import {
   findScenePanelNodeByPath,
   loadScenePanelTreeNodes,
@@ -24,10 +25,16 @@ const diagnosticsStore = useEditorDiagnosticsStore()
 const workspaceStore = useWorkspaceStore()
 const tabsStore = useTabsStore()
 const fileSystemEvents = useFileSystemEvents()
+const externalDropZoneRef = useTemplateRef<HTMLElement>('externalDropZoneRef')
 
 const scenePath = computedAsync(async () => {
   const gamePath = workspaceStore.currentGame?.path
   return gamePath ? gameSceneDir(AbsPath.from(gamePath)) : ''
+})
+
+const externalFileImport = useExternalFileDropImport({
+  dropZone: externalDropZoneRef,
+  rootDirectory: () => scenePath.value || undefined,
 })
 
 let isLoading = $ref(false)
@@ -207,7 +214,7 @@ onScopeDispose(() => {
 </script>
 
 <template>
-  <div class="group/scene rounded flex flex-col h-full divide-y">
+  <div ref="externalDropZoneRef" class="group/scene rounded flex flex-col h-full divide-y">
     <div class="px-2 py-1 flex items-center justify-between">
       <h3 class="text-sm font-medium flex text-nowrap items-center">
         <Layers class="mr-2 shrink-0 h-4 w-4" />
@@ -242,6 +249,7 @@ onScopeDispose(() => {
       :is-loading="isLoading"
       tree-name="scene"
       enable-drag-transfer
+      :external-drop-target-path="externalFileImport.targetDirectory.value"
       :root-path="scenePath"
       :is-path-operation-disabled="isProtectedSceneEntry"
       :default-file-name-parts="{ stem: '', extension: '.txt' }"

--- a/src/components/file-viewer/FileViewer.spec.ts
+++ b/src/components/file-viewer/FileViewer.spec.ts
@@ -1682,6 +1682,50 @@ describe('FileViewer', () => {
     }])
   })
 
+  it('外部文件拖拽时只高亮命中的目录项', async () => {
+    viewportWidthMock.value = 780
+
+    const file = createItem(1)
+    const directory = createDirectoryItem(2, {
+      name: 'folder',
+      path: '/assets/folder',
+    })
+
+    renderInBrowser(FileViewer, {
+      props: {
+        externalDropTargetPath: directory.path,
+        items: [file, directory],
+        viewMode: 'grid',
+      },
+      global: {
+        stubs: globalStubs,
+      },
+    })
+    await nextTick()
+
+    expect(getFileViewerItemElement(directory)).toHaveClass('bg-accent')
+    expect(getFileViewerItemElement(directory)).not.toHaveClass('outline')
+    expect(getFileViewerItemElement(file)).not.toHaveClass('outline')
+  })
+
+  it('外部文件拖拽到当前目录时会高亮资源根区域', async () => {
+    const rootDirectory = createDirectoryItem(0, { path: '/assets' })
+
+    renderInBrowser(FileViewer, {
+      props: {
+        dropTargetDirectory: rootDirectory,
+        externalDropTargetPath: rootDirectory.path,
+        items: [createItem(1)],
+      },
+      global: {
+        stubs: globalStubs,
+      },
+    })
+    await nextTick()
+
+    expect(document.querySelector('[data-file-viewer-root-surface]')).toHaveClass('bg-accent/35')
+  })
+
   it('投放判断拒绝时不会触发 fileTransferDrop', async () => {
     viewportWidthMock.value = 780
 

--- a/src/components/file-viewer/FileViewer.vue
+++ b/src/components/file-viewer/FileViewer.vue
@@ -11,6 +11,7 @@ import { FileViewerItem, FileViewerPreviewSize, FileViewerSortBy, FileViewerSort
 import { createItemComparator } from '~/utils/sort'
 
 import type { StyleValue } from 'vue'
+import type { AbsPath } from '~/domain/path'
 import type { DragTransferOperation, FileSystemDragPayload } from '~/types/drag-drop'
 import type { SortableItemAccessor } from '~/utils/sort'
 
@@ -19,6 +20,8 @@ interface FileViewerProps {
   items: FileViewerItem[]
   /** 当前需要额外高亮的条目路径 */
   highlightedItemPath?: string
+  /** 系统文件拖放当前命中的目录路径 */
+  externalDropTargetPath?: AbsPath
   /** 资源预览的工作区根目录 */
   previewCwd?: string
   /** 资源预览服务地址 */
@@ -85,6 +88,7 @@ defineSlots<{
 const {
   items,
   highlightedItemPath,
+  externalDropTargetPath,
   previewCwd,
   previewBaseUrl,
   viewMode = 'list',
@@ -483,9 +487,10 @@ defineExpose(fileViewerExpose)
       @update:sort-order="(nextSortOrder) => emit('update:sortOrder', nextSortOrder)"
     />
     <div
+      data-file-viewer-root-surface="true"
       :class="[
         'flex-1 min-h-0',
-        isRootDropTargetActive ? 'bg-accent/35' : '',
+        isRootDropTargetActive || externalDropTargetPath === dropTargetDirectory?.path ? 'bg-accent/35' : '',
       ]"
     >
       <ScrollArea ref="scrollAreaRef" class="flex-scroll-area h-full min-h-0">
@@ -513,9 +518,10 @@ defineExpose(fileViewerExpose)
 
         <FileViewerBody
           v-else
-          :active-root-drop-target="isRootDropTargetActive"
+          :active-root-drop-target="isRootDropTargetActive || externalDropTargetPath === dropTargetDirectory?.path"
           :can-drop-file-transfer="canDropFileTransfer"
           :enable-drag-transfer="enableDragTransfer"
+          :external-drop-target-path="externalDropTargetPath"
           :highlighted-item-path="highlightedItemPath"
           :view-mode="viewMode"
           :virtual-rows="virtualizer.virtualRows.value"

--- a/src/components/file-viewer/FileViewerBody.vue
+++ b/src/components/file-viewer/FileViewerBody.vue
@@ -7,6 +7,7 @@ import { useDroppableRegistry } from '~/composables/useDroppableRegistry'
 import { formatFileSize } from '~/utils/format'
 import { isValidPositiveNumber } from '~/utils/sort'
 
+import type { AbsPath } from '~/domain/path'
 import type { DragTransferOperation, FileSystemDragPayload } from '~/types/drag-drop'
 import type { FileViewerItem, FileViewerPreviewSize, FileViewerVirtualRow } from '~/types/file-viewer'
 
@@ -39,6 +40,7 @@ interface FileViewerBodyProps {
     operation: DragTransferOperation,
   ) => boolean
   getDragSourceProps?: () => FileViewerDragSourceHandlers
+  externalDropTargetPath?: AbsPath
   highlightedItemPath?: string
   viewMode: 'list' | 'grid'
   virtualRows: FileViewerVirtualRow[]
@@ -62,6 +64,7 @@ const {
   enableDragTransfer = false,
   canDropFileTransfer,
   getDragSourceProps,
+  externalDropTargetPath,
   highlightedItemPath,
   viewMode,
   virtualRows,
@@ -277,7 +280,13 @@ function getFileViewerItemBind(item: FileViewerItem): FileViewerDragSourceHandle
 }
 
 function getFileViewerDropTargetClass(item: FileViewerItem): string {
-  if (!item.isDir || activeDropTargetPath !== item.path) {
+  if (
+    !item.isDir
+    || (
+      activeDropTargetPath !== item.path
+      && externalDropTargetPath !== item.path
+    )
+  ) {
     return ''
   }
 

--- a/src/composables/__tests__/useTauriDropZone.browser.test.ts
+++ b/src/composables/__tests__/useTauriDropZone.browser.test.ts
@@ -37,11 +37,19 @@ function setDevicePixelRatio(value: number): void {
 }
 
 async function renderDropZone() {
+  const onEnter = vi.fn()
   const onDrop = vi.fn()
+  const onDropTarget = vi.fn()
   const Harness = defineComponent({
     setup() {
       const target = ref<HTMLElement>()
-      useTauriDropZone(target, onDrop)
+      const dropZone = useTauriDropZone(target, {
+        onEnter,
+        onDrop(paths) {
+          onDrop(paths)
+          onDropTarget(dropZone.targetElement.value)
+        },
+      })
 
       return () => h('div', {
         ref: target,
@@ -60,19 +68,19 @@ async function renderDropZone() {
   const result = render(Harness)
   await vi.waitFor(() => expect(webviewMockState.handler).toBeTypeOf('function'))
 
-  return { onDrop, result }
+  return { onDrop, onDropTarget, onEnter, result }
 }
 
-function emitDrop(paths: string[], position: PhysicalPosition): void {
+function emitDragDrop(payload: DragDropEvent): void {
   webviewMockState.handler?.({
     event: 'tauri://drag-drop',
     id: 1,
-    payload: {
-      paths,
-      position,
-      type: 'drop',
-    },
+    payload,
   })
+}
+
+function emitDrop(paths: string[], position: PhysicalPosition): void {
+  emitDragDrop({ paths, position, type: 'drop' })
 }
 
 beforeEach(() => {
@@ -91,11 +99,12 @@ afterEach(() => {
 describe('useTauriDropZone', () => {
   it('在 1x DPI 下使用原生坐标命中放置区域', async () => {
     setDevicePixelRatio(1)
-    const { onDrop, result } = await renderDropZone()
+    const { onDrop, onDropTarget, result } = await renderDropZone()
 
     emitDrop([standardDpiPath], new PhysicalPosition(75, 75))
 
     expect(onDrop).toHaveBeenCalledWith([standardDpiPath])
+    expect(onDropTarget).toHaveBeenCalledWith(expect.any(HTMLElement))
     result.unmount()
   })
 
@@ -116,6 +125,28 @@ describe('useTauriDropZone', () => {
     emitDrop([outsidePath], new PhysicalPosition(250, 250))
 
     expect(onDrop).not.toHaveBeenCalled()
+    result.unmount()
+  })
+
+  it('文件先进入窗口其他区域再移入放置区域时会沿用 enter 的路径', async () => {
+    setDevicePixelRatio(1)
+    const { onDrop, onEnter, result } = await renderDropZone()
+
+    emitDragDrop({
+      paths: [outsidePath],
+      position: new PhysicalPosition(10, 10),
+      type: 'enter',
+    })
+    expect(onEnter).not.toHaveBeenCalled()
+
+    emitDragDrop({
+      position: new PhysicalPosition(75, 75),
+      type: 'over',
+    })
+    expect(onEnter).toHaveBeenCalledWith([outsidePath])
+
+    emitDrop([outsidePath], new PhysicalPosition(75, 75))
+    expect(onDrop).toHaveBeenCalledWith([outsidePath])
     result.unmount()
   })
 })

--- a/src/composables/__tests__/useTauriDropZone.browser.test.ts
+++ b/src/composables/__tests__/useTauriDropZone.browser.test.ts
@@ -40,11 +40,13 @@ async function renderDropZone() {
   const onEnter = vi.fn()
   const onDrop = vi.fn()
   const onDropTarget = vi.fn()
+  const onLeave = vi.fn()
   const Harness = defineComponent({
     setup() {
       const target = ref<HTMLElement>()
       const dropZone = useTauriDropZone(target, {
         onEnter,
+        onLeave,
         onDrop(paths) {
           onDrop(paths)
           onDropTarget(dropZone.targetElement.value)
@@ -68,7 +70,7 @@ async function renderDropZone() {
   const result = render(Harness)
   await vi.waitFor(() => expect(webviewMockState.handler).toBeTypeOf('function'))
 
-  return { onDrop, onDropTarget, onEnter, result }
+  return { onDrop, onDropTarget, onEnter, onLeave, result }
 }
 
 function emitDragDrop(payload: DragDropEvent): void {
@@ -125,6 +127,24 @@ describe('useTauriDropZone', () => {
     emitDrop([outsidePath], new PhysicalPosition(250, 250))
 
     expect(onDrop).not.toHaveBeenCalled()
+    result.unmount()
+  })
+
+  it('文件先进入放置区域再在区域外放下时会清理拖放状态', async () => {
+    setDevicePixelRatio(1)
+    const { onDrop, onEnter, onLeave, result } = await renderDropZone()
+
+    emitDragDrop({
+      paths: [standardDpiPath],
+      position: new PhysicalPosition(75, 75),
+      type: 'enter',
+    })
+    expect(onEnter).toHaveBeenCalledWith([standardDpiPath])
+
+    emitDrop([standardDpiPath], new PhysicalPosition(250, 250))
+
+    expect(onDrop).not.toHaveBeenCalled()
+    expect(onLeave).toHaveBeenCalledOnce()
     result.unmount()
   })
 

--- a/src/composables/useTauriDropZone.ts
+++ b/src/composables/useTauriDropZone.ts
@@ -31,6 +31,10 @@ export interface UseTauriDropZoneReturn {
    * 是否在拖放区域上方
    */
   isOverDropZone: Ref<boolean>
+  /**
+   * 当前原生拖拽坐标命中的最深层 DOM 元素
+   */
+  targetElement: Ref<Element | undefined>
 }
 
 export function useTauriDropZone(
@@ -39,7 +43,8 @@ export function useTauriDropZone(
 ): UseTauriDropZoneReturn {
   const isOverDropZone = ref(false)
   const files = ref<string[] | undefined>(undefined)
-  let counter = 0
+  const targetElement = shallowRef<Element>()
+  let dragPaths: string[] | undefined
   let unlisten: (() => void) | undefined
 
   // 处理简化的参数形式
@@ -60,18 +65,15 @@ export function useTauriDropZone(
     const isOverTarget = isElementInTarget(element)
 
     if (isOverTarget && !wasOverDropZone) {
-      counter += 1
       isOverDropZone.value = true
-      if (paths) {
-        normalizedOptions.onEnter?.(paths)
-      }
+      targetElement.value = element ?? undefined
+      normalizedOptions.onEnter?.(paths ?? dragPaths ?? [])
     } else if (!isOverTarget && wasOverDropZone) {
-      counter = Math.max(0, counter - 1)
-      if (counter === 0) {
-        isOverDropZone.value = false
-      }
+      isOverDropZone.value = false
+      targetElement.value = undefined
       normalizedOptions.onLeave?.()
     } else if (isOverTarget && wasOverDropZone) {
+      targetElement.value = element ?? undefined
       normalizedOptions.onOver?.()
     }
   }
@@ -84,6 +86,8 @@ export function useTauriDropZone(
   function handleDragDropEvent(payload: DragDropEvent): void {
     switch (payload.type) {
       case 'enter': {
+        dragPaths = payload.paths
+        files.value = payload.paths
         if (payload.position) {
           updateDropZoneState(elementAtPosition(payload.position), payload.paths)
         }
@@ -92,28 +96,30 @@ export function useTauriDropZone(
 
       case 'over': {
         if (payload.position) {
-          updateDropZoneState(elementAtPosition(payload.position))
+          updateDropZoneState(elementAtPosition(payload.position), dragPaths)
         }
         break
       }
 
       case 'drop': {
         if (payload.position) {
-          if (isElementInTarget(elementAtPosition(payload.position)) && payload.paths) {
+          const element = elementAtPosition(payload.position)
+          if (isElementInTarget(element) && payload.paths) {
+            targetElement.value = element ?? undefined
             files.value = payload.paths
             normalizedOptions.onDrop?.(payload.paths)
           }
-          counter = 0
           isOverDropZone.value = false
+          targetElement.value = undefined
+          dragPaths = undefined
         }
         break
       }
 
       case 'leave': {
-        counter = Math.max(0, counter - 1)
-        if (counter === 0) {
-          isOverDropZone.value = false
-        }
+        isOverDropZone.value = false
+        targetElement.value = undefined
+        dragPaths = undefined
         normalizedOptions.onLeave?.()
         break
       }
@@ -134,5 +140,6 @@ export function useTauriDropZone(
   return {
     files,
     isOverDropZone,
+    targetElement,
   }
 }

--- a/src/composables/useTauriDropZone.ts
+++ b/src/composables/useTauriDropZone.ts
@@ -102,16 +102,21 @@ export function useTauriDropZone(
       }
 
       case 'drop': {
+        let handledDrop = false
         if (payload.position) {
           const element = elementAtPosition(payload.position)
           if (isElementInTarget(element) && payload.paths) {
             targetElement.value = element ?? undefined
             files.value = payload.paths
             normalizedOptions.onDrop?.(payload.paths)
+            handledDrop = true
           }
-          isOverDropZone.value = false
-          targetElement.value = undefined
-          dragPaths = undefined
+        }
+        isOverDropZone.value = false
+        targetElement.value = undefined
+        dragPaths = undefined
+        if (!handledDrop) {
+          normalizedOptions.onLeave?.()
         }
         break
       }

--- a/src/features/editor/external-file-import/__tests__/external-file-import.browser.test.ts
+++ b/src/features/editor/external-file-import/__tests__/external-file-import.browser.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+
+import { AbsPath } from '~/domain/path'
+import { resolveExternalFileDropTargetDirectory } from '~/features/editor/external-file-import/external-file-import'
+
+function createDropTarget(dataset: Record<string, string>): HTMLElement {
+  const target = document.createElement('button')
+  Object.assign(target.dataset, dataset)
+  const child = document.createElement('span')
+  target.append(child)
+  document.body.append(target)
+  return child
+}
+
+describe('resolveExternalFileDropTargetDirectory', () => {
+  it('会解析场景树和资源浏览器中的目录节点', () => {
+    const root = AbsPath.from('/project/game/scene')
+    const sceneTarget = createDropTarget({
+      fileTreeDropTargetPath: '/project/game/scene/chapter',
+      fileTreeIsDir: 'true',
+      fileTreePath: '/project/game/scene/chapter',
+    })
+
+    expect(resolveExternalFileDropTargetDirectory(sceneTarget, root))
+      .toBe('/project/game/scene/chapter')
+
+    const assetTarget = createDropTarget({
+      fileViewerIsDir: 'true',
+      fileViewerPath: '/project/game/scene/shared',
+    })
+
+    expect(resolveExternalFileDropTargetDirectory(assetTarget, root))
+      .toBe('/project/game/scene/shared')
+  })
+
+  it('场景树文件节点会解析到树模型提供的父目录目标', () => {
+    const root = AbsPath.from('/project/game/scene')
+    const fileTarget = createDropTarget({
+      fileTreeDropTargetPath: '/project/game/scene/chapter',
+      fileTreeIsDir: 'false',
+      fileTreePath: '/project/game/scene/chapter/opening.txt',
+    })
+
+    expect(resolveExternalFileDropTargetDirectory(fileTarget, root))
+      .toBe('/project/game/scene/chapter')
+  })
+
+  it('文件节点或根目录外伪造路径会回退到当前浏览目录', () => {
+    const root = AbsPath.from('/project/game/background')
+    const fileTarget = createDropTarget({
+      fileViewerIsDir: 'false',
+      fileViewerPath: '/project/game/background/hero.png',
+    })
+    const outsideTarget = createDropTarget({
+      fileViewerIsDir: 'true',
+      fileViewerPath: '/outside',
+    })
+    const rootSurface = document.createElement('div')
+    rootSurface.dataset.fileViewerRootSurface = 'true'
+    const blankTarget = document.createElement('span')
+    rootSurface.append(blankTarget)
+    document.body.append(rootSurface)
+
+    expect(resolveExternalFileDropTargetDirectory(fileTarget, root)).toBe(root)
+    expect(resolveExternalFileDropTargetDirectory(outsideTarget, root)).toBe(root)
+    expect(resolveExternalFileDropTargetDirectory(blankTarget, root)).toBe(root)
+  })
+
+  it('面板标题等非内容区域不会被识别为根目录目标', () => {
+    const root = AbsPath.from('/project/game/background')
+    const header = document.createElement('button')
+    document.body.append(header)
+
+    expect(resolveExternalFileDropTargetDirectory(header, root)).toBeUndefined()
+  })
+})

--- a/src/features/editor/external-file-import/__tests__/external-file-import.test.ts
+++ b/src/features/editor/external-file-import/__tests__/external-file-import.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { AbsPath } from '~/domain/path'
+import { importExternalFiles } from '~/features/editor/external-file-import/external-file-import'
+
+describe('importExternalFiles', () => {
+  it('会规范化并按路径查找键去重外部路径', async () => {
+    const importExternalEntry = vi.fn(async (sourcePath: AbsPath, targetDirectory: AbsPath) =>
+      AbsPath.append(targetDirectory, AbsPath.basename(sourcePath)),
+    )
+
+    const result = await importExternalFiles([
+      String.raw`c:\Assets\Hero.png`,
+      'C:/assets/hero.png',
+    ], AbsPath.from('D:/Game/game/figure'), { importExternalEntry })
+
+    expect(importExternalEntry).toHaveBeenCalledOnce()
+    expect(importExternalEntry).toHaveBeenCalledWith('C:/Assets/Hero.png', 'D:/Game/game/figure')
+    expect(result).toEqual({
+      failures: [],
+      successes: [{
+        sourcePath: 'C:/Assets/Hero.png',
+        targetPath: 'D:/Game/game/figure/Hero.png',
+      }],
+    })
+  })
+
+  it('单项失败时会继续导入剩余文件并返回完整汇总', async () => {
+    const importExternalEntry = vi.fn(async (sourcePath: AbsPath, targetDirectory: AbsPath) => {
+      if (sourcePath.endsWith('/broken.png')) {
+        throw new Error('copy failed')
+      }
+      return AbsPath.append(targetDirectory, AbsPath.basename(sourcePath))
+    })
+
+    const result = await importExternalFiles([
+      'relative.png',
+      '/assets/broken.png',
+      '/assets/valid.png',
+    ], AbsPath.from('/game/background'), { importExternalEntry })
+
+    expect(importExternalEntry).toHaveBeenCalledTimes(2)
+    expect(importExternalEntry).toHaveBeenNthCalledWith(1, '/assets/broken.png', '/game/background')
+    expect(importExternalEntry).toHaveBeenNthCalledWith(2, '/assets/valid.png', '/game/background')
+    expect(result.successes).toEqual([{
+      sourcePath: '/assets/valid.png',
+      targetPath: '/game/background/valid.png',
+    }])
+    expect(result.failures).toHaveLength(2)
+    expect(result.failures.map(failure => failure.sourcePath)).toEqual([
+      'relative.png',
+      '/assets/broken.png',
+    ])
+  })
+})

--- a/src/features/editor/external-file-import/__tests__/external-file-import.test.ts
+++ b/src/features/editor/external-file-import/__tests__/external-file-import.test.ts
@@ -4,14 +4,14 @@ import { AbsPath } from '~/domain/path'
 import { importExternalFiles } from '~/features/editor/external-file-import/external-file-import'
 
 describe('importExternalFiles', () => {
-  it('会规范化并按路径查找键去重外部路径', async () => {
+  it('会规范化并按路径去重外部路径', async () => {
     const importExternalEntry = vi.fn(async (sourcePath: AbsPath, targetDirectory: AbsPath) =>
       AbsPath.append(targetDirectory, AbsPath.basename(sourcePath)),
     )
 
     const result = await importExternalFiles([
       String.raw`c:\Assets\Hero.png`,
-      'C:/assets/hero.png',
+      'C:/Assets/Hero.png',
     ], AbsPath.from('D:/Game/game/figure'), { importExternalEntry })
 
     expect(importExternalEntry).toHaveBeenCalledOnce()
@@ -22,6 +22,32 @@ describe('importExternalFiles', () => {
         sourcePath: 'C:/Assets/Hero.png',
         targetPath: 'D:/Game/game/figure/Hero.png',
       }],
+    })
+  })
+
+  it('不会合并大小写不同的外部路径', async () => {
+    const importExternalEntry = vi.fn(async (sourcePath: AbsPath, targetDirectory: AbsPath) =>
+      AbsPath.append(targetDirectory, AbsPath.basename(sourcePath)),
+    )
+
+    const result = await importExternalFiles([
+      'C:/Assets/Hero.png',
+      'C:/assets/hero.png',
+    ], AbsPath.from('D:/Game/game/figure'), { importExternalEntry })
+
+    expect(importExternalEntry).toHaveBeenCalledTimes(2)
+    expect(result).toEqual({
+      failures: [],
+      successes: [
+        {
+          sourcePath: 'C:/Assets/Hero.png',
+          targetPath: 'D:/Game/game/figure/Hero.png',
+        },
+        {
+          sourcePath: 'C:/assets/hero.png',
+          targetPath: 'D:/Game/game/figure/hero.png',
+        },
+      ],
     })
   })
 

--- a/src/features/editor/external-file-import/__tests__/useExternalFileDropImport.browser.test.ts
+++ b/src/features/editor/external-file-import/__tests__/useExternalFileDropImport.browser.test.ts
@@ -1,0 +1,272 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent, h } from 'vue'
+
+import { renderInBrowser } from '~/__tests__/browser-render'
+import { AbsPath } from '~/domain/path'
+
+import { useExternalFileDropImport } from '../useExternalFileDropImport'
+
+import type { UseTauriDropZoneOptions } from '~/composables/useTauriDropZone'
+
+const {
+  dropZoneMockState,
+  importExternalFilesMock,
+  toastErrorMock,
+  toastWarningMock,
+} = vi.hoisted(() => ({
+  dropZoneMockState: {
+    options: undefined as UseTauriDropZoneOptions | undefined,
+    targetElement: undefined as { value: Element | undefined } | undefined,
+  },
+  importExternalFilesMock: vi.fn(),
+  toastErrorMock: vi.fn(),
+  toastWarningMock: vi.fn(),
+}))
+
+vi.mock('vue-sonner', () => ({
+  toast: {
+    error: toastErrorMock,
+    warning: toastWarningMock,
+  },
+}))
+
+vi.mock('~/composables/useTauriDropZone', async () => {
+  const { shallowRef } = await import('vue')
+  return {
+    useTauriDropZone: (_target: unknown, options: UseTauriDropZoneOptions) => {
+      dropZoneMockState.options = options
+      const targetElement = shallowRef<Element>()
+      dropZoneMockState.targetElement = targetElement
+      return {
+        files: shallowRef<string[]>(),
+        isOverDropZone: shallowRef(false),
+        targetElement,
+      }
+    },
+  }
+})
+
+vi.mock('../external-file-import', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../external-file-import')>()
+  return {
+    ...original,
+    importExternalFiles: importExternalFilesMock,
+  }
+})
+
+const rootDirectory = AbsPath.from('/project/game/scene')
+const messages = {
+  'zh-Hans': {
+    edit: {
+      externalFileImport: {
+        busy: '另一批文件仍在导入中',
+        failed: '{count} 个项目导入失败',
+        failedItems: '失败项目：{names}',
+        partial: '已导入 {successCount} 个项目，{failedCount} 个失败',
+        renamedConflicts: '已自动重命名 {count} 个同名项目',
+      },
+    },
+  },
+}
+
+function renderComposable() {
+  let result: ReturnType<typeof useExternalFileDropImport> | undefined
+  const Harness = defineComponent({
+    setup() {
+      result = useExternalFileDropImport({
+        dropZone: undefined,
+        rootDirectory,
+      })
+      return () => h('div')
+    },
+  })
+
+  const rendered = renderInBrowser(Harness, {
+    browser: {
+      i18nMode: 'localized',
+      messages,
+    },
+  })
+
+  const rootSurface = document.createElement('div')
+  rootSurface.dataset.fileViewerRootSurface = 'true'
+  if (dropZoneMockState.targetElement) {
+    dropZoneMockState.targetElement.value = rootSurface
+  }
+
+  return {
+    rendered,
+    result: result as ReturnType<typeof useExternalFileDropImport>,
+  }
+}
+
+function drop(paths: string[]): void {
+  const onDrop = dropZoneMockState.options?.onDrop
+  expect(onDrop).toBeTypeOf('function')
+  onDrop?.(paths)
+}
+
+beforeEach(() => {
+  dropZoneMockState.options = undefined
+  dropZoneMockState.targetElement = undefined
+  importExternalFilesMock.mockReset()
+  toastErrorMock.mockReset()
+  toastWarningMock.mockReset()
+})
+
+describe('useExternalFileDropImport', () => {
+  it('命中子目录时会把该目录传给导入流程', async () => {
+    importExternalFilesMock.mockResolvedValue({ failures: [], successes: [] })
+    const { rendered, result } = renderComposable()
+    const directory = document.createElement('div')
+    const child = document.createElement('span')
+    directory.dataset.fileTreeDropTargetPath = '/project/game/scene/chapter-1'
+    directory.dataset.fileTreeIsDir = 'true'
+    directory.dataset.fileTreePath = '/project/game/scene/chapter-1'
+    directory.append(child)
+    if (dropZoneMockState.targetElement) {
+      dropZoneMockState.targetElement.value = child
+    }
+
+    dropZoneMockState.options?.onEnter?.(['/downloads/start.txt'])
+
+    expect(result.targetDirectory.value).toBe('/project/game/scene/chapter-1')
+
+    drop(['/downloads/start.txt'])
+    await vi.waitFor(() => expect(importExternalFilesMock).toHaveBeenCalledWith(
+      ['/downloads/start.txt'],
+      '/project/game/scene/chapter-1',
+    ))
+    rendered.unmount()
+  })
+
+  it('拖拽经过不同目录并离开时会同步清理目标高亮', () => {
+    const { rendered, result } = renderComposable()
+    const firstDirectory = document.createElement('div')
+    firstDirectory.dataset.fileTreeDropTargetPath = '/project/game/scene/chapter-1'
+    firstDirectory.dataset.fileTreePath = '/project/game/scene/chapter-1'
+    firstDirectory.dataset.fileTreeIsDir = 'true'
+    const secondDirectory = document.createElement('div')
+    secondDirectory.dataset.fileTreeDropTargetPath = '/project/game/scene/chapter-2'
+    secondDirectory.dataset.fileTreePath = '/project/game/scene/chapter-2'
+    secondDirectory.dataset.fileTreeIsDir = 'true'
+
+    if (dropZoneMockState.targetElement) {
+      dropZoneMockState.targetElement.value = firstDirectory
+    }
+    dropZoneMockState.options?.onEnter?.([])
+    expect(result.targetDirectory.value).toBe('/project/game/scene/chapter-1')
+
+    if (dropZoneMockState.targetElement) {
+      dropZoneMockState.targetElement.value = secondDirectory
+    }
+    dropZoneMockState.options?.onOver?.()
+    expect(result.targetDirectory.value).toBe('/project/game/scene/chapter-2')
+
+    dropZoneMockState.options?.onLeave?.()
+    expect(result.targetDirectory.value).toBeUndefined()
+    rendered.unmount()
+  })
+
+  it('全部成功且未改名时保持静默', async () => {
+    importExternalFilesMock.mockResolvedValue({
+      failures: [],
+      successes: [{
+        sourcePath: AbsPath.from('/downloads/hero.png'),
+        targetPath: AbsPath.from('/project/game/scene/hero.png'),
+      }],
+    })
+    const { rendered } = renderComposable()
+
+    drop(['/downloads/hero.png'])
+    await vi.waitFor(() => expect(importExternalFilesMock).toHaveBeenCalledOnce())
+
+    expect(toastWarningMock).not.toHaveBeenCalled()
+    expect(toastErrorMock).not.toHaveBeenCalled()
+    rendered.unmount()
+  })
+
+  it('全部成功且发生冲突改名时也保持静默', async () => {
+    importExternalFilesMock.mockResolvedValue({
+      failures: [],
+      successes: [{
+        sourcePath: AbsPath.from('/downloads/hero.png'),
+        targetPath: AbsPath.from('/project/game/scene/hero (1).png'),
+      }],
+    })
+    const { rendered } = renderComposable()
+
+    drop(['/downloads/hero.png'])
+    await vi.waitFor(() => expect(importExternalFilesMock).toHaveBeenCalledOnce())
+
+    expect(toastWarningMock).not.toHaveBeenCalled()
+    expect(toastErrorMock).not.toHaveBeenCalled()
+    rendered.unmount()
+  })
+
+  it('部分失败时同时反馈成功数、失败项和冲突改名', async () => {
+    importExternalFilesMock.mockResolvedValue({
+      failures: [{ sourcePath: '/downloads/broken.png', error: new Error('broken') }],
+      successes: [{
+        sourcePath: AbsPath.from('/downloads/hero.png'),
+        targetPath: AbsPath.from('/project/game/scene/hero (1).png'),
+      }],
+    })
+    const { rendered } = renderComposable()
+
+    drop(['/downloads/broken.png', '/downloads/hero.png'])
+
+    await vi.waitFor(() => expect(toastWarningMock).toHaveBeenCalledWith(
+      '已导入 1 个项目，1 个失败',
+      { description: '失败项目：broken.png\n已自动重命名 1 个同名项目' },
+    ))
+    expect(toastErrorMock).not.toHaveBeenCalled()
+    rendered.unmount()
+  })
+
+  it('全部失败时列出失败项目且不发送成功通知', async () => {
+    importExternalFilesMock.mockResolvedValue({
+      failures: [
+        { sourcePath: '/downloads/a.png', error: new Error('a') },
+        { sourcePath: '/downloads/b.png', error: new Error('b') },
+        { sourcePath: '/downloads/c.png', error: new Error('c') },
+        { sourcePath: '/downloads/d.png', error: new Error('d') },
+      ],
+      successes: [],
+    })
+    const { rendered } = renderComposable()
+
+    drop(['/downloads/a.png', '/downloads/b.png', '/downloads/c.png', '/downloads/d.png'])
+
+    await vi.waitFor(() => expect(toastErrorMock).toHaveBeenCalledWith(
+      '4 个项目导入失败',
+      { description: '失败项目：a.png, b.png, c.png (+1)' },
+    ))
+    rendered.unmount()
+  })
+
+  it('导入期间拒绝启动第二批并在首批结束后恢复空闲', async () => {
+    let finishImport: ((value: { failures: never[], successes: never[] }) => void) | undefined
+    importExternalFilesMock
+      .mockImplementationOnce(() => new Promise((resolve) => {
+        finishImport = resolve
+      }))
+      .mockResolvedValue({ failures: [], successes: [] })
+    const { rendered } = renderComposable()
+
+    drop(['/downloads/first.png'])
+    await vi.waitFor(() => expect(importExternalFilesMock).toHaveBeenCalledOnce())
+    drop(['/downloads/second.png'])
+
+    expect(importExternalFilesMock).toHaveBeenCalledOnce()
+    expect(toastWarningMock).toHaveBeenCalledWith('另一批文件仍在导入中')
+
+    finishImport?.({ failures: [], successes: [] })
+    await Promise.resolve()
+    await Promise.resolve()
+
+    drop(['/downloads/third.png'])
+    await vi.waitFor(() => expect(importExternalFilesMock).toHaveBeenCalledTimes(2))
+    rendered.unmount()
+  })
+})

--- a/src/features/editor/external-file-import/external-file-import.ts
+++ b/src/features/editor/external-file-import/external-file-import.ts
@@ -1,0 +1,100 @@
+import { AbsPath } from '~/domain/path'
+import { gameFs } from '~/services/game-fs'
+import { fromExternalAbsPath } from '~/services/platform/path-boundary'
+import { toLookupPathKey } from '~/services/resource-path/lookup'
+
+export interface ExternalFileImportSuccess {
+  sourcePath: AbsPath
+  targetPath: AbsPath
+}
+
+export interface ExternalFileImportFailure {
+  sourcePath: string
+  error: unknown
+}
+
+export interface ExternalFileImportResult {
+  failures: ExternalFileImportFailure[]
+  successes: ExternalFileImportSuccess[]
+}
+
+export interface ExternalFileImportGateway {
+  importExternalEntry: (sourcePath: AbsPath, targetDirectory: AbsPath) => Promise<AbsPath>
+}
+
+interface NormalizedExternalPaths {
+  failures: ExternalFileImportFailure[]
+  paths: AbsPath[]
+}
+
+const externalDropItemSelector = '[data-file-tree-path], [data-file-viewer-path]'
+const externalDropRootSurfaceSelector = '[data-file-tree-root-surface], [data-file-viewer-root-surface]'
+
+function normalizeExternalPaths(rawPaths: readonly string[]): NormalizedExternalPaths {
+  const failures: ExternalFileImportFailure[] = []
+  const paths = new Map<ReturnType<typeof toLookupPathKey>, AbsPath>()
+
+  for (const rawPath of rawPaths) {
+    try {
+      const path = fromExternalAbsPath(rawPath)
+      const key = toLookupPathKey(path)
+      if (!paths.has(key)) {
+        paths.set(key, path)
+      }
+    } catch (error) {
+      failures.push({ sourcePath: rawPath, error })
+    }
+  }
+
+  return {
+    failures,
+    paths: [...paths.values()],
+  }
+}
+
+export async function importExternalFiles(
+  rawPaths: readonly string[],
+  targetDirectory: AbsPath,
+  gateway: ExternalFileImportGateway = gameFs,
+): Promise<ExternalFileImportResult> {
+  const normalized = normalizeExternalPaths(rawPaths)
+  const failures = [...normalized.failures]
+  const successes: ExternalFileImportSuccess[] = []
+
+  for (const sourcePath of normalized.paths) {
+    try {
+      // eslint-disable-next-line no-await-in-loop -- 批量导入按拖放顺序执行，确保同名项依次获得稳定的唯一名称。
+      const targetPath = await gateway.importExternalEntry(sourcePath, targetDirectory)
+      successes.push({ sourcePath, targetPath })
+    } catch (error) {
+      failures.push({ sourcePath, error })
+    }
+  }
+
+  return { failures, successes }
+}
+
+export function resolveExternalFileDropTargetDirectory(
+  element: Element | undefined,
+  rootDirectory: AbsPath,
+): AbsPath | undefined {
+  const itemElement = element?.closest<HTMLElement>(externalDropItemSelector)
+  if (!itemElement && !element?.closest<HTMLElement>(externalDropRootSurfaceSelector)) {
+    return
+  }
+
+  const rawPath = itemElement?.dataset.fileTreeDropTargetPath
+    ?? (itemElement?.dataset.fileViewerIsDir === 'true' ? itemElement.dataset.fileViewerPath : undefined)
+
+  if (!rawPath) {
+    return rootDirectory
+  }
+
+  try {
+    const targetDirectory = AbsPath.from(rawPath)
+    AbsPath.relativize(targetDirectory, rootDirectory)
+    return targetDirectory
+  } catch {
+    return rootDirectory
+  }
+}

--- a/src/features/editor/external-file-import/external-file-import.ts
+++ b/src/features/editor/external-file-import/external-file-import.ts
@@ -1,7 +1,6 @@
 import { AbsPath } from '~/domain/path'
 import { gameFs } from '~/services/game-fs'
 import { fromExternalAbsPath } from '~/services/platform/path-boundary'
-import { toLookupPathKey } from '~/services/resource-path/lookup'
 
 export interface ExternalFileImportSuccess {
   sourcePath: AbsPath
@@ -32,15 +31,12 @@ const externalDropRootSurfaceSelector = '[data-file-tree-root-surface], [data-fi
 
 function normalizeExternalPaths(rawPaths: readonly string[]): NormalizedExternalPaths {
   const failures: ExternalFileImportFailure[] = []
-  const paths = new Map<ReturnType<typeof toLookupPathKey>, AbsPath>()
+  const paths = new Set<AbsPath>()
 
   for (const rawPath of rawPaths) {
     try {
       const path = fromExternalAbsPath(rawPath)
-      const key = toLookupPathKey(path)
-      if (!paths.has(key)) {
-        paths.set(key, path)
-      }
+      paths.add(path)
     } catch (error) {
       failures.push({ sourcePath: rawPath, error })
     }
@@ -48,7 +44,7 @@ function normalizeExternalPaths(rawPaths: readonly string[]): NormalizedExternal
 
   return {
     failures,
-    paths: [...paths.values()],
+    paths: [...paths],
   }
 }
 

--- a/src/features/editor/external-file-import/useExternalFileDropImport.ts
+++ b/src/features/editor/external-file-import/useExternalFileDropImport.ts
@@ -1,0 +1,115 @@
+import { useTauriDropZone } from '~/composables/useTauriDropZone'
+import { AbsPath } from '~/domain/path'
+import {
+  importExternalFiles,
+  resolveExternalFileDropTargetDirectory,
+} from '~/features/editor/external-file-import/external-file-import'
+
+import type {
+  ExternalFileImportFailure,
+  ExternalFileImportSuccess,
+} from '~/features/editor/external-file-import/external-file-import'
+
+export interface UseExternalFileDropImportOptions {
+  dropZone: MaybeRefOrGetter<HTMLElement | null | undefined>
+  rootDirectory: MaybeRefOrGetter<AbsPath | undefined>
+}
+
+function getFailureName(failure: ExternalFileImportFailure): string {
+  try {
+    return AbsPath.basename(AbsPath.from(failure.sourcePath)) || failure.sourcePath
+  } catch {
+    return failure.sourcePath
+  }
+}
+
+export function useExternalFileDropImport(options: UseExternalFileDropImportOptions) {
+  const { t } = useI18n()
+  const targetDirectory = shallowRef<AbsPath>()
+  const isImporting = shallowRef(false)
+
+  function getRootDirectory(): AbsPath | undefined {
+    return toValue(options.rootDirectory)
+  }
+
+  function updateTargetDirectory(element: Element | undefined): AbsPath | undefined {
+    const rootDirectory = getRootDirectory()
+    targetDirectory.value = rootDirectory
+      ? resolveExternalFileDropTargetDirectory(element, rootDirectory)
+      : undefined
+    return targetDirectory.value
+  }
+
+  function formatFailureDescription(failures: readonly ExternalFileImportFailure[]): string {
+    const visibleNames = failures.slice(0, 3).map(failure => getFailureName(failure))
+    const remainingCount = failures.length - visibleNames.length
+    const names = remainingCount > 0
+      ? `${visibleNames.join(', ')} (+${remainingCount})`
+      : visibleNames.join(', ')
+    return t('edit.externalFileImport.failedItems', { names })
+  }
+
+  function formatConflictDescription(successes: readonly ExternalFileImportSuccess[]): string {
+    const renamedCount = successes.filter(success =>
+      AbsPath.basename(success.sourcePath) !== AbsPath.basename(success.targetPath),
+    ).length
+    return renamedCount > 0
+      ? t('edit.externalFileImport.renamedConflicts', { count: renamedCount })
+      : ''
+  }
+
+  async function runImport(paths: string[], importTarget: AbsPath): Promise<void> {
+    if (isImporting.value) {
+      toast.warning(t('edit.externalFileImport.busy'))
+      return
+    }
+
+    isImporting.value = true
+    try {
+      const result = await importExternalFiles(paths, importTarget)
+      const successCount = result.successes.length
+      const failedCount = result.failures.length
+
+      if (failedCount === 0) {
+        return
+      }
+
+      if (successCount > 0) {
+        const conflictDescription = formatConflictDescription(result.successes)
+        toast.warning(t('edit.externalFileImport.partial', { failedCount, successCount }), {
+          description: [formatFailureDescription(result.failures), conflictDescription].filter(Boolean).join('\n'),
+        })
+        return
+      }
+
+      toast.error(t('edit.externalFileImport.failed', { count: failedCount }), {
+        description: formatFailureDescription(result.failures),
+      })
+    } finally {
+      isImporting.value = false
+    }
+  }
+
+  const dropZone = useTauriDropZone(options.dropZone, {
+    onEnter() {
+      updateTargetDirectory(dropZone.targetElement.value)
+    },
+    onOver() {
+      updateTargetDirectory(dropZone.targetElement.value)
+    },
+    onDrop(paths) {
+      const importTarget = updateTargetDirectory(dropZone.targetElement.value)
+      if (importTarget) {
+        void runImport(paths, importTarget)
+      }
+      targetDirectory.value = undefined
+    },
+    onLeave() {
+      targetDirectory.value = undefined
+    },
+  })
+
+  return {
+    targetDirectory: readonly(targetDirectory),
+  }
+}

--- a/src/locales/en.yml
+++ b/src/locales/en.yml
@@ -811,6 +811,12 @@ edit:
   scenePanel:
     scene: Scene
     resource: Resource
+  externalFileImport:
+    partial: Imported {successCount} item(s); {failedCount} failed
+    failed: Failed to import {count} item(s)
+    failedItems: "Failed: {names}"
+    renamedConflicts: Renamed {count} conflicting item(s)
+    busy: Another file import is still running
   statusBar:
     frames: "{count} frames"
     resourceIndexBuilding: Indexing resources

--- a/src/locales/ja.yml
+++ b/src/locales/ja.yml
@@ -811,6 +811,12 @@ edit:
   scenePanel:
     scene: シーン
     resource: リソース
+  externalFileImport:
+    partial: "{successCount} 件をインポートし、{failedCount} 件が失敗しました"
+    failed: "{count} 件のインポートに失敗しました"
+    failedItems: "失敗: {names}"
+    renamedConflicts: "同名の {count} 件を自動的に名前変更しました"
+    busy: 別のファイルインポートが実行中です
   statusBar:
     frames: "{count} フレーム"
     resourceIndexBuilding: リソースをインデックスしています

--- a/src/locales/zh-Hans.yml
+++ b/src/locales/zh-Hans.yml
@@ -811,6 +811,12 @@ edit:
   scenePanel:
     scene: 场景
     resource: 资源
+  externalFileImport:
+    partial: 已导入 {successCount} 个项目，{failedCount} 个失败
+    failed: "{count} 个项目导入失败"
+    failedItems: "失败项目：{names}"
+    renamedConflicts: 已自动重命名 {count} 个同名项目
+    busy: 另一批文件仍在导入中
   statusBar:
     frames: "{count} 帧"
     resourceIndexBuilding: 正在构建资源索引

--- a/src/locales/zh-Hant.yml
+++ b/src/locales/zh-Hant.yml
@@ -811,6 +811,12 @@ edit:
   scenePanel:
     scene: 場景
     resource: 資源
+  externalFileImport:
+    partial: 已匯入 {successCount} 個項目，{failedCount} 個失敗
+    failed: "{count} 個項目匯入失敗"
+    failedItems: "失敗項目：{names}"
+    renamedConflicts: 已自動重新命名 {count} 個同名項目
+    busy: 另一批檔案仍在匯入中
   statusBar:
     frames: "{count} 幀"
     resourceIndexBuilding: 正在建立資源索引

--- a/src/services/__tests__/game-fs.test.ts
+++ b/src/services/__tests__/game-fs.test.ts
@@ -10,6 +10,7 @@ const {
   createFileMock,
   createFolderMock,
   copyFileMock,
+  importExternalEntryMock,
   deleteFileMock,
   ensureWritableMock,
   getFolderContentsMock,
@@ -19,6 +20,7 @@ const {
   resolvePreviewSiteMock,
   registerPendingFileWriteMock,
   rollbackPendingFileWriteMock,
+  statMock,
   fsRenameFileMock,
   vfsRenamePathMock,
   readFileMock,
@@ -36,6 +38,7 @@ const {
   createFileMock: vi.fn(),
   createFolderMock: vi.fn(),
   copyFileMock: vi.fn(),
+  importExternalEntryMock: vi.fn(),
   deleteFileMock: vi.fn(),
   ensureWritableMock: vi.fn(),
   getFolderContentsMock: vi.fn(),
@@ -45,6 +48,7 @@ const {
   resolvePreviewSiteMock: vi.fn(),
   registerPendingFileWriteMock: vi.fn(),
   rollbackPendingFileWriteMock: vi.fn(),
+  statMock: vi.fn(),
   fsRenameFileMock: vi.fn(),
   vfsRenamePathMock: vi.fn(),
   readFileMock: vi.fn(),
@@ -60,6 +64,7 @@ const {
 vi.mock('@tauri-apps/plugin-fs', () => ({
   mkdir: mkdirMock,
   readFile: readFileMock,
+  stat: statMock,
   writeFile: writeBinaryFileMock,
   writeTextFile: writeTextFileMock,
 }))
@@ -85,6 +90,7 @@ vi.mock('~/commands/fs', () => ({
     createFile: createFileMock,
     createFolder: createFolderMock,
     copyFile: copyFileMock,
+    importExternalEntry: importExternalEntryMock,
     moveFile: fsMoveFileMock,
     renameFile: fsRenameFileMock,
   },
@@ -112,6 +118,7 @@ describe('gameFs', () => {
     createFileMock.mockReset()
     createFolderMock.mockReset()
     copyFileMock.mockReset()
+    importExternalEntryMock.mockReset()
     deleteFileMock.mockReset()
     ensureWritableMock.mockReset()
     getFolderContentsMock.mockReset()
@@ -122,6 +129,7 @@ describe('gameFs', () => {
     resolvePreviewSiteMock.mockReset()
     registerPendingFileWriteMock.mockReset()
     rollbackPendingFileWriteMock.mockReset()
+    statMock.mockReset()
     readFileMock.mockReset()
     fsRenameFileMock.mockReset()
     vfsRenamePathMock.mockReset()
@@ -141,6 +149,7 @@ describe('gameFs', () => {
     getFolderContentsMock.mockResolvedValue([])
     readFileMock.mockResolvedValue(new Uint8Array([1, 2, 3]))
     resolveFilePathMock.mockImplementation(async (path: string) => path)
+    statMock.mockResolvedValue({ isDirectory: false })
     useWorkspaceStoreMock.mockReturnValue({
       CWD: '/project',
       currentGame: {
@@ -458,5 +467,92 @@ describe('gameFs', () => {
     expect(mkdirMock).toHaveBeenCalledWith('/game/bgm (1)', { recursive: true })
     expect(createFileMock).not.toHaveBeenCalled()
     expect(createFolderMock).not.toHaveBeenCalled()
+  })
+
+  it('从外部导入时会按 overlay 可见内容避让同名项并写入 upper 路径', async () => {
+    useFileStoreMock.mockReturnValue({
+      copyEntry: copyEntryMock,
+      deleteEntry: vi.fn(async () => false),
+      ensureWritable: ensureWritableMock,
+      getFolderContents: getFolderContentsMock,
+      initialized: Promise.resolve(),
+      isVfs: true,
+      resolveFilePath: resolveFilePathMock,
+    })
+    getFolderContentsMock.mockResolvedValueOnce([{ name: 'hero.png' }])
+    ensureWritableMock.mockResolvedValueOnce('/project/.overlay/game/background/hero (1).png')
+    importExternalEntryMock.mockResolvedValueOnce('hero (1).png')
+
+    await expect(gameFs.importExternalEntry(
+      AbsPath.from('C:/Downloads/hero.png'),
+      AbsPath.from('/project/game/background'),
+    )).resolves.toBe('/project/game/background/hero (1).png')
+
+    expect(ensureWritableMock).toHaveBeenCalledWith('/project/game/background/hero (1).png')
+    expect(importExternalEntryMock).toHaveBeenCalledWith(
+      'C:/Downloads/hero.png',
+      '/project/.overlay/game/background',
+      'hero (1).png',
+      '/project',
+    )
+    expect(copyEntryMock).not.toHaveBeenCalled()
+    expect(resolveFilePathMock).not.toHaveBeenCalled()
+    expect(touchCurrentGameLastModifiedMock).toHaveBeenCalledOnce()
+  })
+
+  it('普通文件系统模式下会把物理目标目录传给外部导入命令', async () => {
+    statMock.mockResolvedValueOnce({ isDirectory: false })
+    importExternalEntryMock.mockResolvedValueOnce('hero.png')
+
+    await expect(gameFs.importExternalEntry(
+      AbsPath.from('C:/Downloads/hero.png'),
+      AbsPath.from('/project/game/background'),
+    )).resolves.toBe('/project/game/background/hero.png')
+
+    expect(importExternalEntryMock).toHaveBeenCalledWith(
+      'C:/Downloads/hero.png',
+      '/project/game/background',
+      'hero.png',
+      '/project',
+    )
+    expect(touchCurrentGameLastModifiedMock).toHaveBeenCalledOnce()
+  })
+
+  it('Rust 原子占名发现物理冲突时会采用命令返回的最终名称', async () => {
+    useFileStoreMock.mockReturnValue({
+      copyEntry: copyEntryMock,
+      deleteEntry: vi.fn(async () => false),
+      ensureWritable: ensureWritableMock,
+      getFolderContents: getFolderContentsMock,
+      initialized: Promise.resolve(),
+      isVfs: true,
+      resolveFilePath: resolveFilePathMock,
+    })
+    getFolderContentsMock.mockResolvedValueOnce([{ name: 'hero.png' }])
+    ensureWritableMock.mockImplementation(async (path: string) => path.replace('/game/', '/.overlay/game/'))
+    importExternalEntryMock.mockResolvedValueOnce('hero (2).png')
+
+    await expect(gameFs.importExternalEntry(
+      AbsPath.from('C:/Other/hero.png'),
+      AbsPath.from('/project/game/background'),
+    )).resolves.toBe('/project/game/background/hero (2).png')
+
+    expect(ensureWritableMock).toHaveBeenCalledOnce()
+    expect(ensureWritableMock).toHaveBeenCalledWith('/project/game/background/hero (1).png')
+    expect(importExternalEntryMock).toHaveBeenCalledWith(
+      'C:/Other/hero.png',
+      '/project/.overlay/game/background',
+      'hero (1).png',
+      '/project',
+    )
+  })
+
+  it('拒绝把外部内容写到当前项目外', async () => {
+    await expect(gameFs.importExternalEntry(
+      AbsPath.from('C:/Downloads/hero.png'),
+      AbsPath.from('/other/game/background'),
+    )).rejects.toMatchObject({ code: 'PATH_DENIED' })
+
+    expect(importExternalEntryMock).not.toHaveBeenCalled()
   })
 })

--- a/src/services/game-fs.ts
+++ b/src/services/game-fs.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, writeFile as writeBinaryFile, writeTextFile } from '@tauri-apps/plugin-fs'
+import { mkdir, readFile, stat, writeFile as writeBinaryFile, writeTextFile } from '@tauri-apps/plugin-fs'
 
 import { fsCmds } from '~/commands/fs'
 import { vfsCmds } from '~/commands/vfs'
@@ -346,6 +346,76 @@ async function copyFile(sourcePath: AbsPath, targetPath: AbsPath): Promise<AbsPa
   }
 }
 
+function getExternalImportProjectRoot(targetPath: AbsPath): AbsPath {
+  const gamePath = useWorkspaceStore().currentGame?.path
+  if (!gamePath || !isPathWithinOrEqual(targetPath, gamePath)) {
+    throw new AppError('PATH_DENIED', '外部文件只能导入当前项目目录')
+  }
+
+  return gamePath
+}
+
+interface ExternalImportTarget {
+  logicalPath: AbsPath
+  writablePath: AbsPath
+}
+
+async function resolveExternalImportTarget(
+  sourceName: string,
+  sourceIsDirectory: boolean,
+  targetPath: AbsPath,
+): Promise<ExternalImportTarget> {
+  const fileStore = useFileStore()
+  const existingItems = await fileStore.getFolderContents(targetPath)
+  const uniqueName = buildUniqueEntryName(
+    sourceName,
+    sourceIsDirectory,
+    new Set(existingItems.map(item => item.name)),
+  )
+  const logicalPath = AbsPath.append(targetPath, uniqueName)
+  return {
+    logicalPath,
+    writablePath: await resolveWritablePath(logicalPath),
+  }
+}
+
+async function importExternalEntry(sourcePath: AbsPath, targetPath: AbsPath): Promise<AbsPath> {
+  const projectRoot = getExternalImportProjectRoot(targetPath)
+
+  const sourceInfo = await stat(sourcePath)
+  const sourceName = AbsPath.basename(sourcePath)
+  if (!sourceName) {
+    throw new AppError('FS_ERROR', '不能导入文件系统根目录')
+  }
+
+  const fileStore = useFileStore()
+  const finishUpdateBlocker = useRuntimeTaskStore()
+    .beginBlockingTask(`import-external-entry:${crypto.randomUUID()}`)
+
+  try {
+    await fileStore.initialized
+    const importTarget = await resolveExternalImportTarget(
+      sourceName,
+      sourceInfo.isDirectory,
+      targetPath,
+    )
+    const importedName = await fsCmds.importExternalEntry(
+      sourcePath,
+      AbsPath.parent(importTarget.writablePath),
+      AbsPath.basename(importTarget.writablePath),
+      projectRoot,
+    )
+    const importedPath = importedName === AbsPath.basename(importTarget.writablePath)
+      ? importTarget.logicalPath
+      : AbsPath.append(targetPath, importedName)
+
+    markPathChanged(importedPath, { includeChildren: sourceInfo.isDirectory })
+    return importedPath
+  } finally {
+    finishUpdateBlocker()
+  }
+}
+
 async function moveFile(sourcePath: AbsPath, targetPath: AbsPath, targetName?: string): Promise<PathMutationResult> {
   assertMutableSceneEntry(sourcePath)
   if (usesTemplateOverlayPath(sourcePath) || usesTemplateOverlayPath(targetPath)) {
@@ -364,5 +434,6 @@ export const gameFs = {
   createFile,
   createFolder,
   copyFile,
+  importExternalEntry,
   moveFile,
 }


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [ ] 错误修复
- [x] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [x] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

支持从操作系统文件管理器将文件或文件夹拖入场景树和资源浏览器。导入过程会校验路径边界、处理同名项目并刷新对应视图；场景树和资源浏览器沿用各自内部拖拽的目标语义与高亮方式。成功导入保持静默，仅在部分失败、全部失败或导入繁忙时反馈。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

用户可以直接将外部文件导入当前项目，减少手动复制和重新定位文件的操作，同时保持项目文件系统和视图状态的一致性。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->

外部拖拽只在场景树和资源浏览器的内容区域生效，面板标题和工具栏不会被识别为导入目标。

### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
