### PR TITLE
🐛 修复模板切换弹窗底部按钮意外靠左

### DIFF
--- a/src/components/modals/SwitchTemplateModal.vue
+++ b/src/components/modals/SwitchTemplateModal.vue
@@ -154,7 +154,7 @@ async function handleResetConfirm() {
         </div>
       </div>
 
-      <DialogFooter class="gap-3 sm:justify-between">
+      <DialogFooter class="gap-3" :class="{ 'sm:justify-between': isDirty }">
         <Button
           v-if="isDirty"
           variant="ghost"


### PR DESCRIPTION
<!--
感谢你对本项目的贡献！
在创建 PR 之前，请确保你已阅读过本项目的贡献指南。
为避免浪费时间，最好先打开与 PR 相关的议题，等待批准后再处理。
-->

### 这个 PR 带来了什么样的更改？
<!--
通过将 "[ ]" 修改为 "[x]" 来选中，至少从中选择一个。
如果要引入新的选项，必须向维护者提出和讨论，并且得到批准。
-->

- [x] 错误修复
- [ ] 新功能
- [ ] 文档/注释
- [ ] 代码格式
- [ ] 代码重构
- [ ] 测试用例
- [ ] 性能优化
- [ ] 外观样式
- [ ] 项目构建
- [ ] 依赖环境
- [ ] 持续集成/部署
- [ ] 其他，请描述:

### 这个 PR 是否存在破坏性变更？
<!--
此更改是否可能导致现有功能无法按预期工作？
如果是，用户可能需要在其应用程序中进行哪些更改？请在其他信息中描述现有应用程序的影响和迁移路径。
-->

- [ ] 是的，并已在 issue #___ 号中获得批准
- [x] 没有

### 描述
<!--
详细描述你做出的更改。
如：修复 Bug 以及解决方案的说明、新功能的使用说明以及实现逻辑。
-->

`SwitchTemplateModal` 底部左侧是「重置模板」、右侧是「取消/保存」，依靠 `sm:justify-between` 两端对齐，而「重置模板」只在当前模板存在覆盖内容时渲染。当模板没有被修改（以及重置成功之后），footer 里只剩「取消/保存」一组按钮，两端对齐退化为左对齐，按钮就贴到了弹窗左侧。

现在只在重置入口存在时才启用两端对齐，其余情况保持 `DialogFooter` 默认的右对齐。

### 动机和背景
<!--
为什么需要更改？它解决了什么问题？
如果这已经在 GitHub Issues 中讨论过，请将其链接到此处。如：resolve #issue编号
-->

模板没有覆盖内容（或重置成功后），弹窗底部的「取消/保存」会贴左，与弹窗其它内容错位。

### 其他信息
<!-- 任何你觉得需要补充说明的信息。 -->



### 检查工作
<!-- 在打开 PR 之前，请检查以下各点，并选中检查完成的工作。 -->
- [ ] 我对我的代码进行了注释，特别是在难以理解的部分
- [ ] 我的更改需要更新文档，并且已对文档进行了相应的更改
- [ ] 我添加了测试并且已经在本地通过，以证明我的修复补丁或新功能有效
- [x] 我已检查并确保更改没有与其他打开的 [Pull Requests](../pulls) 重复
