### PR TITLE
⚡️ 消除语句编辑器单次更新中的重复整篇解析与内容哈希

### DIFF
--- a/src/domain/script/__tests__/roundtrip.test.ts
+++ b/src/domain/script/__tests__/roundtrip.test.ts
@@ -260,6 +260,15 @@ describe('sentence', () => {
     expect(first.map(range => range.rawText)).toEqual(['Alice:hello;', 'Bob:world;'])
   })
 
+  it('行尾不同的同一份文本共享解析结果', () => {
+    const lf = ['Alice:hello;', 'Bob:world;'].join('\n')
+    const first = buildStatementSourceRanges(lf, LATEST_ENGINE_RUNTIME_CAPABILITIES)
+    const second = buildStatementSourceRanges(lf.replaceAll('\n', '\r\n'), LATEST_ENGINE_RUNTIME_CAPABILITIES)
+
+    expect(second).toBe(first)
+    expect(first.map(range => range.rawText)).toEqual(['Alice:hello;', 'Bob:world;'])
+  })
+
   it('语法能力不同的整篇解析结果不共用缓存', () => {
     const raw = ['changeFigure:hero.png', '  -id=hero -left;'].join('\n')
 

--- a/src/domain/script/__tests__/roundtrip.test.ts
+++ b/src/domain/script/__tests__/roundtrip.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 import { commandType } from 'webgal-parser/src/interface/sceneInterface'
 
-import { LEGACY_ENGINE_RUNTIME_CAPABILITIES } from '~/domain/engine/runtime-capabilities'
+import { LATEST_ENGINE_RUNTIME_CAPABILITIES, LEGACY_ENGINE_RUNTIME_CAPABILITIES } from '~/domain/engine/runtime-capabilities'
 
 import {
   parseChooseContent,
@@ -248,5 +248,27 @@ describe('sentence', () => {
     })
     expect('parsed' in (statement as object)).toBe(false)
     expect('parseError' in (statement as object)).toBe(false)
+  })
+
+  it('同一份文本的整篇解析结果在多个消费者之间共享', () => {
+    const raw = ['Alice:hello;', 'Bob:world;'].join('\n')
+    const first = buildStatementSourceRanges(raw, LATEST_ENGINE_RUNTIME_CAPABILITIES)
+    // 内容相同的独立字符串同样命中，一次编辑只解析一次
+    const second = buildStatementSourceRanges(['Alice:hello;', 'Bob:world;'].join('\n'), LATEST_ENGINE_RUNTIME_CAPABILITIES)
+
+    expect(second).toBe(first)
+    expect(first.map(range => range.rawText)).toEqual(['Alice:hello;', 'Bob:world;'])
+  })
+
+  it('语法能力不同的整篇解析结果不共用缓存', () => {
+    const raw = ['changeFigure:hero.png', '  -id=hero -left;'].join('\n')
+
+    const multiline = buildStatementSourceRanges(raw, LATEST_ENGINE_RUNTIME_CAPABILITIES)
+    const perLine = buildStatementSourceRanges(raw, LEGACY_ENGINE_RUNTIME_CAPABILITIES)
+
+    expect(multiline).toHaveLength(1)
+    expect(perLine).toHaveLength(2)
+    expect(buildStatementSourceRanges(raw, LEGACY_ENGINE_RUNTIME_CAPABILITIES)).toBe(perLine)
+    expect(buildStatementSourceRanges(raw, LATEST_ENGINE_RUNTIME_CAPABILITIES)).toBe(multiline)
   })
 })

