### PR TITLE
♻️ 合并引擎标签的重复实现

### DIFF
--- a/src/components/editor/EditorStatusBar.vue
+++ b/src/components/editor/EditorStatusBar.vue
@@ -24,7 +24,7 @@ import {
 import { useModalStore } from '~/stores/modal'
 import { useWorkspaceStore } from '~/stores/workspace'
 import { handleError } from '~/utils/error-handler'
-import { formatEngineLabel, formatFileSize } from '~/utils/format'
+import { formatFileSize, formatNameWithVersion } from '~/utils/format'
 
 const { t, locale } = useI18n()
 
@@ -67,7 +67,9 @@ watch(() => workspaceStore.currentGame?.engineId, async (engineId) => {
   if (workspaceStore.currentGame?.engineId !== engineId) {
     return
   }
-  engineLabel = engine && isEngineUsable(engine) ? formatEngineLabel(engine) : undefined
+  engineLabel = engine && isEngineUsable(engine)
+    ? formatNameWithVersion(engine.name, engine.version)
+    : undefined
 }, { immediate: true })
 
 function openSwitchEngine() {

--- a/src/components/editor/EditorStatusBar.vue
+++ b/src/components/editor/EditorStatusBar.vue
@@ -13,7 +13,6 @@ import {
   resolveEditorStatusBarMetrics,
   shouldShowEditorStatusBarRelativeTime,
 } from '~/features/editor/status-bar/editor-status-bar'
-import { formatEngineLabel } from '~/lib/engine-label'
 import dayjs from '~/plugins/dayjs'
 import { getLanguageDisplayName } from '~/plugins/editor'
 import { isEngineUsable } from '~/services/engine-manager'
@@ -25,7 +24,7 @@ import {
 import { useModalStore } from '~/stores/modal'
 import { useWorkspaceStore } from '~/stores/workspace'
 import { handleError } from '~/utils/error-handler'
-import { formatFileSize } from '~/utils/format'
+import { formatEngineLabel, formatFileSize } from '~/utils/format'
 
 const { t, locale } = useI18n()
 

--- a/src/components/home/templates-tab/TemplateSourcesPopoverContent.vue
+++ b/src/components/home/templates-tab/TemplateSourcesPopoverContent.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
 import { Folder } from '@lucide/vue'
 
+import { formatNameWithVersion } from '~/utils/format'
+
 import type { TemplateGroupSourceItem } from '~/features/home/templates-tab/template-groups'
 
 defineProps<{
@@ -15,9 +17,7 @@ function resolveSourceLabel(source: TemplateGroupSourceItem): string {
   if (source.kind === 'standalone') {
     return source.name
   }
-  return source.engineVersion
-    ? `${source.engineName} ${source.engineVersion}`
-    : source.engineName
+  return formatNameWithVersion(source.engineName, source.engineVersion)
 }
 </script>
 

--- a/src/components/modals/DeleteEngineModal.vue
+++ b/src/components/modals/DeleteEngineModal.vue
@@ -3,6 +3,7 @@ import { TriangleAlert } from '@lucide/vue'
 
 import { useDeleteConfirmation } from '~/composables/useDeleteConfirmation'
 import { engineManager } from '~/services/engine-manager'
+import { formatNameWithVersion } from '~/utils/format'
 
 import type { Engine } from '~/database/model'
 
@@ -15,7 +16,7 @@ const props = defineProps<{
 
 const isUnavailable = $computed(() => props.engine.availability !== 'available')
 const engineDisplayName = $computed(() =>
-  props.engine.version ? `${props.engine.name} ${props.engine.version}` : props.engine.name,
+  formatNameWithVersion(props.engine.name, props.engine.version),
 )
 
 const { associatedGames, isDeleteBlocked, isConfirmDisabled, handleConfirm } =

--- a/src/components/modals/GameDependencyResolutionModal.vue
+++ b/src/components/modals/GameDependencyResolutionModal.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { usePreferenceStore } from '~/stores/preference'
+import { formatNameWithVersion } from '~/utils/format'
 
 import type {
   ImportDependencyIssueReason,
@@ -8,7 +9,7 @@ import type {
   ImportEngineDependencyIssue,
   ImportTemplateResolutionResult,
 } from '~/types/import-dependency-resolution'
-import type { EngineRef, TemplateBinding } from '~/types/project-config'
+import type { TemplateBinding } from '~/types/project-config'
 
 let open = $(defineModel<boolean>('open'))
 
@@ -39,11 +40,10 @@ const preferredEngineId = $computed(() =>
   props.context.engine?.current?.id ?? preferenceStore.defaultEngineId,
 )
 
-const engineReference = $computed(() =>
-  props.context.engine?.current
-    ? formatEngineReference(props.context.engine.current)
-    : undefined,
-)
+const engineReference = $computed(() => {
+  const engine = props.context.engine?.current
+  return engine ? formatNameWithVersion(engine.id, engine.version) : undefined
+})
 const templateReference = $computed(() => props.context.template?.displayName)
 const isRuntimeRebind = $computed(() => props.context.purpose === 'runtimeRebind')
 const title = $computed(() =>
@@ -107,10 +107,6 @@ const canConfirm = $computed(() =>
   (!needsEngine || !!selectedEngineId)
   && (!needsTemplate || !!selectedTemplateDecision),
 )
-
-function formatEngineReference(engine: EngineRef) {
-  return engine.version ? `${engine.id} ${engine.version}` : engine.id
-}
 
 function resolveEngineReasonLabel(issue: ImportEngineDependencyIssue | undefined) {
   if (!issue) {

--- a/src/components/shared/TemplateSelector.vue
+++ b/src/components/shared/TemplateSelector.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { useEngines, useTemplates } from '~/composables/useDatabase'
 import { isEngineEditorCompatible } from '~/services/engine-manager'
-import { formatEngineLabel } from '~/utils/format'
+import { formatNameWithVersion } from '~/utils/format'
 
 import type { Engine } from '~/database/model'
 import type { TemplateBinding } from '~/types/project-config'
@@ -44,7 +44,7 @@ const followEngineLabel = $computed(() => {
     return t('modals.createGame.templateFollowEngine')
   }
   return t('modals.createGame.templateFollowEngineWithName', {
-    name: formatEngineLabel(currentEngine),
+    name: formatNameWithVersion(currentEngine.name, currentEngine.version),
   })
 })
 
@@ -109,10 +109,8 @@ const selectedLabel = $computed(() => {
       item => item.engineId === binding.engine.id && item.version === binding.engine.version,
     )
     return engine
-      ? formatEngineLabel(engine)
-      : (binding.engine.version
-          ? `${binding.engine.id} ${binding.engine.version}`
-          : binding.engine.id)
+      ? formatNameWithVersion(engine.name, engine.version)
+      : formatNameWithVersion(binding.engine.id, binding.engine.version)
   }
   return binding.name
 })
@@ -151,7 +149,7 @@ const selectedLabel = $computed(() => {
             :key="engine.id"
             :value="encodeEngineRef(engine.engineId, engine.version)"
           >
-            {{ formatEngineLabel(engine) }}
+            {{ formatNameWithVersion(engine.name, engine.version) }}
           </SelectItem>
         </SelectGroup>
       </template>

--- a/src/components/shared/TemplateSelector.vue
+++ b/src/components/shared/TemplateSelector.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { useEngines, useTemplates } from '~/composables/useDatabase'
-import { formatEngineLabel } from '~/lib/engine-label'
 import { isEngineEditorCompatible } from '~/services/engine-manager'
+import { formatEngineLabel } from '~/utils/format'
 
 import type { Engine } from '~/database/model'
 import type { TemplateBinding } from '~/types/project-config'

--- a/src/composables/__tests__/useTemplateLabel.test.ts
+++ b/src/composables/__tests__/useTemplateLabel.test.ts
@@ -30,7 +30,7 @@ vi.mock('~/database/db', () => ({
   },
 }))
 
-vi.mock('~/lib/engine-label', () => ({
+vi.mock('~/utils/format', () => ({
   formatEngineLabel: vi.fn((engine: { name?: string, engineId?: string }) => engine.name ?? engine.engineId ?? ''),
 }))
 

--- a/src/composables/__tests__/useTemplateLabel.test.ts
+++ b/src/composables/__tests__/useTemplateLabel.test.ts
@@ -30,10 +30,6 @@ vi.mock('~/database/db', () => ({
   },
 }))
 
-vi.mock('~/utils/format', () => ({
-  formatEngineLabel: vi.fn((engine: { name?: string, engineId?: string }) => engine.name ?? engine.engineId ?? ''),
-}))
-
 vi.mock('~/services/engine-manager', () => ({
   isEngineUsable: vi.fn(() => true),
 }))

--- a/src/composables/useTemplateLabel.ts
+++ b/src/composables/useTemplateLabel.ts
@@ -1,11 +1,11 @@
 import { projectConfigCmds } from '~/commands/project-config'
 import { db } from '~/database/db'
 import { AbsPath, RelPath } from '~/domain/path'
-import { formatEngineLabel } from '~/lib/engine-label'
 import { isEngineUsable } from '~/services/engine-manager'
 import { caseFoldedEquals, toLookupPathKey } from '~/services/resource-path/lookup'
 import { useWorkspaceStore } from '~/stores/workspace'
 import { handleError } from '~/utils/error-handler'
+import { formatEngineLabel } from '~/utils/format'
 
 import { useFileSystemEvents } from './useFileSystemEvents'
 

--- a/src/composables/useTemplateLabel.ts
+++ b/src/composables/useTemplateLabel.ts
@@ -5,7 +5,7 @@ import { isEngineUsable } from '~/services/engine-manager'
 import { caseFoldedEquals, toLookupPathKey } from '~/services/resource-path/lookup'
 import { useWorkspaceStore } from '~/stores/workspace'
 import { handleError } from '~/utils/error-handler'
-import { formatEngineLabel } from '~/utils/format'
+import { formatNameWithVersion } from '~/utils/format'
 
 import { useFileSystemEvents } from './useFileSystemEvents'
 
@@ -26,10 +26,6 @@ function isPathWithinOrEqual(path: AbsPath, root: AbsPath): boolean {
   return toLookupPathKey(path).startsWith(`${toLookupPathKey(root)}/`)
 }
 
-function formatBuiltinFallbackLabel(id: string, version: string | undefined): string {
-  return version ? `${id} ${version}` : id
-}
-
 async function resolveBindingLabel(
   binding: TemplateBinding | undefined,
   fallbackEngineId: string | undefined,
@@ -44,9 +40,9 @@ async function resolveBindingLabel(
       ? undefined
       : await db.engines.where('[engineId+version]').equals([id, version]).first()
     if (!engine) {
-      return { label: formatBuiltinFallbackLabel(id, version), followingEngine: false }
+      return { label: formatNameWithVersion(id, version), followingEngine: false }
     }
-    return { label: isEngineUsable(engine) ? formatEngineLabel(engine) : undefined, followingEngine: false }
+    return { label: isEngineUsable(engine) ? formatNameWithVersion(engine.name, engine.version) : undefined, followingEngine: false }
   }
 
   // 缺省 → 跟随当前引擎；引擎记录缺失或不可用时不暴露 UUID/旧名，由调用方按 followingEngine + label undefined 决定占位文案
@@ -54,7 +50,7 @@ async function resolveBindingLabel(
     return EMPTY_STATE
   }
   const engine = await db.engines.get(fallbackEngineId)
-  const label = engine && isEngineUsable(engine) ? formatEngineLabel(engine) : undefined
+  const label = engine && isEngineUsable(engine) ? formatNameWithVersion(engine.name, engine.version) : undefined
   return { label, followingEngine: true }
 }
 

--- a/src/lib/engine-label.ts
+++ b/src/lib/engine-label.ts
@@ -1,7 +1,0 @@
-/**
- * 引擎显示标签格式化：`${name} ${version}`，没有版本时只返回名称。
- * 用于状态栏、模板/引擎选择器以及切换弹窗等所有需要展示引擎的位置。
- */
-export function formatEngineLabel(engine: { name: string, version?: string }): string {
-  return engine.version ? `${engine.name} ${engine.version}` : engine.name
-}

--- a/src/services/game-manager.ts
+++ b/src/services/game-manager.ts
@@ -28,6 +28,7 @@ import { useResourceStore } from '~/stores/resource'
 import { useRuntimeTaskStore } from '~/stores/runtime-task'
 import { useWorkspaceStore } from '~/stores/workspace'
 import { AppError } from '~/types/errors'
+import { formatNameWithVersion } from '~/utils/format'
 
 import type { GameConfigEntry } from '~/commands/game'
 import type { Engine, Game, Template } from '~/database/model'
@@ -505,9 +506,7 @@ function formatTemplateBindingName(binding: TemplateBinding): string {
       return binding.name
     }
     case 'engineBuiltin': {
-      return binding.engine.version
-        ? `${binding.engine.id} ${binding.engine.version}`
-        : binding.engine.id
+      return formatNameWithVersion(binding.engine.id, binding.engine.version)
     }
     default: {
       return binding satisfies never

--- a/src/utils/__tests__/format.test.ts
+++ b/src/utils/__tests__/format.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { formatFileSize } from '~/utils/format'
+import { formatFileSize, formatNameWithVersion } from '~/utils/format'
 
 describe('formatFileSize', () => {
   it('字节级大小会直接输出整数 B', () => {
@@ -19,5 +19,16 @@ describe('formatFileSize', () => {
   it('超过 1 GiB 时会继续按最高单位格式化', () => {
     expect(formatFileSize(5 * 1024 ** 3)).toBe('5.0 GiB')
     expect(formatFileSize(12.4 * 1024 ** 3)).toBe('12 GiB')
+  })
+})
+
+describe('formatNameWithVersion', () => {
+  it('有版本时用空格连接名称与版本', () => {
+    expect(formatNameWithVersion('WebGAL', '4.4.0')).toBe('WebGAL 4.4.0')
+  })
+
+  it('版本缺失或为空时只返回名称，不留下多余空格', () => {
+    expect(formatNameWithVersion('WebGAL', undefined)).toBe('WebGAL')
+    expect(formatNameWithVersion('WebGAL', '')).toBe('WebGAL')
   })
 })

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -19,9 +19,9 @@ export function formatFileSize(bytes: number): string {
 }
 
 /**
- * 引擎显示标签格式化：`${name} ${version}`，没有版本时只返回名称。
- * 用于状态栏、模板/引擎选择器以及切换弹窗等所有需要展示引擎的位置。
+ * 名称与可选版本的展示格式：`${name} ${version}`，没有版本时只返回名称。
+ * 引擎记录、引擎引用（记录不可解析时降级用 id）以及模板来源等需要展示带版本标识的位置共用此规则。
  */
-export function formatEngineLabel(engine: { name: string, version?: string }): string {
-  return engine.version ? `${engine.name} ${engine.version}` : engine.name
+export function formatNameWithVersion(name: string, version?: string): string {
+  return version ? `${name} ${version}` : name
 }

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -17,3 +17,11 @@ export function formatFileSize(bytes: number): string {
   const value = size < 10 ? size.toFixed(1) : String(Math.round(size))
   return `${value} ${FILE_SIZE_UNITS[unitIndex]}`
 }
+
+/**
+ * 引擎显示标签格式化：`${name} ${version}`，没有版本时只返回名称。
+ * 用于状态栏、模板/引擎选择器以及切换弹窗等所有需要展示引擎的位置。
+ */
+export function formatEngineLabel(engine: { name: string, version?: string }): string {
+  return engine.version ? `${engine.name} ${engine.version}` : engine.name
+}


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [ ] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [x] 代码重构
- [ ] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

行为不变的内部整理，分两个提交：先移动，再去重。

`src/lib` 在本仓库只服务于 shadcn 生成的 `cn`，项目自有的纯格式化函数不适合放在那里，已迁入 `utils`。

“名称 + 可选版本”此前在状态栏、模板选择、模板来源、引擎删除与依赖解析等处各写了一遍，现合并为一个共享函数；各调用点自身的分支判断保持不变。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

同一展示规则散落在多处实现，调整格式（分隔符、缺失版本的处理）时容易改漏，也没有明确的归属。

`lib` 与 `utils` 并存会让新文件的落点出现二义性，长期容易退化为默认堆放目录，因此项目自有工具统一收在 `utils`。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [x] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [x] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
