### PR TITLE
🐛 修复文件名含 `#` 等字符时图片无法显示

### DIFF
--- a/src/services/platform/__tests__/asset-url.test.ts
+++ b/src/services/platform/__tests__/asset-url.test.ts
@@ -41,6 +41,24 @@ describe('assetUrl', () => {
     expect(getAssetUrl(String.raw`/games/demo/assets\bg\cover image.png`)).toBe('http://127.0.0.1:8899/game/demo/assets/bg/cover%20image.png')
   })
 
+  it('会将文件名中的 # 编码为路径内容而不是 URL fragment', () => {
+    expect(resolveAssetUrl('/games/demo/game/figure/file#with#hash-测试.png', {
+      cwd: '/games/demo',
+      previewBaseUrl: 'http://127.0.0.1:8899/game/demo/',
+      cacheVersion: CACHE_VERSION,
+      thumbnail: { width: 64, height: 64, resizeMode: 'contain' },
+    })).toBe(
+      'http://127.0.0.1:8899/game/demo/game/figure/file%23with%23hash-%E6%B5%8B%E8%AF%95.png?t=1710000000000&w=64&h=64&fit=contain',
+    )
+  })
+
+  it('会将文件名中的 URL 保留字符编码为路径内容', () => {
+    expect(resolveAssetUrl('/games/demo/assets/100%?#.png', {
+      cwd: '/games/demo',
+      previewBaseUrl: 'http://127.0.0.1:8899/game/demo/',
+    })).toBe('http://127.0.0.1:8899/game/demo/assets/100%25%3F%23.png')
+  })
+
   it('传入 cacheVersion 时会附带时间戳参数用于缓存破坏', () => {
     const getAssetUrlWithCacheVersion = getAssetUrl as (
       assetPath: string,

--- a/src/services/platform/asset-url.ts
+++ b/src/services/platform/asset-url.ts
@@ -118,7 +118,10 @@ export function resolveAssetUrl(assetPath: string, options: AssetUrlOptions): st
     throw new Error(`资源路径不在当前工作区内: ${assetPath}`)
   }
 
-  const relativePath = resolvedPath.segments.slice(resolvedCwd.segments.length).join('/')
+  const relativePath = resolvedPath.segments
+    .slice(resolvedCwd.segments.length)
+    .map(segment => encodeURIComponent(segment))
+    .join('/')
   const previewBaseUrl = options.previewBaseUrl.endsWith('/')
     ? options.previewBaseUrl
     : `${options.previewBaseUrl}/`


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [x] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [x] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

修复资源文件名包含 `#` 等 URL 保留字符时，图片无法正常显示的问题。

资源 URL 生成逻辑此前会将未经编码的文件系统路径直接传入 `URL` 构造函数，导致文件名中的 `#` 被解析为 URL fragment，服务端只能收到井号之前的路径。

现在会在工作区路径校验完成后逐段编码相对路径，同时保留 `/` 的目录分隔语义。文件名中的 `#`、`?` 和 `%` 将作为路径内容正确编码，不再影响 URL 的 fragment 或查询参数。

增加了包含 Unicode 字符、多个井号、缩略图查询参数及其他 URL 保留字符的回归测试。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

文件名包含 `#` 时，资源预览地址会在井号处被截断，导致图片请求指向错误的文件路径，资源列表和预览中的图片无法显示。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