--- a/src/domain/script/sentence.ts
+++ b/src/domain/script/sentence.ts
@@ -111,7 +111,10 @@ function parseStatementSourceRanges(
  * 解析全文，并保留每条逻辑语句在原始文本中的行范围。
  *
  * 解析器会为续行生成占位语句以保持物理行数量；这里排除占位语句，
- * 再以解析器给出的范围截取原始行，保留用户的缩进与换行格式。
+ * 再以解析器给出的范围截取原始行，保留用户的缩进与语句内换行。
+ *
+ * 行尾统一成 LF 后解析与比较：调用方拿到的文本行尾并不一致（Monaco 原样文本是 CRLF，
+ * 逐行截取后拼回来的却是 LF），统一后同一份文本只解析一次；写回时由文档 metadata 还原。
  *
  * 返回值由多个调用方共享，必须视为只读。
  */
@@ -119,16 +122,17 @@ export function buildStatementSourceRanges(
   text: string,
   capabilities?: StatementSyntaxCapabilities,
 ): StatementSourceRange[] {
+  const normalizedText = text.includes('\r') ? text.replaceAll('\r\n', '\n') : text
   const capabilitiesKey = createSyntaxCapabilitiesKey(capabilities)
 
   for (const entry of sourceRangesCache) {
-    if (entry.text === text && entry.capabilitiesKey === capabilitiesKey) {
+    if (entry.text === normalizedText && entry.capabilitiesKey === capabilitiesKey) {
       return entry.ranges
     }
   }
 
-  const ranges = parseStatementSourceRanges(text, capabilities)
-  sourceRangesCache.unshift({ capabilitiesKey, ranges, text })
+  const ranges = parseStatementSourceRanges(normalizedText, capabilities)
+  sourceRangesCache.unshift({ capabilitiesKey, ranges, text: normalizedText })
   sourceRangesCache.length = Math.min(sourceRangesCache.length, SOURCE_RANGES_CACHE_LIMIT)
   return ranges
 }

--- a/src/domain/script/sentence.ts
+++ b/src/domain/script/sentence.ts
@@ -53,13 +53,24 @@ export function createEmptySentence(): ISentence {
   }
 }
 
-/**
- * 解析全文，并保留每条逻辑语句在原始文本中的行范围。
- *
- * 解析器会为续行生成占位语句以保持物理行数量；这里排除占位语句，
- * 再以解析器给出的范围截取原始行，保留用户的缩进与换行格式。
- */
-export function buildStatementSourceRanges(
+interface StatementSourceRangesCacheEntry {
+  capabilitiesKey: string
+  ranges: StatementSourceRange[]
+  text: string
+}
+
+/** 一次编辑里文档模型重建、诊断标记、语句高亮与侧栏快照会解析同一份文本，这里共享最近的结果 */
+const sourceRangesCache: StatementSourceRangesCacheEntry[] = []
+
+/** 上限 2 覆盖「当前文本 + 上一份（如语句组弹窗草稿）」，再多会长期占用整篇解析结果的内存 */
+const SOURCE_RANGES_CACHE_LIMIT = 2
+
+/** 缓存键只需包含影响切分的两个能力开关 */
+function createSyntaxCapabilitiesKey(capabilities?: StatementSyntaxCapabilities): string {
+  return `${capabilities?.multilineStatements ?? 'default'}|${capabilities?.sceneSemantics ?? 'default'}`
+}
+
+function parseStatementSourceRanges(
   text: string,
   capabilities?: StatementSyntaxCapabilities,
 ): StatementSourceRange[] {
@@ -94,6 +105,32 @@ export function buildStatementSourceRanges(
       rawText: lines.slice(sentence.startLine, sentence.endLine + 1).join('\n'),
       startLine: sentence.startLine,
     }))
+}
+
+/**
+ * 解析全文，并保留每条逻辑语句在原始文本中的行范围。
+ *
+ * 解析器会为续行生成占位语句以保持物理行数量；这里排除占位语句，
+ * 再以解析器给出的范围截取原始行，保留用户的缩进与换行格式。
+ *
+ * 返回值由多个调用方共享，必须视为只读。
+ */
+export function buildStatementSourceRanges(
+  text: string,
+  capabilities?: StatementSyntaxCapabilities,
+): StatementSourceRange[] {
+  const capabilitiesKey = createSyntaxCapabilitiesKey(capabilities)
+
+  for (const entry of sourceRangesCache) {
+    if (entry.text === text && entry.capabilitiesKey === capabilitiesKey) {
+      return entry.ranges
+    }
+  }
+
+  const ranges = parseStatementSourceRanges(text, capabilities)
+  sourceRangesCache.unshift({ capabilitiesKey, ranges, text })
+  sourceRangesCache.length = Math.min(sourceRangesCache.length, SOURCE_RANGES_CACHE_LIMIT)
+  return ranges
 }
 
 /**

--- a/src/features/editor/diagnostics/__tests__/useEditorDiagnostics.test.ts
+++ b/src/features/editor/diagnostics/__tests__/useEditorDiagnostics.test.ts
@@ -328,6 +328,46 @@ describe('useEditorDiagnostics', () => {
     scope.stop()
   })
 
+  it('没有场景内容令牌的文档（动画草稿）等长编辑后仍重新发布诊断', async () => {
+    const path = AbsPath.from('/game/animation/story.json')
+    const diagnosticsStore = {
+      invalidateSource: vi.fn(),
+      publish: vi.fn(),
+    }
+    const textProjection = reactive({
+      kind: 'animation' as const,
+      syncError: 'invalid-animation-json' as const,
+      textContent: '{invalid',
+    })
+
+    useEditorDiagnosticsStoreMock.mockReturnValue(diagnosticsStore)
+    useEditorStoreMock.mockReturnValue({
+      getTextProjectionState: () => textProjection,
+      getVisualProjectionState: () => undefined,
+      peekSceneContentChangeToken: () => undefined,
+    })
+    useResourceIndexMock.mockReturnValue({
+      hasAssetKey: vi.fn(() => false),
+      revision: shallowRef(0),
+      status: shallowRef('ready'),
+    })
+    useTabsStoreMock.mockReturnValue(reactive({ tabs: [{ path }] }))
+
+    const scope = effectScope()
+    scope.run(useEditorDiagnostics)
+    expect(diagnosticsStore.publish).toHaveBeenLastCalledWith(path, [
+      expect.objectContaining({ code: 'invalid-animation-json' }),
+    ])
+    diagnosticsStore.publish.mockClear()
+
+    // 等长替换：除内容本身外没有任何字段变化
+    textProjection.textContent = '{invaliX'
+    await nextTick()
+
+    expect(diagnosticsStore.publish).toHaveBeenCalledTimes(1)
+    scope.stop()
+  })
+
   it('资源索引变化时令牌未变也强制重算所有打开文档', async () => {
     const firstPath = AbsPath.from('/game/scene/first.txt')
     const secondPath = AbsPath.from('/game/scene/second.txt')

--- a/src/features/editor/diagnostics/__tests__/useEditorDiagnostics.test.ts
+++ b/src/features/editor/diagnostics/__tests__/useEditorDiagnostics.test.ts
@@ -71,7 +71,7 @@ describe('useEditorDiagnostics', () => {
       })],
     ])
     const resourceRevision = shallowRef(0)
-    const sceneRevision = shallowRef('revision-1')
+    const sceneToken = shallowRef('token-1')
     const tabsStore = reactive({
       tabs: [{ path: openPath }],
     })
@@ -80,7 +80,7 @@ describe('useEditorDiagnostics', () => {
     useEditorStoreMock.mockReturnValue({
       getTextProjectionState: vi.fn(() => undefined),
       getVisualProjectionState: (path: AbsPath) => visualProjections.get(path),
-      peekSceneRevision: vi.fn(() => sceneRevision.value),
+      peekSceneContentChangeToken: vi.fn(() => sceneToken.value),
     })
     useResourceIndexMock.mockReturnValue({
       hasAssetKey: vi.fn(() => false),
@@ -104,7 +104,7 @@ describe('useEditorDiagnostics', () => {
     expect(diagnosticsStore.invalidateSource).toHaveBeenCalledWith('resource')
     expect(diagnosticsStore.publish).toHaveBeenCalledTimes(2)
 
-    sceneRevision.value = 'revision-2'
+    sceneToken.value = 'token-2'
     await nextTick()
 
     expect(diagnosticsStore.publish).toHaveBeenCalledTimes(3)
@@ -126,7 +126,7 @@ describe('useEditorDiagnostics', () => {
     useEditorStoreMock.mockReturnValue({
       getTextProjectionState: vi.fn(() => undefined),
       getVisualProjectionState: vi.fn(() => visualProjection),
-      peekSceneRevision: vi.fn(() => visualProjection.kind),
+      peekSceneContentChangeToken: vi.fn(() => visualProjection.kind),
     })
     useResourceIndexMock.mockReturnValue({
       hasAssetKey: vi.fn(() => true),
@@ -166,7 +166,7 @@ describe('useEditorDiagnostics', () => {
         kind: 'scene' as const,
         statements: buildStatements('changeFigure:hero.json;'),
       })),
-      peekSceneRevision: vi.fn(() => 'revision-1'),
+      peekSceneContentChangeToken: vi.fn(() => 'revision-1'),
     })
     useResourceIndexMock.mockReturnValue({
       hasAssetKey: vi.fn(() => true),
@@ -209,7 +209,7 @@ describe('useEditorDiagnostics', () => {
         kind: 'scene' as const,
         statements: buildStatements('say:hello -voice.opus;'),
       })),
-      peekSceneRevision: vi.fn(() => 'revision-1'),
+      peekSceneContentChangeToken: vi.fn(() => 'revision-1'),
     })
     useResourceIndexMock.mockReturnValue({
       hasAssetKey: vi.fn(() => true),
@@ -252,7 +252,7 @@ describe('useEditorDiagnostics', () => {
         runtimeCapabilities: resourceStore.currentEngineRuntimeCapabilities,
         statements: buildStatements('changeFigure: hero.png -left13;'),
       })),
-      peekSceneRevision: vi.fn(() => 'revision-1'),
+      peekSceneContentChangeToken: vi.fn(() => 'revision-1'),
     })
     useResourceIndexMock.mockReturnValue({
       hasAssetKey: vi.fn(() => true),
@@ -273,6 +273,110 @@ describe('useEditorDiagnostics', () => {
     await nextTick()
 
     expect(diagnosticsStore.publish).toHaveBeenLastCalledWith(path, [])
+    scope.stop()
+  })
+
+  it('只重新诊断内容令牌变化的标签页', async () => {
+    const changedPath = AbsPath.from('/game/scene/changed.txt')
+    const stablePath = AbsPath.from('/game/scene/stable.txt')
+    const diagnosticsStore = {
+      invalidateSource: vi.fn(),
+      publish: vi.fn(),
+    }
+    const tokens = reactive(new Map<AbsPath, string>([
+      [changedPath, 'token-1'],
+      [stablePath, 'token-2'],
+    ]))
+    const visualProjections = new Map([
+      [changedPath, reactive({
+        kind: 'scene' as const,
+        statements: buildStatements('label:start;\nlabel:start;'),
+      })],
+      [stablePath, reactive({
+        kind: 'scene' as const,
+        statements: buildStatements('label:other;\nlabel:other;'),
+      })],
+    ])
+
+    useEditorDiagnosticsStoreMock.mockReturnValue(diagnosticsStore)
+    useEditorStoreMock.mockReturnValue({
+      getTextProjectionState: vi.fn(() => undefined),
+      getVisualProjectionState: (path: AbsPath) => visualProjections.get(path),
+      peekSceneContentChangeToken: (path: AbsPath) => tokens.get(path),
+    })
+    useResourceIndexMock.mockReturnValue({
+      hasAssetKey: vi.fn(() => true),
+      revision: shallowRef(0),
+      status: shallowRef('ready'),
+    })
+    useTabsStoreMock.mockReturnValue(reactive({
+      tabs: [{ path: changedPath }, { path: stablePath }],
+    }))
+
+    const scope = effectScope()
+    scope.run(useEditorDiagnostics)
+    expect(diagnosticsStore.publish).toHaveBeenCalledTimes(2)
+    diagnosticsStore.publish.mockClear()
+
+    tokens.set(changedPath, 'token-1-updated')
+    await nextTick()
+
+    expect(diagnosticsStore.publish).toHaveBeenCalledTimes(1)
+    expect(diagnosticsStore.publish).toHaveBeenCalledWith(changedPath, expect.arrayContaining([
+      expect.objectContaining({ code: 'duplicate-label' }),
+    ]))
+    scope.stop()
+  })
+
+  it('资源索引变化时令牌未变也强制重算所有打开文档', async () => {
+    const firstPath = AbsPath.from('/game/scene/first.txt')
+    const secondPath = AbsPath.from('/game/scene/second.txt')
+    const diagnosticsStore = {
+      invalidateSource: vi.fn(),
+      publish: vi.fn(),
+    }
+    const resourceRevision = shallowRef(0)
+    const visualProjections = new Map([
+      [firstPath, reactive({
+        kind: 'scene' as const,
+        statements: buildStatements('changeBg:missing.png;'),
+      })],
+      [secondPath, reactive({
+        kind: 'scene' as const,
+        statements: buildStatements('changeBg:missing.png;'),
+      })],
+    ])
+
+    useEditorDiagnosticsStoreMock.mockReturnValue(diagnosticsStore)
+    useEditorStoreMock.mockReturnValue({
+      getTextProjectionState: vi.fn(() => undefined),
+      getVisualProjectionState: (path: AbsPath) => visualProjections.get(path),
+      peekSceneContentChangeToken: vi.fn(() => 'unchanged-token'),
+    })
+    useResourceIndexMock.mockReturnValue({
+      hasAssetKey: vi.fn(() => false),
+      revision: resourceRevision,
+      status: shallowRef('ready'),
+    })
+    useTabsStoreMock.mockReturnValue(reactive({
+      tabs: [{ path: firstPath }, { path: secondPath }],
+    }))
+
+    const scope = effectScope()
+    scope.run(useEditorDiagnostics)
+    diagnosticsStore.publish.mockClear()
+
+    resourceRevision.value++
+    await nextTick()
+
+    expect(diagnosticsStore.invalidateSource).toHaveBeenCalledWith('resource')
+    expect(diagnosticsStore.publish).toHaveBeenCalledTimes(2)
+    expect(diagnosticsStore.publish).toHaveBeenCalledWith(firstPath, [
+      expect.objectContaining({ code: 'missing-resource' }),
+    ])
+    expect(diagnosticsStore.publish).toHaveBeenCalledWith(secondPath, [
+      expect.objectContaining({ code: 'missing-resource' }),
+    ])
     scope.stop()
   })
 })

--- a/src/features/editor/diagnostics/useEditorDiagnostics.ts
+++ b/src/features/editor/diagnostics/useEditorDiagnostics.ts
@@ -5,6 +5,13 @@ import { useEditorDiagnosticsStore } from '~/stores/editor-diagnostics'
 import { useResourceStore } from '~/stores/resource'
 import { useTabsStore } from '~/stores/tabs'
 
+import type { AbsPath } from '~/domain/path'
+
+interface PublishDiagnosticsOptions {
+  /** 资源索引或引擎能力变化时，诊断结论整体失效，必须无视令牌强制重算 */
+  force?: boolean
+}
+
 export function useEditorDiagnostics(): void {
   const diagnosticsStore = useEditorDiagnosticsStore()
   const editorStore = useEditorStore()
@@ -12,10 +19,37 @@ export function useEditorDiagnostics(): void {
   const resourceStore = useResourceStore()
   const tabsStore = useTabsStore()
 
-  function publishOpenDocumentDiagnostics(): void {
+  // 各标签页已发布诊断对应的内容令牌；watcher 整体触发时跳过令牌未变的文档
+  const publishedTokens = new Map<AbsPath, string>()
+
+  function readDiagnosticsToken(path: AbsPath): string {
+    const textProjection = editorStore.getTextProjectionState(path)
+    const visualProjection = editorStore.getVisualProjectionState(path)
+    return [
+      editorStore.peekSceneContentChangeToken(path) ?? '',
+      textProjection?.kind ?? '',
+      textProjection?.syncError ?? '',
+      textProjection?.textContent.length ?? '',
+      visualProjection?.kind ?? '',
+    ].join('|')
+  }
+
+  function publishOpenDocumentDiagnostics(options: PublishDiagnosticsOptions = {}): void {
     const canCheckResources = resourceIndex.status.value === 'ready'
+    const openPaths = new Set(tabsStore.tabs.map(tab => tab.path))
+    for (const path of publishedTokens.keys()) {
+      if (!openPaths.has(path)) {
+        publishedTokens.delete(path)
+      }
+    }
 
     for (const tab of tabsStore.tabs) {
+      const token = readDiagnosticsToken(tab.path)
+      if (!options.force && publishedTokens.get(tab.path) === token) {
+        continue
+      }
+      publishedTokens.set(tab.path, token)
+
       const textProjection = editorStore.getTextProjectionState(tab.path)
       const visualProjection = editorStore.getVisualProjectionState(tab.path)
       const canDiagnose = visualProjection?.kind === 'scene' || textProjection?.kind === 'animation'
@@ -41,25 +75,27 @@ export function useEditorDiagnostics(): void {
       const textProjection = editorStore.getTextProjectionState(tab.path)
       return [
         tab.path,
-        editorStore.peekSceneRevision(tab.path),
+        editorStore.peekSceneContentChangeToken(tab.path),
         textProjection?.kind,
         textProjection?.syncError,
         textProjection?.runtimeCapabilities,
+        // 草稿内容不落事务（非法动画 JSON），用字符串身份兜底
+        textProjection?.textContent,
       ] as const
     }),
-    publishOpenDocumentDiagnostics,
-    { deep: true, immediate: true },
+    () => publishOpenDocumentDiagnostics(),
+    { immediate: true },
   )
 
   watch(() => resourceIndex.revision.value, () => {
     diagnosticsStore.invalidateSource('resource')
-    publishOpenDocumentDiagnostics()
+    publishOpenDocumentDiagnostics({ force: true })
   })
 
   watch(() => [
     resourceStore.currentEngineCapabilities,
     resourceStore.currentEngineRuntimeCapabilities,
   ], () => {
-    publishOpenDocumentDiagnostics()
+    publishOpenDocumentDiagnostics({ force: true })
   })
 }

--- a/src/features/editor/diagnostics/useEditorDiagnostics.ts
+++ b/src/features/editor/diagnostics/useEditorDiagnostics.ts
@@ -22,16 +22,21 @@ export function useEditorDiagnostics(): void {
   // 各标签页已发布诊断对应的内容令牌；watcher 整体触发时跳过令牌未变的文档
   const publishedTokens = new Map<AbsPath, string>()
 
-  function readDiagnosticsToken(path: AbsPath): string {
+  function readDiagnosticsToken(path: AbsPath): { skippable: boolean, token: string } {
     const textProjection = editorStore.getTextProjectionState(path)
     const visualProjection = editorStore.getVisualProjectionState(path)
-    return [
-      editorStore.peekSceneContentChangeToken(path) ?? '',
-      textProjection?.kind ?? '',
-      textProjection?.syncError ?? '',
-      textProjection?.textContent.length ?? '',
-      visualProjection?.kind ?? '',
-    ].join('|')
+    const sceneContentToken = editorStore.peekSceneContentChangeToken(path)
+    return {
+      // 场景文档的内容变更必然替换 model 并推进令牌，可以按令牌跳过；
+      // 动画草稿这类内容变化不落事务、令牌反映不了，必须每次触发都重算
+      skippable: sceneContentToken !== undefined,
+      token: [
+        sceneContentToken ?? '',
+        textProjection?.kind ?? '',
+        textProjection?.syncError ?? '',
+        visualProjection?.kind ?? '',
+      ].join('|'),
+    }
   }
 
   function publishOpenDocumentDiagnostics(options: PublishDiagnosticsOptions = {}): void {
@@ -44,8 +49,8 @@ export function useEditorDiagnostics(): void {
     }
 
     for (const tab of tabsStore.tabs) {
-      const token = readDiagnosticsToken(tab.path)
-      if (!options.force && publishedTokens.get(tab.path) === token) {
+      const { skippable, token } = readDiagnosticsToken(tab.path)
+      if (!options.force && skippable && publishedTokens.get(tab.path) === token) {
         continue
       }
       publishedTokens.set(tab.path, token)

--- a/src/plugins/editor/diagnostics.ts
+++ b/src/plugins/editor/diagnostics.ts
@@ -40,7 +40,9 @@ export function updateEditorDiagnostics(
   const canCheckResources = Boolean(workspace.currentGame?.path) && resourceIndex.status.value === 'ready'
   const markers: monaco.editor.IMarkerData[] = []
   const lines = model.getLinesContent()
-  const source = lines.join('\n')
+  // 用 model.getValue() 而非 lines.join('\n')：前者与事务写入文档模型的文本一致（含 CRLF），
+  // 可命中整篇解析缓存；lines 仍用于行列定位。
+  const source = model.getValue()
   const ranges = buildStatementSourceRanges(source, runtimeCapabilities)
   const sentences = ranges.map(range => range.parsed)
 

--- a/src/stores/editor.ts
+++ b/src/stores/editor.ts
@@ -24,6 +24,11 @@ import { AppError } from '~/types/errors'
 import { handleError } from '~/utils/error-handler'
 
 import { createEditorDocumentActions } from './internal/editor-document-actions'
+import {
+  createSceneBufferRevision,
+  createSceneContentChangeToken,
+  getEffectiveSceneBufferContent,
+} from './internal/editor-document-revision'
 import { createEditorDocumentSaveSnapshot, saveEditorDocument } from './internal/editor-document-save'
 import {
   createLoadedDocumentState,
@@ -87,34 +92,6 @@ export type {
 
 const PREVIEW_SYNC_DEDUPE_WINDOW_MS = 160
 const AUTO_SAVE_DEBOUNCE_MS = 500
-const REVISION_HASH_MODULUS = 2 ** 32
-
-function hashRevisionContent(content: string): string {
-  let hash = 0
-  for (const char of content) {
-    hash = Math.trunc(Math.imul(31, hash) + (char.codePointAt(0) ?? 0)) % REVISION_HASH_MODULUS
-  }
-  return hash.toString(16)
-}
-
-function getEffectiveSceneBufferContent(session: EditableEditorSession): string {
-  return session.textState.textSource === 'draft'
-    ? session.textState.textContent
-    : getDocumentTextContent(session.document)
-}
-
-function createSceneBufferRevision(session: EditableEditorSession): string {
-  const content = getEffectiveSceneBufferContent(session)
-  const { document, textState } = session
-  return [
-    document.historyRevision,
-    document.engine.sequenceNumber,
-    document.savedSequenceNumber,
-    textState.textSource,
-    content.length,
-    hashRevisionContent(content),
-  ].join(':')
-}
 
 function sameEngineRuntimeCapabilities(
   current: EngineRuntimeCapabilities,
@@ -203,6 +180,19 @@ export const useEditorStore = defineStore('editor', () => {
     }
 
     return createSceneBufferRevision(session)
+  }
+
+  /**
+   * 内容变更令牌：不遍历内容，供响应式消费者判断内容是否变化。
+   * 外部重构/回滚的并发校验必须用 peekSceneRevision。
+   */
+  function peekSceneContentChangeToken(path: AbsPath): string | undefined {
+    const session = getEditableSession(path)
+    if (!session || session.document.model.kind !== 'scene') {
+      return undefined
+    }
+
+    return createSceneContentChangeToken(session)
   }
 
   function applySystemRefactor(
@@ -886,6 +876,7 @@ export const useEditorStore = defineStore('editor', () => {
     canRedoDocument,
     getDirtyBufferContent,
     peekSceneBuffer,
+    peekSceneContentChangeToken,
     peekSceneRevision,
     readTextDocumentFile,
     applySystemRefactor,

--- a/src/stores/internal/__tests__/editor-document-revision.test.ts
+++ b/src/stores/internal/__tests__/editor-document-revision.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest'
+
+import { createDocumentModel } from '~/domain/document/document-model'
+import { LATEST_ENGINE_RUNTIME_CAPABILITIES } from '~/domain/engine/runtime-capabilities'
+import { AbsPath } from '~/domain/path'
+
+import {
+  createSceneBufferRevision,
+  createSceneContentChangeToken,
+  hashDocumentContent,
+} from '../editor-document-revision'
+import { createLoadedDocumentState, invalidateDocumentTextCache } from '../editor-document-state'
+import { createEditableSession } from '../editor-session'
+
+import type { EditableEditorSession } from '../editor-session'
+
+const SCENE_PATH = AbsPath.from('/game/scene/start.txt')
+
+/** 参考实现：锁定哈希取值，更换算法会让已写入的 revision 失效 */
+function referenceHash(content: string): string {
+  let hash = 0
+  for (const char of content) {
+    hash = Math.trunc(Math.imul(31, hash) + (char.codePointAt(0) ?? 0)) % 2 ** 32
+  }
+  return hash.toString(16)
+}
+
+function createSceneSession(content: string): EditableEditorSession {
+  return createEditableSession(
+    SCENE_PATH,
+    createLoadedDocumentState('scene', content, undefined, LATEST_ENGINE_RUNTIME_CAPABILITIES),
+    'visual',
+  )
+}
+
+describe('hashDocumentContent', () => {
+  it('与逐码点参考实现逐位一致', () => {
+    const corpus = [
+      '',
+      'a',
+      'say:hello;',
+      '中文台词内容',
+      '👨‍👩‍👧‍👦',
+      '\uD800',
+      '\uD800a',
+      'a\uDC00',
+      '𝄞 clef',
+      '中文\n😀\n结尾',
+      'say:👩‍🚀 -vocal=a.mp3;'.repeat(50),
+    ]
+
+    for (const content of corpus) {
+      expect(hashDocumentContent(content)).toBe(referenceHash(content))
+    }
+  })
+
+  it('长度相同但内容不同的文本给出不同取值', () => {
+    expect(hashDocumentContent('Alice:hello;')).not.toBe(hashDocumentContent('Alice:world;'))
+  })
+})
+
+describe('场景 buffer 内容标识', () => {
+  it('内容变化后变更令牌与 revision 都变化', () => {
+    const session = createSceneSession('Alice:hello;')
+    const tokenBefore = createSceneContentChangeToken(session)
+    const revisionBefore = createSceneBufferRevision(session)
+
+    session.document.model = createDocumentModel({
+      kind: 'scene',
+      content: 'Alice:hello, world;',
+      runtimeCapabilities: LATEST_ENGINE_RUNTIME_CAPABILITIES,
+    })
+    invalidateDocumentTextCache(session.document)
+
+    expect(createSceneContentChangeToken(session)).not.toBe(tokenBefore)
+    expect(createSceneBufferRevision(session)).not.toBe(revisionBefore)
+  })
+
+  it('长度相同的不同内容也能被 revision 区分', () => {
+    // revision 是外部重构的并发令牌，不能退化成计数器或长度比较
+    expect(createSceneBufferRevision(createSceneSession('Alice:hello;')))
+      .not.toBe(createSceneBufferRevision(createSceneSession('Alice:world;')))
+  })
+
+  it('文本投影草稿的内容变化反映在变更令牌中', () => {
+    const session = createSceneSession('Alice:hello;')
+    session.textState.textSource = 'draft'
+    const tokenBefore = createSceneContentChangeToken(session)
+
+    session.textState.textContent = '{invalid'
+
+    expect(createSceneContentChangeToken(session)).not.toBe(tokenBefore)
+  })
+
+  it('仅替换文档模型（外部重构路径）也会推进变更令牌', () => {
+    const session = createSceneSession('Alice:hello;')
+    const tokenBefore = createSceneContentChangeToken(session)
+
+    // 外部重构路径：只替换模型并失效文本缓存，不提交事务
+    session.document.model = createDocumentModel({
+      kind: 'scene',
+      content: 'Alice:hello;',
+      runtimeCapabilities: LATEST_ENGINE_RUNTIME_CAPABILITIES,
+    })
+    invalidateDocumentTextCache(session.document)
+
+    expect(createSceneContentChangeToken(session)).not.toBe(tokenBefore)
+  })
+})

--- a/src/stores/internal/editor-document-revision.ts
+++ b/src/stores/internal/editor-document-revision.ts
@@ -1,0 +1,58 @@
+import { getDocumentTextContent } from './editor-document-state'
+
+import type { EditableEditorSession } from './editor-session'
+
+const REVISION_HASH_MODULUS = 2 ** 32
+
+/** 文本投影处于草稿态时取草稿，否则取文档序列化结果 */
+export function getEffectiveSceneBufferContent(session: EditableEditorSession): string {
+  return session.textState.textSource === 'draft'
+    ? session.textState.textContent
+    : getDocumentTextContent(session.document)
+}
+
+/**
+ * 内容变更令牌：只读 Θ(1) 字段，供响应式消费者判断内容是否变化。
+ *
+ * 令牌必须覆盖全部内容变更路径：替换 model 推进 contentVersion，撤销/重做推进
+ * historyRevision；文本投影草稿（非法动画 JSON）不落事务，因此一并带上 textSource、
+ * syncError 与内容长度。
+ */
+export function createSceneContentChangeToken(session: EditableEditorSession): string {
+  const { document, textState } = session
+  return [
+    document.contentVersion,
+    document.historyRevision,
+    document.engine.sequenceNumber,
+    document.savedSequenceNumber,
+    textState.textSource,
+    textState.syncError ?? '',
+    textState.textContent.length,
+  ].join(':')
+}
+
+/**
+ * 内容 revision：外部重构与回滚的乐观并发令牌，必须能区分任意两份不同内容，
+ * 不能退化成计数器或长度比较。
+ */
+export function createSceneBufferRevision(session: EditableEditorSession): string {
+  const content = getEffectiveSceneBufferContent(session)
+  const { document, textState } = session
+  return [
+    document.historyRevision,
+    document.engine.sequenceNumber,
+    document.savedSequenceNumber,
+    textState.textSource,
+    content.length,
+    hashDocumentContent(content),
+  ].join(':')
+}
+
+/** 取值参与外部重构的并发令牌，算法不可更改 */
+export function hashDocumentContent(content: string): string {
+  let hash = 0
+  for (const char of content) {
+    hash = Math.trunc(Math.imul(31, hash) + (char.codePointAt(0) ?? 0)) % REVISION_HASH_MODULUS
+  }
+  return hash.toString(16)
+}

--- a/src/stores/internal/editor-document-state.ts
+++ b/src/stores/internal/editor-document-state.ts
@@ -16,6 +16,8 @@ export interface DocumentState {
   savedTextContent: string
   /** 缓存的文本内容，model 变更后置为 undefined，按需重新序列化 */
   cachedTextContent: string | undefined
+  /** 内容版本号：model 被替换时递增，供消费者判断内容是否变化而无需重算内容哈希 */
+  contentVersion: number
 }
 
 export type DocumentStateOfKind<TKind extends DocumentKind> = DocumentState & {
@@ -95,6 +97,7 @@ export function createDocumentState(model: DocumentModel, savedTextContent: stri
     savedSequenceNumber: 0,
     savedTextContent,
     cachedTextContent: undefined,
+    contentVersion: 0,
   }) as DocumentState
 }
 
@@ -114,9 +117,10 @@ export function getDocumentTextContent(doc: DocumentState): string {
   return content
 }
 
-/** model 变更后调用，使文本缓存失效 */
+/** model 变更后调用：使文本缓存失效并推进内容版本号；所有替换 model 的路径都必须经过这里 */
 export function invalidateDocumentTextCache(doc: DocumentState): void {
   doc.cachedTextContent = undefined
+  doc.contentVersion++
 }
 
 export function isDocumentDirty(document: DocumentState): boolean {


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [ ] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [x] 代码重构
- [ ] 测试用例
- [x] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

消除三类整篇粒度的重复计算：

1. 文本模式一次按键会触发 4 次互不复用的整篇解析（文档模型重建、Monaco 诊断标记、多行语句高亮、文本模式侧栏快照）。`buildStatementSourceRanges`（`src/domain/script/sentence.ts`）现在按「文本 + 语法能力」缓存最近两份解析结果，四个消费者共享同一次解析；诊断标记改用 `model.getValue()` 作为解析文本，CRLF 文件同样命中缓存。
2. 可视化模式的诊断 watcher 每次提交都对每个打开标签页整篇算一次逐码点哈希（N=4000 时 2.6ms / N=8000 时 5.0ms），且任一标签页编辑会让所有打开文档重算诊断。`DocumentState` 新增 `contentVersion`（在 `invalidateDocumentTextCache` 中递增，事务、外部重构、能力切换同一入口），新增 `createSceneContentChangeToken` 只用 Θ(1) 字段；watcher 改用它并按标签页令牌跳过未变化的文档，资源索引与引擎能力变化仍强制全量重算。
3. 新增 `src/stores/internal/editor-document-revision.ts`，把「变更令牌」与「含整篇哈希的完整 revision」拆开；revision 的字符串格式与哈希实现都没动。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

大脚本下语句编辑（尤其文本模式输入）有可感知延迟。资源密集合成脚本、四个整篇消费者串行执行、重复测量取最小值：

| 语句数 | 改动前 | 改动后 |
| --- | --- | --- |
| 1000 | 9.30ms | 0.86ms |
| 4000 | 55.36ms | 5.37ms |
| 8000 | 156.85ms | 17.82ms |

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->

诊断触发条件由「整篇哈希变化」换成等价的内容令牌：令牌未变的文档不再重复发布，但发布内容与之前一致。

### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [x] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
