### PR TITLE
🐛 消除效果编辑器连续操作的预览延迟

### DIFF
--- a/src/components/editor/effect-editor/EffectDraftCategorySection.spec.ts
+++ b/src/components/editor/effect-editor/EffectDraftCategorySection.spec.ts
@@ -296,19 +296,15 @@ describe('EffectDraftCategorySection', () => {
     await page.getByRole('button', { name: '清除 Tint' }).click()
 
     expect(clearPaths).toHaveBeenCalledWith(['position.x'], {
-      schedule: 'immediate',
       flush: true,
     })
     expect(clearPaths).toHaveBeenCalledWith(['alpha'], {
-      schedule: 'immediate',
       flush: true,
     })
     expect(clearPaths).toHaveBeenCalledWith(['scale.x', 'scale.y'], {
-      schedule: 'immediate',
       flush: true,
     })
     expect(clearPaths).toHaveBeenCalledWith(['colorRed', 'colorGreen', 'colorBlue'], {
-      schedule: 'immediate',
       flush: true,
     })
   })

--- a/src/components/editor/effect-editor/EffectDraftCategorySection.vue
+++ b/src/components/editor/effect-editor/EffectDraftCategorySection.vue
@@ -20,8 +20,7 @@ const props = defineProps<Props>()
 type EffectDraftRenderItem = EffectDraftCategoryRenderModel['items'][number]
 type EffectDraftClearableItem = Exclude<EffectDraftRenderItem, { kind: 'choice' | 'flip-actions' | 'position' }>
 
