### PR TITLE
⚡️ 降低图标编辑器预览重绘开销

### DIFF
--- a/src/components/modals/game-config/IconEditorDialog.vue
+++ b/src/components/modals/game-config/IconEditorDialog.vue
@@ -293,7 +293,7 @@ const previewItems = $computed((): PreviewItem[] => [
               >
                 <article
                   v-for="preview in previewItems"
-                  :key="`${preview.key}-${previewVersion}`"
+                  :key="preview.key"
                   class="flex max-w-[clamp(8rem,22vh,11rem)] min-w-0 w-full items-center"
                   data-testid="icon-editor-preview-item"
                 >
@@ -309,6 +309,7 @@ const previewItems = $computed((): PreviewItem[] => [
                         :state="state"
                         :kind="preview.key"
                         :label="preview.label"
+                        :version="previewVersion"
                         class="size-full"
                       />
                     </div>

--- a/src/components/modals/game-config/IconEditorPreviewCanvas.spec.ts
+++ b/src/components/modals/game-config/IconEditorPreviewCanvas.spec.ts
@@ -5,8 +5,9 @@ import { createDefaultIconEditorState } from '~/features/modals/game-config/icon
 
 import IconEditorPreviewCanvas from './IconEditorPreviewCanvas.vue'
 
-const { renderIconCanvasMock } = vi.hoisted(() => ({
+const { renderIconCanvasMock, renderIconPreviewCanvasMock } = vi.hoisted(() => ({
   renderIconCanvasMock: vi.fn(() => document.createElement('canvas')),
+  renderIconPreviewCanvasMock: vi.fn(() => document.createElement('canvas')),
 }))
 
 vi.mock('~/features/modals/game-config/icon-editor/icon-editor-render', async () => {
@@ -17,6 +18,7 @@ vi.mock('~/features/modals/game-config/icon-editor/icon-editor-render', async ()
   return {
     ...actual,
     renderIconCanvas: renderIconCanvasMock,
+    renderIconPreviewCanvas: renderIconPreviewCanvasMock,
   }
 })
 
@@ -28,6 +30,7 @@ describe('IconEditorPreviewCanvas', () => {
     nextFrameId = 0
     scheduledFrames = []
     renderIconCanvasMock.mockClear()
+    renderIconPreviewCanvasMock.mockClear()
     vi.stubGlobal('requestAnimationFrame', vi.fn((callback: FrameRequestCallback) => {
       scheduledFrames.push(callback)
       nextFrameId += 1
@@ -54,10 +57,10 @@ describe('IconEditorPreviewCanvas', () => {
     const result = await renderInBrowser(Harness)
 
     expect(scheduledFrames).toHaveLength(1)
-    expect(renderIconCanvasMock).not.toHaveBeenCalled()
+    expect(renderIconPreviewCanvasMock).not.toHaveBeenCalled()
 
     scheduledFrames.shift()?.(performance.now())
-    expect(renderIconCanvasMock).toHaveBeenCalledOnce()
+    expect(renderIconPreviewCanvasMock).toHaveBeenCalledOnce()
 
     state.foregroundScale = 1.25
     state.foregroundOffsetRatio = { x: 0.1, y: 0.2 }
@@ -66,8 +69,58 @@ describe('IconEditorPreviewCanvas', () => {
     expect(scheduledFrames).toHaveLength(1)
 
     scheduledFrames.shift()?.(performance.now())
-    expect(renderIconCanvasMock).toHaveBeenCalledTimes(2)
+    expect(renderIconPreviewCanvasMock).toHaveBeenCalledTimes(2)
 
     await result.unmount()
+  })
+
+  it('按预览显示尺寸组合画布，不按导出分辨率重算', async () => {
+    const state = reactive(createDefaultIconEditorState())
+    const Harness = defineComponent({
+      setup() {
+        return () => h(IconEditorPreviewCanvas, {
+          kind: 'web',
+          label: 'preview',
+          state,
+        })
+      },
+    })
+    await renderInBrowser(Harness)
+
+    scheduledFrames.shift()?.(performance.now())
+
+    expect(renderIconPreviewCanvasMock).toHaveBeenCalledWith(state, expect.objectContaining({
+      kind: 'web',
+      size: 192,
+      sourceSize: 384,
+    }))
+  })
+
+  it('版本号变化触发重绘而不重建画布', async () => {
+    const state = reactive(createDefaultIconEditorState())
+    const version = ref(0)
+    const Harness = defineComponent({
+      setup() {
+        return () => h(IconEditorPreviewCanvas, {
+          kind: 'web',
+          label: 'preview',
+          state,
+          version: version.value,
+        })
+      },
+    })
+    const result = await renderInBrowser(Harness)
+
+    scheduledFrames.shift()?.(performance.now())
+    expect(renderIconPreviewCanvasMock).toHaveBeenCalledOnce()
+    const canvas = result.container.querySelector('canvas')
+
+    // 载入还原这类改动不经过响应式 state，靠版本号触发重绘；画布节点必须复用，否则每次更新都重建
+    version.value = 1
+    await nextTick()
+    scheduledFrames.shift()?.(performance.now())
+
+    expect(renderIconPreviewCanvasMock).toHaveBeenCalledTimes(2)
+    expect(result.container.querySelector('canvas')).toBe(canvas)
   })
 })

--- a/src/components/modals/game-config/IconEditorPreviewCanvas.vue
+++ b/src/components/modals/game-config/IconEditorPreviewCanvas.vue
@@ -1,5 +1,8 @@
 <script setup lang="ts">
-import { renderIconCanvas } from '~/features/modals/game-config/icon-editor/icon-editor-render'
+import {
+  createIconRenderScratch,
+  renderIconPreviewCanvas,
+} from '~/features/modals/game-config/icon-editor/icon-editor-render'
 
 import type { IconPreviewKind } from '~/features/modals/game-config/icon-editor/icon-editor-render'
 import type { IconEditorState } from '~/features/modals/game-config/icon-editor/icon-editor-state'
@@ -8,9 +11,18 @@ interface Props {
   kind: IconPreviewKind
   label: string
   state: IconEditorState
+  /** 每次改动递增：既用于触发重绘，也用于复用同一次改动各变体共有的组合结果 */
+  version?: number
 }
 
 const props = defineProps<Props>()
+
+/** 预览画布的显示边长；组合画布按 2 倍取，兼顾高分屏且不按导出分辨率重算 */
+const PREVIEW_CANVAS_SIZE = 192
+const PREVIEW_SOURCE_SIZE = PREVIEW_CANVAS_SIZE * 2
+
+// 本预览复用自己那套中间画布：拖拽中每次重绘都新建画布 + 取上下文是主要开销
+const scratch = createIconRenderScratch()
 
 const canvas = $(useTemplateRef<HTMLCanvasElement>('canvas'))
 let scheduledFrameId: number | undefined
@@ -20,9 +32,12 @@ function drawPreview() {
     return
   }
 
-  const source = renderIconCanvas(props.state, {
+  const source = renderIconPreviewCanvas(props.state, {
     kind: props.kind,
-    size: 192,
+    revision: props.version ?? 0,
+    size: PREVIEW_CANVAS_SIZE,
+    sourceSize: PREVIEW_SOURCE_SIZE,
+    scratch,
   })
   const context = canvas.getContext('2d')
   context?.clearRect(0, 0, canvas.width, canvas.height)
@@ -51,7 +66,7 @@ onBeforeUnmount(() => {
 })
 
 watch(
-  () => props.state,
+  [() => props.state, () => props.version],
   scheduleDraw,
   { deep: true },
 )
@@ -60,8 +75,8 @@ watch(
 <template>
   <canvas
     ref="canvas"
-    width="192"
-    height="192"
+    :width="PREVIEW_CANVAS_SIZE"
+    :height="PREVIEW_CANVAS_SIZE"
     role="img"
     :aria-label="props.label"
   />

--- a/src/features/modals/game-config/icon-editor/__tests__/icon-editor-render.browser.test.ts
+++ b/src/features/modals/game-config/icon-editor/__tests__/icon-editor-render.browser.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { renderIconCanvas } from '../icon-editor-render'
+import { renderIconCanvas, renderIconPreviewCanvas } from '../icon-editor-render'
 import { createDefaultIconEditorState } from '../icon-editor-state'
 
 import type { IconEditorImageSource } from '../icon-editor-state'
@@ -190,5 +190,52 @@ describe('renderIconCanvas', () => {
 
     expect(readAlpha(canvas, 1, 48)).toBe(0)
     expect(readAlpha(canvas, 6, 48)).toBe(255)
+  })
+
+  it('降低组合画布分辨率不改动构图，只影响采样精度', () => {
+    const state = createDefaultIconEditorState()
+    state.foregroundImage = createWideImageSource()
+    state.iconShape = 'square'
+
+    const canvas = renderIconCanvas(state, {
+      kind: 'android-full-bleed',
+      size: 64,
+      sourceSize: 384,
+    })
+
+    expect(canvas.width).toBe(64)
+    expect(canvas.height).toBe(64)
+    // 长边适配：上下留白仍是底色，左右中段仍是前景图
+    expect(readPixel(canvas, 0, 0)).toEqual(new Uint8ClampedArray([255, 255, 255, 255]))
+    expect(readAlpha(canvas, 0, 32)).toBe(255)
+    expect(readAlpha(canvas, 32, 32)).toBe(255)
+    expect(readPixel(canvas, 63, 63)).toEqual(new Uint8ClampedArray([255, 255, 255, 255]))
+  })
+
+  it('预览变体按 revision 复用组合结果，递增后才反映新状态', () => {
+    const state = createDefaultIconEditorState()
+
+    const first = renderIconPreviewCanvas(state, { kind: 'android-full-bleed', revision: 1, size: 8, sourceSize: 32 })
+    expect(readPixel(first, 0, 0)).toEqual(new Uint8ClampedArray([255, 255, 255, 255]))
+
+    // 不递增 revision：组合结果被复用，改动要等下一次 revision 才可见
+    state.backgroundColor = '#FF0000'
+    const reused = renderIconPreviewCanvas(state, { kind: 'android-full-bleed', revision: 1, size: 8, sourceSize: 32 })
+    expect(readPixel(reused, 0, 0)).toEqual(new Uint8ClampedArray([255, 255, 255, 255]))
+
+    const recomposed = renderIconPreviewCanvas(state, { kind: 'android-full-bleed', revision: 2, size: 8, sourceSize: 32 })
+    expect(readPixel(recomposed, 0, 0)).toEqual(new Uint8ClampedArray([255, 0, 0, 255]))
+  })
+
+  it('预览路径的裁剪变体共用主安全区裁剪', () => {
+    const state = createDefaultIconEditorState()
+    state.foregroundImage = createSolidImageSource()
+
+    const round = renderIconPreviewCanvas(state, { kind: 'android-round', revision: 3, size: 96, sourceSize: 384 })
+    const maskable = renderIconPreviewCanvas(state, { kind: 'web-maskable', revision: 3, size: 96, sourceSize: 384 })
+
+    expect(readAlpha(round, 1, 48)).toBe(0)
+    expect(readAlpha(round, 48, 48)).toBe(255)
+    expect(readAlpha(maskable, 48, 48)).toBe(255)
   })
 })

--- a/src/features/modals/game-config/icon-editor/icon-editor-render.ts
+++ b/src/features/modals/game-config/icon-editor/icon-editor-render.ts
@@ -18,6 +18,11 @@ export type IconPreviewKind =
 export interface IconRenderOptions {
   kind: IconPreviewKind
   size: number
+  /**
+   * 组合画布的分辨率，默认按导出分辨率 {@link ICON_EDITOR_CANVAS_SIZE}。
+   * 预览按显示尺寸取值即可：画布成本随面积下降，颜色/变换调整不必按导出分辨率重算。
+   */
+  sourceSize?: number
 }
 
 interface IconClipOptions {
@@ -56,6 +61,50 @@ function get2dContext(canvas: HTMLCanvasElement | OffscreenCanvas): CanvasRender
     throw new Error('无法创建图标画布')
   }
   return context
+}
+
+type RenderContext = CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D
+
+interface RenderTarget {
+  canvas: HTMLCanvasElement | OffscreenCanvas
+  context: RenderContext
+}
+
+/**
+ * 一次渲染要经过组合、裁剪、缩放多个中间画布；预览还会连续渲染多个变体。
+ * 复用这些画布可以省掉重复的分配与取上下文（实测占单次预览渲染的大头），
+ * 每次取用时按角色清空，语义与新建画布一致。
+ */
+export type IconRenderScratch = Map<string, RenderTarget>
+
+export function createIconRenderScratch(): IconRenderScratch {
+  return new Map()
+}
+
+function acquireRenderTarget(
+  scratch: IconRenderScratch | undefined,
+  role: string,
+  width: number,
+  height = width,
+): RenderTarget {
+  const targetWidth = Math.max(1, Math.round(width))
+  const targetHeight = Math.max(1, Math.round(height))
+  if (!scratch) {
+    const canvas = createCanvas(targetWidth, targetHeight)
+    return { canvas, context: get2dContext(canvas) }
+  }
+
+  const key = `${role}:${targetWidth}x${targetHeight}`
+  const existing = scratch.get(key)
+  if (existing) {
+    existing.context.clearRect(0, 0, targetWidth, targetHeight)
+    return existing
+  }
+
+  const canvas = createCanvas(targetWidth, targetHeight)
+  const target: RenderTarget = { canvas, context: get2dContext(canvas) }
+  scratch.set(key, target)
+  return target
 }
 
 function getSourceSize(image: HTMLImageElement): { height: number, width: number } {
@@ -120,6 +169,7 @@ function drawCenteredImage(
   source: IconEditorImageSource,
   offsetRatio: IconEditorOffsetRatio,
   scale: number,
+  baseSize: number,
 ) {
   const { height, width } = getSourceSize(source.image)
   if (width <= 0 || height <= 0) {
@@ -127,10 +177,10 @@ function drawCenteredImage(
   }
 
   const imageAspectRatio = width / height
-  const targetWidth = (imageAspectRatio > 1 ? ICON_EDITOR_CANVAS_SIZE : ICON_EDITOR_CANVAS_SIZE * imageAspectRatio) * scale
-  const targetHeight = (imageAspectRatio > 1 ? ICON_EDITOR_CANVAS_SIZE / imageAspectRatio : ICON_EDITOR_CANVAS_SIZE) * scale
-  const targetX = (ICON_EDITOR_CANVAS_SIZE - targetWidth) / 2 + offsetRatio.x * ICON_EDITOR_CANVAS_SIZE
-  const targetY = (ICON_EDITOR_CANVAS_SIZE - targetHeight) / 2 + offsetRatio.y * ICON_EDITOR_CANVAS_SIZE
+  const targetWidth = (imageAspectRatio > 1 ? baseSize : baseSize * imageAspectRatio) * scale
+  const targetHeight = (imageAspectRatio > 1 ? baseSize / imageAspectRatio : baseSize) * scale
+  const targetX = (baseSize - targetWidth) / 2 + offsetRatio.x * baseSize
+  const targetY = (baseSize - targetHeight) / 2 + offsetRatio.y * baseSize
 
   context.drawImage(source.image, targetX, targetY, targetWidth, targetHeight)
 }
@@ -138,31 +188,34 @@ function drawCenteredImage(
 function drawComposedIcon(
   context: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
   state: IconEditorState,
+  baseSize: number,
 ) {
-  context.clearRect(0, 0, ICON_EDITOR_CANVAS_SIZE, ICON_EDITOR_CANVAS_SIZE)
+  context.clearRect(0, 0, baseSize, baseSize)
 
   if (state.backgroundType === 'image' && state.backgroundImage) {
-    drawCenteredImage(context, state.backgroundImage, state.backgroundOffsetRatio, state.backgroundScale)
+    drawCenteredImage(context, state.backgroundImage, state.backgroundOffsetRatio, state.backgroundScale, baseSize)
   } else {
     context.fillStyle = state.backgroundColor
-    context.fillRect(0, 0, ICON_EDITOR_CANVAS_SIZE, ICON_EDITOR_CANVAS_SIZE)
+    context.fillRect(0, 0, baseSize, baseSize)
   }
 
   if (state.foregroundImage) {
-    drawCenteredImage(context, state.foregroundImage, state.foregroundOffsetRatio, state.foregroundScale)
+    drawCenteredImage(context, state.foregroundImage, state.foregroundOffsetRatio, state.foregroundScale, baseSize)
   }
 }
 
 function clipToCanvas(
   sourceCanvas: HTMLCanvasElement | OffscreenCanvas,
   options: IconClipOptions,
+  scratch: IconRenderScratch | undefined,
 ): HTMLCanvasElement | OffscreenCanvas {
   const insetWidth = sourceCanvas.width * options.inset
   const insetHeight = sourceCanvas.height * options.inset
   const clippedWidth = sourceCanvas.width - insetWidth * 2
   const clippedHeight = sourceCanvas.height - insetHeight * 2
-  const clippedCanvas = createCanvas(clippedWidth, clippedHeight)
-  const clippedContext = get2dContext(clippedCanvas)
+  const clippedTarget = acquireRenderTarget(scratch, 'clip', clippedWidth, clippedHeight)
+  const clippedCanvas = clippedTarget.canvas
+  const clippedContext = clippedTarget.context
 
   clippedContext.imageSmoothingEnabled = true
   clippedContext.imageSmoothingQuality = 'high'
@@ -191,23 +244,21 @@ function clipToCanvas(
     return clippedCanvas
   }
 
-  const paddedCanvas = createCanvas(sourceCanvas.width, sourceCanvas.height)
-  const paddedContext = get2dContext(paddedCanvas)
+  const paddedTarget = acquireRenderTarget(scratch, 'padded', sourceCanvas.width, sourceCanvas.height)
+  const paddedContext = paddedTarget.context
   paddedContext.imageSmoothingEnabled = true
   paddedContext.imageSmoothingQuality = 'high'
   paddedContext.drawImage(clippedCanvas, insetWidth, insetHeight)
-  return paddedCanvas
+  return paddedTarget.canvas
 }
 
 function createPreviewCanvas(
   sourceCanvas: HTMLCanvasElement | OffscreenCanvas,
+  maskableCanvas: HTMLCanvasElement | OffscreenCanvas,
   kind: IconPreviewKind,
   shape: IconEditorShape,
+  scratch: IconRenderScratch | undefined,
 ): HTMLCanvasElement | OffscreenCanvas {
-  const maskableCanvas = clipToCanvas(sourceCanvas, {
-    inset: CLIP_INSET.main,
-    shape: 'square',
-  })
   const roundedClipRadius = resolveRoundedClipRadius(maskableCanvas)
 
   switch (kind) {
@@ -220,28 +271,28 @@ function createPreviewCanvas(
         preservePadding: true,
         radius: roundedClipRadius,
         shape: 'rounded',
-      })
+      }, scratch)
     }
     case 'android-round': {
       return clipToCanvas(maskableCanvas, {
         inset: CLIP_INSET.android.round,
         preservePadding: true,
         shape: 'circle',
-      })
+      }, scratch)
     }
     case 'desktop': {
       return clipToCanvas(maskableCanvas, {
         inset: CLIP_INSET.desktop,
         radius: roundedClipRadius,
         shape,
-      })
+      }, scratch)
     }
     case 'web': {
       return clipToCanvas(maskableCanvas, {
         inset: CLIP_INSET.web,
         radius: roundedClipRadius,
         shape,
-      })
+      }, scratch)
     }
     case 'web-maskable': {
       return maskableCanvas
@@ -253,15 +304,84 @@ function createPreviewCanvas(
   }
 }
 
-export function renderIconCanvas(state: IconEditorState, options: IconRenderOptions): HTMLCanvasElement | OffscreenCanvas {
-  const sourceCanvas = createCanvas(ICON_EDITOR_CANVAS_SIZE)
-  const sourceContext = get2dContext(sourceCanvas)
-  drawComposedIcon(sourceContext, state)
-  const previewCanvas = createPreviewCanvas(sourceCanvas, options.kind, state.iconShape)
+function createMaskableCanvas(
+  sourceCanvas: HTMLCanvasElement | OffscreenCanvas,
+  scratch: IconRenderScratch | undefined,
+): HTMLCanvasElement | OffscreenCanvas {
+  return clipToCanvas(sourceCanvas, {
+    inset: CLIP_INSET.main,
+    shape: 'square',
+  }, scratch)
+}
 
-  const outputCanvas = createCanvas(options.size)
-  get2dContext(outputCanvas).drawImage(previewCanvas, 0, 0, options.size, options.size)
-  return outputCanvas
+export function renderIconCanvas(
+  state: IconEditorState,
+  options: IconRenderOptions,
+): HTMLCanvasElement | OffscreenCanvas {
+  const baseSize = options.sourceSize ?? ICON_EDITOR_CANVAS_SIZE
+  const sourceTarget = acquireRenderTarget(undefined, 'source', baseSize)
+  drawComposedIcon(sourceTarget.context, state, baseSize)
+  const maskableCanvas = createMaskableCanvas(sourceTarget.canvas, undefined)
+  const previewCanvas = createPreviewCanvas(sourceTarget.canvas, maskableCanvas, options.kind, state.iconShape, undefined)
+
+  const outputTarget = acquireRenderTarget(undefined, 'output', options.size)
+  outputTarget.context.drawImage(previewCanvas, 0, 0, options.size, options.size)
+  return outputTarget.canvas
+}
+
+/** 同一次改动的多个预览变体共用的组合结果 */
+interface IconPreviewComposition {
+  maskableCanvas: HTMLCanvasElement | OffscreenCanvas
+  revision: number
+  sourceCanvas: HTMLCanvasElement | OffscreenCanvas
+  sourceSize: number
+}
+
+let previewComposition: IconPreviewComposition | undefined
+
+export interface IconPreviewRenderOptions {
+  kind: IconPreviewKind
+  /** 每次改动递增，用于判断能否复用上一次的组合结果 */
+  revision: number
+  size: number
+  sourceSize?: number
+  scratch?: IconRenderScratch
+}
+
+/**
+ * 预览渲染：一次改动会渲染多个变体（不同裁剪方式），组合与主安全区裁剪对所有变体相同。
+ * 按 revision 复用这两步，只让各变体做自己那一段裁剪与缩放。
+ */
+export function renderIconPreviewCanvas(
+  state: IconEditorState,
+  options: IconPreviewRenderOptions,
+): HTMLCanvasElement | OffscreenCanvas {
+  const sourceSize = options.sourceSize ?? ICON_EDITOR_CANVAS_SIZE
+  if (
+    !previewComposition
+    || previewComposition.revision !== options.revision
+    || previewComposition.sourceSize !== sourceSize
+  ) {
+    const sourceTarget = acquireRenderTarget(options.scratch, 'source', sourceSize)
+    drawComposedIcon(sourceTarget.context, state, sourceSize)
+    previewComposition = {
+      maskableCanvas: createMaskableCanvas(sourceTarget.canvas, options.scratch),
+      revision: options.revision,
+      sourceCanvas: sourceTarget.canvas,
+      sourceSize,
+    }
+  }
+
+  const previewCanvas = createPreviewCanvas(
+    previewComposition.sourceCanvas,
+    previewComposition.maskableCanvas,
+    options.kind,
+    state.iconShape,
+    options.scratch,
+  )
+  const outputTarget = acquireRenderTarget(options.scratch, 'output', options.size)
+  outputTarget.context.drawImage(previewCanvas, 0, 0, options.size, options.size)
+  return outputTarget.canvas
 }
 
 export function renderIconSourceSnapshotCanvas(source: IconEditorImageSource): HTMLCanvasElement | OffscreenCanvas {


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [ ] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [ ] 测试用例
- [x] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

图标编辑器的预览在拖拽变换、调色时按帧重绘，而每次重绘都要先按导出分辨率（1536²）组合整张画布，再缩到 192 显示；组合、裁剪、缩放各自新建中间画布，同一次改动的多个预览变体还会把相同的前两步重做一遍。拖拽期间这些开销直接压在指针事件之间。

本次把预览的渲染路径按它的实际需要重做：

- 组合画布按显示尺寸取值（192 的 2 倍，兼顾高分屏），面积降到原来的 1/16。
- 中间画布改为复用，省掉每次都重新分配画布与取上下文。
- 同一次改动的多个预览变体共用组合结果与主安全区裁剪，各自只做自己那一段裁剪与缩放。
- 预览画布按版本号触发重绘，不再整体重建；载入还原这类不经过响应式 state 的改动也走同一条路径。

导出图标的路径不受影响，仍按导出分辨率组合，产物与此前一致；预览本身除采样精度外构图不变。界面没有可见变化。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

上一版预览不区分「预览」与「导出」两条路径的开销要求，每次重绘都按导出分辨率组合。颜色选择器重构（#338）让背景色拖拽接入实时预览流，预览按帧触发的频率变高，原本就存在的开销变得更明显。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->

**值得留意的实现约束**

预览复用组合结果以传入的版本号为准，因此图标编辑器的任何状态改动都必须递增 `previewVersion`，否则预览会停留在上一次的组合结果上。现有 setter 都满足这一点，后续新增状态改动时需要一并递增。

### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [x] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
