### PR TITLE
🐛 修复可视化编辑器折叠状态下的底部拖拽异常

### DIFF
--- a/src/components/editor/VisualEditorScene.spec.ts
+++ b/src/components/editor/VisualEditorScene.spec.ts
@@ -267,7 +267,7 @@ describe('VisualEditorScene', () => {
       reorderStatements: reorderStatementsMock,
       selectedStatementId: 2,
       statementSortVirtualAdapter: statementSortVirtualAdapterMock,
-      totalSize: 120,
+      totalSize: computed(() => 120),
       virtualRows: [
         { index: 0, key: 0, start: 0 },
         { index: 1, key: 1, start: 48 },
@@ -345,7 +345,7 @@ describe('VisualEditorScene', () => {
       reorderStatements: reorderStatementsMock,
       selectedStatementId: 1,
       statementSortVirtualAdapter: statementSortVirtualAdapterMock,
-      totalSize: 144,
+      totalSize: computed(() => 144),
       virtualRows: [
         { index: 0, key: 1, start: 0 },
         { index: 1, key: 2, start: 48 },
@@ -548,7 +548,7 @@ describe('VisualEditorScene', () => {
       reorderStatements: reorderStatementsMock,
       selectedStatementId: 1,
       statementSortVirtualAdapter: statementSortVirtualAdapterMock,
-      totalSize: 300,
+      totalSize: computed(() => 300),
       virtualRows: [
         { index: 0, key: 1, start: 0 },
         { index: 1, key: 2, start: 100 },
@@ -593,6 +593,39 @@ describe('VisualEditorScene', () => {
     expect(gapDropSlot).not.toBeNull()
     expect(headDropSlot!.classList.contains('pointer-events-none')).toBe(true)
     expect(gapDropSlot!.classList.contains('pointer-events-none')).toBe(true)
+  })
+
+  it('尾部投放区仅以标准插入带侵入最后一行并覆盖底部空白', async () => {
+    const editSettings = reactive({
+      collapseStatementsOnSidebarOpen: true,
+    })
+    useEditSettingsStoreMock.mockReturnValue(editSettings)
+
+    renderInBrowser(VisualEditorScene, {
+      props: { state: createSceneState() },
+      global: {
+        plugins: [createPinia()],
+        stubs: globalStubs,
+      },
+    })
+    await nextTick()
+
+    const tailDropSlot = document.querySelector<HTMLElement>('[data-visual-drop-slot="tail"]')
+    const statementList = document.querySelector<HTMLElement>('[role="listbox"]')
+
+    expect(tailDropSlot).not.toBeNull()
+    expect(statementList).not.toBeNull()
+    expect(statementList!.style.height).toBe('calc(120px - 0.25rem)')
+    // 起点只侵入最后一行 8px，其余命中层脱离布局流并向下覆盖空白。
+    expect(tailDropSlot!.classList.contains('absolute')).toBe(true)
+    expect(tailDropSlot!.classList.contains('bottom-0')).toBe(true)
+    expect(tailDropSlot!.style.top).toBe('calc(104px - 0.25rem)')
+
+    editSettings.collapseStatementsOnSidebarOpen = false
+    await nextTick()
+
+    expect(statementList!.style.height).toBe('calc(120px - 0.375rem)')
+    expect(tailDropSlot!.style.top).toBe('calc(104px - 0.375rem)')
   })
 
   it('为 head / gap / update / tail 注册 drop target，并把 drop 目标传给 runtime', async () => {
@@ -771,6 +804,15 @@ describe('VisualEditorScene', () => {
     expect(insertIndicator!.className).toContain('drop-insert-indicator-before')
     expect((insertIndicator as HTMLElement).style.top).toBe('-0.125rem')
     expect(result.container.querySelector('[data-visual-drop-indicator="update"]')).toBeNull()
+
+    const tailConfig = registerDroppable.mock.calls.find(([, config]) =>
+      config.id === 'visual-editor:tail',
+    )?.[1]
+    gapConfig.onDragLeave(payload)
+    tailConfig.onDragEnter(payload)
+    await nextTick()
+
+    expect((result.container.querySelector('[data-visual-drop-indicator="insert"]') as HTMLElement).style.top).toBe('12px')
   })
 
   it('拖过更新区时会显示语义化更新指示器', async () => {

--- a/src/components/editor/VisualEditorScene.vue
+++ b/src/components/editor/VisualEditorScene.vue
@@ -154,9 +154,12 @@ const statementRowGapSize = computed(() =>
 const statementRowGapHalfSize = computed(() =>
   editSettings.collapseStatementsOnSidebarOpen ? '0.125rem' : '0.1875rem',
 )
-const tailDropAreaSize = `${INSERT_BAND_SIZE_PX * 4}px`
-const tailDropAreaOffset = computed(() =>
-  `calc(-${INSERT_BAND_SIZE_PX * 2}px - ${statementRowGapSize.value})`,
+const statementListHeight = computed(() =>
+  `calc(${totalSize.value}px - ${statementRowGapSize.value})`,
+)
+// 与普通插入槽保持一致：先向上侵入最后一张卡片 8px，再向下延伸覆盖尾部空白。
+const tailDropAreaTop = computed(() =>
+  `calc(${totalSize.value}px - ${INSERT_BAND_SIZE_PX * 2}px - ${statementRowGapSize.value})`,
 )
 const headDropTargetTopInset = `-${INSERT_BAND_SIZE_PX}px`
 const headDropIndicatorTopInset = `-${INSERT_BAND_SIZE_PX / 2}px`
@@ -325,7 +328,7 @@ tryOnUnmounted(() => {
   <div ref="editorSurfaceRef" tabindex="-1" class="outline-none h-full">
     <ScrollArea ref="scrollAreaRef" class="h-full" :style="{ opacity: isPositioning ? 0 : 1 }">
       <div
-        class="flex flex-col"
+        class="flex flex-col relative"
         data-visual-editor-content
         :style="{ minHeight: contentMinHeight }"
       >
@@ -356,7 +359,17 @@ tryOnUnmounted(() => {
           />
         </div>
 
-        <div v-else ref="statementListRef" role="listbox" :aria-label="$t('edit.visualEditor.statementList')" :style="{ height: `${totalSize}px`, width: '100%', position: 'relative' }">
+        <div
+          v-else
+          ref="statementListRef"
+          role="listbox"
+          :aria-label="$t('edit.visualEditor.statementList')"
+          :style="{
+            height: statementListHeight,
+            width: '100%',
+            position: 'relative',
+          }"
+        >
           <div
             v-for="row in renderedStatementRows"
             :key="row.key"
@@ -429,11 +442,9 @@ tryOnUnmounted(() => {
           :ref="value => registerDropTarget('tail', resolveHTMLElement(value), tailDropTarget)"
           data-visual-drop-slot="tail"
           :class="{'pointer-events-none': !isDropHitTestingEnabled}"
-          class="mx-2 flex-1 relative"
+          class="inset-x-2 bottom-0 absolute"
           :style="{
-            flexBasis: tailDropAreaSize,
-            minHeight: tailDropAreaSize,
-            marginTop: tailDropAreaOffset,
+            top: tailDropAreaTop,
           }"
         >
           <div

--- a/src/composables/__tests__/useDragSort.test.ts
+++ b/src/composables/__tests__/useDragSort.test.ts
@@ -927,6 +927,61 @@ describe('useDragSort', () => {
     expect(sort.targetIndex.value).toBe(22)
   })
 
+  it('虚拟列表折叠行拖到列表底部时会落到最后一项', () => {
+    vi.useFakeTimers()
+    setupDragDocument()
+    setupAnimationFrame()
+    setupGlobalListeners()
+
+    const itemsRef = shallowRef(['item-0', 'item-1'])
+    const elements = [
+      createDragElement(0, createVerticalRect(0, 48)),
+      createDragElement(1, createVerticalRect(48, 48)),
+    ]
+    const onSort = vi.fn()
+    const sort = useDragSort<string>({
+      autoScroll: false,
+      direction: 'vertical',
+      getKey: item => item,
+      getPayload: () => tabPayload,
+      items: itemsRef,
+      onSort,
+      virtualAdapter: {
+        getEstimatedItemSize: () => 100,
+        getItemCount: () => itemsRef.value.length,
+        getScrollOffset: () => 0,
+        getVisibleItems: () => [
+          { index: 0, size: 48, start: 0 },
+          { index: 1, size: 48, start: 48 },
+        ],
+        invalidate: vi.fn(),
+      },
+    })
+    sort.containerRef.value = createContainer(elements, createVerticalRect(0, 1000))
+
+    sort.getItemProps(0).onPointerdown(createPointerEvent({
+      clientX: 10,
+      clientY: 10,
+      currentTarget: elements[0],
+      pointerId: 28,
+      target: elements[0],
+    }))
+    startDrag(elements[0], 28, 10, 10)
+    moveDrag(28, 10, 24)
+
+    expect(sort.targetIndex.value).toBe(1)
+
+    elements[0].dispatch('pointerup', {
+      clientX: 10,
+      clientY: 24,
+      pointerId: 28,
+      target: elements[0],
+    })
+    vi.runOnlyPendingTimers()
+
+    expect(onSort).toHaveBeenCalledWith(0, 1)
+  })
+
   it('虚拟列表排序提交后会通知 virtualizer 重新测量', async () => {
     vi.useFakeTimers()
     setupDragDocument()

--- a/src/composables/useDragSort.ts
+++ b/src/composables/useDragSort.ts
@@ -580,6 +580,15 @@ export function useDragSort<T>(options: UseDragSortOptions<T>): UseDragSortRetur
       const firstMainStart = firstProjectedItem.mainStartInContent
       const lastMainEnd = lastProjectedItem.mainStartInContent + lastProjectedItem.mainSize
 
+      // 投影末尾不含被拖拽行，因此尾部目标优先于估算尺寸命中。
+      if (
+        isMovingDown
+        && lastProjectedItem.index === adapter.getItemCount() - 1
+        && leadingMainInContent >= lastProjectedItem.projectedMainStartInContent + lastProjectedItem.mainSize
+      ) {
+        return adapter.getItemCount() - 1
+      }
+
       if (leadingMainInContent >= firstMainStart && leadingMainInContent <= lastMainEnd) {
         const targetItem = projectedItems.find((item) => {
           const midpoint = item.mainStartInContent + item.mainSize / 2


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [x] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [x] 测试用例
- [ ] 性能优化
- [x] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

修复可视化编辑器在折叠状态下将语句拖拽至列表底部时，语句可能被插入非预期位置的排序异常。

- 当真实末项可见，且拖拽前缘已经越过移除源项后的列表投影末端时，明确将目标位置判定为列表末尾。
- 调整底部投放区域的布局，使短列表中的底部空白区域仍可触发插入。
- 将底部投放区域向最后一行的侵入高度限制为标准的 8px，避免影响最后一行语句的替换操作。
- 扣除末行间距，使底部可见留白与顶部保持一致。
- 补充折叠语句排序、底部投放区域布局及插入指示器测试。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

折叠语句的实际高度与虚拟列表的估算高度存在差异。拖拽到列表底部时，基于估算位置计算出的目标索引可能停留在其他项的位置，导致最终排序与用户预期不符。

同时，底部投放区域需要兼顾两个交互目标：短列表中的空白区域应能接收拖放，而投放区域又不能过度覆盖最后一行，干扰语句替换。此次修改统一了上下留白的视觉高度，并限定了底部区域对最后一行的侵入范围。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [x] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