-const CLEAR_IMMEDIATE_OPTIONS = {
-  schedule: 'immediate',
+const CLEAR_OPTIONS = {
   flush: true,
 } as const
 const LINKED_SLIDER_AXES = [0, 1] as const
@@ -60,7 +59,7 @@ function getClearButtonClass(paths: readonly string[]): string {
 }
 
 function clearPaths(paths: readonly string[]): void {
-  props.controls.clearPaths(paths, CLEAR_IMMEDIATE_OPTIONS)
+  props.controls.clearPaths(paths, CLEAR_OPTIONS)
 }
 
 function getClearPropertyLabel(label: Parameters<EffectDraftLabelResolver>[0]): string {

--- a/src/components/editor/effect-editor/EffectDraftForm.vue
+++ b/src/components/editor/effect-editor/EffectDraftForm.vue
@@ -250,7 +250,6 @@ function flipScaleAxis(axis: TransformScaleAxis): void {
   emitTransform(transformToFields(nextTransform), {
     deferAutoApply: false,
     flush: true,
-    schedule: 'immediate',
   })
 }
 

--- a/src/features/editor/effect-editor/__tests__/useEffectClearControls.test.ts
+++ b/src/features/editor/effect-editor/__tests__/useEffectClearControls.test.ts
@@ -33,7 +33,6 @@ describe('useEffectClearControls', () => {
     expect(controls.canClearPaths(['scale.x', 'scale.y'])).toBe(true)
 
     controls.clearPaths(['scale.x', 'scale.y'], {
-      schedule: 'immediate',
       flush: true,
     })
 
@@ -41,7 +40,6 @@ describe('useEffectClearControls', () => {
     expect(fields['scale.y']).toBeUndefined()
     expect(fields.alpha).toBe('0.5')
     expect(emitTransform).toHaveBeenCalledWith(fields, {
-      schedule: 'immediate',
       flush: true,
       deferAutoApply: false,
     })
@@ -54,7 +52,6 @@ describe('useEffectClearControls', () => {
     expect(controls.canClearPaths(['blur'])).toBe(false)
 
     controls.clearPaths(['blur'], {
-      schedule: 'immediate',
       flush: true,
     })
 

--- a/src/features/editor/effect-editor/__tests__/useEffectColorControl.test.ts
+++ b/src/features/editor/effect-editor/__tests__/useEffectColorControl.test.ts
@@ -75,7 +75,6 @@ describe('useEffectColorControl', () => {
       b: '56',
     })
     expect(emitTransform).toHaveBeenLastCalledWith(fields, {
-      schedule: 'color',
       flush: true,
       deferAutoApply: false,
     })
@@ -105,7 +104,6 @@ describe('useEffectColorControl', () => {
     control.handleColorPickerChange(field, { rgba: { r: 10, g: 20, b: 30 } })
 
     expect(emitTransform).toHaveBeenLastCalledWith(fields, {
-      schedule: 'color',
       deferAutoApply: true,
     })
 
@@ -113,7 +111,6 @@ describe('useEffectColorControl', () => {
 
     expect(emitTransform).toHaveBeenCalledTimes(2)
     expect(emitTransform).toHaveBeenLastCalledWith(fields, {
-      schedule: 'color',
       flush: true,
       deferAutoApply: false,
     })
@@ -138,7 +135,6 @@ describe('useEffectColorControl', () => {
     expect(cancelPreview).toHaveBeenCalledOnce()
     expect(emitTransform).toHaveBeenCalledTimes(1)
     expect(emitTransform).toHaveBeenLastCalledWith(expect.any(Object), {
-      schedule: 'color',
       deferAutoApply: true,
     })
   })

--- a/src/features/editor/effect-editor/__tests__/useEffectContinuousControls.test.ts
+++ b/src/features/editor/effect-editor/__tests__/useEffectContinuousControls.test.ts
@@ -256,7 +256,7 @@ describe('useEffectContinuousControls', () => {
     vi.unstubAllGlobals()
   })
 
-  it('updateNumberField 支持裁剪并按 continuous 模式 flush', () => {
+  it('updateNumberField 支持裁剪并 flush 最终值', () => {
     const { deps, emitTransform, fields } = createDeps()
     const controls = useEffectContinuousControls(deps)
 
@@ -267,7 +267,6 @@ describe('useEffectContinuousControls', () => {
 
     expect(fields.x).toBe('10')
     expect(emitTransform).toHaveBeenCalledWith(fields, {
-      schedule: 'continuous',
       flush: true,
       deferAutoApply: false,
     })
@@ -296,16 +295,15 @@ describe('useEffectContinuousControls', () => {
 
     expect(emitTransform).toHaveBeenCalledTimes(1)
     expect(emitTransform).toHaveBeenLastCalledWith(fields, {
-      schedule: 'continuous',
       flush: false,
       deferAutoApply: true,
+      frameReady: true,
     })
 
     numberScrub.end(createPointerEvent({ clientX: 105 }))
 
     expect(emitTransform).toHaveBeenCalledTimes(2)
     expect(emitTransform).toHaveBeenLastCalledWith(fields, {
-      schedule: 'continuous',
       flush: true,
       deferAutoApply: false,
     })
@@ -333,9 +331,9 @@ describe('useEffectContinuousControls', () => {
     expect(cancelPreview).toHaveBeenCalledOnce()
     expect(emitTransform).toHaveBeenCalledTimes(1)
     expect(emitTransform).toHaveBeenLastCalledWith(expect.any(Object), {
-      schedule: 'continuous',
       flush: false,
       deferAutoApply: true,
+      frameReady: true,
     })
   })
 
@@ -360,9 +358,9 @@ describe('useEffectContinuousControls', () => {
 
     expect(emitTransform).toHaveBeenCalledTimes(1)
     expect(emitTransform).toHaveBeenLastCalledWith(fields, {
-      schedule: 'continuous',
       flush: undefined,
       deferAutoApply: true,
+      frameReady: true,
     })
   })
 
@@ -411,7 +409,6 @@ describe('useEffectContinuousControls', () => {
     expect(fields.alpha).toBe('0.6')
     expect(emitTransform).toHaveBeenCalledTimes(1)
     expect(emitTransform).toHaveBeenLastCalledWith(fields, {
-      schedule: 'continuous',
       flush: true,
       deferAutoApply: false,
     })
@@ -507,9 +504,9 @@ describe('useEffectContinuousControls', () => {
     expect(emitTransform).toHaveBeenLastCalledWith(expect.objectContaining({
       blur: '8',
     }), {
-      schedule: 'continuous',
       flush: undefined,
       deferAutoApply: true,
+      frameReady: true,
     })
   })
 
@@ -538,9 +535,9 @@ describe('useEffectContinuousControls', () => {
     expect(emitTransform).toHaveBeenLastCalledWith(expect.objectContaining({
       alpha: '0.8',
     }), {
-      schedule: 'continuous',
       flush: undefined,
       deferAutoApply: true,
+      frameReady: true,
     })
   })
 
@@ -590,9 +587,9 @@ describe('useEffectContinuousControls', () => {
     expect(emitTransform).toHaveBeenLastCalledWith(expect.objectContaining({
       blur: '8',
     }), {
-      schedule: 'continuous',
       flush: undefined,
       deferAutoApply: true,
+      frameReady: true,
     })
   })
 
@@ -644,9 +641,9 @@ describe('useEffectContinuousControls', () => {
     expect(cancelPreview).toHaveBeenCalledOnce()
     expect(emitTransform).toHaveBeenCalledTimes(1)
     expect(emitTransform).toHaveBeenLastCalledWith(expect.any(Object), {
-      schedule: 'continuous',
       flush: false,
       deferAutoApply: true,
+      frameReady: true,
     })
   })
 

--- a/src/features/editor/effect-editor/__tests__/useEffectEditorProvider-preview.test.ts
+++ b/src/features/editor/effect-editor/__tests__/useEffectEditorProvider-preview.test.ts
@@ -28,8 +28,8 @@ describe('createEffectPreviewEmitter', () => {
         blur: '8',
       },
       {
-        schedule: 'continuous',
         deferAutoApply: true,
+        frameReady: true,
       },
     )
 
@@ -41,8 +41,8 @@ describe('createEffectPreviewEmitter', () => {
     ])
     expect(previewPayloads).toEqual([
       {
-        schedule: 'continuous',
         flush: false,
+        frameReady: true,
       },
     ])
   })
@@ -62,7 +62,6 @@ describe('createEffectPreviewEmitter', () => {
     emitter.emitTransform(
       { alpha: '1' },
       {
-        schedule: 'immediate',
         flush: true,
         deferAutoApply: false,
       },
@@ -74,7 +73,6 @@ describe('createEffectPreviewEmitter', () => {
       flush: true,
     })
     expect(previewPayloads.at(-1)).toEqual({
-      schedule: 'immediate',
       flush: true,
     })
   })

--- a/src/features/editor/effect-editor/__tests__/useEffectEditorProvider-queue.test.ts
+++ b/src/features/editor/effect-editor/__tests__/useEffectEditorProvider-queue.test.ts
@@ -299,7 +299,7 @@ describe('useEffectEditorProvider', () => {
 
     await provider.open(createOpenTarget({ onApply: applyMock }))
     provider.updateDraft({ transform: { blur: 12 } })
-    provider.requestPreview({ schedule: 'immediate' })
+    provider.requestPreview({})
     await vi.waitFor(() => {
       expect(provider.canApply).toBe(true)
     })
@@ -437,7 +437,7 @@ describe('useEffectEditorProvider', () => {
     }))
 
     provider.updateDraft({ transform: { alpha: 0.5 } })
-    provider.requestPreview({ schedule: 'immediate' })
+    provider.requestPreview({})
     await vi.waitFor(() => {
       expect(debugCommanderMock.setEffect).toHaveBeenCalledTimes(1)
     })
@@ -461,7 +461,7 @@ describe('useEffectEditorProvider', () => {
     }))
 
     provider.updateDraft({ transform: {} })
-    provider.requestPreview({ schedule: 'immediate' })
+    provider.requestPreview({})
     await vi.waitFor(() => {
       expect(debugCommanderMock.setEffect).toHaveBeenCalledTimes(1)
     })
@@ -483,7 +483,7 @@ describe('useEffectEditorProvider', () => {
     }))
 
     provider.updateDraft({ transform: { blur: 12 } }, { deferAutoApply: true })
-    provider.requestPreview({ schedule: 'immediate' })
+    provider.requestPreview({})
     await vi.waitFor(() => {
       expect(debugCommanderMock.setEffect).toHaveBeenCalledTimes(1)
     })
@@ -507,12 +507,12 @@ describe('useEffectEditorProvider', () => {
     }))
 
     provider.updateDraft({ transform: { blur: 12 } }, { deferAutoApply: true })
-    provider.requestPreview({ schedule: 'immediate' })
+    provider.requestPreview({})
     await vi.waitFor(() => {
       expect(debugCommanderMock.setEffect).toHaveBeenCalledTimes(1)
     })
 
-    provider.requestPreview({ schedule: 'immediate', flush: true })
+    provider.requestPreview({ flush: true })
     await vi.waitFor(() => {
       expect(debugCommanderMock.setEffect).toHaveBeenCalledTimes(2)
     })
@@ -593,7 +593,7 @@ describe('useEffectEditorProvider', () => {
     ])
   })
 
-  it('同一帧内多次 immediate preview 只发送最新草稿', async () => {
+  it('同一帧内多次预览只发送最新草稿', async () => {
     useEditSettingsStore().autoApplyEffectEditorChanges = false
 
     const frameCallbacks: FrameRequestCallback[] = []
@@ -610,11 +610,11 @@ describe('useEffectEditorProvider', () => {
     vi.stubGlobal('cancelAnimationFrame', vi.fn())
 
     provider.updateDraft({ transform: { blur: 12 } }, { deferAutoApply: true })
-    provider.requestPreview({ schedule: 'immediate' })
+    provider.requestPreview({})
     provider.updateDraft({ transform: { blur: 16 } }, { deferAutoApply: true })
-    provider.requestPreview({ schedule: 'immediate' })
+    provider.requestPreview({})
     provider.updateDraft({ transform: { blur: 20 } }, { deferAutoApply: true })
-    provider.requestPreview({ schedule: 'immediate' })
+    provider.requestPreview({})
 
     expect(debugCommanderMock.setEffect).not.toHaveBeenCalled()
     expect(frameCallbacks).toHaveLength(1)
@@ -626,6 +626,33 @@ describe('useEffectEditorProvider', () => {
     })
     expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', { blur: 20 }, {
       phase: 'preview',
+    })
+  })
+
+  it('已位于帧回调的预览不会等待下一帧', async () => {
+    useEditSettingsStore().autoApplyEffectEditorChanges = false
+
+    const frameCallbacks: FrameRequestCallback[] = []
+    const provider = createProvider()
+
+    await provider.open(createOpenTarget({
+      baseSentence: createBaseSentence('{"blur":8}'),
+    }))
+
+    vi.stubGlobal('requestAnimationFrame', vi.fn((callback: FrameRequestCallback) => {
+      frameCallbacks.push(callback)
+      return frameCallbacks.length
+    }))
+    vi.stubGlobal('cancelAnimationFrame', vi.fn())
+
+    provider.updateDraft({ transform: { blur: 12 } }, { deferAutoApply: true })
+    provider.requestPreview({ frameReady: true })
+
+    expect(frameCallbacks).toHaveLength(0)
+    await vi.waitFor(() => {
+      expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', { blur: 12 }, {
+        phase: 'preview',
+      })
     })
   })
 
@@ -646,9 +673,9 @@ describe('useEffectEditorProvider', () => {
     vi.stubGlobal('cancelAnimationFrame', vi.fn())
 
     provider.updatePreviewTransform(() => ({ blur: 12 }))
-    provider.requestPreview({ schedule: 'immediate' })
+    provider.requestPreview({})
     provider.updatePreviewTransform(() => ({ blur: 20 }))
-    provider.requestPreview({ schedule: 'immediate' })
+    provider.requestPreview({})
 
     expect(provider.session?.draft.transform).toEqual({ blur: 8 })
     expect(debugCommanderMock.setEffect).not.toHaveBeenCalled()
@@ -684,15 +711,15 @@ describe('useEffectEditorProvider', () => {
     }))
 
     provider.updateDraft({ transform: { blur: 12 } }, { deferAutoApply: true })
-    provider.requestPreview({ schedule: 'immediate' })
+    provider.requestPreview({})
     await vi.waitFor(() => {
       expect(previewCalls).toEqual([{ blur: 12 }])
     })
 
     provider.updateDraft({ transform: { blur: 16 } })
-    provider.requestPreview({ schedule: 'immediate' })
+    provider.requestPreview({})
     provider.updateDraft({ transform: { blur: 20 } })
-    provider.requestPreview({ schedule: 'immediate' })
+    provider.requestPreview({})
 
     expect(previewCalls).toEqual([{ blur: 12 }])
 
@@ -728,7 +755,7 @@ describe('useEffectEditorProvider', () => {
     }))
 
     provider.updateDraft({ transform: { blur: 12 } }, { deferAutoApply: true })
-    provider.requestPreview({ schedule: 'immediate' })
+    provider.requestPreview({})
 
     await vi.waitFor(() => {
       expect(debugCommanderMock.setEffect).toHaveBeenCalledTimes(1)
@@ -761,7 +788,7 @@ describe('useEffectEditorProvider', () => {
     }))
 
     provider.updateDraft({ transform: { blur: 12 } }, { deferAutoApply: true })
-    provider.requestPreview({ schedule: 'immediate' })
+    provider.requestPreview({})
 
     await vi.waitFor(() => {
       expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', { blur: 12 }, {
@@ -799,7 +826,7 @@ describe('useEffectEditorProvider', () => {
     }))
 
     provider.updateDraft({ transform: { blur: 12 } }, { deferAutoApply: true })
-    provider.requestPreview({ schedule: 'immediate' })
+    provider.requestPreview({})
 
     await vi.waitFor(() => {
       expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', { blur: 12 }, {
@@ -841,7 +868,7 @@ describe('useEffectEditorProvider', () => {
     }))
 
     provider.updateDraft({ transform: { blur: 12 } }, { deferAutoApply: true })
-    provider.requestPreview({ schedule: 'immediate' })
+    provider.requestPreview({})
 
     await vi.waitFor(() => {
       expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', { blur: 12 }, {
@@ -875,7 +902,7 @@ describe('useEffectEditorProvider', () => {
     }))
 
     provider.updateDraft({ transform: { blur: 12 } }, { deferAutoApply: true })
-    provider.requestPreview({ schedule: 'immediate' })
+    provider.requestPreview({})
 
     await vi.waitFor(() => {
       expect(debugCommanderMock.setEffect).toHaveBeenCalledTimes(1)
@@ -883,7 +910,7 @@ describe('useEffectEditorProvider', () => {
 
     debugCommanderMock.setEffect.mockClear()
     provider.updateDraft({ transform: { blur: 20 } }, { deferAutoApply: true })
-    provider.requestPreview({ schedule: 'immediate' })
+    provider.requestPreview({})
 
     await vi.waitFor(() => {
       expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', { blur: 20 }, {
@@ -918,7 +945,7 @@ describe('useEffectEditorProvider', () => {
     }))
 
     provider.updateDraft({ transform: { blur: 12 } }, { deferAutoApply: true })
-    provider.requestPreview({ schedule: 'immediate' })
+    provider.requestPreview({})
 
     await vi.waitFor(() => {
       expect(order).toEqual(['preview:start'])
@@ -961,16 +988,16 @@ describe('useEffectEditorProvider', () => {
     }))
 
     provider.updateDraft({ transform: { blur: 12 } }, { deferAutoApply: true })
-    provider.requestPreview({ schedule: 'immediate' })
+    provider.requestPreview({})
 
     await vi.waitFor(() => {
       expect(order).toEqual(['preview:start:12'])
     })
 
     provider.updateDraft({ transform: { blur: 16 } })
-    provider.requestPreview({ schedule: 'immediate', flush: true })
+    provider.requestPreview({ flush: true })
     provider.updateDraft({ transform: { blur: 20 } }, { deferAutoApply: true })
-    provider.requestPreview({ schedule: 'immediate' })
+    provider.requestPreview({})
 
     previewResolvers[0]?.()
     await vi.waitFor(() => {
@@ -988,13 +1015,13 @@ describe('useEffectEditorProvider', () => {
     }))
 
     provider.updateDraft({ transform: { blur: 12 } }, { deferAutoApply: true })
-    provider.requestPreview({ schedule: 'immediate' })
+    provider.requestPreview({})
     await vi.waitFor(() => {
       expect(debugCommanderMock.setEffect).toHaveBeenCalledTimes(1)
     })
 
     provider.updateDraft({ transform: { blur: 12 } }, { deferAutoApply: false })
-    provider.requestPreview({ schedule: 'continuous', flush: true })
+    provider.requestPreview({ flush: true })
 
     await vi.waitFor(() => {
       expect(debugCommanderMock.setEffect).toHaveBeenCalledTimes(2)
@@ -1015,7 +1042,7 @@ describe('useEffectEditorProvider', () => {
       baseSentence: createBaseSentence('{"blur":8}'),
     }))
 
-    provider.requestPreview({ schedule: 'immediate', flush: true })
+    provider.requestPreview({ flush: true })
     await Promise.resolve()
 
     expect(debugCommanderMock.setEffect).not.toHaveBeenCalled()
@@ -1031,7 +1058,7 @@ describe('useEffectEditorProvider', () => {
       effectTarget: '',
     }))
 
-    provider.requestPreview({ schedule: 'immediate', flush: true })
+    provider.requestPreview({ flush: true })
     await Promise.resolve()
 
     expect(loggerWarnMock).not.toHaveBeenCalled()
@@ -1122,7 +1149,7 @@ describe('useEffectEditorProvider', () => {
     vi.mocked(baselineClient.syncScene).mockClear()
 
     provider.updateDraft({ transform: { blur: 12 } })
-    provider.requestPreview({ schedule: 'immediate' })
+    provider.requestPreview({})
     await vi.waitFor(() => {
       expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', {
         blur: 12,
@@ -1180,7 +1207,7 @@ describe('useEffectEditorProvider', () => {
     vi.mocked(baselineClient.syncScene).mockClear()
 
     provider.updateDraft({ transform: { blur: 12 } })
-    provider.requestPreview({ schedule: 'immediate' })
+    provider.requestPreview({})
     await vi.waitFor(() => {
       expect(order).toEqual(['preview:start'])
     })
@@ -1207,7 +1234,7 @@ describe('useEffectEditorProvider', () => {
     }))
 
     provider.updateDraft({ transform: { blur: 16 } })
-    provider.requestPreview({ schedule: 'immediate' })
+    provider.requestPreview({})
 
     await vi.waitFor(() => {
       expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', { blur: 16 }, {
@@ -1218,7 +1245,7 @@ describe('useEffectEditorProvider', () => {
     debugCommanderMock.setEffect.mockClear()
 
     provider.updateDraft({ transform: { blur: 20 } }, { deferAutoApply: true })
-    provider.requestPreview({ schedule: 'immediate' })
+    provider.requestPreview({})
 
     await vi.waitFor(() => {
       expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', { blur: 20 }, {
@@ -1258,7 +1285,7 @@ describe('useEffectEditorProvider', () => {
     debugCommanderMock.setEffect.mockClear()
 
     provider.updateDraft({ transform: { blur: 20 } }, { deferAutoApply: true })
-    provider.requestPreview({ schedule: 'immediate' })
+    provider.requestPreview({})
 
     await vi.waitFor(() => {
       expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', { blur: 20 }, {
@@ -1289,7 +1316,7 @@ describe('useEffectEditorProvider', () => {
     }))
 
     provider.updateDraft({ transform: { blur: 16 } })
-    provider.requestPreview({ schedule: 'immediate' })
+    provider.requestPreview({})
 
     await vi.waitFor(() => {
       expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', { blur: 16 }, {
@@ -1299,7 +1326,7 @@ describe('useEffectEditorProvider', () => {
     debugCommanderMock.setEffect.mockClear()
 
     provider.updateDraft({ transform: { blur: 20 } }, { deferAutoApply: true })
-    provider.requestPreview({ schedule: 'immediate' })
+    provider.requestPreview({})
 
     await vi.waitFor(() => {
       expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', { blur: 20 }, {
@@ -1335,7 +1362,7 @@ describe('useEffectEditorProvider', () => {
     }))
 
     provider.updateDraft({ transform: { blur: 12 } })
-    provider.requestPreview({ schedule: 'immediate' })
+    provider.requestPreview({})
     await vi.waitFor(() => {
       expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', { blur: 12 }, {
         phase: 'preview',
@@ -1376,7 +1403,7 @@ describe('useEffectEditorProvider', () => {
     }))
 
     provider.updateDraft({ transform: { blur: 12 } })
-    provider.requestPreview({ schedule: 'immediate' })
+    provider.requestPreview({})
     await vi.waitFor(() => {
       expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', { blur: 12 }, {
         phase: 'preview',
@@ -1420,7 +1447,7 @@ describe('useEffectEditorProvider', () => {
 
     debugCommanderMock.setEffect.mockClear()
     provider.updateDraft({ transform: { blur: 20 } }, { deferAutoApply: true })
-    provider.requestPreview({ schedule: 'immediate' })
+    provider.requestPreview({})
 
     await vi.waitFor(() => {
       expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', { blur: 20 }, {
@@ -1450,7 +1477,7 @@ describe('useEffectEditorProvider', () => {
 
     debugCommanderMock.setEffect.mockClear()
     provider.updateDraft({ transform: { blur: 20 } }, { deferAutoApply: true })
-    provider.requestPreview({ schedule: 'immediate' })
+    provider.requestPreview({})
 
     expect(debugCommanderMock.setEffect).not.toHaveBeenCalled()
     expect(provider.session?.draft.transform).toEqual({ blur: 12 })
@@ -1516,7 +1543,7 @@ describe('useEffectEditorProvider', () => {
 
     debugCommanderMock.setEffect.mockClear()
     provider.updateDraft({ transform: { blur: 20 } }, { deferAutoApply: true })
-    provider.requestPreview({ schedule: 'immediate' })
+    provider.requestPreview({})
 
     await vi.waitFor(() => {
       expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', { blur: 20 }, {
@@ -1731,16 +1758,16 @@ describe('useEffectEditorProvider', () => {
     }))
 
     provider.updateDraft({ transform: { blur: 12 } }, { deferAutoApply: true })
-    provider.requestPreview({ schedule: 'immediate' })
+    provider.requestPreview({})
 
     await vi.waitFor(() => {
       expect(order).toEqual(['preview:start:12'])
     })
 
     provider.updateDraft({ transform: { blur: 16 } })
-    provider.requestPreview({ schedule: 'immediate', flush: true })
+    provider.requestPreview({ flush: true })
     provider.updateDraft({ transform: { blur: 20 } }, { deferAutoApply: true })
-    provider.requestPreview({ schedule: 'immediate' })
+    provider.requestPreview({})
 
     previewResolvers[0]?.()
 
@@ -1780,16 +1807,16 @@ describe('useEffectEditorProvider', () => {
     }))
 
     provider.updateDraft({ transform: { blur: 12 } }, { deferAutoApply: true })
-    provider.requestPreview({ schedule: 'immediate' })
+    provider.requestPreview({})
 
     await vi.waitFor(() => {
       expect(order).toEqual(['preview:start:12'])
     })
 
     provider.updateDraft({ transform: { blur: 16 } })
-    provider.requestPreview({ schedule: 'immediate', flush: true })
+    provider.requestPreview({ flush: true })
     provider.updateDraft({ transform: { blur: 20 } }, { deferAutoApply: true })
-    provider.requestPreview({ schedule: 'immediate' })
+    provider.requestPreview({})
 
     previewResolvers[0]?.()
 
@@ -1859,39 +1886,11 @@ describe('useEffectEditorProvider', () => {
     }))
 
     provider.updateDraft({ transform: { blur: 12 } })
-    provider.requestPreview({ schedule: 'frame' })
+    provider.requestPreview({})
     await provider.cancelPreview()
 
     expect(debugCommanderMock.setEffect).not.toHaveBeenCalled()
     expect(baselineClient.syncScene).not.toHaveBeenCalled()
-  })
-
-  it('取消交互会丢弃尚未触发的 continuous trailing preview', async () => {
-    useEditSettingsStore().autoApplyEffectEditorChanges = false
-    vi.useFakeTimers()
-    vi.setSystemTime(0)
-
-    try {
-      const provider = createProvider()
-
-      await provider.open(createOpenTarget({
-        baseSentence: createBaseSentence('{"blur":8}'),
-      }))
-
-      provider.updateDraft({ transform: { blur: 16 } })
-      provider.updateDraft({ transform: { blur: 20 } }, { deferAutoApply: true })
-      provider.requestPreview({ schedule: 'continuous' })
-
-      expect(debugCommanderMock.setEffect).not.toHaveBeenCalled()
-
-      await provider.cancelPreview()
-      await vi.advanceTimersByTimeAsync(40)
-
-      expect(debugCommanderMock.setEffect).not.toHaveBeenCalled()
-      expect(provider.session?.draft.transform).toEqual({ blur: 16 })
-    } finally {
-      vi.useRealTimers()
-    }
   })
 
   it('取消已发送 preview 时会等待 preview 后发送 rollback draft restore', async () => {
@@ -1928,7 +1927,7 @@ describe('useEffectEditorProvider', () => {
     vi.mocked(baselineClient.syncScene).mockClear()
 
     provider.updateDraft({ transform: { blur: 12 } }, { deferAutoApply: true })
-    provider.requestPreview({ schedule: 'immediate' })
+    provider.requestPreview({})
     await vi.waitFor(() => {
       expect(order).toEqual(['preview:start'])
     })
@@ -1958,7 +1957,7 @@ describe('useEffectEditorProvider', () => {
     vi.mocked(baselineClient.syncScene).mockClear()
 
     provider.updateDraft({ transform: { blur: 12 } })
-    provider.requestPreview({ schedule: 'immediate' })
+    provider.requestPreview({})
     await vi.waitFor(() => {
       expect(debugCommanderMock.setEffect).toHaveBeenCalledTimes(1)
     })
@@ -1966,7 +1965,7 @@ describe('useEffectEditorProvider', () => {
     await provider.cancelPreview()
     debugCommanderMock.setEffect.mockClear()
 
-    provider.requestPreview({ schedule: 'immediate' })
+    provider.requestPreview({})
 
     await vi.waitFor(() => {
       expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', { blur: 12 }, {
@@ -2009,7 +2008,7 @@ describe('useEffectEditorProvider', () => {
     vi.mocked(baselineClient.syncScene).mockClear()
 
     provider.updateDraft({ transform: { blur: 12 } })
-    provider.requestPreview({ schedule: 'immediate' })
+    provider.requestPreview({})
     await vi.waitFor(() => {
       expect(order).toEqual(['preview:start'])
     })
@@ -2107,7 +2106,7 @@ describe('useEffectEditorProvider', () => {
       duration: '100',
       transform: { alpha: 0.2 },
     })
-    provider.requestPreview({ schedule: 'immediate' })
+    provider.requestPreview({})
     await vi.waitFor(() => {
       expect(runtimeCalls.length).toBe(1)
     })
@@ -2121,7 +2120,7 @@ describe('useEffectEditorProvider', () => {
       duration: '200',
       transform: { alpha: 0.8 },
     })
-    provider.requestPreview({ schedule: 'immediate' })
+    provider.requestPreview({})
     expect(applyCalls).toHaveLength(0)
     expect(runtimeCalls.length).toBe(1)
 
@@ -2166,7 +2165,7 @@ describe('useEffectEditorProvider', () => {
 
     provider.updateDraft({ transform: { blur: 12 } }, { deferAutoApply: true })
     provider.updateDraft({ transform: { blur: 16 } })
-    provider.requestPreview({ schedule: 'immediate', flush: true })
+    provider.requestPreview({ flush: true })
 
     await vi.waitFor(() => {
       expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', { blur: 16 }, {
@@ -2211,7 +2210,7 @@ describe('useEffectEditorProvider', () => {
 
     provider.updateDraft({ transform: { blur: 12 } }, { deferAutoApply: true })
     provider.updateDraft({ transform: { blur: 16 } })
-    provider.requestPreview({ schedule: 'immediate', flush: true })
+    provider.requestPreview({ flush: true })
 
     await vi.waitFor(() => {
       expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', { blur: 16 }, {
@@ -2272,7 +2271,7 @@ describe('useEffectEditorProvider', () => {
 
     provider.updateDraft({ transform: { blur: 12 } }, { deferAutoApply: true })
     provider.updateDraft({ transform: { blur: 16 } })
-    provider.requestPreview({ schedule: 'immediate', flush: true })
+    provider.requestPreview({ flush: true })
 
     await vi.waitFor(() => {
       expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', { blur: 16 }, {

--- a/src/features/editor/effect-editor/__tests__/useEffectEditorProvider-queue.test.ts
+++ b/src/features/editor/effect-editor/__tests__/useEffectEditorProvider-queue.test.ts
@@ -656,6 +656,38 @@ describe('useEffectEditorProvider', () => {
     })
   })
 
+  it('已位于帧回调的预览会取代同帧内排队的默认预览', async () => {
+    useEditSettingsStore().autoApplyEffectEditorChanges = false
+
+    const frameCallbacks = new Map<number, FrameRequestCallback>()
+    const provider = createProvider()
+
+    await provider.open(createOpenTarget({
+      baseSentence: createBaseSentence('{"blur":8}'),
+    }))
+
+    vi.stubGlobal('requestAnimationFrame', vi.fn((callback: FrameRequestCallback) => {
+      const frameId = frameCallbacks.size + 1
+      frameCallbacks.set(frameId, callback)
+      return frameId
+    }))
+    vi.stubGlobal('cancelAnimationFrame', vi.fn((frameId: number) => {
+      frameCallbacks.delete(frameId)
+    }))
+
+    provider.updateDraft({ transform: { blur: 12 } }, { deferAutoApply: true })
+    provider.requestPreview({})
+    provider.requestPreview({ frameReady: true })
+
+    expect(frameCallbacks.size).toBe(0)
+    await vi.waitFor(() => {
+      expect(debugCommanderMock.setEffect).toHaveBeenCalledTimes(1)
+    })
+    expect(debugCommanderMock.setEffect).toHaveBeenCalledWith('fig-center', { blur: 12 }, {
+      phase: 'preview',
+    })
+  })
+
   it('预览覆盖态不会改写响应式 draft，且同一帧只发送最新覆盖值', async () => {
     useEditSettingsStore().autoApplyEffectEditorChanges = false
 

--- a/src/features/editor/effect-editor/types.ts
+++ b/src/features/editor/effect-editor/types.ts
@@ -1,7 +1,7 @@
-/** emitTransform 的调度选项 */
+/** emitTransform 的提交选项 */
 export interface EmitTransformOptions {
-  schedule: 'continuous' | 'color' | 'immediate'
   deferAutoApply?: boolean
+  frameReady?: boolean
   flush?: boolean
 }
 

--- a/src/features/editor/effect-editor/useEffectColorControl.ts
+++ b/src/features/editor/effect-editor/useEffectColorControl.ts
@@ -37,7 +37,7 @@ export function useEffectColorControl(deps: EffectControlDeps) {
     deps.setNumericField(fields, param.colorPaths[1], color[1])
     deps.setNumericField(fields, param.colorPaths[2], color[2])
 
-    deps.emitTransform(fields, { schedule: 'color', ...options })
+    deps.emitTransform(fields, options)
   }
 
   function flushColorInteraction(param: EffectColorField) {

--- a/src/features/editor/effect-editor/useEffectContinuousControls.ts
+++ b/src/features/editor/effect-editor/useEffectContinuousControls.ts
@@ -25,8 +25,8 @@ const SLIDER_CENTER_SNAP_TOLERANCE = 0.02
 // 按住 Shift 时旋钮的角度吸附步进（每 15 度）
 const DIAL_DEGREE_SNAP = 15
 
-function createContinuousTransformOptions(flush?: boolean): EmitTransformOptions {
-  return { schedule: 'continuous', flush, deferAutoApply: !flush }
+function createTransformUpdateOptions(flush?: boolean): EmitTransformOptions {
+  return { flush, deferAutoApply: !flush }
 }
 
 function getFieldValueWithDefault(
@@ -135,7 +135,10 @@ export function useEffectContinuousControls(deps: EffectControlDeps) {
       if (!pending) {
         return
       }
-      deps.emitTransform(pending.fields, pending.options)
+      deps.emitTransform(pending.fields, {
+        ...pending.options,
+        frameReady: true,
+      })
     })
   }
 
@@ -174,7 +177,7 @@ export function useEffectContinuousControls(deps: EffectControlDeps) {
     const fields = deps.getFields()
     if (!rawValue && rawValue !== 0) {
       delete fields[path]
-      emitContinuousTransform(fields, createContinuousTransformOptions(options?.flush), {
+      emitContinuousTransform(fields, createTransformUpdateOptions(options?.flush), {
         touchedPaths: [path],
       })
       return undefined
@@ -205,7 +208,7 @@ export function useEffectContinuousControls(deps: EffectControlDeps) {
     deps.setNumericField(result.fields, param.key, finalValue)
     emitContinuousTransform(
       result.fields,
-      createContinuousTransformOptions(options.flush),
+      createTransformUpdateOptions(options.flush),
       { timing: emitTiming, touchedPaths: [param.key] },
     )
   }
@@ -330,7 +333,7 @@ export function useEffectContinuousControls(deps: EffectControlDeps) {
     deps.setNumericField(result.fields, param.key, normalized)
     emitContinuousTransform(
       result.fields,
-      createContinuousTransformOptions(options.flush),
+      createTransformUpdateOptions(options.flush),
       {
         timing: options.fromSlider ? 'nextFrame' : 'immediate',
         touchedPaths: [param.key],
@@ -422,7 +425,7 @@ export function useEffectContinuousControls(deps: EffectControlDeps) {
         delete fields[passivePath]
         emitContinuousTransform(
           fields,
-          createContinuousTransformOptions(options.flush),
+          createTransformUpdateOptions(options.flush),
           {
             timing: options.fromSlider ? 'nextFrame' : 'immediate',
             touchedPaths: [activePath, passivePath],
@@ -465,7 +468,7 @@ export function useEffectContinuousControls(deps: EffectControlDeps) {
 
     emitContinuousTransform(
       result.fields,
-      createContinuousTransformOptions(options.flush),
+      createTransformUpdateOptions(options.flush),
       {
         timing: options.fromSlider ? 'nextFrame' : 'immediate',
         touchedPaths,
@@ -518,7 +521,7 @@ export function useEffectContinuousControls(deps: EffectControlDeps) {
     deps.setNumericField(result.fields, param.key, storeValue)
     emitContinuousTransform(
       result.fields,
-      createContinuousTransformOptions(options.flush),
+      createTransformUpdateOptions(options.flush),
       { timing: emitTiming, touchedPaths: [param.key] },
     )
   }

--- a/src/features/editor/effect-editor/useEffectEditorProvider.ts
+++ b/src/features/editor/effect-editor/useEffectEditorProvider.ts
@@ -17,10 +17,9 @@ import type { EmitTransformOptions } from '~/features/editor/effect-editor/types
 import type { TransformBaselineSessionClient } from '~/features/editor/transform-resolution/baseline-session'
 import type { TransformBaselineSource } from '~/features/editor/transform-resolution/model'
 
-export type EffectEditorPreviewSchedule = 'continuous' | 'color' | 'frame' | 'immediate'
-
 export interface EffectEditorPreviewPayload {
-  schedule: EffectEditorPreviewSchedule
+  /** 预览请求已在 requestAnimationFrame 回调中触发。 */
+  frameReady?: boolean
   flush?: boolean
 }
 
@@ -79,8 +78,6 @@ const EFFECT_EDITOR_PROVIDER_KEY: InjectionKey<ReturnType<typeof createEffectEdi
 type EffectEditorCloseAction = 'save' | 'discard' | 'cancel'
 type EffectPreviewRequestKind = 'preview' | 'commit' | 'restore'
 type PreviewRuntimeSyncState = 'ready' | 'terminal-unsynced'
-const CONTINUOUS_PREVIEW_THROTTLE_MS = 40
-
 interface EffectPreviewOwnerRequest {
   draftSnapshot: EffectEditorDraft
   errorMessage: string
@@ -103,8 +100,12 @@ function cloneDraft(draft: EffectEditorDraft): EffectEditorDraft {
 }
 
 export function createEffectPreviewEmitter(options: EffectPreviewEmitterOptions) {
-  function emitPreview(schedule: EffectEditorPreviewSchedule, flush: boolean = false) {
-    options.emitPreview({ schedule, flush })
+  function emitPreview(flush: boolean = false, frameReady: boolean = false) {
+    const payload: EffectEditorPreviewPayload = { flush }
+    if (frameReady) {
+      payload.frameReady = true
+    }
+    options.emitPreview(payload)
   }
 
   function emitTransform(fields: Record<string, string>, emitOptions: EmitTransformOptions) {
@@ -113,7 +114,7 @@ export function createEffectPreviewEmitter(options: EffectPreviewEmitterOptions)
       deferAutoApply: emitOptions.deferAutoApply,
       flush: emitOptions.flush,
     })
-    emitPreview(emitOptions.schedule, emitOptions.flush)
+    emitPreview(emitOptions.flush, emitOptions.frameReady)
   }
 
   return {
@@ -189,41 +190,7 @@ export function createEffectEditorProvider(options: CreateEffectEditorProviderOp
   let visualPreviewDirty = false
   let previewSyncState: PreviewRuntimeSyncState = 'ready'
   let previewSyncStateWarned = false
-  let continuousPreviewTimerId: ReturnType<typeof setTimeout> | undefined
-  let lastContinuousPreviewAt = 0
   let isClosing = false
-
-  function clearContinuousPreviewTimer(): void {
-    if (continuousPreviewTimerId === undefined) {
-      return
-    }
-
-    clearTimeout(continuousPreviewTimerId)
-    continuousPreviewTimerId = undefined
-  }
-
-  function sendContinuousPreviewNow(): void {
-    clearContinuousPreviewTimer()
-    lastContinuousPreviewAt = Date.now()
-    scheduleFramePreviewBoundary()
-  }
-
-  function scheduleContinuousPreview(): void {
-    const elapsed = Date.now() - lastContinuousPreviewAt
-    if (elapsed >= CONTINUOUS_PREVIEW_THROTTLE_MS) {
-      sendContinuousPreviewNow()
-      return
-    }
-
-    if (continuousPreviewTimerId !== undefined) {
-      return
-    }
-
-    continuousPreviewTimerId = setTimeout(() => {
-      continuousPreviewTimerId = undefined
-      sendContinuousPreviewNow()
-    }, CONTINUOUS_PREVIEW_THROTTLE_MS - elapsed)
-  }
 
   function canSendPreview(): boolean {
     return editSettings.enableLivePreview
@@ -286,7 +253,6 @@ export function createEffectEditorProvider(options: CreateEffectEditorProviderOp
   }
 
   function cancelScheduledPreview() {
-    clearContinuousPreviewTimer()
     cancelFramePreview?.()
     cancelFramePreview = undefined
   }
@@ -368,14 +334,6 @@ export function createEffectEditorProvider(options: CreateEffectEditorProviderOp
 
     const frameId = requestAnimationFrame(run)
     cancelFramePreview = () => cancelAnimationFrame(frameId)
-  }
-
-  function requestFramePreview(): void {
-    scheduleFramePreviewBoundary()
-  }
-
-  function requestColorPreview(): void {
-    scheduleFramePreviewBoundary()
   }
 
   async function commitDraft(
@@ -675,29 +633,13 @@ export function createEffectEditorProvider(options: CreateEffectEditorProviderOp
       return
     }
 
-    // 预览调度策略：
-    // - immediate: 进入全局帧边界（用于离散操作如 segmented 切换）
-    // - frame: 通过 rAF 合并同帧内的多次交互态更新（如变换控件拖拽）
-    // - color: 通过 rAF 合并同帧内的多次颜色变更（color picker 高频触发）
-    // - continuous（default）: 节流发送（用于拖拽滑块等连续操作）
-    switch (payload.schedule) {
-      case 'immediate': {
-        requestFramePreview()
-        break
-      }
-      case 'frame': {
-        requestFramePreview()
-        break
-      }
-      case 'color': {
-        requestColorPreview()
-        break
-      }
-      default: {
-        scheduleContinuousPreview()
-        break
-      }
+    if (payload.frameReady) {
+      enqueuePreview()
+      return
     }
+
+    // 尚未位于帧回调的交互在全局帧边界合并。
+    scheduleFramePreviewBoundary()
   }
 
   function updateDraft(
@@ -1193,8 +1135,6 @@ export function createEffectEditorProvider(options: CreateEffectEditorProviderOp
     previewTransformOverride = undefined
     visualPreviewDirty = false
     resetPreviewSyncState()
-    clearContinuousPreviewTimer()
-    lastContinuousPreviewAt = 0
     isClosing = false
     scheduleSessionBaselineResolution(sessionId, target, lineCommandString)
     return true

--- a/src/features/editor/effect-editor/useEffectEditorProvider.ts
+++ b/src/features/editor/effect-editor/useEffectEditorProvider.ts
@@ -634,6 +634,7 @@ export function createEffectEditorProvider(options: CreateEffectEditorProviderOp
     }
 
     if (payload.frameReady) {
+      cancelScheduledPreview()
       enqueuePreview()
       return
     }

--- a/src/features/editor/effect-editor/useEffectSegmentedControl.ts
+++ b/src/features/editor/effect-editor/useEffectSegmentedControl.ts
@@ -79,7 +79,7 @@ export function useEffectSegmentedControl(options: UseEffectSegmentedControlOpti
       delete fields[param.key]
     }
 
-    options.emitTransform(fields, { schedule: 'immediate', flush: true })
+    options.emitTransform(fields, { flush: true })
   }
 
   function segmentedControlId(path: string): string {

--- a/src/features/editor/shell/__tests__/useEditorPanelShell.test.ts
+++ b/src/features/editor/shell/__tests__/useEditorPanelShell.test.ts
@@ -341,7 +341,6 @@ describe('useEditorPanelShell', () => {
     expect(effectEditorProviderMock.requestPreview).toHaveBeenCalledTimes(2)
     expect(effectEditorProviderMock.requestPreview).toHaveBeenCalledWith({
       flush: true,
-      schedule: 'immediate',
     })
 
     scope.stop()

--- a/src/features/editor/shell/useEditorPanelShell.ts
+++ b/src/features/editor/shell/useEditorPanelShell.ts
@@ -126,7 +126,6 @@ export function useEditorPanelShell(options: UseEditorPanelShellOptions) {
     })
     effectEditorProvider.requestPreview({
       flush: true,
-      schedule: 'immediate',
     })
   }
 

--- a/src/features/editor/transform-overlay/__tests__/useTransformOverlayBridge.test.ts
+++ b/src/features/editor/transform-overlay/__tests__/useTransformOverlayBridge.test.ts
@@ -194,7 +194,6 @@ describe('useTransformOverlayBridge', () => {
     })
     expect(provider.requestPreview).toHaveBeenCalledWith({
       flush: undefined,
-      schedule: 'frame',
     })
   })
 
@@ -318,7 +317,6 @@ describe('useTransformOverlayBridge', () => {
     })
     expect(provider.requestPreview).toHaveBeenLastCalledWith({
       flush: true,
-      schedule: 'immediate',
     })
   })
 

--- a/src/features/editor/transform-overlay/useTransformOverlayBridge.ts
+++ b/src/features/editor/transform-overlay/useTransformOverlayBridge.ts
@@ -160,7 +160,6 @@ export function useTransformOverlayBridge(options: UseTransformOverlayBridgeOpti
 
     options.provider.requestPreview({
       flush: options_.flush,
-      schedule: options_.flush ? 'immediate' : 'frame',
     })
   }
 


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [x] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [x] 代码重构
- [x] 测试用例
- [x] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

移除效果编辑器预览的多模式调度与 40ms 连续预览节流，统一由 rAF 合并非帧内请求。

连续表单控件和标签拖拽已在自身 rAF 回调内完成字段合并时，携带 `frameReady` 直接进入预览队列，避免 Provider 再等待一帧。最终提交仍保留 `flush` 语义。

同时清理已废弃调度字段、重复分支、过时命名，以及仅覆盖已删除 trailing timer 行为的测试。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

效果编辑器拖拽开始时，预览会因节流和二次 rAF 调度落后于变换框，表现为短暂停留后跳到预期位置。本更改消除该启动阶段的额外等待，同时保留同帧合并以控制实时预览频率。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
