### PR TITLE
🐛 修复放大预览 iframe 越界响应编辑器事件

### DIFF
--- a/src/components/editor/PreviewPanel.spec.ts
+++ b/src/components/editor/PreviewPanel.spec.ts
@@ -487,6 +487,70 @@ describe('PreviewPanel', () => {
     expect(getComputedStyle(overlay as HTMLElement).cursor).toBe('grab')
   })
 
+  it('放大预览后 viewport 外的编辑器区域不会命中 iframe', async () => {
+    const rendered = renderInBrowser(PreviewPanel, {
+      global: {
+        plugins: [createPreviewPanelLiteI18n()],
+        stubs: globalStubs,
+      },
+    })
+    rendered.container.style.height = '500px'
+    rendered.container.style.position = 'relative'
+    rendered.container.style.width = '200px'
+
+    await vi.waitFor(() => {
+      expect(getGameConfigMock).toHaveBeenCalledTimes(1)
+    })
+
+    const viewport = document.querySelector<HTMLElement>('[data-testid="preview-viewport"]')
+    const outputSurface = document.querySelector<HTMLElement>('[data-testid="preview-output-surface"]')
+    const canvas = document.querySelector<HTMLElement>('[data-testid="preview-canvas"]')
+    const { iframe, iframeWindow } = getPreviewIframe()
+    expect(viewport).not.toBeNull()
+    expect(outputSurface).not.toBeNull()
+    expect(canvas).not.toBeNull()
+
+    await vi.waitFor(() => {
+      expect(parsePreviewTransform(canvas?.style.transform ?? '').zoom).not.toBe(1)
+    })
+
+    const editor = document.createElement('div')
+    editor.dataset.testid = 'editor-hit-sentinel'
+    editor.style.position = 'fixed'
+    editor.style.left = `${viewport?.getBoundingClientRect().right ?? 0}px`
+    editor.style.top = '0'
+    editor.style.width = '32px'
+    editor.style.height = '100vh'
+    document.body.append(editor)
+
+    try {
+      for (let index = 0; index < 10; index++) {
+        dispatchPreviewWheelMessage(iframeWindow, {
+          clientX: 100,
+          clientY: 100,
+          ctrlKey: true,
+          deltaY: -1,
+          metaKey: false,
+        })
+      }
+      await nextTick()
+
+      const viewportRect = viewport?.getBoundingClientRect()
+      const canvasRect = canvas?.getBoundingClientRect()
+      expect(outputSurface?.classList.contains('overflow-hidden')).toBe(true)
+      expect(canvasRect?.right).toBeGreaterThan(viewportRect?.right ?? 0)
+
+      const hitTarget = document.elementFromPoint(
+        (viewportRect?.right ?? 0) + 8,
+        8,
+      )
+      expect(hitTarget).toBe(editor)
+      expect(hitTarget).not.toBe(iframe)
+    } finally {
+      editor.remove()
+    }
+  })
+
   it('iframe 内松开空格后会立即用 auto 光标重置覆盖层', async () => {
     renderInBrowser(PreviewPanel, {
       global: {

--- a/src/components/editor/PreviewPanel.spec.ts
+++ b/src/components/editor/PreviewPanel.spec.ts
@@ -521,13 +521,15 @@ describe('PreviewPanel', () => {
     editor.style.top = '0'
     editor.style.width = '32px'
     editor.style.height = '100vh'
+    // 哨兵必须位于预览画布下方，命中断言才能证明 iframe 越界已被裁剪
+    editor.style.zIndex = '-1'
     document.body.append(editor)
 
     try {
-      for (let index = 0; index < 10; index++) {
+      for (let index = 0; index < 32; index++) {
         dispatchPreviewWheelMessage(iframeWindow, {
           clientX: 100,
-          clientY: 100,
+          clientY: 400,
           ctrlKey: true,
           deltaY: -1,
           metaKey: false,
@@ -537,7 +539,6 @@ describe('PreviewPanel', () => {
 
       const viewportRect = viewport?.getBoundingClientRect()
       const canvasRect = canvas?.getBoundingClientRect()
-      expect(outputSurface?.classList.contains('overflow-hidden')).toBe(true)
       expect(canvasRect?.right).toBeGreaterThan(viewportRect?.right ?? 0)
 
       const hitTarget = document.elementFromPoint(

--- a/src/components/editor/PreviewPanel.vue
+++ b/src/components/editor/PreviewPanel.vue
@@ -102,6 +102,8 @@ const previewCanvasStyle = $computed(() => ({
   width: `${stageWidth}px`,
 }))
 const previewOutputSurfaceStyle = $computed(() => ({
+  // 裁剪经过 transform 放大的 iframe，避免其命中区域越出预览边界响应编辑器事件
+  overflow: 'hidden' as const,
   filter: preferenceStore.previewBrightnessEnabled
     ? `brightness(${percentageToRatio(preferenceStore.previewBrightness[0])})`
     : undefined,
@@ -608,7 +610,7 @@ onBeforeUnmount(() => {
       >
         <div
           data-testid="preview-output-surface"
-          class="bg-muted inset-0 absolute overflow-hidden"
+          class="bg-muted inset-0 absolute"
           :style="previewOutputSurfaceStyle"
         >
           <div

--- a/src/components/editor/PreviewPanel.vue
+++ b/src/components/editor/PreviewPanel.vue
@@ -608,7 +608,7 @@ onBeforeUnmount(() => {
       >
         <div
           data-testid="preview-output-surface"
-          class="bg-muted inset-0 absolute"
+          class="bg-muted inset-0 absolute overflow-hidden"
           :style="previewOutputSurfaceStyle"
         >
           <div


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [x] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [x] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

修复预览画布放大后 iframe 实际触发区域越过预览边界，导致编辑器区域的指针事件被 iframe 响应的问题。

为 `preview-output-surface` 增加独立的溢出裁剪边界，使经过 CSS transform 放大的 iframe 仍只能在预览输出区域内接收指针事件。

新增浏览器回归测试，验证放大预览后 viewport 外的区域不会命中 iframe。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

预览 canvas 使用 CSS transform 缩放，但输出层原本允许内容溢出。放大 iframe 后，其 compositing 和命中区域可能覆盖相邻编辑器，造成光标穿透编辑器并触发预览内容响应。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
