### PR TITLE
🐛 修复拖拽标签页时的边缘缝隙与文字跳动

### DIFF
--- a/src/composables/__tests__/useDragSort.test.ts
+++ b/src/composables/__tests__/useDragSort.test.ts
@@ -250,6 +250,32 @@ function styleRecord(style: StyleValue | undefined): Record<string, string> {
   return (style ?? {}) as Record<string, string>
 }
 
+function parseOverlayBox(style: StyleValue | undefined): { height: number, width: number, x: number, y: number } {
+  const record = styleRecord(style)
+
+  return {
+    height: Number.parseFloat(record.height ?? ''),
+    width: Number.parseFloat(record.width ?? ''),
+    x: Number.parseFloat(record.left ?? ''),
+    y: Number.parseFloat(record.top ?? ''),
+  }
+}
+
+function parseOverlayClip(style: StyleValue | undefined): { bottom: number, left: number, right: number, top: number } {
+  const clipPath = styleRecord(style).clipPath ?? ''
+  const match = /^inset\((-?[\d.]+)px calc\(100% - (-?[\d.]+)px\) calc\(100% - (-?[\d.]+)px\) (-?[\d.]+)px\)$/.exec(clipPath)
+  if (!match) {
+    throw new Error(`无法解析浮层 clip-path: ${clipPath}`)
+  }
+
+  return {
+    bottom: Number(match[3]),
+    left: Number(match[4]),
+    right: Number(match[2]),
+    top: Number(match[1]),
+  }
+}
+
 function createSortFixture(itemsRef: Ref<string[]> = shallowRef(['a', 'b', 'c'])) {
   const elements = [
     createDragElement(0, createRect(0, 100)),
@@ -477,7 +503,8 @@ describe('useDragSort', () => {
     startDrag(elements[0], 8, 60)
 
     expect(styleRecord(sort.overlayState.value?.overlayStyle)).toMatchObject({
-      transform: 'translate3d(50px, 0px, 0)',
+      left: '50px',
+      top: '0px',
     })
     expect(sort.targetIndex.value).toBe(1)
     expect(sort.getItemStyle(1)).toMatchObject({
@@ -673,8 +700,59 @@ describe('useDragSort', () => {
     expect(sort.targetIndex.value).toBe(2)
     expect(styleRecord(sort.overlayState.value?.overlayStyle)).toMatchObject({
       height: '32px',
-      transform: 'translate3d(150px, 8px, 0)',
+      left: '150px',
+      top: '8px',
       width: '100px',
+    })
+  })
+
+  it('分数坐标下浮层与源元素逐像素重合，裁剪框不侵入源元素', () => {
+    setupDragDocument()
+    setupAnimationFrame()
+    setupGlobalListeners()
+    // 复现真实编辑器标签栏的分数坐标：Windows 125%/150% 缩放下布局位置不是整数 CSS 像素。
+    vi.stubGlobal('devicePixelRatio', 1.5)
+    const tabRect = createRect(380.859375, 111.1875, 71.5625, 32)
+    const elements = [createDragElement(0, tabRect)]
+    const sort = useDragSort<string>({
+      autoScroll: false,
+      direction: 'horizontal',
+      getKey: item => item,
+      getPayload: () => tabPayload,
+      items: shallowRef(['a']),
+      onSort: vi.fn(),
+    })
+    sort.containerRef.value = createContainer(elements, tabRect)
+
+    sort.getItemProps(0).onPointerdown(createPointerEvent({
+      clientX: 400,
+      clientY: 80,
+      currentTarget: elements[0],
+      pointerId: 9,
+      target: elements[0],
+    }))
+    elements[0].dispatch('pointermove', {
+      clientX: 410,
+      clientY: 80,
+      pointerId: 9,
+      target: elements[0],
+    })
+
+    // 浮层位置保留 rect 原始值：任何取整都会让浮层与源元素错开，进而在标签边缘露出底色缝隙或让文字跳动。
+    expect(parseOverlayBox(sort.overlayState.value?.overlayStyle)).toEqual({
+      height: 32,
+      width: 111.1875,
+      x: 380.859375,
+      y: 71.5625,
+    })
+
+    // 裁剪框等价于窗口内缩到视口边缘，这里视口与源元素同框，因此四条边必须与源元素完全一致，
+    // 否则 1px 的 border-r 会被裁掉一半而看起来消失。
+    expect(parseOverlayClip(sort.overlayState.value?.overlayFrameStyle)).toEqual({
+      bottom: 103.5625,
+      left: 380.859375,
+      right: 492.046875,
+      top: 71.5625,
     })
   })
 
@@ -1035,7 +1113,8 @@ describe('useDragSort', () => {
     expect(sort.phase.value).toBe('settling')
     expect(sort.targetIndex.value).toBe(22)
     expect(styleRecord(sort.overlayState.value?.overlayStyle)).toMatchObject({
-      transform: 'translate3d(0px, 200px, 0)',
+      left: '0px',
+      top: '200px',
     })
     expect(styleRecord(sort.overlayState.value?.overlayFrameStyle)).toMatchObject({
       clipPath: 'inset(0px calc(100% - 320px) calc(100% - 250px) 0px)',

--- a/src/composables/useDragSort.ts
+++ b/src/composables/useDragSort.ts
@@ -167,12 +167,15 @@ function createTranslate(direction: DragSortDirection, distance: number): string
     : `translate3d(0, ${distance}px, 0)`
 }
 
+// 浮层必须与源元素逐像素重合：用 transform 定位会把浮层提升为合成层，分数缩放下合成层落在半个设备像素上，
+// 边缘发虚、内容偏移；改用 left/top 让浮层走与源元素相同的布局与绘制路径，盒模型与文字都由浏览器按同一
+// 规则吸附，因此位置取 rect 原始值即可，不做任何取整。
 function getFixedRect(direction: DragSortDirection, rect: LayoutRect): FixedRect {
   return {
-    height: Math.round(direction === 'horizontal' ? rect.crossSize : rect.mainSize),
-    width: Math.round(direction === 'horizontal' ? rect.mainSize : rect.crossSize),
-    x: Math.round(direction === 'horizontal' ? rect.mainStart : rect.crossStart),
-    y: Math.round(direction === 'horizontal' ? rect.crossStart : rect.mainStart),
+    height: direction === 'horizontal' ? rect.crossSize : rect.mainSize,
+    width: direction === 'horizontal' ? rect.mainSize : rect.crossSize,
+    x: direction === 'horizontal' ? rect.mainStart : rect.crossStart,
+    y: direction === 'horizontal' ? rect.crossStart : rect.mainStart,
   }
 }
 
@@ -191,7 +194,8 @@ function createOverlayStyle(direction: DragSortDirection, rect: LayoutRect, tran
 
   return {
     height: `${height}px`,
-    transform: `translate3d(${x}px, ${y}px, 0)`,
+    left: `${x}px`,
+    top: `${y}px`,
     transition,
     width: `${width}px`,
     zIndex: '9999',
@@ -895,7 +899,7 @@ export function useDragSort<T>(options: UseDragSortOptions<T>): UseDragSortRetur
       targetIndex: clamp(targetIndex.value, 0, Math.max(0, options.items.value.length - 1)),
     }
     phase.value = 'settling'
-    updateOverlay(position, 'settling', `transform ${SETTLING_DURATION_MS}ms ease`)
+    updateOverlay(position, 'settling', `left ${SETTLING_DURATION_MS}ms ease, top ${SETTLING_DURATION_MS}ms ease`)
     scheduleCommit()
   }
 


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [x] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [ ] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

拖拽浮层改用 `left`/`top` 布局定位，位置和尺寸直接取元素原始坐标，不再取整；结算动画的过渡属性同步调整。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

拖拽编辑器标签页时，标签边缘会露出底色缝隙，位置还不固定（全屏后从顶部变到底部），文件名文字也会轻微跳动。

根因是浮层位置被取整、且用 `transform` 定位，导致它和源元素的盒模型与文字都对不齐。改用布局定位后，浮层与源元素走同一条布局与绘制路径，两者逐像素重合。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [x] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
